### PR TITLE
Added workdir to wineexec

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -162,7 +162,7 @@ Currently, the following tasks are implemented:
 
 wine: ``wineexec`` Runs a windows executable. Parameters are ``executable``,
 ``args`` (optional arguments passed to the executable), ``prefix`` (optional
-WINEPREFIX).
+WINEPREFIX), ``workdir`` (optional working directory).
 
 wine: ``winetricks`` Runs winetricks with the ``app`` argument. ``prefix`` is
 an optional WINEPREFIX path.

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -33,7 +33,7 @@ def create_prefix(prefix, arch='win32'):
     wineexec('', prefix=prefix, wine_path='wineboot', arch=arch)
 
 
-def wineexec(executable, args="", prefix=None, wine_path='wine', arch='win32'):
+def wineexec(executable, args="", prefix=None, wine_path='wine', arch='win32', workdir=None):
     if not prefix:
         prefix = ""
     else:
@@ -45,7 +45,7 @@ def wineexec(executable, args="", prefix=None, wine_path='wine', arch='win32'):
         arch, prefix, wine_path, executable, args
     )
     logger.debug("Running wine command: %s", command)
-    subprocess.Popen(command, shell=True, stdout=subprocess.PIPE).communicate()
+    subprocess.Popen(command, cwd=workdir, shell=True, stdout=subprocess.PIPE).communicate()
 
 
 def winetricks(app, prefix=None, arch='win32', silent=False):


### PR DESCRIPTION
Might want to add it to execute() in installer.py too, but it's using
subprocess.call() which doesn't seem to have a working dir argument,
contrary to subprocess.Popen()
