### PR TITLE
[winesteam] Add 64-bit prefix support

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -393,6 +393,9 @@ class ScriptInterpreter(CommandsMixin):
             except KeyError:
                 raise ScriptingError("Missing appid for steam game")
 
+            if 'arch' in self.script['game']:
+                self.steam_data['arch'] = self.script['game']['arch']
+
             commands = self.script.get('installer', [])
             self.steam_data['platform'] = 'windows' \
                 if self.runner == 'winesteam' else 'linux'
@@ -646,6 +649,9 @@ class ScriptInterpreter(CommandsMixin):
         appid = self.steam_data['appid']
         if not steam_runner.get_game_path_from_appid(appid):
             logger.debug("Installing steam game %s", appid)
+            steam_runner.config = LutrisConfig(runner_slug=self.runner)
+            if 'arch' in self.steam_data:
+                steam_runner.config.game_config['arch'] = self.steam_data['arch']
             AsyncCall(steam_runner.install_game, None, appid, is_game_files)
 
             self.install_start_time = time.localtime()


### PR DESCRIPTION
With this patch, you can set the architecture in winesteam lutris installer scripts for games that require 64-bit.
```
game:
  appid: 12345
  arch: win64
```
It will create the win64 wineprefix `$HOME/.local/share/lutris/runners/winesteam/prefix64` and run steam from the 32-bit install, so you don't have to have two steam installations on disk.

This seem to require a system-install of Wine (64-bit obviously), because else Lutris tries to run it with it's default 32-bit wine, but that's related to the Wine runner.

Shoutout to **[DK] derklempner** who brought this to attention!