### PR TITLE
Fix zdoom file and executable args

### DIFF
--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -20,6 +20,12 @@ class zdoom(Runner):
             'type': 'file',
             'label': 'PWAD file',
             'help': ("Used to load one or more PWAD files which generally contain user-created levels.")
+        },
+        {
+            'option': 'warp',
+            'type': 'string',
+            'label': 'Warp to map',
+            'help': ("Starts the game on the given map.")
         }
     ]
     runner_options = [
@@ -106,6 +112,11 @@ class zdoom(Runner):
         skill = self.game_config.get('skill')
         if skill:
             command.append('-skill %s' % skill)
+
+        # Append the warp map.
+        warp = self.game_config.get('warp')
+        if warp:
+            command.append('-warp %s' % warp)
 
         # Append the wad file to load, if provided.
         wad = self.game_config.get('main_file')

--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -85,7 +85,12 @@ class zdoom(Runner):
         return os.path.join(settings.RUNNER_DIR, 'zdoom')
 
     @property
+    def main_file(self):
+        return self.game_config.get('main_file') or ''
+
+    @property
     def working_dir(self):
+        """Return the working directory to use when running the game."""
         return os.path.dirname(self.main_file) \
             or super(zdoom, self).working_dir
 
@@ -109,23 +114,27 @@ class zdoom(Runner):
                 command.append('-%s' % option)
 
         # Append the skill level.
-        skill = self.game_config.get('skill')
+        skill = self.runner_config.get('skill')
         if skill:
-            command.append('-skill %s' % skill)
+            command.append('-skill')
+            command.append(skill)
 
         # Append the warp map.
         warp = self.game_config.get('warp')
         if warp:
-            command.append('-warp %s' % warp)
+            command.append('-warp')
+            command.append(warp)
 
         # Append the wad file to load, if provided.
         wad = self.game_config.get('main_file')
         if wad:
-            command.append('-iwad %s' % wad)
+            command.append('-iwad')
+            command.append(wad)
 
         # Append the pwad files to load, if provided.
         pwad = self.game_config.get('file')
         if pwad:
-            command.append('-file %s' % pwad)
+            command.append('-file')
+            command.append(pwad)
 
         return {'command': command}

--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -14,6 +14,12 @@ class zdoom(Runner):
             'type': 'file',
             'label': 'WAD file',
             'help': ("The game data, commonly called a WAD file.")
+        },
+        {
+            'option': 'file',
+            'type': 'file',
+            'label': 'PWAD file',
+            'help': ("Used to load one or more PWAD files which generally contain user-created levels.")
         }
     ]
     runner_options = [
@@ -70,7 +76,7 @@ class zdoom(Runner):
     ]
 
     def get_executable(self):
-        return os.path.join(settings.RUNNER_DIR, 'zdoom/zdoom')
+        return os.path.join(settings.RUNNER_DIR, 'zdoom')
 
     @property
     def working_dir(self):
@@ -105,5 +111,10 @@ class zdoom(Runner):
         wad = self.game_config.get('main_file')
         if wad:
             command.append('-iwad %s' % wad)
+
+        # Append the pwad files to load, if provided.
+        pwad = self.game_config.get('file')
+        if pwad:
+            command.append('-file %s' % pwad)
 
         return {'command': command}

--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -17,7 +17,7 @@ class zdoom(Runner):
         },
         {
             'option': 'file',
-            'type': 'file',
+            'type': 'string',
             'label': 'PWAD file',
             'help': ("Used to load one or more PWAD files which generally contain user-created levels.")
         },
@@ -72,11 +72,11 @@ class zdoom(Runner):
             "default": '',
             "choices": {
                 ("None", ''),
-                ("Please Don't Kill Me (0)", '0'),
-                ("Will This Hurt? (1)", '1'),
-                ("Bring On The Pain (2)", '2'),
-                ("Extreme Carnage (3)", '3'),
-                ("Insanity! (4)", '4'),
+                ("I'm Too Young To Die (0)", '0'),
+                ("Hey, Not Too Rough (1)", '1'),
+                ("Hurt Me Plenty (2)", '2'),
+                ("Ultra-Violence (3)", '3'),
+                ("Nightmare! (4)", '4'),
             }
         }
     ]
@@ -85,14 +85,9 @@ class zdoom(Runner):
         return os.path.join(settings.RUNNER_DIR, 'zdoom')
 
     @property
-    def main_file(self):
-        return self.game_config.get('main_file') or ''
-
-    @property
     def working_dir(self):
-        """Return the working directory to use when running the game."""
-        return os.path.dirname(self.main_file) \
-            or super(zdoom, self).working_dir
+        # Run in the installed game's directory.
+        return self.game_path
 
     def play(self):
         command = [
@@ -111,30 +106,29 @@ class zdoom(Runner):
         boolOptions = ['nomusic', 'nosfx', 'nosound', '2', '4', 'nostartup']
         for option in boolOptions:
             if self.runner_config.get(option):
-                command.append('-%s' % option)
+                command.append("-%s" % option)
 
         # Append the skill level.
         skill = self.runner_config.get('skill')
         if skill:
-            command.append('-skill')
-            command.append(skill)
+            command.append("-skill %s" % skill)
 
         # Append the warp map.
         warp = self.game_config.get('warp')
         if warp:
-            command.append('-warp')
-            command.append(warp)
+            command.append("-warp %s" % warp)
 
         # Append the wad file to load, if provided.
         wad = self.game_config.get('main_file')
         if wad:
-            command.append('-iwad')
-            command.append(wad)
+            command.append("-iwad %s" % wad)
 
         # Append the pwad files to load, if provided.
         pwad = self.game_config.get('file')
         if pwad:
-            command.append('-file')
-            command.append(pwad)
+            command.append("-file %s" % pwad)
+
+        # TODO: Find out why the paths are not found correctly. Something wrong with working_dir?
+        print(command)
 
         return {'command': command}


### PR DESCRIPTION
Adds the `-file` argument to load multiple WAD files, as well as fixes the runner location.