### PR TITLE
Remember Lutris window maximized state

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -66,6 +66,8 @@ class LutrisWindow(Gtk.ApplicationWindow):
         width = int(settings.read_setting('width') or 800)
         height = int(settings.read_setting('height') or 600)
         self.window_size = (width, height)
+        self.maximized  = settings.read_setting('maximized') == 'True'
+
         view_type = self.get_view_type()
         self.load_icon_type_from_settings(view_type)
         self.filter_installed = \
@@ -83,6 +85,8 @@ class LutrisWindow(Gtk.ApplicationWindow):
                          icon_name='lutris',
                          application=application,
                          **kwargs)
+        if self.maximized:
+            self.maximize()
         self.init_template()
         self._init_actions()
 
@@ -439,8 +443,15 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
     @GtkTemplate.Callback
     def on_resize(self, widget, *args):
-        """WTF is this doing?"""
-        self.window_size = widget.get_size()
+        """Size-allocate signal.
+
+        Updates stored window size and maximized state.
+        """
+        if not widget.get_window():
+            return
+        self.maximized = widget.is_maximized()
+        if not self.maximized:
+            self.window_size = widget.get_size()
 
     @GtkTemplate.Callback
     def on_destroy(self, *args):
@@ -459,6 +470,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
         width, height = self.window_size
         settings.write_setting('width', width)
         settings.write_setting('height', height)
+        settings.write_setting('maximized', self.maximized)
 
     @GtkTemplate.Callback
     def on_preferences_activate(self, *args):

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -26,7 +26,7 @@
     <property name="window_position">center</property>
     <property name="icon_name">lutris</property>
     <signal name="destroy" handler="on_destroy" swapped="no"/>
-    <signal name="configure-event" handler="on_resize"/>
+    <signal name="size-allocate" handler="on_resize" swapped="no"/>
     <child>
       <object class="GtkBox" id="main_box">
         <property name="visible">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -344,7 +344,7 @@
                 </child>
               </object>
               <packing>
-                <property name="resize">False</property>
+                <property name="resize">True</property>
                 <property name="shrink">True</property>
               </packing>
             </child>


### PR DESCRIPTION
Maximized state is stored in the lutris.conf file. Now it will only store the window size when not maximized, as expected. Before it stored the size when maximized too, so when you launched Lutris again it would cover the screen but unmaximized state.
Also makes the side panel to not change width when the window is resized/maximized.