### PR TITLE
[reicast] Only load joypads once

### DIFF
--- a/lutris/pga.py
+++ b/lutris/pga.py
@@ -288,7 +288,7 @@ def get_used_platforms():
     """Return a list of platforms currently in use"""
     with sql.db_cursor(PGA_DB) as cursor:
         query = ("select distinct platform from games "
-                 "where platform is not null order by platform")
+                 "where platform is not null and platform is not '' order by platform")
         rows = cursor.execute(query)
         results = rows.fetchall()
     return [result[0] for result in results if result[0]]

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -16,6 +16,8 @@ class reicast(Runner):
     platforms = ['Sega Dreamcast']
     runner_executable = 'reicast/reicast.elf'
 
+    joypads = None
+
     game_options = [{
         'option': 'iso',
         'type': 'file',
@@ -24,64 +26,11 @@ class reicast(Runner):
                  "Supported formats: ISO, CDI")
     }]
 
-    def __init__(self, config=None):
-        super(reicast, self).__init__(config)
-
-        self._joypads = None
-
-        self.runner_options = [
-            {
-                'option': 'fullscreen',
-                'type': 'bool',
-                'label': 'Fullscreen',
-                'default': False,
-            },
-            {
-                'option': 'device_id_1',
-                'type': 'choice',
-                'label': 'Joypad 1',
-                'choices': self.get_joypads(),
-                'default': '-1'
-            },
-            {
-                'option': 'device_id_2',
-                'type': 'choice',
-                'label': 'Joypad 2',
-                'choices': self.get_joypads(),
-                'default': '-1'
-            },
-            {
-                'option': 'device_id_3',
-                'type': 'choice',
-                'label': 'Joypad 3',
-                'choices': self.get_joypads(),
-                'default': '-1'
-            },
-            {
-                'option': 'device_id_4',
-                'type': 'choice',
-                'label': 'Joypad 4',
-                'choices': self.get_joypads(),
-                'default': '-1'
-            }
-        ]
-
-    def install(self, version=None, downloader=None, callback=None):
-        def on_runner_installed(*args):
-            mapping_path = system.create_folder('~/.reicast/mappings')
-            mapping_source = os.path.join(settings.RUNNER_DIR, 'reicast/mappings')
-            for mapping_file in os.listdir(mapping_source):
-                shutil.copy(os.path.join(mapping_source, mapping_file), mapping_path)
-
-            system.create_folder('~/.reicast/data')
-            NoticeDialog("You have to copy valid BIOS files to ~/.reicast/data "
-                         "before playing")
-        super(reicast, self).install(version, downloader, on_runner_installed)
-
-    def get_joypads(self):
+    @staticmethod
+    def get_joypads():
         """Return list of joypad in a format usable in the options"""
-        if self._joypads:
-            return self._joypads
+        if reicast.joypads:
+            return reicast.joypads
         joypad_list = [('No joystick', '-1')]
         joypad_devices = joypad.get_joypads()
         name_counter = Counter([j[1] for j in joypad_devices])
@@ -99,8 +48,60 @@ class reicast(Runner):
             if index:
                 joy_name += " (%d)" % index
             joypad_list.append((joy_name, dev_id))
-        self._joypads = joypad_list
+        reicast.joypads = joypad_list
         return joypad_list
+
+    def __init__(self, config=None):
+        super(reicast, self).__init__(config)
+
+        self.runner_options = [
+            {
+                'option': 'fullscreen',
+                'type': 'bool',
+                'label': 'Fullscreen',
+                'default': False,
+            },
+            {
+                'option': 'device_id_1',
+                'type': 'choice',
+                'label': 'Joypad 1',
+                'choices': reicast.get_joypads(),
+                'default': '-1'
+            },
+            {
+                'option': 'device_id_2',
+                'type': 'choice',
+                'label': 'Joypad 2',
+                'choices': reicast.get_joypads(),
+                'default': '-1'
+            },
+            {
+                'option': 'device_id_3',
+                'type': 'choice',
+                'label': 'Joypad 3',
+                'choices': reicast.get_joypads(),
+                'default': '-1'
+            },
+            {
+                'option': 'device_id_4',
+                'type': 'choice',
+                'label': 'Joypad 4',
+                'choices': reicast.get_joypads(),
+                'default': '-1'
+            }
+        ]
+
+    def install(self, version=None, downloader=None, callback=None):
+        def on_runner_installed(*args):
+            mapping_path = system.create_folder('~/.reicast/mappings')
+            mapping_source = os.path.join(settings.RUNNER_DIR, 'reicast/mappings')
+            for mapping_file in os.listdir(mapping_source):
+                shutil.copy(os.path.join(mapping_source, mapping_file), mapping_path)
+
+            system.create_folder('~/.reicast/data')
+            NoticeDialog("You have to copy valid BIOS files to ~/.reicast/data "
+                         "before playing")
+        super(reicast, self).install(version, downloader, on_runner_installed)
 
     def write_config(self, config):
         parser = ConfigParser()


### PR DESCRIPTION
This reduces the time it takes to open Lutris from 10 seconds to 3. Also speeds up the time it takes to open the runner manager.

This fix make it so reicast runner only loads the joypad list/evdev devices once.