### PR TITLE
Add global setting to set SDL_GAMECONTROLLERCONFIG

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -197,6 +197,14 @@ class Game(object):
             self.state = self.STATE_STOPPED
             return
 
+        sdl_gamecontrollerconfig = system_config.get('sdl_gamecontrollerconfig')
+        if sdl_gamecontrollerconfig:
+            path = os.path.expanduser(sdl_gamecontrollerconfig)
+            if os.path.exists(path):
+                with open(path, "r") as f:
+                    sdl_gamecontrollerconfig = f.read()
+            env['SDL_GAMECONTROLLERCONFIG']  = sdl_gamecontrollerconfig
+
         sdl_video_fullscreen = system_config.get('sdl_video_fullscreen') or ''
         env['SDL_VIDEO_FULLSCREEN_DISPLAY'] = sdl_video_fullscreen
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -187,7 +187,6 @@ system_options = [
         'condition': system.find_executable('pulseaudio'),
         'help': ('Set the environment variable PULSE_LATENCY_MSEC=60 to improve '
                  'audio quality on some games')
-
     },
     {
         'option': 'use_us_layout',
@@ -214,6 +213,14 @@ system_options = [
         'condition': system.find_executable('xboxdrv'),
         'help': ("Command line options for xboxdrv, a driver for XBOX 360"
                  "controllers. Requires the xboxdrv package installed.")
+    },
+    {
+        'option': 'sdl_gamecontrollerconfig',
+        'type': 'string',
+        'label': 'SDL2 gamepad mapping',
+        'advanced': True,
+        'help': ("SDL_GAMECONTROLLERCONFIG mapping string or path to a custom"
+                 "gamecontrollerdb.txt file containing mappings.")
     },
     {
         'option': 'xephyr',


### PR DESCRIPTION
SDL_GAMECONTROLLERCONFIG is very useful for using non-standard mappings in any SDL-based games, which includes XInput games on Wine using koku-xinput-wine.

This is one way to achieve it, I'm open to suggestions on better options though.