### PR TITLE
Rework platform

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -62,6 +62,9 @@ class Game(object):
             value += " (%s)" % self.runner_name
         return value
 
+    def get_platform(self, string=True):
+        return self.runner.get_platform(string=string)
+
     def show_error_message(self, message):
         """Display an error message based on the runner's output."""
         if "CUSTOM" == message['error']:

--- a/lutris/gui/config_dialogs.py
+++ b/lutris/gui/config_dialogs.py
@@ -77,8 +77,7 @@ class GameDialogCommon(object):
         self.runner_box = self._get_runner_box()
         info_box.pack_start(self.runner_box, False, False, 5)  # Runner
 
-        info_box.pack_start(self._get_platform_box(), False, False, 5)
-        info_box.pack_start(self._get_year_box(), False, False, 5)
+        info_box.pack_start(self._get_year_box(), False, False, 5)  # Year
 
         info_sw = self.build_scrolled_window(info_box)
         self._add_notebook_tab(info_sw, "Game info")
@@ -160,21 +159,6 @@ class GameDialogCommon(object):
         banner_box.pack_start(self.icon_button, False, False, 0)
         banner_box.pack_start(reset_icon_button, False, False, 0)
         return banner_box
-
-    def _get_platform_box(self):
-        box = Gtk.HBox()
-
-        label = Gtk.Label(label="Platform")
-        box.pack_start(label, False, False, 20)
-
-        self.platform_entry = Gtk.Entry()
-        if self.game:
-            self.platform_entry.set_text(self.game.platform)
-            if self.game.runner:
-                self.platform_entry.set_placeholder_text(self.game.runner.platform)
-        box.pack_start(self.platform_entry, True, True, 20)
-
-        return box
 
     def _get_year_box(self):
         box = Gtk.HBox()
@@ -356,11 +340,6 @@ class GameDialogCommon(object):
 
         self._rebuild_tabs()
         self.notebook.set_current_page(current_page)
-        if self.runner_name:
-            runner = runners.import_runner(self.runner_name)
-            self.platform_entry.set_placeholder_text(runner.platform)
-        else:
-            self.platform_entry.set_placeholder_text('')
 
     def _rebuild_tabs(self):
         for i in range(self.notebook.get_n_pages(), 1, -1):
@@ -396,8 +375,6 @@ class GameDialogCommon(object):
         if not self.game:
             self.game = Game()
 
-        platform = self.platform_entry.get_text()
-
         year = None
         if self.year_entry.get_text():
             year = int(self.year_entry.get_text())
@@ -409,7 +386,6 @@ class GameDialogCommon(object):
         runner = runner_class(self.lutris_config)
         self.game.name = name
         self.game.slug = self.slug
-        self.game.platform = platform
         self.game.year = year
         self.game.runner_name = self.runner_name
         self.game.config = self.lutris_config

--- a/lutris/gui/flowbox.py
+++ b/lutris/gui/flowbox.py
@@ -3,6 +3,7 @@ from lutris.runners import import_runner
 from lutris.util.log import logger
 from gi.repository import Gtk, Gdk, GObject, GLib
 from lutris.gui.widgets import get_pixbuf_for_game
+from lutris.game import Game
 
 try:
     FlowBox = Gtk.FlowBox
@@ -19,7 +20,8 @@ class GameItem(Gtk.VBox):
         self.icon_type = icon_type
 
         self.parent = parent
-        self.game = game
+        self.game = Game(game['id'])
+        self.id = game['id']
         self.name = game['name']
         self.slug = game['slug']
         self.runner = game['runner']
@@ -50,7 +52,7 @@ class GameItem(Gtk.VBox):
         self.image.set_from_pixbuf(pixbuf)
 
     def get_label(self):
-        self.label = Gtk.Label(self.game['name'])
+        self.label = Gtk.Label(self.name)
         self.label.set_size_request(184, 40)
 
         if self.icon_type == 'banner':
@@ -116,7 +118,7 @@ class GameFlowBox(FlowBox):
         if not children:
             return
         game_item = children[0].get_children()[0]
-        return game_item.game['id']
+        return game_item.game.id
 
     def populate_games(self, games):
         loader = self._fill_store_generator(games)
@@ -146,13 +148,12 @@ class GameFlowBox(FlowBox):
             if self.filter_runner != game.runner:
                 return False
         if self.filter_platform:
-            platform = game.platform
-            if not platform:
-                runner = import_runner(game.runner)()
-                if runner and runner.is_installed():
-                    platform = runner.platform
-            if self.filter_platform != platform:
+            platform = game.game.get_platform(string=False)
+            if len(self.filter_platform) > len(platform):
                 return False
+            for i, f in enumerate(self.filter_platform):
+                if f != platform[i]:
+                    return False
         return True
 
     def sort_func(self, child1, child2):

--- a/lutris/gui/flowbox.py
+++ b/lutris/gui/flowbox.py
@@ -148,6 +148,8 @@ class GameFlowBox(FlowBox):
             if self.filter_runner != game.runner:
                 return False
         if self.filter_platform:
+            if not game.game.runner:
+                return False
             platform = game.game.get_platform(string=False)
             if len(self.filter_platform) > len(platform):
                 return False

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -62,7 +62,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.game_launch_time = 0
         self.last_selected_game = None
         self.selected_runner = None
-        self.selected_runner = None
+        self.selected_platform = None
 
         # Load settings
         width = int(settings.read_setting('width') or 800)
@@ -739,15 +739,15 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.sidebar_paned.set_position(width)
 
     def on_sidebar_changed(self, widget):
-        selected_filter = widget.get_selected_filter()
+        type, slug = widget.get_selected_filter()
         selected_runner = None
         selected_platform = None
-        if not selected_filter:
+        if not slug:
             pass
-        elif selected_filter.startswith('platform:'):
-            selected_platform = selected_filter.split(':', 2)[1]
-        else:
-            selected_runner = selected_filter
+        elif type == 'platforms':
+            selected_platform = slug.split(' / ')
+        elif type == 'runners':
+            selected_runner = slug
         self.set_selected_filter(selected_runner, selected_platform)
 
     def set_selected_filter(self, runner, platform):

--- a/lutris/gui/runnersdialog.py
+++ b/lutris/gui/runnersdialog.py
@@ -74,7 +74,13 @@ class RunnersDialog(Gtk.Window):
     def get_runner_hbox(self, runner_name):
         # Get runner details
         runner = runners.import_runner(runner_name)()
-        platform = runner.platform
+        platform = runner.platforms
+        if (isinstance(platform, tuple) or isinstance(platform, list)) and isinstance(platform[0], tuple):
+            platform = map(lambda p: ' '.join(p), platform)
+            platform = sorted(list(set(platform)))
+            platform = ', '.join(platform)
+        if not isinstance(platform, str):
+            platform = ' '.join(platform)
         description = runner.description
 
         hbox = Gtk.HBox()

--- a/lutris/pga.py
+++ b/lutris/pga.py
@@ -124,9 +124,9 @@ def set_config_paths():
             )
 
 
-def get_games(name_filter=None, filter_installed=False, filter_runner=None):
+def get_games(name_filter=None, filter_installed=False, filter_runner=None, select='*'):
     """Get the list of every game in database."""
-    query = "select * from games"
+    query = "select " + select + " from games"
     params = []
     filters = []
     if name_filter:

--- a/lutris/platforms.py
+++ b/lutris/platforms.py
@@ -32,6 +32,7 @@ def load_platforms():
 def get_active(sort=True):
     """Return a list of platforms with games (strings)."""
     active_platforms = []
+    stubs = set()
     all_games = pga.get_games(filter_installed=True, select='id')
     for game in all_games:
         # load game info
@@ -42,13 +43,19 @@ def get_active(sort=True):
         # convert to tuple if string
         if isinstance(platform, str):
             platform = (platform,)
-        prefix = ''
 
+        stub = ' / '.join(platform[:-1])
+
+        prefix = ''
         for p in platform:
             p = prefix + p
             prefix = p + ' / '
-            if p not in active_platforms:
-                active_platforms.append(p)
+        if p not in active_platforms:
+            active_platforms.append(p)
+            if stub in stubs and stub not in active_platforms:
+                active_platforms.append(stub)
+            stubs.add(stub)
+
     return sorted(active_platforms) if sort else active_platforms
 
 

--- a/lutris/platforms.py
+++ b/lutris/platforms.py
@@ -1,22 +1,55 @@
 """Generic platform functions."""
 
 from lutris import pga
-from lutris.runners import import_runner
+from lutris import runners
+from lutris.game import Game
+
+# gets populated by load_platforms()
+__all__ = {}
 
 
-def get_installed(sort=True):
-    """Return a list of installed platforms (strings)."""
-    installed_platforms = []
-    all_games = pga.get_games(filter_installed=True)
+def load_platforms():
+    for runner_name in runners.__all__:
+        runner = runners.import_runner(runner_name)()
+        platforms = runner.platforms
+
+        # convert platforms into a 2D tuple
+        if type(platforms) is str:
+            platforms = (platforms,)
+        if (isinstance(platforms, tuple) or isinstance(platforms, list)) and not isinstance(platforms[0], tuple):
+            platforms = (platforms,)
+
+        for platform in platforms:
+            prefix = ''
+            for p in platform:
+                p = prefix + p
+                prefix = p + ' / '
+                if not __all__.get(p):
+                    __all__[p] = []
+                __all__.get(p).append(runner_name)
+
+
+def get_active(sort=True):
+    """Return a list of platforms with games (strings)."""
+    active_platforms = []
+    all_games = pga.get_games(filter_installed=True, select='id')
     for game in all_games:
-        if not game.get('runner'):
-            continue
-        platform = game.get('platform')
+        # load game info
+        game = Game(id=game.get('id'))
+        platform = game.get_platform(string=False)
         if not platform:
-            runner = import_runner(game.get('runner'))()
+            continue
+        # convert to tuple if string
+        if isinstance(platform, str):
+            platform = (platform,)
+        prefix = ''
 
-            if runner and runner.is_installed():
-                platform = runner.platform
-        if platform not in installed_platforms:
-            installed_platforms.append(platform)
-    return sorted(installed_platforms) if sort else installed_platforms
+        for p in platform:
+            p = prefix + p
+            prefix = p + ' / '
+            if p not in active_platforms:
+                active_platforms.append(p)
+    return sorted(active_platforms) if sort else active_platforms
+
+
+load_platforms()

--- a/lutris/runners/ags.py
+++ b/lutris/runners/ags.py
@@ -6,7 +6,7 @@ from lutris.runners.runner import Runner
 class ags(Runner):
     human_name = "Adventure Game Studio"
     description = "Graphics adventure engine"
-    platform = 'PC'
+    platforms = 'PC'
     runner_executable = 'ags/ags.sh'
     game_options = [{
         'option': 'main_file',

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -12,7 +12,7 @@ from lutris.util import display, extract, system
 class atari800(Runner):
     description = "Runs Atari 8bit games"
     human_name = "Atari800"
-    platform = "Atari 8bit computers"
+    platforms = ('Atari', '8bit computers')
     runner_executable = 'atari800/bin/atari800'
     bios_url = (
         "http://kent.dl.sourceforge.net/project/atari800/"

--- a/lutris/runners/browser.py
+++ b/lutris/runners/browser.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 class browser(Runner):
     human_name = "Browser"
     description = "Runs browser games"
-    platform = "Web"
+    platforms = "Web"
     description = "Runs games in the browser"
     game_options = [
         {

--- a/lutris/runners/citra.py
+++ b/lutris/runners/citra.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 
 class citra(Runner):
     human_name = "Citra"
-    platform = 'Nintendo 3DS'
+    platforms = ('Nintendo', '3DS')
     description = 'Nintendo 3DS emulator'
     runner_executable = 'citra/citra-qt'
     game_options = [{

--- a/lutris/runners/desmume.py
+++ b/lutris/runners/desmume.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 
 class desmume(Runner):
     human_name = "DeSmuME"
-    platform = 'Nintendo DS'
+    platforms = ('Nintendo', 'DS')
     description = 'Nintendo DS emulator'
     runner_executable = 'desmume/bin/desmume'
     game_options = [{

--- a/lutris/runners/dgen.py
+++ b/lutris/runners/dgen.py
@@ -6,7 +6,7 @@ from lutris.runners.runner import Runner
 class dgen(Runner):
     human_name = "DGen"
     description = "Sega Genesis emulator"
-    platform = 'Sega Genesis'
+    platforms = ('Sega', 'Genesis')
     runner_executable = 'dgen/bin/dgen'
     game_options = [{
         'option': 'main_file',

--- a/lutris/runners/dolphin.py
+++ b/lutris/runners/dolphin.py
@@ -5,7 +5,10 @@ from lutris.runners.runner import Runner
 class dolphin(Runner):
     description = "Gamecube and Wii emulator"
     human_name = "Dolphin"
-    platform = "Nintendo Gamecube, Nintendo Wii"
+    platforms = (
+        ('Nintendo', 'Gamecube'),
+        ('Nintendo', 'Wii'),
+    )
     runnable_alone = True
     runner_executable = 'dolphin/dolphin-emu'
     game_options = [
@@ -14,6 +17,15 @@ class dolphin(Runner):
             "type": "file",
             "default_path": "game_path",
             "label": "ISO file"
+        },
+        {
+            'option': 'platform',
+            'type': 'choice',
+            'label': 'Platform',
+            'choices': (
+                ('Nintendo Gamecube', '0'),
+                ('Nintendo Wii', '1')
+            )
         }
     ]
     runner_options = []
@@ -24,6 +36,14 @@ class dolphin(Runner):
             'default': True,
         }
     ]
+
+    @property
+    def platform(self):
+        sel_platform = self.game_config.get('platform')
+        if sel_platform:
+            return self.platforms[int(sel_platform)]
+        else:
+            return ('',)
 
     def play(self):
         iso = self.game_config.get('main_file') or ''

--- a/lutris/runners/dosbox.py
+++ b/lutris/runners/dosbox.py
@@ -48,7 +48,7 @@ def makeconfig(path, drives, commands):
 class dosbox(Runner):
     human_name = "DOSBox"
     description = "MS-Dos emulator"
-    platform = "MS-DOS"
+    platforms = "MS-DOS"
     description = "DOS Emulator"
     runnable_alone = True
     runner_executable = "dosbox/bin/dosbox"

--- a/lutris/runners/frotz.py
+++ b/lutris/runners/frotz.py
@@ -8,7 +8,7 @@ from lutris.runners.runner import Runner
 class frotz(Runner):
     human_name = "Frotz"
     description = "Z-code emulator for text adventure games such as Zork."
-    platform = "Z-Machine"
+    platforms = "Z-Machine"
     runner_executable = 'frotz/frotz'
 
     game_options = [

--- a/lutris/runners/fsuae.py
+++ b/lutris/runners/fsuae.py
@@ -5,7 +5,28 @@ from lutris.util.display import get_current_resolution
 class fsuae(Runner):
     human_name = "FS-UAE"
     description = "Amiga emulator"
-    platform = "Amiga"
+    platforms = (
+        ('Amiga', '500'),
+        ('Amiga', '500+'),
+        ('Amiga', '600'),
+        ('Amiga', '1000'),
+        ('Amiga', '1200'),
+        ('Amiga', '1200'),
+        ('Amiga', '4000'),
+        ('Amiga', 'CD32'),
+        ('Commodore', 'CDTV'),
+    )
+    model_choices = [
+        ("Amiga 500", 'A500'),
+        ("Amiga 500+ with 1 MB chip RAM", 'A500+'),
+        ("Amiga 600 with 1 MB chip RAM", 'A600'),
+        ("Amiga 1000 with 512 KB chip RAM", 'A1000'),
+        ("Amiga 1200 with 2 MB chip RAM", 'A1200'),
+        ("Amiga 1200 but with 68020 processor", 'A1200/020'),
+        ("Amiga 4000 with 2 MB chip RAM and a 68040", 'A4000/040'),
+        ("Amiga CD32", 'CD32'),
+        ("Commodore CDTV", 'CDTV'),
+    ]
     runner_executable = 'fs-uae/fs-uae'
     game_options = [
         {
@@ -32,17 +53,7 @@ class fsuae(Runner):
             "option": "model",
             "label": "Amiga model",
             "type": "choice",
-            "choices": [
-                ("Amiga 500", 'A500'),
-                ("Amiga 500+ with 1 MB chip RAM", 'A500+'),
-                ("Amiga 600 with 1 MB chip RAM", 'A600'),
-                ("Amiga 1000 with 512 KB chip RAM", 'A1000'),
-                ("Amiga 1200 with 2 MB chip RAM", 'A1200'),
-                ("Amiga 1200 but with 68020 processor", 'A1200/020'),
-                ("Amiga 4000 with 2 MB chip RAM and a 68040", 'A4000/040'),
-                ("CD32 unit", 'CD32'),
-                ("Commodore CDTV unit", 'CDTV'),
-            ],
+            "choices": model_choices,
             'default': 'A500',
             'help': ("Specify the Amiga model you want to emulate.")
         },
@@ -77,6 +88,15 @@ class fsuae(Runner):
                      "the displays of yesteryear.")
         }
     ]
+
+    @property
+    def platform(self):
+        model = self.runner_config.get('model')
+        if model:
+            for i, m in enumerate(self.model_choices):
+                if m[1] == model:
+                    return self.platforms[i]
+        return ('',)
 
     def insert_floppies(self):
         disks = []

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -9,7 +9,7 @@ from lutris.util import system
 class hatari(Runner):
     human_name = "Hatari"
     description = "Atari ST computers emulator"
-    platform = "Atari ST computers"
+    platforms = ('Atari', 'ST')
     runnable_alone = True
     runner_executable = 'hatari/bin/hatari'
     game_options = [

--- a/lutris/runners/jzintv.py
+++ b/lutris/runners/jzintv.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 class jzintv(Runner):
     human_name = "jzIntv"
     description = "Intellivision Emulator"
-    platform = "Intellivision"
+    platforms = "Intellivision"
     runner_executable = 'jzintv/bin/jzintv'
     game_options = [{
         'option': 'main_file',

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -7,6 +7,8 @@ from lutris import settings
 
 
 def get_cores():
+    # Don't forget to update self.platforms
+    # The order has to be the same!
     return [
         ('4do (3DO)', '4do'),
         ('FCEUmm (Nintendo Entertainment System)', 'fceumm'),
@@ -23,7 +25,7 @@ def get_cores():
         ('Mednafen PSX (Sony Playstation)', 'mednafen_psx'),
         ('Mednafen PSX OpenGL (Sony Playstation)', 'mednafen_psx_hw'),
         ('Mupen64Plus (Nintendo 64)', 'mupen64plus'),
-        ('O2EM (Magnavox Odyssey 2)', 'o2em'),
+        ('O2EM (Magnavox Odyssey²)', 'o2em'),
         ('PCSX Rearmed (Sony Playstation)', 'pcsx_rearmed'),
         ('PicoDrive (Sega Genesis)', 'picodrive'),
         ('PPSSPP (PlayStation Portable)', 'ppsspp'),
@@ -54,7 +56,32 @@ def get_default_info_directory():
 class libretro(Runner):
     human_name = "libretro"
     description = "Multi system emulator"
-    platform = "libretro"
+    platforms = (
+        ('3DO',),
+        ('Nintendo', 'NES'),
+        ('Sinclair', 'ZX Spectrum'),
+        ('Nintendo', 'Game Boy Color'),
+        ('Sega', 'Genesis'),
+        ('Atari', 'Lynx'),
+        ('Atari', 'ST/STE/TT/Falcon'),
+        ('SNK', 'Neo Geo Pocket'),
+        ('NEC', 'PC Engine (TurboGrafx-16)'),
+        ('NEC', 'PC-FX'),
+        ('NEC', 'PC Engine (SuperGrafx)'),
+        ('Bandai', 'WonderSwan'),
+        ('Sony', 'PlayStation'),
+        ('Sony', 'PlayStation'),
+        ('Nintendo', 'N64'),
+        ('Magnavox', 'Odyssey²'),
+        ('Sony', 'PlayStation'),
+        ('Sega', 'Genesis'),
+        ('Sony', 'PlayStation Portable'),
+        ('Sega', 'Dreamcast'),
+        ('Nintendo', 'SNES'),
+        ('Sega', 'Saturn'),
+        ('Nintendo', 'Game Boy Advance'),
+        ('Nintendo', 'Game Boy Advance'),
+    )
     runnable_alone = True
     runner_executable = 'retroarch/retroarch'
 
@@ -86,6 +113,16 @@ class libretro(Runner):
             'default': get_default_config_path()
         }
     ]
+
+    @property
+    def platform(self):
+        core = self.game_config.get('core')
+        if core:
+            cores = get_cores()
+            for i, c in enumerate(cores):
+                if c[1] == core:
+                    return self.platforms[i]
+        return ('',)
 
     def get_core_path(self, core):
         return os.path.join(settings.RUNNER_DIR,

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -8,7 +8,7 @@ from lutris.runners.runner import Runner
 class linux(Runner):
     human_name = "Linux"
     description = "Runs native games"
-    platform = "PC/Linux"
+    platforms = ('PC', 'Linux')
 
     game_options = [
         {

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -6,7 +6,7 @@ from lutris.runners.runner import Runner
 class mame(Runner):
     human_name = "MAME"
     description = "Arcade game emulator"
-    platform = "Arcade"
+    platforms = "Arcade"
     runner_executable = 'mame/mame'
     game_options = [
         {

--- a/lutris/runners/mednafen.py
+++ b/lutris/runners/mednafen.py
@@ -9,17 +9,30 @@ class mednafen(Runner):
     human_name = "Mednafen"
     description = ("Multi-system emulator including NES, GB(A), PC Engine "
                    "support.")
-    platform = ("Atari Lynx, GameBoy, GameBoy Color, "
-                "GameBoy Advance, NES, PC Engine (TurboGrafx 16), PC-FX, "
-                "SuperGrafx, NeoGeo Pocket, NeoGeo Pocket Color, WonderSwan")
-    runner_executable = 'mednafen/bin/mednafen'
+    # TODO: Add more platforms/machines
+    platforms = (
+        ('Nintendo', 'NES'),
+        ('NEC', 'PC Engine (TurboGrafx-16)'),
+        ('Nintendo', 'Game Boy'),
+        ('Nintendo', 'Game Boy Advance'),
+        ('Sony', 'PlayStation'),
+        # ('Atari', 'Lynx'),
+        # ('Nintendo', 'Game Boy Color'),
+        # ('NEC', 'PC Engine (TurboGrafx-16)'),
+        # ('NEC', 'PC-FX'),
+        # ('NEC', 'PC Engine (SuperGrafx)'),
+        # ('SNK', 'Neo Geo Pocket'),
+        # ('SNK', 'Neo Geo Pocket Color'),
+        # ('Bandai', 'WonderSwan'),
+    )
     machine_choices = (
         ("NES", "nes"),
         ("PC Engine", "pce"),
         ('Game Boy', 'gb'),
         ('Game Boy Advance', 'gba'),
-        ('Playstation', 'psx')
+        ('PlayStation', 'psx'),
     )
+    runner_executable = 'mednafen/bin/mednafen'
     game_options = [
         {
             "option": "main_file",
@@ -81,6 +94,15 @@ class mednafen(Runner):
             "default": "hq4x",
         }
     ]
+
+    @property
+    def platform(self):
+        machine = self.game_config.get('machine')
+        if machine:
+            for i, m in enumerate(self.machine_choices):
+                if m[1] == machine:
+                    return self.platforms[i]
+        return ('',)
 
     def find_joysticks(self):
         """ Detect connected joysticks and return their ids """

--- a/lutris/runners/mess.py
+++ b/lutris/runners/mess.py
@@ -6,7 +6,27 @@ from lutris.runners.runner import Runner
 class mess(Runner):
     human_name = "MESS"
     description = "Multi-system (consoles and computers) emulator"
-    platform = 'multi-platform'
+    # TODO: A lot of platforms/machines are missing
+    platforms = (
+        ('Amstrad', 'CPC 464'),
+        ('Amstrad', 'CPC 6128'),
+        ('Amstrad', 'GX4000'),
+        ('Apple', 'II'),
+        ('Apple', 'IIGS'),
+        ('Commodore', '64'),
+        ('Sinclair', 'ZX Spectrum'),
+        ('Sinclair', 'ZX Spectrum 128'),
+    )
+    machine_choices = [
+        ("Amstrad CPC 464", 'cpc464'),
+        ("Amstrad CPC 6128", 'cpc6128'),
+        ("Amstrad GX4000", 'gx4000'),
+        ("Apple II", 'apple2ee'),
+        ("Apple IIGS", 'apple2gs'),
+        ("Commodore 64", 'c64'),
+        ("ZX Spectrum", 'spectrum'),
+        ("ZX Spectrum 128", 'spec128'),
+    ]
     runner_executable = "mess/mess"
     game_options = [
         {
@@ -19,16 +39,7 @@ class mess(Runner):
             'option': 'machine',
             'type': 'choice_with_entry',
             'label': "Machine",
-            'choices': [
-                ("Amstrad CPC 464", 'cpc464'),
-                ("Amstrad CPC 6128", 'cpc6128'),
-                ("Amstrad GX4000", 'gx4000'),
-                ("Apple II", 'apple2ee'),
-                ("Apple IIGS", 'apple2gs'),
-                ("Commodore 64", 'c64'),
-                ("ZX Spectrum", 'spectrum'),
-                ("ZX Spectrum 128", 'spec128'),
-            ],
+            'choices': machine_choices,
             'help': ("The emulated machine.")
         },
         {
@@ -57,6 +68,15 @@ class mess(Runner):
                      "necessary to the emulation.")
         }
     ]
+
+    @property
+    def platform(self):
+        machine = self.game_config.get('machine')
+        if machine:
+            for i, m in enumerate(self.machine_choices):
+                if m[1] == machine:
+                    return self.platforms[i]
+        return ('',)
 
     @property
     def working_dir(self):

--- a/lutris/runners/mupen64plus.py
+++ b/lutris/runners/mupen64plus.py
@@ -7,7 +7,7 @@ from lutris.runners.runner import Runner
 class mupen64plus(Runner):
     human_name = "Mupen64Plus"
     description = "Nintendo 64 emulator"
-    platform = "Nintendo 64"
+    platforms = ('Nintendo', 'N64')
     runner_executable = 'mupen64plus/mupen64plus'
     game_options = [{
         'option': 'main_file',

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -5,8 +5,13 @@ from lutris.runners.runner import Runner
 
 class o2em(Runner):
     human_name = "O2EM"
-    description = "Magnavox Oyssey² Emulator"
-    platform = "Magnavox Odyssey 2, Phillips Videopac+"
+    description = "Magnavox Osyssey² Emulator"
+    platforms = (
+        ('Magnavox', 'Odyssey²'),
+        ('Phillips', 'C52'),
+        ('Phillips', 'Videopac+'),
+        ('Brandt', 'Jopac'),
+    )
     bios_path = os.path.expanduser("~/.o2em/bios")
     runner_executable = 'o2em/o2em'
 
@@ -73,6 +78,15 @@ class o2em(Runner):
                      "the displays of yesteryear.")
         }
     ]
+
+    @property
+    def platform(self):
+        bios = self.runner_config.get('bios')
+        if bios:
+            for i, b in enumerate(self.bios_choices):
+                if b[1] == bios:
+                    return self.platforms[i]
+        return ('',)
 
     def install(self, version=None, downloader=None, callback=None):
         def on_runner_installed(*args):

--- a/lutris/runners/osmose.py
+++ b/lutris/runners/osmose.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 class osmose(Runner):
     human_name = "Osmose"
     description = "Sega Master System Emulator"
-    platform = "Sega Master System"
+    platforms = ('Sega', 'Master System')
     runner_executable = 'osmose/osmose'
     game_options = [
         {

--- a/lutris/runners/pcsx2.py
+++ b/lutris/runners/pcsx2.py
@@ -4,8 +4,8 @@ from lutris.runners.runner import Runner
 
 class pcsx2(Runner):
     human_name = "PCSX2"
-    description = "Playstation 2 emulator"
-    platform = "Sony Playstation 2"
+    description = "PlayStation 2 emulator"
+    platforms = ('Sony', 'PlayStation 2')
     runner_executable = 'pcsx2/PCSX2'
     game_options = [
         {

--- a/lutris/runners/pcsxr.py
+++ b/lutris/runners/pcsxr.py
@@ -9,7 +9,7 @@ from lutris.util import system
 class pcsxr(Runner):
     human_name = "PCSX-Reloaded"
     description = "PlayStation emulator"
-    platform = "Sony Playstation"
+    platforms = ('Sony', 'Playstation')
     runnable_alone = True
     runner_executable = 'pcsxr/bin/pcsxr'
     game_options = [

--- a/lutris/runners/ppsspp.py
+++ b/lutris/runners/ppsspp.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 class ppsspp(Runner):
     human_name = "PPSSPP"
     description = "Sony PSP emulator"
-    platform = "Sony PSP"
+    platforms = ('Sony', 'PlayStation Portable')
     runner_executable = 'ppsspp/PPSSPPSDL'
     game_options = [
         {

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -13,7 +13,7 @@ from lutris.gui.dialogs import NoticeDialog
 class reicast(Runner):
     human_name = "Reicast"
     description = "Sega Dreamcast emulator"
-    platform = "Sega Dreamcast"
+    platforms = ('Sega', 'Dreamcast')
     runner_executable = 'reicast/reicast.elf'
 
     game_options = [{

--- a/lutris/runners/residualvm.py
+++ b/lutris/runners/residualvm.py
@@ -9,7 +9,7 @@ RESIDUALVM_CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".residualvmrc")
 
 class residualvm(Runner):
     human_name = "ResidualVM"
-    platform = "3D point-and-click games"
+    platforms = "3D point-and-click games"  # TODO
     description = ("Runs various 3D point-and-click adventure games, "
                    "like Grim Fandango and Escape from Monkey Island.")
     runner_executable = 'residualvm/residualvm'

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -33,7 +33,7 @@ def get_arch():
 class Runner(object):
     """Generic runner (base class for other runners)."""
     multiple_versions = False
-    platform = NotImplemented
+    platforms = NotImplemented
     runnable_alone = False
     game_options = []
     runner_options = []
@@ -127,6 +127,21 @@ class Runner(object):
     def machine(self):
         self.logger.error("runner.machine accessed, please use platform")
         return self.platform
+
+    @property
+    def platform(self):
+        return self.platforms
+
+    def get_platform(self, string=False):
+        isstr = type(self.platforms) is str
+        if string and not isstr:
+            return ' / '.join(self.platform)
+        elif string and isstr:
+            return self.platform
+        elif isstr:
+            return (self.platform,)
+        else:
+            return self.platform
 
     def get_runner_options(self):
         runner_options = self.runner_options[:]

--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -11,7 +11,7 @@ SCUMMVM_CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".scummvmrc")
 class scummvm(Runner):
     description = "Runs various 2D point-and-click adventure games."
     human_name = "ScummVM"
-    platform = "2D point-and-click games"
+    platforms = "2D point-and-click games"  # TODO
     runnable_alone = True
     runner_executable = 'scummvm/bin/scummvm'
     game_options = [

--- a/lutris/runners/snes9x.py
+++ b/lutris/runners/snes9x.py
@@ -12,7 +12,7 @@ SNES9X_DIR = os.path.join(settings.DATA_DIR, "runners/snes9x")
 class snes9x(Runner):
     description = "Super Nintendo emulator"
     human_name = "Snes9x"
-    platform = "Super Nintendo"
+    platforms = ('Nintendo', 'SNES')
     runnable_alone = True
     runner_executable = "snes9x/bin/snes9x-gtk"
     game_options = [

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -37,7 +37,7 @@ def is_running():
 class steam(Runner):
     description = "Runs Steam for Linux games"
     human_name = "Steam"
-    platform = "PC/Linux (Steam)"
+    platforms = ('PC', 'Linux')
     runnable_alone = True
     game_options = [
         {

--- a/lutris/runners/stella.py
+++ b/lutris/runners/stella.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 class stella(Runner):
     description = "Atari 2600 emulator"
     human_name = "Stella"
-    platform = "Atari 2600"
+    platforms = ('Atari', '2600')
     runnable_alone = True
     runner_executable = "stella/bin/stella"
     game_options = [

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -8,7 +8,7 @@ from lutris.runners.runner import Runner
 class vice(Runner):
     description = "Commodore Emulator"
     human_name = "Vice"
-    platform = "Commodore 64"
+    platforms = ('Commodore', '64')
 
     game_options = [{
         "option": "main_file",

--- a/lutris/runners/virtualjaguar.py
+++ b/lutris/runners/virtualjaguar.py
@@ -5,7 +5,7 @@ from lutris.runners.runner import Runner
 class virtualjaguar(Runner):
     description = "Atari Jaguar emulator"
     human_name = "Virtual Jaguar"
-    platform = "Atari Jaguar"
+    platforms = ('Atari', 'Jaguar')
     runnable_alone = True
     runner_executable = 'virtualjaguar/virtualjaguar'
     game_options = [

--- a/lutris/runners/web.py
+++ b/lutris/runners/web.py
@@ -15,7 +15,7 @@ DEFAULT_ICON = os.path.join(datapath.get(), 'media/default_icon.png')
 class web(Runner):
     human_name = "Web"
     description = "Runs web based games"
-    platform = "Web"
+    platforms = "Web"
     game_options = [
         {
             "option": "main_file",

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -305,7 +305,7 @@ def support_legacy_version(version):
 class wine(Runner):
     description = "Runs Windows games"
     human_name = "Wine"
-    platform = 'PC/Windows'
+    platforms = ('PC', 'Windows')
     multiple_versions = True
     game_options = [
         {

--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -51,7 +51,7 @@ class winesteam(wine.wine):
     description = "Runs Steam for Windows games"
     multiple_versions = False
     human_name = "Wine Steam"
-    platform = "PC/Windows (Steam)"
+    platform = ('PC', 'Windows')
     runnable_alone = True
     depends_on = wine.wine
     game_options = [

--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -6,7 +6,7 @@ class zdoom(Runner):
     # http://zdoom.org/wiki/Command_line_parameters
     description = "ZDoom DOOM Game Engine"
     human_name = "ZDoom"
-    platform = "PC"
+    platforms = "PC"
     runner_executable = 'zdoom/zdoom'
     game_options = [
         {


### PR DESCRIPTION
Here is a preview:
![screenshot](https://cloud.githubusercontent.com/assets/1264014/23645847/811a4c28-030e-11e7-930b-23ed94aeeb24.png)
This rework of platform in runners makes it easier to filter games by platform and manufacturer. Multi-platform runners (such as libretro) convert the selected core to a platform valaue that appears in the sidebar and in the list view column. For example Linux games appear both in platform "PC" and "PC Linux".