### PR TITLE
Add "View on Lutris.net" context menu item to games

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -111,6 +111,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
              self.remove_menu_shortcut),
             ('install_more', "Install (add) another version", self.on_install_clicked),
             ('remove', "Remove", self.on_remove_game),
+            ('view', "View on Lutris.net", self.on_view_game),
         ]
         self.menu = ContextualMenu(main_entries)
         self.view.contextual_menu = self.menu
@@ -647,6 +648,10 @@ class LutrisWindow(Gtk.ApplicationWindow):
             dialogs.NoticeDialog(
                 "Can't open %s \nThe folder doesn't exist." % path
             )
+
+    def on_view_game(self, widget):
+        game = Game(self.view.selected_game)
+        self._open_browser('https://lutris.net/games/' + game.slug)
 
     def on_edit_game_configuration(self, widget):
         """Edit game preferences."""


### PR DESCRIPTION
It won't work for games that aren't on the Lutris website yet, but better than nothing!
Works for both installed and uninstalled games.