### PR TITLE
load multiline strings from vdf

### DIFF
--- a/lutris/util/steam.py
+++ b/lutris/util/steam.py
@@ -31,6 +31,12 @@ def vdf_parse(steam_config_file, config):
             return config
         if not line or line.strip() == "}":
             return config
+        while not line.strip().endswith("\""):
+            nextline = steam_config_file.readline()
+            if not nextline:
+                break
+            line = line[:-1] + nextline
+
         line_elements = line.strip().split("\"")
         if len(line_elements) == 3:
             key = line_elements[1]


### PR DESCRIPTION
Some multiline config variables are currently not read from steam's config.

My steam config contains these lines at the end:
```
	"SDL_GamepadBind"		"03000000de280000fc11000001000000,Steam Controller,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,
03000000de280000ff11000001000000,Steam Virtual Gamepad,a:b0,b:b1,back:b6,dpdown:h0.4,dpleft:h0.8,dpright:h0.2,dpup:h0.1,guide:b8,leftshoulder:b4,leftstick:b9,lefttrigger:a2,leftx:a0,lefty:a1,rightshoulder:b5,rightstick:b10,righttrigger:a5,rightx:a3,righty:a4,start:b7,x:b2,y:b3,"
```

I guess it's not that important. I stumbled upon this trying out lutris 0.3.8, where lutris just failed to load. That's why I wrote a patch in the first place.

But if lutris writes back the config (sorry, I didn't check that), this data won't get lost.