### PR TITLE
Properly hide and show the sidebar when toggled

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -139,8 +139,8 @@ class LutrisWindow(object):
         self.view.contextual_menu = self.menu
 
         # Sidebar
-        sidebar_paned = self.builder.get_object('sidebar_paned')
-        sidebar_paned.set_position(150)
+        self.sidebar_paned = self.builder.get_object('sidebar_paned')
+        self.sidebar_paned.set_position(150)
         self.sidebar_treeview = SidebarTreeView()
         self.sidebar_treeview.connect('cursor-changed', self.on_sidebar_changed)
         self.sidebar_viewport = self.builder.get_object('sidebar_viewport')
@@ -154,6 +154,8 @@ class LutrisWindow(object):
             self.sidebar_viewport.hide()
         self.builder.connect_signals(self)
         self.connect_signals()
+
+        self.statusbar = self.builder.get_object("statusbar")
 
         # XXX Hide PGA config menu item until it actually gets implemented
         pga_menuitem = self.builder.get_object('pga_menuitem')
@@ -654,10 +656,18 @@ class LutrisWindow(object):
 
     def toggle_sidebar(self, _widget=None):
         if self.sidebar_visible:
-            self.sidebar_viewport.hide()
+            self.sidebar_paned.remove(self.games_scrollwindow)
+            self.main_box.remove(self.sidebar_paned)
+            self.main_box.remove(self.statusbar)
+            self.main_box.pack_start(self.games_scrollwindow, True, True, 0)
+            self.main_box.pack_start(self.statusbar, False, False, 0)
             settings.write_setting('sidebar_visible', 'false')
         else:
-            self.sidebar_viewport.show()
+            self.main_box.remove(self.games_scrollwindow)
+            self.sidebar_paned.add2(self.games_scrollwindow)
+            self.main_box.remove(self.statusbar)
+            self.main_box.pack_start(self.sidebar_paned, True, True, 0)
+            self.main_box.pack_start(self.statusbar, False, False, 0)
             settings.write_setting('sidebar_visible', 'true')
         self.sidebar_visible = not self.sidebar_visible
 


### PR DESCRIPTION
This removes widgets and re-packs them when toggling the sidebar.

When hiding the sidebar:
- Removes games_scrollwindow from sidebar_paned, as well as statusbar and sidebar_paned from main_box
- Packs games_scrollwindow and statusbar back into main_box

When showing the sidebar:
- Removes games_scrollwindow and statusbar from main_box
- Packs games_scrollwindow in sidebar_paned
- Packs sidebar_paned and statusbar back into main_box

This is how it looks with the sidebar hidden:
![screenshot from 2016-04-23 00-53-47](https://cloud.githubusercontent.com/assets/1087450/14756852/f39e1818-08ed-11e6-9e1f-e80135f0a122.png)
And with it added back in:
![screenshot from 2016-04-23 00-53-58](https://cloud.githubusercontent.com/assets/1087450/14756856/0048ae02-08ee-11e6-815d-064da045d1bf.png)
