### PR TITLE
[WIP] Update to GTK3.14+

### DIFF
--- a/bin/lutris
+++ b/bin/lutris
@@ -12,29 +12,37 @@
 #
 # You should have received a copy of the GNU General Public License along
 # with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+'''
 import dbus
 import dbus.service
+'''
 import os
 import sys
+'''
 import logging
 import optparse
+'''
 import signal
+'''
 import time
 import json
+'''
 
 # pylint: disable=E0611
-import gi
-gi.require_version('Gdk', '3.0')
-gi.require_version('Gtk', '3.0')
 
+import gi
+# gi.require_version('Gdk', '3.0')
+gi.require_version('Gtk', '3.0')
+'''
 from dbus.mainloop.glib import DBusGMainLoop
 DBusGMainLoop(set_as_default=True)
 
 from gi.repository import Gdk, Gtk, GObject, GLib
+'''
+from gi.repository import Gtk
 
 from os.path import realpath, dirname, normpath
-
+'''
 LAUNCH_PATH = dirname(realpath(__file__))
 if LAUNCH_PATH != "/usr/bin":
     SOURCE_PATH = normpath(os.path.join(LAUNCH_PATH, '..'))
@@ -50,7 +58,9 @@ from lutris.game import Game
 from lutris.gui.installgamedialog import InstallerDialog
 from lutris.settings import VERSION
 from lutris.util import service
-
+'''
+from lutris.gui.application import Application
+'''
 # Support for command line options.
 parser = optparse.OptionParser(version="%prog " + VERSION)
 parser.add_option("-v", "--verbose", action="store_true", dest="verbose",
@@ -112,9 +122,12 @@ check_config(force_wipe=False)
 
 installer = False
 game = None
+'''
 
+app = Application()
 signal.signal(signal.SIGINT, signal.SIG_DFL)
 
+'''
 # D-Bus init
 
 bus = dbus.SessionBus()
@@ -197,3 +210,6 @@ if game_slug or installer:
 lutris.run(int(time.time()))
 if lutris.is_running():
     Gdk.notify_startup_complete()
+'''
+
+app.run(sys.argv)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python2
+# -*- Mode: Python; coding: utf-8; indent-tabs-mode: nil; tab-width: 4 -*-
+
+import logging
+import json
+
+from gi.repository import GLib, Gio, Gtk
+
+from lutris.util.log import logger
+from lutris.config import check_config
+from lutris.game import Game
+from lutris import pga
+from lutris.settings import VERSION, GAME_CONFIG_DIR
+from lutris.gui.installgamedialog import InstallerDialog
+from lutris.gui.lutriswindow import LutrisWindow
+
+
+class Application(Gtk.Application):
+    def __init__(self):
+        Gtk.Application.__init__(
+                self, application_id='net.lutris',
+                flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
+        GLib.set_application_name('Lutris')
+        self.window = None
+
+        self.add_main_option(
+                 "verbose", "v", GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "Verbose output", None)
+        self.add_main_option(
+                 "debug", "d", GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "Show debug messages", None)
+        self.add_main_option(
+                 "install", "i", GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "Install a game from a yml file", None)
+        self.add_main_option(
+                 "list-games", "l", GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "List games in database", None)
+        self.add_main_option(
+                 "installed", "o", GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "Only list installed games", None)
+        self.add_main_option(
+                 "list-steam", "s", GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "List Steam (Windows) games", None)
+        self.add_main_option(
+                 "json", "j", GLib.OptionFlags.NONE, GLib.OptionArg.NONE,
+                 "Display the list of games in JSON format", None)
+        self.add_main_option(
+                 "reinstall", '\0', GLib.OptionFlags.NONE,
+                 GLib.OptionArg.NONE, "Reinstall game", None)
+        self.add_main_option(
+                 GLib.OPTION_REMAINING, '\0', GLib.OptionFlags.NONE,
+                 GLib.OptionArg.STRING_ARRAY, '"lutris:" uri to open', 'URI')
+
+    def do_startup(self):
+        Gtk.Application.do_startup(self)
+
+    def do_activate(self):
+        if not self.window:
+            self.window = LutrisWindow()
+            self.add_window(self.window.window)
+        self.window.window.present()
+
+    def do_command_line(self, command_line):
+        options = command_line.get_options_dict()
+
+        console = logging.StreamHandler()
+        fmt = '%(levelname)-8s %(asctime)s [%(module)s]:%(message)s'
+        formatter = logging.Formatter(fmt)
+        console.setFormatter(formatter)
+        logger.addHandler(console)
+        logger.setLevel(logging.ERROR)
+
+        if options.contains('verbose'):
+            logger.setLevel(logging.INFO)
+
+        if options.contains('debug'):
+            logger.setLevel(logging.DEBUG)
+
+        if options.contains('list-games'):
+            game_list = pga.get_games()
+            if options.contains('list_installed'):
+                game_list = [game for game in game_list if game['installed']]
+            if options.contains('json'):
+                games = []
+                for game in game_list:
+                    games.append({
+                        'id': game['id'],
+                        'slug': game['slug'],
+                        'name': game['name'],
+                        'runner': game['runner'],
+                        'directory': game['directory'] or '-'
+                    })
+                    print json.dumps(games, indent=2).encode('utf-8')
+            else:
+                for game in game_list:
+                    print u"{:4} | {:<40} | {:<40} | {:<15} | {:<64}".format(
+                        game['id'],
+                        game['name'][:40],
+                        game['slug'][:40],
+                        game['runner'],
+                        game['directory'] or '-'
+                    ).encode('utf-8')
+            exit()
+
+        if options.contains('list-steam'):
+            from lutris.runners import winesteam
+            steam_runner = winesteam.winesteam()
+            print steam_runner.get_appid_list()
+            exit()
+
+
+
+        self.activate()
+        return 0
+
+    def do_shutdown(self):
+        Gtk.Application.do_shutdown(self)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -3,9 +3,12 @@
 
 import logging
 import json
+import os
+import dialogs
 
 from gi.repository import GLib, Gio, Gtk
 
+from lutris.util import datapath
 from lutris.util.log import logger
 from lutris.config import check_config
 from lutris.game import Game
@@ -13,6 +16,8 @@ from lutris import pga
 from lutris.settings import VERSION, GAME_CONFIG_DIR
 from lutris.gui.installgamedialog import InstallerDialog
 from lutris.gui.lutriswindow import LutrisWindow
+from lutris.gui.runnersdialog import RunnersDialog
+from lutris.gui.config_dialogs import SystemConfigDialog
 
 
 class Application(Gtk.Application):
@@ -54,10 +59,36 @@ class Application(Gtk.Application):
     def do_startup(self):
         Gtk.Application.do_startup(self)
 
+        action = Gio.SimpleAction.new('preferences', None)
+        action.connect('activate', self.on_preferences)
+        self.add_action(action)
+
+        action = Gio.SimpleAction.new('runners', None)
+        action.connect('activate', self.on_runners)
+        self.add_action(action)
+
+        action = Gio.SimpleAction.new('pga', None)
+        action.connect('activate', self.on_pga)
+        self.add_action(action)
+
+        action = Gio.SimpleAction.new('about', None)
+        action.connect('activate', self.on_about)
+        self.add_action(action)
+
+        action = Gio.SimpleAction.new('quit', None)
+        action.connect('activate', self.on_quit)
+        self.add_action(action)
+
+        builder = Gtk.Builder.new_from_file(os.path.join(datapath.get(), 'gtk', 'menus.ui'))
+        appmenu = builder.get_object('app-menu')
+        self.set_app_menu(appmenu)
+
     def do_activate(self):
         if not self.window:
-            self.window = LutrisWindow()
-            self.add_window(self.window.window)
+            self.window = LutrisWindow(self).window
+            provider = Gtk.CssProvider()
+            provider.load_from_path(os.path.join(datapath.get(), 'ui', 'style.css'))
+            gtk.StyleContext.add_provider_for_screen(self.window.get_screen(), provider, 600)
         self.window.window.present()
 
     def do_command_line(self, command_line):
@@ -115,3 +146,19 @@ class Application(Gtk.Application):
 
     def do_shutdown(self):
         Gtk.Application.do_shutdown(self)
+        self.quit()
+
+    def on_about(self, action, param):
+        dialogs.AboutDialog()
+
+    def on_preferences(self, action, param):
+        SystemConfigDialog()
+
+    def on_runners(self, action, param):
+        RunnersDialog()
+
+    def on_pga(self, action, param):
+        dialogs.PgaSourceDialog()
+
+    def on_quit(self, action, param):
+        self.quit()

--- a/share/lutris/gtk/menus.ui
+++ b/share/lutris/gtk/menus.ui
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <menu id="app-menu">
+    <section>
+      <item>
+	<attribute name="action">app.runners</attribute>
+        <attribute name="label" translatable="yes">_Runners</attribute>
+      </item>
+      <item>
+	<attribute name="action">app.pga</attribute>
+        <attribute name="label" translatable="yes">_Archives</attribute>
+      </item>
+      <item>
+	<attribute name="action">app.preferences</attribute>
+        <attribute name="label" translatable="yes">_Preferences</attribute>
+      </item>
+    </section>
+    <section>
+      <item>
+        <attribute name="action">app.about</attribute>
+        <attribute name="label" translatable="yes">_About</attribute>
+      </item>
+      <item>
+        <attribute name="action">app.quit</attribute>
+        <attribute name="label" translatable="yes">_Quit</attribute>
+        <attribute name="accel">&lt;Primary&gt;q</attribute>
+    </item>
+    </section>
+  </menu>
+</interface>
+

--- a/share/lutris/ui/LutrisWindow.ui
+++ b/share/lutris/ui/LutrisWindow.ui
@@ -1,615 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.14"/>
-  <!-- interface-local-resource-path ../media -->
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">preferences-desktop</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">text-x-generic</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image3">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">application-exit</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
+  <requires lib="gtk+" version="3.20"/>
   <object class="GtkImage" id="image4">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">media-playback-start</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image5">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">media-playback-stop</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
+    <property name="icon_name">list-add-symbolic</property>
   </object>
   <object class="GtkImage" id="image6">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="icon_name">list-add</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image7">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">list-remove</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkImage" id="image8">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="icon_name">help-about</property>
-    <property name="use_fallback">True</property>
-    <property name="icon_size">1</property>
-  </object>
-  <object class="GtkRadioAction" id="radioaction1">
-    <property name="hide_if_empty">False</property>
-    <property name="draw_as_radio">True</property>
-  </object>
-  <object class="GtkListStore" id="sidebar_liststore"/>
-  <object class="GtkImage" id="view_grid_symbolic">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="xpad">4</property>
-    <property name="pixel_size">16</property>
-    <property name="icon_name">view-grid-symbolic</property>
-  </object>
-  <object class="GtkImage" id="view_list_symbolic">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="xpad">4</property>
-    <property name="pixel_size">16</property>
-    <property name="icon_name">view-list-symbolic</property>
+    <property name="icon_name">system-search-symbolic</property>
+    <property name="icon_size">2</property>
   </object>
   <object class="GtkApplicationWindow" id="window">
     <property name="can_focus">False</property>
-    <property name="title" translatable="yes">Lutris</property>
-    <property name="window_position">center</property>
-    <property name="icon">../media/lutris.svg</property>
-    <property name="icon_name">lutris</property>
+    <property name="show_menubar">False</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
     <child>
-      <object class="GtkBox" id="main_box">
+      <object class="GtkBox">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkMenuBar" id="main_menubar">
+          <object class="GtkStack" id="stack">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <child>
-              <object class="GtkMenuItem" id="lutris_menuitem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Lutris</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="lutris_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkMenuItem" id="connect_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Connect to your Lutris account</property>
-                        <property name="label" translatable="yes">Connect</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_connect" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="disconnect_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Disconnect</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_disconnect" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="register_account">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Register a new account on lutris.net</property>
-                        <property name="label" translatable="yes">Register account</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_register_account" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="synchronize_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Manually re-synchronize your games.</property>
-                        <property name="label" translatable="yes">Synchronize library</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_synchronize_manually" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="runners_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="tooltip_text" translatable="yes">Install and configure the game runners</property>
-                        <property name="label" translatable="yes">Manage runners</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_runners_activate" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="pga_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Manage Game Archives</property>
-                        <property name="use_underline">True</property>
-                        <signal name="activate" handler="on_pga_menuitem_activate" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="preferences_menuitem">
-                        <property name="label" translatable="yes">_Preferences</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="has_tooltip">True</property>
-                        <property name="tooltip_markup" translatable="yes">configure the default options</property>
-                        <property name="tooltip_text" translatable="yes">configure the default options</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image1</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_preferences_activate" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="quit_menuitem">
-                        <property name="label">_Quit</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image3</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_destroy" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="view_menuitem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_View</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="view_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="filter_installed">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">I_nstalled games only</property>
-                        <property name="use_underline">True</property>
-                        <signal name="toggled" handler="on_show_installed_games_toggled" swapped="no"/>
-                        <accelerator key="h" signal="activate" modifiers="GDK_CONTROL_MASK"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separatormenuitem3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkRadioMenuItem" id="gridview_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Grid</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <property name="draw_as_radio">True</property>
-                        <signal name="toggled" handler="on_viewmenu_toggled" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkRadioMenuItem" id="listview_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_List</property>
-                        <property name="use_underline">True</property>
-                        <property name="draw_as_radio">True</property>
-                        <property name="group">gridview_menuitem</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separatormenuitem1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkMenuItem" id="icon_type_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Icon style</property>
-                        <property name="use_underline">True</property>
-                        <child type="submenu">
-                          <object class="GtkMenu" id="menu1">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkRadioMenuItem" id="banner_small_menuitem">
-                                <property name="name">banner_small</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Small banner</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_as_radio">True</property>
-                                <signal name="activate" handler="on_icon_type_activate" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkRadioMenuItem" id="banner_menuitem">
-                                <property name="name">banner</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Banner</property>
-                                <property name="use_underline">True</property>
-                                <property name="active">True</property>
-                                <property name="draw_as_radio">True</property>
-                                <property name="group">banner_small_menuitem</property>
-                                <signal name="activate" handler="on_icon_type_activate" swapped="no"/>
-                              </object>
-                            </child>
-                            <child>
-                              <object class="GtkRadioMenuItem" id="icon_menuitem">
-                                <property name="name">icon</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">Icon</property>
-                                <property name="use_underline">True</property>
-                                <property name="draw_as_radio">True</property>
-                                <property name="group">banner_small_menuitem</property>
-                                <signal name="activate" handler="on_icon_type_activate" swapped="no"/>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separatormenuitem2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkCheckMenuItem" id="sidebar_menuitem">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">_Side panel</property>
-                        <property name="use_underline">True</property>
-                        <property name="active">True</property>
-                        <signal name="toggled" handler="toggle_sidebar" swapped="no"/>
-                        <accelerator key="F9" signal="activate"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="game_menuitem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Game</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="game_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkImageMenuItem" id="playgame_menuitem">
-                        <property name="label" translatable="yes">_Play</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image4</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_game_run" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="stopgame_menuitem">
-                        <property name="label">_Stop</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image5</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_game_stop" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="addgame_menuitem">
-                        <property name="label">_Add</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image6</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="add_game" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="removegame_menuitem">
-                        <property name="label">_Remove</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image7</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_remove_game" swapped="no"/>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorMenuItem" id="separator2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                    </child>
-                    <child>
-                      <object class="GtkImageMenuItem" id="view_game_log">
-                        <property name="label" translatable="yes">View last game's _log</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image2</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="on_view_game_log_activate" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-            <child>
-              <object class="GtkMenuItem" id="help_menuitem">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="label" translatable="yes">_Help</property>
-                <property name="use_underline">True</property>
-                <child type="submenu">
-                  <object class="GtkMenu" id="help_menu">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkImageMenuItem" id="imagemenuitem10">
-                        <property name="label">_About</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="use_underline">True</property>
-                        <property name="image">image8</property>
-                        <property name="use_stock">False</property>
-                        <signal name="activate" handler="about" swapped="no"/>
-                      </object>
-                    </child>
-                  </object>
-                </child>
-              </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkToolbar" id="lutris_toolbar">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="toolbar_style">icons</property>
-            <property name="icon_size">4</property>
-            <child>
-              <object class="GtkToolButton" id="play_button">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Play game</property>
-                <property name="label" translatable="yes">Play</property>
-                <property name="icon_name">media-playback-start</property>
-                <signal name="clicked" handler="on_game_run" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolButton" id="stop_button">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Stop game</property>
-                <property name="label" translatable="yes">Stop</property>
-                <property name="icon_name">media-playback-stop</property>
-                <signal name="clicked" handler="on_game_stop" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolButton" id="add_game_button">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Manually add a game</property>
-                <property name="label" translatable="yes">Add Game</property>
-                <property name="icon_name">list-add</property>
-                <signal name="clicked" handler="add_game" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolButton" id="delete_button">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Remove game from library</property>
-                <property name="label" translatable="yes">Remove</property>
-                <property name="icon_name">edit-delete</property>
-                <signal name="clicked" handler="on_remove_game" swapped="no"/>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSeparatorToolItem" id="toolbutton1">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="draw">False</property>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolItem" id="search_area">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_right">10</property>
-                <child>
-                  <object class="GtkEntry" id="search_entry">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
-                    <property name="invisible_char">•</property>
-                    <property name="width_chars">30</property>
-                    <property name="primary_icon_name">edit-find</property>
-                    <property name="secondary_icon_name">edit-clear</property>
-                    <property name="primary_icon_activatable">False</property>
-                    <property name="primary_icon_sensitive">False</property>
-                    <property name="primary_icon_tooltip_text" translatable="yes">Filter the list of games</property>
-                    <signal name="changed" handler="on_search_entry_changed" swapped="no"/>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolItem" id="view_switcher_toolbutton">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkBox" id="view_switcher_box">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkRadioButton" id="switch_grid_view_btn">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">Grid view</property>
-                        <property name="image">view_grid_symbolic</property>
-                        <property name="xalign">0</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">False</property>
-                        <signal name="toggled" handler="on_viewbtn_toggled" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkRadioButton" id="switch_list_view_btn">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="receives_default">False</property>
-                        <property name="tooltip_text" translatable="yes">List view</property>
-                        <property name="image">view_list_symbolic</property>
-                        <property name="xalign">0</property>
-                        <property name="active">True</property>
-                        <property name="draw_indicator">False</property>
-                        <property name="group">switch_grid_view_btn</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
-                    <style>
-                      <class name="linked"/>
-                    </style>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="homogeneous">True</property>
-              </packing>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkAlignment" id="splash_alignment">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="top_padding">50</property>
-            <property name="bottom_padding">50</property>
-            <property name="left_padding">150</property>
-            <property name="right_padding">150</property>
+            <property name="transition_type">slide-left</property>
             <child>
               <object class="GtkBox" id="splash_box">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="valign">center</property>
                 <property name="orientation">vertical</property>
-                <property name="spacing">10</property>
-                <property name="baseline_position">top</property>
                 <child>
                   <object class="GtkLabel" id="title_label">
                     <property name="visible">True</property>
@@ -621,7 +44,8 @@
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
+                    <property name="padding">15</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
@@ -634,7 +58,7 @@
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
@@ -644,13 +68,12 @@
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="resize_mode">queue</property>
                     <property name="relief">none</property>
                     <signal name="activate-link" handler="add_game" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">2</property>
                   </packing>
                 </child>
@@ -665,7 +88,7 @@
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">3</property>
                   </packing>
                 </child>
@@ -680,173 +103,288 @@
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
+                    <property name="fill">True</property>
                     <property name="position">4</property>
                   </packing>
                 </child>
               </object>
-            </child>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkPaned" id="sidebar_paned">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <child>
-              <object class="GtkScrolledWindow" id="scrolledwindow1">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">in</property>
-                <child>
-                  <object class="GtkViewport" id="sidebar_viewport">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <placeholder/>
-                    </child>
-                  </object>
-                </child>
-              </object>
               <packing>
-                <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="name">splash_box</property>
+                <property name="title" translatable="yes">splash_box</property>
               </packing>
             </child>
             <child>
-              <object class="GtkScrolledWindow" id="games_scrollwindow">
+              <object class="GtkBox" id="main_box">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="shadow_type">etched-in</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
                 <child>
-                  <placeholder/>
+                  <object class="GtkRevealer" id="search_revealer">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkToolbar" id="lutris_toolbar">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkToolItem" id="search_area">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkSearchEntry" id="search_entry">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="margin_left">30</property>
+                                <property name="margin_right">30</property>
+                                <property name="margin_start">30</property>
+                                <property name="margin_end">30</property>
+                                <property name="invisible_char">•</property>
+                                <property name="width_chars">30</property>
+                                <property name="primary_icon_activatable">False</property>
+                                <property name="primary_icon_sensitive">False</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="homogeneous">True</property>
+                          </packing>
+                        </child>
+                        <style>
+                          <class name="search-bar"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkOverlay" id="overlay">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <child>
+                      <object class="GtkScrolledWindow" id="games_scrollwindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hscrollbar_policy">never</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="index">-1</property>
+                      </packing>
+                    </child>
+                    <child type="overlay">
+                      <object class="GtkBox" id="box6">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="valign">end</property>
+                        <property name="margin_right">10</property>
+                        <property name="margin_end">10</property>
+                        <property name="orientation">vertical</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                        <style>
+                          <class name="floating-bar"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
-                <property name="shrink">True</property>
+                <property name="name">page1</property>
+                <property name="title" translatable="yes">page1</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="loading_box">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">10</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">end</property>
+                    <property name="label" translatable="yes">Loading games…</property>
+                    <attributes>
+                      <attribute name="scale" value="1.5"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinner" id="spinner">
+                    <property name="height_request">40</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="valign">start</property>
+                    <property name="active">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">page0</property>
+                <property name="title" translatable="yes">page0</property>
+                <property name="position">2</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">True</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">1</property>
           </packing>
         </child>
         <child>
-          <object class="GtkStatusbar" id="statusbar">
+          <object class="GtkStatusbar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="spacing">2</property>
+            <property name="margin_left">10</property>
+            <property name="margin_right">10</property>
+            <property name="margin_start">10</property>
+            <property name="margin_end">10</property>
+            <property name="margin_top">6</property>
+            <property name="margin_bottom">6</property>
+            <property name="spacing">6</property>
+            <property name="homogeneous">True</property>
             <child>
-              <object class="GtkBox" id="status_box">
+              <object class="GtkLabel" id="connection_label">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkImage" id="js1image">
-                    <property name="can_focus">False</property>
-                    <property name="xpad">2</property>
-                    <property name="pixbuf">../media/gamepad.png</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkImage" id="js0image">
-                    <property name="can_focus">False</property>
-                    <property name="xpad">2</property>
-                    <property name="pixbuf">../media/gamepad.png</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkImage" id="js3image">
-                    <property name="can_focus">False</property>
-                    <property name="xpad">2</property>
-                    <property name="pixbuf">../media/gamepad.png</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkImage" id="js2image">
-                    <property name="can_focus">False</property>
-                    <property name="xpad">2</property>
-                    <property name="pixbuf">../media/gamepad.png</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="status_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xpad">5</property>
-                    <property name="ypad">5</property>
-                    <property name="label" translatable="yes">Lutris</property>
-                    <property name="lines">1</property>
-                    <property name="xalign">0</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">4</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel" id="connection_label">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label" translatable="yes">label</property>
-                    <property name="xalign">1</property>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">5</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSeparator" id="status_separator">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">6</property>
-                  </packing>
-                </child>
+                <property name="justify">right</property>
+                <property name="lines">1</property>
               </object>
               <packing>
-                <property name="expand">True</property>
+                <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">0</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>
           <packing>
             <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">4</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar" id="headerbar1">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="title">Lutris</property>
+        <property name="show_close_button">True</property>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkMenuButton" id="account_menu_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <child>
+                  <object class="GtkImage" id="image10">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">avatar-default-symbolic</property>
+                    <property name="icon_size">2</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="add_game_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="image">image4</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkBox" id="box2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="spacing">5</property>
+            <child>
+              <object class="GtkToggleButton" id="search_toggle_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="action_name">win.search</property>
+                <property name="image">image6</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="view_menu_btn">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <child>
+                  <object class="GtkImage" id="image7">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">open-menu-symbolic</property>
+                    <property name="icon_size">2</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
           </packing>
         </child>
       </object>

--- a/share/lutris/ui/LutrisWindow.ui
+++ b/share/lutris/ui/LutrisWindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.20.0 -->
 <interface>
-  <requires lib="gtk+" version="3.10"/>
+  <requires lib="gtk+" version="3.14"/>
   <!-- interface-local-resource-path ../media -->
   <object class="GtkImage" id="image1">
     <property name="visible">True</property>
@@ -78,7 +78,7 @@
     <property name="pixel_size">16</property>
     <property name="icon_name">view-list-symbolic</property>
   </object>
-  <object class="GtkWindow" id="window">
+  <object class="GtkApplicationWindow" id="window">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Lutris</property>
     <property name="window_position">center</property>

--- a/share/lutris/ui/account-menu-popover.ui
+++ b/share/lutris/ui/account-menu-popover.ui
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class ="GtkPopoverMenu" id="account_menu_widget">
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">9</property>
+        <property name="orientation">vertical</property>
+        <property name="width_request">160</property>
+        <child>
+          <object class="GtkLabel" id="connection_label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">6</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="disconnect_btn">
+            <property name="visible">False</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Disconnect</property>
+            <signal name="clicked" handler="on_disconnect" swapped="no"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="register_btn">
+            <property name="visible">False</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Register</property>
+            <signal name="clicked" handler="on_register_account" swapped="no"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="connect_btn">
+            <property name="visible">False</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Connect</property>
+            <signal name="clicked" handler="on_connect" swapped="no"/>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="sync_btn">
+            <property name="visible">False</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Syncronize Library</property>
+            <signal name="clicked" handler="on_synchronize_manually" swapped="no"/>
+          </object>
+        </child>
+      </object>
+    </child>
+  </object>
+</interface>

--- a/share/lutris/ui/style.css
+++ b/share/lutris/ui/style.css
@@ -1,0 +1,28 @@
+/* Floating status bar */
+.floating-bar {
+  padding: 2px;
+  background-color: @theme_base_color;
+  border-width: 1px;
+  border-style: solid solid none;
+  border-color: @borders;
+  border-radius: 3px 3px 0 0;
+}
+
+.floating-bar.bottom.left { /* axes left border and border radius */
+  border-left-style: none;
+  border-top-left-radius: 0;
+}
+.floating-bar.bottom.right { /* axes right border and border radius */
+  border-right-style: none;
+  border-top-right-radius: 0;
+}
+
+.floating-bar:backdrop {
+  background-color: @theme_unfocused_base_color;
+  border-color: @unfocused_borders;
+}
+
+.floating-bar .label {
+  padding: 2px 5px;
+}
+

--- a/share/lutris/ui/view-menu-popover.ui
+++ b/share/lutris/ui/view-menu-popover.ui
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <object class ="GtkPopoverMenu" id="view_menu_widget">
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">9</property>
+        <property name="orientation">vertical</property>
+        <property name="width_request">160</property>
+        <child>
+          <object class="GtkBox" id="views_box">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin-bottom">6</property>
+            <style>
+                <class name="linked"/>
+            </style>
+            <child>
+              <object class="GtkModelButton" id="grid_button">
+                <property name="visible">True</property>
+                <property name="text">Grid</property>
+                <property name="action-name">win.view-mode</property>
+                <property name="action-target">'grid'</property>
+                <property name="iconic">True</property>
+                <property name="centered">True</property>
+                <property name="icon">icon_grid</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkModelButton" id="list_button">
+                <property name="visible">True</property>
+                <property name="text">List</property>
+                <property name="action-name">win.view-mode</property>
+                <property name="action-target">'list'</property>
+                <property name="iconic">True</property>
+                <property name="centered">True</property>
+                <property name="icon">icon_list</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child>
+          <object class="GtkScale" id="zoom_level_scale">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="draw_value">False</property>
+            <property name="has_origin">False</property>
+            <property name="adjustment">zoom_adjustment</property>
+            <property name="round_digits">0</property>
+            <property name="restrict_to_fill_level">False</property>
+            <marks>
+              <mark value="0" position="bottom"/>
+              <mark value="1" position="bottom"/>
+              <mark value="2" position="bottom"/>
+            </marks>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="show_installed_only">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">Installed Games Only</property>
+            <property name="action-name">win.show-installed-only</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="menu-name">filter_box</property>
+            <property name="text" translatable="yes">Filter by runner…</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="margin-top">6</property>
+            <property name="margin-bottom">6</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="stop">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Stop Current Game</property>
+            <property name="action-name">win.stop-current-game</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton" id="view_logs">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">View Last Games' _Logs</property>
+            <property name="action-name">win.view-last-logs</property>
+          </object>
+        </child>
+      </object>
+    </child>
+    <child>
+      <object class="GtkBox" id="filter_box">
+      <property name="visible">True</property>
+      <property name="orientation">vertical</property>
+      <property name="margin">10</property>
+    </object>
+    <packing>
+      <property name="submenu">filter_box</property>
+    </packing>
+  </child>
+  </object>
+  <object class="GThemedIcon" id="icon_grid">
+    <property name="name">view-grid-symbolic</property>
+  </object>
+  <object class="GThemedIcon" id="icon_list">
+    <property name="name">view-list-symbolic</property>
+  </object>
+  <object class="GtkAdjustment" id="zoom_adjustment">
+    <property name="lower">0</property>
+    <property name="upper">2</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+    <property name="value">1</property>
+  </object>
+</interface>


### PR DESCRIPTION
_**Don't merge this while there is a [WIP] prefix to it. It will break things.**_ (You probably know that, but just to be sure :p )

This is a pull request to track my update of the UI to GTK 3.14+ and a general cleanup of the whole UI.

As discussed with strycore on IRC, when practical or needed, I'll implement a version check for higher GTK versions and handle things differently for Ubuntu 16.04 (GTK 3.18) and newer distros, in order to keep deprecated things to a minimum and making the update easier once SteamOS updates from 3.14 to a newer version.

## Todo list

- [x] **04/23/2016** - Initial porting to Gtk.Application()
- [x] **04/23/2016** - Redesign the main interface
    - [ ] Fix major breakages

## Description of the changes

### Initial porting to Gtk.Application()

This takes the patch from TingPing and updates it to work with the current code.
It doesn't use anything more recent than GTK 3.0 at the moment, so it shouldn't pose any problem.

### Redesign the main interface

![screenshot from 2016-04-23 19-55-21](https://cloud.githubusercontent.com/assets/1087450/14763144/5e8e2bc8-098d-11e6-931c-155fecd9ac6f.png)
![screenshot from 2016-04-23 20-42-50](https://cloud.githubusercontent.com/assets/1087450/14763368/06be8f1c-0994-11e6-9a00-8d0ab581a0b5.png)


Another (partial) port of a patch by TingPing.
This changes most of the main UI to implement modern GTK interface design.
It also manages to break most things, due to being such a huge change. I somehow managed to break the settings writing, so pretty much nothing works properly. All of this will be fixed in future commits.
This is currently untested on GTK 3.14. I need to spin up a SteamOS VM and see how it handles things, but I want to fix basic operation first.