### PR TITLE
Don't fallback wine version for installers. Fixes #530

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -334,6 +334,8 @@ class ScriptInterpreter(CommandsMixin):
                 version = self._get_runner_version()
                 if version:
                     params['version'] = version
+                    # Force the wine version to be installed
+                    params['fallback'] = False
             if not runner.is_installed(**params):
                 self.runners_to_install.append(runner)
         self.install_runners()

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -601,7 +601,7 @@ class wine(Runner):
         else:
             return os.path.join(WINE_DIR, version, 'bin/wine')
 
-    def get_executable(self, version=None):
+    def get_executable(self, version=None, fallback=True):
         """Return the path to the Wine executable.
         A specific version can be specified if needed.
         """
@@ -614,18 +614,20 @@ class wine(Runner):
         if os.path.exists(wine_path):
             return wine_path
 
-        # Fallback to default version
-        default_version = get_default_version()
-        logger.warning("No wine version %s found, falling back to %s", version, default_version)
-        return self.get_path_for_version(default_version)
+        if fallback:
+            # Fallback to default version
+            default_version = get_default_version()
+            logger.warning("No wine version %s found, falling back to %s",
+                           version, default_version)
+            return self.get_path_for_version(default_version)
 
-    def is_installed(self, version=None):
+    def is_installed(self, version=None, fallback=True):
         """Check if Wine is installed.
         If no version is passed, checks if any version of wine is available
         """
         if not version:
             return len(get_wine_versions()) > 0
-        executable = self.get_executable(version)
+        executable = self.get_executable(version, fallback)
         if executable:
             return os.path.exists(executable)
         else:

--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -258,14 +258,14 @@ class winesteam(wine.wine):
             dialog.run()
             on_steam_downloaded()
 
-    def is_wine_installed(self, version=None):
-        return super(winesteam, self).is_installed(version=version)
+    def is_wine_installed(self, version=None, fallback=True):
+        return super(winesteam, self).is_installed(version=version, fallback=fallback)
 
-    def is_installed(self, version=None):
+    def is_installed(self, version=None, fallback=True):
         """Checks if wine is installed and if the steam executable is on the
            harddrive.
         """
-        wine_installed = self.is_wine_installed(version)
+        wine_installed = self.is_wine_installed(version, fallback)
         if not wine_installed:
             logger.warning('wine is not installed')
             return False


### PR DESCRIPTION
Installers were unable to force install a particular Wine version.