### PR TITLE
EvilConfigParser: set strict=False to prevent DuplicateOptionError

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -355,7 +355,8 @@ class CommandsMixin(object):
             os.makedirs(basedir)
 
         parser = EvilConfigParser(allow_no_value=True,
-                                  dict_type=MultiOrderedDict)
+                                  dict_type=MultiOrderedDict,
+                                  strict=False)
         parser.optionxform = str  # Preserve text case
         parser.read(config_file)
 


### PR DESCRIPTION
Since Python 3.2, configparser will throw 'DuplicateOptionError' if it encounters an ini file with duplicate options, unless you use strict=False. This was causing scripts like Deus Ex (GOG) to fail for me on Fedora 25.

`ERROR    2016-11-29 15:00:40,483 [jobs]:Error while completing task <bound method CommandsMixin.write_config of <lutris.installer.interpreter.ScriptInterpreter object at 0x7fd724142a20>>: While reading from '/home/steven/Games/deus-ex/drive_c/GOG Games/Deus Ex GOTY/System/DeusEx.ini' [line 43]: option 'Paths' in section 'Core.System' already exists
<class 'configparser.DuplicateOptionError'> While reading from '/home/steven/Games/deus-ex/drive_c/GOG Games/Deus Ex GOTY/System/DeusEx.ini' [line 43]: option 'Paths' in section 'Core.System' already exists
  File "/usr/lib/python3.5/site-packages/lutris/util/jobs.py", line 29, in target
    result = self.function(*args, **kwargs)
  File "/usr/lib/python3.5/site-packages/lutris/installer/commands.py", line 360, in write_config
    parser.optionxform = str  # Preserve text case
  File "/usr/lib64/python3.5/configparser.py", line 696, in read
    self._read(fp, filename)
  File "/usr/lib64/python3.5/configparser.py", line 1089, in _read
    fpname, lineno)
`