### PR TITLE
Clean up stdout_monitor if pipe is broken

### DIFF
--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -123,9 +123,12 @@ class LutrisThread(threading.Thread):
 
         if self.watch:
             GLib.timeout_add(HEARTBEAT_DELAY, self.watch_children)
-            self.stdout_monitor = GLib.io_add_watch(self.game_process.stdout, GLib.IO_IN, self.on_stdout_output)
+            self.stdout_monitor = GLib.io_add_watch(self.game_process.stdout, GLib.IO_IN | GLib.IO_HUP, self.on_stdout_output)
 
     def on_stdout_output(self, fd, condition):
+        if condition == GLib.IO_HUP:
+            self.stdout_monitor = None
+            return False
         if not self.is_running:
             return False
         try:


### PR DESCRIPTION
This PR causes the io watch of the stdout_monitor to be cleaned up if the pipe is broken. This happens for example if a steam game is started and steam is already running in the background. In this case the started process (which will be the `LutrisThread.game_process`) will merely send a signal to the actual steam process and then terminate - causing a broken stdout pipe.

Performing this cleanup fixes several issues:
1. For some reason beyond my knowledge PyGTK causes 100% CPU load on one processor if there is an io watch on a broken pipe. (Which seems to be the cause of #573 )
2. The io watch isn't always cleaned up properly right now. For example if the game process gets killed via the stop button in Lutris no cleanup will be performed. This causes memory and cpu to leak as io watches and zombie child processes will stack up over time (the io watch holds a reference to the game process which prevents it from being cleaned up).