### PR TITLE
[wine] Fix DLL overrides

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -548,7 +548,14 @@ class wine(Runner):
                 'advanced': True,
                 'help': ("Output debugging information in the game log "
                          "(might affect performance)")
-            }
+            },
+            {
+                'option': 'overrides',
+                'type': 'mapping',
+                'label': 'DLL overrides',
+                'advanced': True,
+                'help': "Sets WINEDLLOVERRIDES when launching the game."
+            },
         ]
 
     @property
@@ -702,9 +709,6 @@ class wine(Runner):
                             wine_path=self.get_executable(), prefix=prefix,
                             arch=self.wine_arch)
         self.set_wine_desktop(enable_wine_desktop)
-        overrides = self.runner_config.get('overrides') or {}
-        for dll, value in overrides.items():
-            prefix_manager.override_dll(dll, value)
 
     def prelaunch(self):
         if not os.path.exists(os.path.join(self.prefix_path, 'user.reg')):
@@ -725,6 +729,20 @@ class wine(Runner):
         env['WINE'] = self.get_executable()
         if self.prefix_path:
             env['WINEPREFIX'] = self.prefix_path
+
+        overrides = self.runner_config.get('overrides')
+        if overrides:
+            arr = []
+            for dll, value in overrides.items():
+                if not value:
+                    value = ''
+                value = value.replace(' ', '')
+                value = value.replace('builtin', 'b')
+                value = value.replace('native', 'n')
+                value = value.replace('disabled', '')
+                arr.append(dll + '=' + value)
+            env['WINEDLLOVERRIDES'] = ','.join(arr)
+
         return env
 
     def get_pids(self, wine_path=None):


### PR DESCRIPTION
The way it was setting Wine's DllOverrides in the registry was not working. This PR fixes it by using WINEDLLOVERRIDES environment variable. It makes it user-configurable as a runner config.

Here is a game you can test with:
https://lutris.net/games/shadowverse/
