### PR TITLE
Fix desktopapps crash

### DIFF
--- a/lutris/util/desktopapps.py
+++ b/lutris/util/desktopapps.py
@@ -18,6 +18,7 @@ IGNORED_GAMES = (
     "fs-uae-arcade", "PCSX2", "ppsspp", "qchdman", "qmc2-sdlmame", "qmc2-arcade",
     "sc-controller", "epsxe"
 )
+
 IGNORED_EXECUTABLES = (
     "lutris", "steam"
 )
@@ -41,12 +42,19 @@ def mark_as_installed(appid, runner_name, game_info):
         installer_slug=game_info['installer_slug']
     )
 
-    game_config = LutrisConfig(
+    config = LutrisConfig(
         runner_slug=runner_name,
         game_config_id=config_id,
     )
-    game_config.raw_game_config.update({'appid': appid, 'exe': game_info['exe'], 'args': game_info['args']})
-    game_config.save()
+    config.raw_game_config.update({
+        'appid': appid,
+        'exe': game_info['exe'],
+        'args': game_info['args']
+    })
+    config.raw_system_config.update({
+        'disable_runtime': True
+    })
+    config.save()
     return game_id
 
 

--- a/lutris/util/desktopapps.py
+++ b/lutris/util/desktopapps.py
@@ -79,16 +79,22 @@ def sync_with_lutris():
     for app in apps:
         game_info = None
         name = app[0]
-        slug = slugify(name)
         appid = app[1]
+        slug = slugify(name)
+
+        # if it fails to get slug from the name
+        if not slug:
+            slug = slugify(appid)
 
         if not name or not slug or not appid:
             logger.error("Failed to load desktop game "
-                         "\"" + str(name) + "\" (" + str(appid) + ".desktop)")
+                         "\"" + str(name) + "\" "
+                         "(app: " + str(appid) + ", slug: " + slug + ")")
             continue
         else:
             logger.debug("Found desktop game "
-                         "\"" + str(name) + "\" (" + str(appid) + ".desktop)")
+                         "\"" + str(name) + "\" "
+                         "(app: " + str(appid) + ", slug: " + slug + ")")
 
         seen_slugs.add(slug)
 

--- a/lutris/util/desktopapps.py
+++ b/lutris/util/desktopapps.py
@@ -81,6 +81,15 @@ def sync_with_lutris():
         name = app[0]
         slug = slugify(name)
         appid = app[1]
+
+        if not name or not slug or not appid:
+            logger.error("Failed to load desktop game "
+                         "\"" + str(name) + "\" (" + str(appid) + ".desktop)")
+            continue
+        else:
+            logger.debug("Found desktop game "
+                         "\"" + str(name) + "\" (" + str(appid) + ".desktop)")
+
         seen_slugs.add(slug)
 
         if slug not in slugs_in_lutris:


### PR DESCRIPTION
When a game's name only had non-ascii characters the slug became an empty string.
The fix makes it fall back to creating a slug of the app name (.desktop file) and an additional if-statement check.