### PR TITLE
Count terminated non child processes to number of terminated_children

### DIFF
--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -267,6 +267,10 @@ class LutrisThread(threading.Thread):
             processes['monitored'].append(str(child))
             if child.state == 'Z':
                 terminated_children += 1
+        for child in self.monitored_processes['monitored']:
+            if child not in processes['monitored']:
+                num_watched_children += 1
+                terminated_children += 1
         return processes, num_children, num_watched_children, terminated_children
 
     def watch_children(self):


### PR DESCRIPTION
Currently the only way lutris checks if a watched process has terminated is to see whether it has become a zombie process. This however does not work for non child processes like steam games (if steam was already running). These games get cleaned up instantly by their parent processes and thus just disappear.

To improve process monitoring this PR additionally compares the list of currently monitored processes with the previous list of monitored processes and treats processed that have disappeared as terminated as well.

Besides greatly improving Steam game monitoring this could possibly help #614 as well (I cant reproduce that issue though, so I can't verify that).