### PR TITLE
flowbox: Fix ImportError for get_pixbuf_for_game

### DIFF
--- a/lutris/gui/flowbox.py
+++ b/lutris/gui/flowbox.py
@@ -1,7 +1,7 @@
 from lutris import pga
 from lutris.util.log import logger
 from gi.repository import Gtk, Gdk, GObject, GLib
-from lutris.gui.widgets import get_pixbuf_for_game
+from lutris.gui.widgets.utils import get_pixbuf_for_game
 from lutris.game import Game
 
 try:


### PR DESCRIPTION
The error was introduced in 60f90f0c58acc3a17365132c541864e284c011e4 and I've stumbled upon this while trying to run the test suite.