### PR TITLE
Add ResidualVM to the list of Runners

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,7 @@ We currently support the following runners:
 * Mame
 * Mess
 * ScummVM
+* ResidualVM
 * Mednafen
 * FS-UAE
 * Vice


### PR DESCRIPTION
It's available here: https://github.com/lutris/lutris/blob/master/lutris/runners/residualvm.py