### PR TITLE
Add basic support for DRI_PRIME

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -302,6 +302,12 @@ class Game(object):
         ld_preload = gameplay_info.get('ld_preload') or ''
         env["LD_PRELOAD"] = ld_preload
 
+        dri_prime = system_config.get('dri_prime')
+        if dri_prime:
+            env["DRI_PRIME"] = "1"
+        else:
+            env["DRI_PRIME"] = "0"
+
         # Runtime management
         ld_library_path = ""
         if self.runner.use_runtime():

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -41,6 +41,10 @@ def get_output_list():
     return choices
 
 
+def get_dri_prime():
+    return len(display.get_providers()) > 1
+
+
 system_options = [
     {
         'option': 'game_path',
@@ -78,6 +82,17 @@ system_options = [
         'help': ("If you have installed the primus package, selecting this "
                  "option will run the game with the primusrun command, "
                  "activating your NVIDIA graphic chip for high 3D "
+                 "performance.")
+    },
+    {
+        'option': 'dri_prime',
+        'type': 'bool',
+        'default': False,
+        'condition': get_dri_prime,
+        'label': 'Use PRIME (hybrid graphics on laptops)',
+        'help': ("If you have open source graphic drivers (Mesa), selecting this "
+                 "option will run the game with the 'DRI_PRIME=1' environment variable, "
+                 "activating your discrete graphic chip for high 3D "
                  "performance.")
     },
     {

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -115,3 +115,31 @@ def change_resolution(resolution):
 def restore_gamma():
     """Restores gamma to a normal level."""
     subprocess.Popen(["xgamma", "-gamma", "1.0"])
+
+
+def get_xrandr_version():
+    """Return the major and minor version of XRandR utility"""
+    pattern = "version"
+    xrandr_output = subprocess.Popen(["xrandr", "--version"],
+                                     stdout=subprocess.PIPE).communicate()[0].decode()
+    position = xrandr_output.find(pattern) + len(pattern)
+    version_str = xrandr_output[position:].strip().split(".")
+    version = { "major" : int(version_str[0]), "minor" : int(version_str[1]) }
+    return version
+
+def get_providers():
+    """Return the list of available graphic cards"""
+    pattern = "name:"
+    providers = list()
+    version = get_xrandr_version()
+
+    if version["major"] == 1 and version["minor"] >= 4:
+        xrandr_output = subprocess.Popen(["xrandr", "--listproviders"],
+                                         stdout=subprocess.PIPE).communicate()[0].decode()
+        for line in xrandr_output.split("\n"):
+            if line.find("Provider ") != 0:
+                continue
+            position = line.find(pattern) + len(pattern)
+            providers.append(line[position:].strip())
+
+    return providers


### PR DESCRIPTION
Depending on the number of available graphic cards (provided by xrandr) show option for enabling DRI_PRIME.
Option will run the game with the 'DRI_PRIME=1' environment variable.

This is basic functionality. In future, it would be better to show available graphic cards and simply let the user to choose one. But it will be much harder to implement (determine which one is sink provider, test it on setup with more displays, ...)