### PR TITLE
Count processes that were just terminated as children

### DIFF
--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -272,6 +272,7 @@ class LutrisThread(threading.Thread):
                 terminated_children += 1
         for child in self.monitored_processes['monitored']:
             if child not in processes['monitored']:
+                num_children += 1
                 num_watched_children += 1
                 terminated_children += 1
         return processes, num_children, num_watched_children, terminated_children


### PR DESCRIPTION
This PR fixes a little oversight by me in #670. I forgot to increment one of the process counters. As far as i can tell this should be without any real consequence (in the worst case Lutris tries to kill processes which are already terminated anyway). I think for the sake of clean code this should be done anyway.