### PR TITLE
Changed wording on the directory dialogue.

### DIFF
--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -61,7 +61,7 @@ class winesteam(wine):
         if installer_path:
             self.msi_exec(installer_path, quiet=True)
         Gdk.threads_enter()
-        dlg = DirectoryDialog('Where is Steam located?')
+        dlg = DirectoryDialog('Where is Steam.exe installed?')
         self.game_path = dlg.folder
         Gdk.threads_leave()
         config = LutrisConfig(runner='winesteam')


### PR DESCRIPTION
This was confusing me when I first ran it, so I changed the wording to both indicate that we're looking for the Windows EXE file and it's location _after_  an already done installation.
