### PR TITLE
Use xdg-open to open the registration page and fallback to Gtk.open_uri() if error

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -2,6 +2,7 @@
 # pylint: disable=E0611
 import os
 import time
+import subprocess
 
 from gi.repository import Gtk, Gdk, GLib
 
@@ -386,7 +387,10 @@ class LutrisWindow(object):
         connection_label.set_text(connection_status)
 
     def on_register_account(self, *args):
-        Gtk.show_uri(None, "http://lutris.net/user/register", Gdk.CURRENT_TIME)
+        try:
+            subprocess.check_call(["xdg-open", "https://lutris.net/user/register"])
+        except CalledProcessError:
+            Gtk.show_uri(None, "https://lutris.net/user/register", Gdk.CURRENT_TIME)
 
     def on_synchronize_manually(self, *args):
         """Callback when Synchronize Library is activated."""


### PR DESCRIPTION
This is a proposal to fix #263.

It adds the standard python module 'subprocess' in the import and changes on_register_account() to use check_call() to invoke xdg-open.
It also handles a (most-likely) rare case where xdg-open would not be available by catching the exception and falling back to Gtk.open_uri()