### PR TITLE
More advanced monitor configuration reset

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -194,7 +194,7 @@ class Game(object):
             self.state = self.STATE_STOPPED
             return
         system_config = self.runner.system_config
-        self.original_outputs = display.get_outputs()
+        self.original_outputs = sorted(display.get_outputs(), key=lambda e: e[0] == system_config.get('display'))
         gameplay_info = self.runner.play()
 
         env = {}

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -90,9 +90,6 @@ def change_resolution(resolution):
         else:
             subprocess.Popen(["xrandr", "-s", resolution])
     else:
-        # do the first monitor again afterwards to avoid 0,0 offset reinitialization errors
-        resolution.append(resolution[0])
-
         for display in resolution:
             display_name = display[0]
             logger.debug("Switching to %s on %s", display[1], display[0])

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -34,9 +34,10 @@ def get_outputs():
             if rotate.startswith('('): # Screen not rotated, no need to include
                 outputs.append((parts[0], geom, "normal"))
             else:
-                geom_parts = geom.split('+')
-                x_y = geom_parts[0].split('x')
-                geom = "{}x{}+{}+{}".format(x_y[1],x_y[0],geom_parts[1],geom_parts[2])
+                if rotate in ("left", "right"):
+                    geom_parts = geom.split('+')
+                    x_y = geom_parts[0].split('x')
+                    geom = "{}x{}+{}+{}".format(x_y[1],x_y[0],geom_parts[1],geom_parts[2])
                 outputs.append((parts[0], geom, rotate))
     return outputs
 

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -99,7 +99,8 @@ def change_resolution(resolution):
             display_resolution = display_geom[0]
             position = (display_geom[1], display_geom[2])
             
-            if len(display) > 2:
+            if len(display) > 2\
+                and display[2] in ('normal', 'left', 'right', 'inverted'):
                 rotation = display[2]
             else:
                 rotation = "normal"

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -32,7 +32,7 @@ def get_outputs():
             if geom.startswith('('):  # Screen turned off, no geometry
                 continue
             if rotate.startswith('('): # Screen not rotated, no need to include
-                outputs.append((parts[0], geom))
+                outputs.append((parts[0], geom, "normal"))
             else:
                 geom_parts = geom.split('+')
                 x_y = geom_parts[0].split('x')


### PR DESCRIPTION
### Allows for 
* **monitor configuration resets with no 0+0 based monitors**
* **rotated monitor resets**
* **inverted monitor resets**

This update extends the current implementation of `get_outputs()` to also retrieve whether a monitor has a rotated configuration. This includes all supported modes detailed in xrandr, which is `'normal', 'left', 'right' or 'inverted'`. This was tested using a 4 monitor configuration with 2 rotated monitors including `'left'` and `'right'`. 

The update allows use of the tuple returned by `get_outputs` for rotation (the current metastructure is now `[name, geometry, rotation]`), and no existing uses of the function had issue with another element being appended to it. Also, since xrandr's returned output will flip the X and Y values of the resolution if a monitor is rotated left or right (ie. 900x1440 in the xrandr output due to 1440x900 rotated left), yet must be set using one of the available modes (ie. 1440x900). The resolution is swapped if needed and the appropriate geometric shape reconstructed. 

Also, my monitor configuration also forced me into an encounter with the multi-monitor reset which is not currently in any Issues. If there are no monitors that reside at the 0+0 origin or the Xorg configuration, the monitors will not be reset correctly as whichever monitor is first set will default to 0+0 after xrandr sets it. I fixed this by sorting the returned list from `get_outputs()` against the display name, making the currently used display last to be set, set only once by `xrandr`, and correctly configured according to the saved monitor configuration. 

I came up with several edge cases and optimizations every time I went to create the pull request so this is more commits than I would have liked. No issues were noted in the testing of this patch. Let me know if there are any changes you would like me to make.

