### PR TITLE
gui: Replace deprecated color overrides with CSS

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -45,6 +45,12 @@ class Application(Gtk.Application):
                                  flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE)
         GLib.set_application_name(_('Lutris'))
         self.window = None
+        self.css_provider = Gtk.CssProvider.new()
+
+        try:
+            self.css_provider.load_from_path(os.path.join(datapath.get(), 'ui', 'log-window.css'))
+        except GLib.Error as e:
+            logger.exception(e)
 
         self.add_main_option('debug',
                              ord('d'),
@@ -127,6 +133,9 @@ class Application(Gtk.Application):
     def do_activate(self):
         if not self.window:
             self.window = LutrisWindow(application=self)
+            screen = self.window.props.screen
+            Gtk.StyleContext.add_provider_for_screen(screen, self.css_provider,
+                                                     Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         self.window.present()
 
     @staticmethod

--- a/lutris/gui/logwindow.py
+++ b/lutris/gui/logwindow.py
@@ -1,34 +1,15 @@
-from gi.repository import Gtk, Gdk, Pango
+from gi.repository import Gtk
 from lutris.gui.widgets import Dialog
 
 
 class LogTextView(Gtk.TextView):
-    bg_rgb = 'rgb(47,47,47)'
-    fg_rgb = 'rgb(255, 199, 116)'
-    font_face = 'Monospace 10'
+    def __init__(self, **kwargs):
+        super().__init__(editable=False, monospace=True,
+                         left_margin=10, wrap_mode=Gtk.WrapMode.CHAR,
+                         **kwargs)
 
-    def __init__(self):
-        super(LogTextView, self).__init__()
-
-        bg_color = Gdk.RGBA()
-        bg_color.parse(self.bg_rgb)
-        fg_color = Gdk.RGBA()
-        fg_color.parse(self.fg_rgb)
-        font_description = Pango.FontDescription(self.font_face)
-
-        self.override_color(Gtk.StateFlags.NORMAL, fg_color)
-        self.override_color(Gtk.StateFlags.SELECTED, bg_color)
-        self.override_background_color(Gtk.StateFlags.NORMAL, bg_color)
-        self.override_background_color(Gtk.StateFlags.SELECTED, fg_color)
-        self.set_left_margin(10)
-        self.set_editable(False)
-        self.set_wrap_mode(Gtk.WrapMode.WORD_CHAR)
-        self.override_font(font_description)
-
-        self.textbuffer = self.get_buffer()
-
-    def set_text(self, content):
-        self.textbuffer.set_text(content)
+        self.get_style_context().add_class('lutris-logview')
+        self.set_text = self.props.buffer.set_text
 
 
 class LogWindow(Dialog):
@@ -38,9 +19,7 @@ class LogWindow(Dialog):
         self.set_size_request(640, 480)
         self.grid = Gtk.Grid()
         self.logtextview = LogTextView()
-        scrolledwindow = Gtk.ScrolledWindow()
-        scrolledwindow.set_hexpand(True)
-        scrolledwindow.set_vexpand(True)
-        scrolledwindow.add(self.logtextview)
+        scrolledwindow = Gtk.ScrolledWindow(hexpand=True, vexpand=True,
+                                            child=self.logtextview)
         self.vbox.add(scrolledwindow)
         self.show_all()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -591,7 +591,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
     @GtkTemplate.Callback
     def on_view_game_log_activate(self, *args):
         if not self.running_game:
-            dialogs.ErrorDialog('No game log available')
+            dialogs.ErrorDialog('No game log available', parent=self)
             return
         log_title = u"Log for {}".format(self.running_game)
         log_window = LogWindow(log_title, self)

--- a/share/lutris/ui/log-window.css
+++ b/share/lutris/ui/log-window.css
@@ -1,0 +1,9 @@
+.lutris-logview > text {
+  color: rgb(255, 199, 116);
+  background-color: rgb(47, 47, 47);
+}
+
+.lutris-logview > text > selection {
+  color: rgb(47, 47, 47);
+  background-color: rgb(255, 199, 116);
+}


### PR DESCRIPTION
Somebody should probably test if this is actually works on Gtk 3.14 since the CSS machinery has had a lot of work. If not this isn't a major issue until Gtk4 anyway.