### PR TITLE
Fix Attribute Error when using lutris --list-games

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -353,4 +353,5 @@ class Application(Gtk.Application):
     def do_shutdown(self):
         logger.info("Shutting down Lutris")
         Gtk.Application.do_shutdown(self)
-        self.window.destroy()
+        if self.window:
+            self.window.destroy()


### PR DESCRIPTION
When running `--list-games`, there is no `self.window`, so calling destroy would cause an error. Checking if the window is available fixes it.