### PR TITLE
Support file ids in args parameter of execute directive

### DIFF
--- a/lutris/installer.py
+++ b/lutris/installer.py
@@ -450,13 +450,16 @@ class ScriptInterpreter(object):
 
     def execute(self, data):
         """Run an executable file"""
+        args = []
         if isinstance(data, dict):
             file_ref = data['file']
-            args = [self._substitute(arg)
-                    for arg in data.get('args', '').split()]
+            for arg in data.get('args', '').split():
+                if arg in self.game_files:
+                    args.append(self._get_file(arg))
+                else:
+                    args.append(self._substitute(arg))
         else:
             file_ref = data
-            args = []
         # Determine whether 'file' value is a file id or a path
         exec_path = self._get_file(file_ref) or self._substitute(file_ref)
         if not exec_path:


### PR DESCRIPTION
This makes it possible to pass file ids as arguments to an arbitrary executable via the args parameter of the execute directive. This is useful when the executable in question is meant to do something with a user provided file.