### PR TITLE
[winesteam] Don't disable DirectWrite

### DIFF
--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -159,9 +159,6 @@ class winesteam(wine.wine):
     def launch_args(self):
         args = [self.get_executable(), self.get_steam_path()]
 
-        # Fix invisible text in Steam
-        args.append('-no-dwrite')
-
         # Try to fix Steam's browser. Never worked but it's supposed to...
         args.append('-no-cef-sandbox')
 
@@ -311,12 +308,6 @@ class winesteam(wine.wine):
         if not os.path.exists(os.path.dirname(prefix_dir)):
             os.makedirs(os.path.dirname(prefix_dir))
         create_prefix(prefix_dir, arch=arch, wine_path=wine_path)
-
-        # Fix steam text display
-        set_regedit("HKEY_CURRENT_USER\Software\Valve\Steam",
-                    'DWriteEnable', '0', 'REG_DWORD',
-                    wine_path=self.get_executable(),
-                    prefix=prefix_dir)
 
     def get_default_prefix(self, arch='win32'):
         """Return the default prefix' path."""

--- a/lutris/util/steam.py
+++ b/lutris/util/steam.py
@@ -300,6 +300,15 @@ def sync_with_lutris():
                 mark_as_uninstalled(game)
 
 
+def set_winesteam_directwrite(prefix_dir, wine_path, enable=True):
+    from lutris.runners import wine
+    # Since Wine 1.7.50, DirectWrite has been fixed
+    wine.set_regedit("HKEY_CURRENT_USER\Software\Valve\Steam",
+                     'DWriteEnable', '1' if enable else '0', 'REG_DWORD',
+                     wine_path=wine_path,
+                     prefix=prefix_dir)
+
+
 class SteamWatcher:
     def __init__(self, steamapps_paths, callback=None):
         self.monitors = []


### PR DESCRIPTION
Since Wine 1.7.50, DirectWrite has been fixed.
Enjoy smooth fonts!

Note: This doesn't enable DirectWrite, you have to do that yourself in Steam settings (or reinstall winesteam)