### PR TITLE
Allow steam and winesteam games to be run without launching Steam

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -595,6 +595,11 @@ class ScriptInterpreter(CommandsMixin):
         if 'game' in self.script:
             config['game'].update(self.script['game'])
             config['game'] = self._substitute_config(config['game'])
+            
+            # steamless_binary64 can be used to specify 64 bit non-steam binaries
+            is_64bit = platform.machine() == "x86_64"
+            if is_64bit and 'steamless_binary64' in config['game']:
+                config['game']['steamless_binary'] = config['game']['steamless_binary64']
 
         yaml_config = yaml.safe_dump(config, default_flow_style=False)
         with open(config_filename, "w") as config_file:


### PR DESCRIPTION
This PR implements a feature that allows to launch Steam (and winesteam) games to be run without launching the Steam client first (if the game supplies a binary that allows this). On Systems where Steam isn't running by default this reduces the startup time of games quite significantly. Whether a game should be started through steam or directly can be specified by the user on a per-game basis.

To allow Lutris to do this I've added the setting `steamless_binary` (`stemless_binary64` for 64 bit binaries) to the installer scripts of games. This setting tells Lutris which binary to run when the steamless launch is enabled. If no steamless binary is provided the "run without steam" setting is ignored.

While the steamless binary itself is a game setting i decided to put the option whether to run the game directly or through steam into the launcher settings since it is desirable to be able to configure this globally.

For testing I used the following modified versions of some installer scripts from the Lutris website:
https://gist.github.com/manuelVo/df501c56df2ebcf6cc3ab6d67d8bdea7