### PR TITLE
Use human name in runner picker

### DIFF
--- a/lutris/gui/config_dialogs.py
+++ b/lutris/gui/config_dialogs.py
@@ -187,7 +187,7 @@ class GameDialogCommon(object):
         for runner in runners.get_installed():
             description = runner.description
             runner_liststore.append(
-                ("%s (%s)" % (runner.name, description), runner.name)
+                ("%s (%s)" % (runner.human_name, description), runner.name)
             )
         return runner_liststore
 


### PR DESCRIPTION
When configuring or adding a game, use the human "full name" of the runner.
For example winesteam becomes Wine Steam.