### PR TITLE
Fix finding joysticks for mednafen

### DIFF
--- a/lutris/runners/mednafen.py
+++ b/lutris/runners/mednafen.py
@@ -88,7 +88,8 @@ class mednafen(Runner):
         if not self.is_installed:
             return []
         output = subprocess.Popen([self.get_executable(), "dummy"],
-                                  stdout=subprocess.PIPE).communicate()[0]
+                                  stdout=subprocess.PIPE,
+                                  universal_newlines=True).communicate()[0]
         ouput = output.split("\n")
         found = False
         joy_list = []


### PR DESCRIPTION
I tried playing a game with mednafen today and it raised a `TypeError` about getting a string where a bytes-like object was needed:

```python-traceback
Traceback (most recent call last):
  File "/usr/bin/lutris", line 191, in <module>
    lutris_game.play()
  File "/usr/lib/python3.5/site-packages/lutris/game.py", line 164, in play
    self.do_play(True)
  File "/usr/lib/python3.5/site-packages/lutris/game.py", line 172, in do_play
    gameplay_info = self.runner.play()
  File "/usr/lib/python3.5/site-packages/lutris/runners/mednafen.py", line 246, in play
    joy_ids = self.find_joysticks()
  File "/usr/lib/python3.5/site-packages/lutris/runners/mednafen.py", line 92, in find_joysticks
    ouput = output.split("\n")
TypeError: a bytes-like object is required, not 'str'
```

---

The communicate method of the Popen class returns a tuple of byte
sequences. The split function is passed a string when it needs a byte
sequence if it is used on a byte sequence. If the Popen constructor is
passed a universal_newlines=True argument the communicate method
returns a string instead.

Given that the rest of the find_joystick function relies on strings
being used it is easier to use universal_newlines=True instead of
changing all the strings to byte sequences.