### PR TITLE
(ZDoom) Fix the warp arguments

### DIFF
--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -98,11 +98,12 @@ class zdoom(Runner):
             command.append("-skill")
             command.append(skill)
 
-        # Append the warp map.
+        # Append the warp arguments.
         warp = self.game_config.get('warp')
         if warp:
             command.append("-warp")
-            command.append(warp)
+            for warparg in warp.split(' '):
+                command.append(warparg)
 
         # Append the wad file to load, if provided.
         wad = self.game_config.get('main_file')


### PR DESCRIPTION
This allows warping to a specific episode and map. To load Episode 2, Map 3, use "2 3".

Fixes John Romero's e1m8b on ZDoom with the Brutal mod at:
https://lutris.net/games/the-ultimate-doom/