### PR TITLE
Fix: installed games getting the "not installed" banner style upon banner download

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -240,7 +240,8 @@ class LutrisWindow(object):
         dialogs.PgaSourceDialog()
 
     def on_image_downloaded(self, game_slug):
-        self.view.update_image(game_slug)
+        is_installed = Game(game_slug).is_installed
+        self.view.update_image(game_slug, is_installed)
 
     def on_search_entry_changed(self, widget):
         self.view.emit('filter-updated', widget.get_text())


### PR DESCRIPTION
PS : I don't understand why you carry the is_installed variable
around in the args of many functions instead of getting/setting it
from the Game object in the fuctions where it's used.
