### PR TITLE
Fix register URL. 404s without a slash.

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -163,7 +163,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
                 lambda *x: self._open_browser('https://lutris.net/games/')
             ),
             'register-account': Action(
-                lambda *x: self._open_browser('https://lutris.net/user/register')
+                lambda *x: self._open_browser('https://lutris.net/user/register/')
             ),
 
             'disconnect': Action(self.on_disconnect),


### PR DESCRIPTION
Commit message is kinda self-explanatory. Used the URL linked on the Lutris page, without the trailing slash the URL 404s.