### PR TITLE
Make sidebar icons visible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,8 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-before_install:
+before_script:
   - sudo apt-get -qq update
-  - sudo apt-get install -y python3-yaml python3-gi gir1.2-gtk-3.0 psmisc
-install:
-  - python setup.py install
+  - sudo apt-get install -y python3-yaml python3-gi gir1.2-gtk-3.0 psmisc gir1.2-glib-2.0 libgirepository1.0-dev
 script: nosetests
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -735,7 +735,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.show_sidebar()
 
     def show_sidebar(self):
-        width = 150 if self.sidebar_visible else 0
+        width = 180 if self.sidebar_visible else 0
         self.sidebar_paned.set_position(width)
 
     def on_sidebar_changed(self, widget):

--- a/lutris/gui/sidebar.py
+++ b/lutris/gui/sidebar.py
@@ -24,7 +24,7 @@ class SidebarTreeView(Gtk.TreeView):
         self.set_model(self.model_filter)
 
         column = Gtk.TreeViewColumn("Runners")
-        column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)
+        # column.set_sizing(Gtk.TreeViewColumnSizing.AUTOSIZE)
 
         # Runner slug
         text_renderer = Gtk.CellRendererText()
@@ -34,7 +34,7 @@ class SidebarTreeView(Gtk.TreeView):
 
         # Icon
         icon_renderer = Gtk.CellRendererPixbuf()
-        icon_renderer.set_property('stock-size', 16)
+        icon_renderer.set_property('width', 20)
         column.pack_start(icon_renderer, False)
         column.add_attribute(icon_renderer, "pixbuf", ICON)
 


### PR DESCRIPTION
I missed them! <3
![screenshot](https://cloud.githubusercontent.com/assets/1264014/23650839/cda57436-0323-11e7-8261-2972a1e50dcb.png)

It adds however an extra space in front of "All runners" and the platforms (you can notice the space between the expand arrow and "All runners").