### PR TITLE
Fix path error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ for directory, _, filenames in os.walk(u'share'):
         for filename in filenames:
             filename = os.path.join(directory, filename)
             files.append(filename)
-        data_files.append((os.path.join('share', dest), files))
+        data_files.append((os.path.join('share', dest[1:]), files))
 
 
 setup(


### PR DESCRIPTION
os.path.join doesn't allow the second parameter to star with '/', we need to remove the first character ('/'). Fix for #148