### PR TITLE
fix Version entry in lutris.desktop

### DIFF
--- a/lutris.desktop
+++ b/lutris.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.3.2
+Version=1.0
 Name=Lutris
 Comment=Lutris application
 Categories=Network;FileTransfer;Game;

--- a/lutris.desktop.in
+++ b/lutris.desktop.in
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.3.2
+Version=1.0
 Name=Lutris
 Comment=Lutris application
 Categories=Game;


### PR DESCRIPTION
Version refers to the spec version, not the program version
http://standards.freedesktop.org/desktop-entry-spec/latest/ar01s05.html
