### PR TITLE
Add year and platform to game config, add platform to list view

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -41,6 +41,7 @@ class Game(object):
         self.directory = game_data.get('directory') or ''
         self.name = game_data.get('name') or ''
         self.is_installed = bool(game_data.get('installed')) or False
+        self.platform = game_data.get('platform') or ''
         self.year = game_data.get('year') or ''
         self.game_config_id = game_data.get('configpath') or ''
         self.steamid = game_data.get('steamid') or ''
@@ -129,6 +130,8 @@ class Game(object):
             name=self.name,
             runner=self.runner_name,
             slug=self.slug,
+            platform=self.platform,
+            year=self.year,
             directory=self.directory,
             installed=self.is_installed,
             configpath=self.config.game_config_id,

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -8,6 +8,7 @@ from lutris.runners.runner import Runner
 class linux(Runner):
     human_name = "Linux"
     description = "Runs native games"
+    platform = "Linux"
 
     game_options = [
         {
@@ -52,7 +53,6 @@ class linux(Runner):
 
     def __init__(self, config=None):
         super(linux, self).__init__(config)
-        self.platform = "Linux games"
         self.ld_preload = None
 
     @property


### PR DESCRIPTION
Year and platform can now be edited when adding/editing game info.
List view shows the "human" name of the runner and added a column for platform (so you can sort by platform!)