### PR TITLE
Fix a crash when game is added without installer and outside the library

### DIFF
--- a/lutris/api.py
+++ b/lutris/api.py
@@ -86,4 +86,25 @@ def get_games(game_slugs=None, page=1):
     else:
         payload = None
     response.get(data=payload)
-    return response.json
+    response_data = response.json
+
+    if not response_data:
+        logger.warning('Unable to get games from API')
+        return None
+
+    results = response_data.get('results', [])
+    while response_data.get('next'):
+        page_match = re.search(r'page=(\d+)', response_data['next'])
+        if page_match:
+            page = page_match.group(1)
+        else:
+            logger.error("No page found in %s", response_data['next'])
+            break
+        page_result = api.get_games(game_slugs=missing_media_slugs, page=page)
+        if not page_result:
+            logger.warning("Unable to get response for page %s", page)
+            break
+        else:
+            results += page_result
+
+    return results

--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -37,24 +37,7 @@ def fetch_icons(game_slugs, callback=None):
     if not missing_media_slugs:
         return
 
-    response = api.get_games(game_slugs=missing_media_slugs)
-    if not response:
-        logger.warning('Unable to get games from API')
-        return
-    results = response['results']
-    while response.get('next'):
-        page_match = re.search(r'page=(\d+)', response['next'])
-        if page_match:
-            page = page_match.group(1)
-        else:
-            logger.error("No page found in %s", response['next'])
-            break
-        response = api.get_games(game_slugs=missing_media_slugs, page=page)
-        if not response:
-            logger.warning("Unable to get response for page %s", page)
-            break
-        else:
-            results += response.get('results', [])
+    results = api.get_games(game_slugs=missing_media_slugs)
 
     banner_downloads = []
     icon_downloads = []


### PR DESCRIPTION
When a game has no installer, you can add manually the game. If the game is not present in library, the dialog crash. Instead, my fix download the game data from remote and add it. If not exists, display a empty dialog.