### PR TITLE
[web] add runner option remove_margin

### DIFF
--- a/lutris/runners/web.py
+++ b/lutris/runners/web.py
@@ -90,6 +90,13 @@ class web(Runner):
             'help': ("Enable this option if you want clicked links to open inside the game window. By default all links open in your default web browser.")
         },
         {
+            "option": "remove_margin",
+            "label": "Remove default <body> margin & padding",
+            "type": "bool",
+            "default": False,
+            'help': ("Sets margin and padding to zero on &lt;html&gt; and &lt;body&gt; elements.")
+        },
+        {
             "option": "enable_flash",
             "label": "Enable Adobe Flash Player",
             "type": "bool",
@@ -229,6 +236,9 @@ class web(Runner):
 
         if self.runner_config.get("open_links"):
             command.append("--open-links")
+
+        if self.runner_config.get("remove_margin"):
+            command.append("--remove-margin")
 
         if self.runner_config.get("devtools"):
             command.append("--devtools")


### PR DESCRIPTION
An easy option to set CSS `margin: 0; padding: 0` on `<body>` and `<html>`

Usage in installer script:
```
web:
  remove_margin: true
```
An [installer script](https://lutris.net/games/install/2851/view) using this feature.