### PR TITLE
gtk-update-icon-cache instead of xdg-icon-resource

### DIFF
--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -1,7 +1,9 @@
 import os
 import re
+import shutil
 import concurrent.futures
 from urllib.parse import urlparse, parse_qsl
+from gi.repository import GLib
 
 from lutris import settings
 from lutris import api
@@ -73,7 +75,13 @@ def fetch_icons(game_slugs, callback=None):
         callback(updated_slugs)
 
 def udpate_desktop_icons():
-    os.system("xdg-icon-resource forceupdate")
+    # Update Icon for GTK+ desktop manager
+    gtk_update_icon_cache = shutil.which("gtk-update-icon-cache")
+    if (gtk_update_icon_cache):
+        os.system("gtk-update-icon-cache -tf %s"
+        % os.path.join(GLib.get_user_data_dir(), 'icons', 'hicolor'))
+
+    # Other desktop manager cache command must be added here when needed
 
 def download_media(url, dest, overwrite=False):
     if os.path.exists(dest):


### PR DESCRIPTION
As wanted by @TingPing, Use directly `gtk-update-icon-cache` to update the icon cache on gtk+ desktop manager.
That means for other (or new) desktop manager, we will need to add their cache command in the future. The rational is that for now only gtk+ need manually update, so `xdg-icon-resource` is just a wrapper around `gtk-update-icon-cache`.

Could someone test it on a KDE deistro to check against regression ?