### PR TITLE
Uniform the way environment variables are get and set.

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -295,36 +295,22 @@ class Game(object):
                                     "%s" % terminal)
                 self.state = self.STATE_STOPPED
                 return
+
         # Env vars
         game_env = gameplay_info.get('env') or {}
         env.update(game_env)
 
-        system_env = system_config.get('env') or {}
-        env.update(system_env)
+        ld_preload = gameplay_info.get('ld_preload')
+        if (ld_preload):
+            env["LD_PRELOAD"] = ld_preload
 
-        ld_preload = gameplay_info.get('ld_preload') or ''
-        env["LD_PRELOAD"] = ld_preload
-
-        dri_prime = system_config.get('dri_prime')
-        if dri_prime:
-            env["DRI_PRIME"] = "1"
-        else:
-            env["DRI_PRIME"] = "0"
-
-        # Runtime management
-        ld_library_path = ""
-        if self.runner.use_runtime():
-            runtime_env = runtime.get_env()
-            if 'STEAM_RUNTIME' in runtime_env and 'STEAM_RUNTIME' not in env:
-                env['STEAM_RUNTIME'] = runtime_env['STEAM_RUNTIME']
-            if 'LD_LIBRARY_PATH' in runtime_env:
-                ld_library_path = runtime_env['LD_LIBRARY_PATH']
         game_ld_libary_path = gameplay_info.get('ld_library_path')
         if game_ld_libary_path:
+            ld_library_path = env.get("LD_LIBRARY_PATH")
             if not ld_library_path:
                 ld_library_path = '$LD_LIBRARY_PATH'
             ld_library_path = ":".join([game_ld_libary_path, ld_library_path])
-        env["LD_LIBRARY_PATH"] = ld_library_path
+            env["LD_LIBRARY_PATH"] = ld_library_path
         # /Env vars
 
         include_processes = shlex.split(system_config.get('include_processes', ''))

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -205,7 +205,7 @@ class steam(Runner):
         return args
 
     def get_env(self):
-        env = {}
+        env = super(steam, self).get_env()
 
         if not self.runner_config.get('lsi_steam') and self.runner_config.get('steam_native_runtime'):
             env['STEAM_RUNTIME'] = '0'

--- a/lutris/runners/web.py
+++ b/lutris/runners/web.py
@@ -150,11 +150,8 @@ class web(Runner):
     ]
     runner_executable = 'web/electron/electron'
 
-    def get_env(self, full=True):
-        if full:
-            env = os.environ.copy()
-        else:
-            env = {}
+    def get_env(self, os_env=True):
+        env = super(web, self).get_env(self, os_env)
 
         env['ENABLE_FLASH_PLAYER'] = '1' if self.runner_config['enable_flash'] else '0'
 

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -900,7 +900,9 @@ class wine(Runner):
         self.set_regedit_keys()
         return True
 
-    def get_env(self, full=True):
+    def get_env(self, os_env=True):
+        env = super(wine, self).get_env(os_env)
+
         if full:
             env = os.environ.copy()
         else:
@@ -980,7 +982,7 @@ class wine(Runner):
             return {'error': 'FILE_NOT_FOUND', 'file': game_exe}
 
         launch_info = {}
-        launch_info['env'] = self.get_env(full=False)
+        launch_info['env'] = self.get_env(os_env=False)
 
         if self.runner_config.get('x360ce-path'):
             self.setup_x360ce(self.runner_config['x360ce-path'])

--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -412,14 +412,14 @@ class winesteam(wine.wine):
         return True
 
     def get_run_data(self):
-        return {'command': self.launch_args, 'env': self.get_env(full=False)}
+        return {'command': self.launch_args, 'env': self.get_env(os_env=False)}
 
     def play(self):
         self.game_launch_time = time.localtime()
         game_args = self.game_config.get('args') or ''
 
         launch_info = {}
-        launch_info['env'] = self.get_env(full=False)
+        launch_info['env'] = self.get_env(os_env=False)
 
         if self.runner_config.get('x360ce-path'):
             self.setup_x360ce(self.runner_config['x360ce-path'])
@@ -487,7 +487,7 @@ class winesteam(wine.wine):
                 return False
         appid = appid if appid else self.appid
 
-        env = self.get_env(full=False)
+        env = self.get_env(os_env=False)
         command = self.launch_args + ['steam://uninstall/%s' % appid]
         self.prelaunch()
         thread = LutrisThread(command, runner=self, env=env, watch=False)


### PR DESCRIPTION
Custom environment variables are not set when launch a runner as standalone. Runner should be launch in the same configuration that game to avoid issue (except change introduced in configuration of a game). 

Since a lot a environment vars where set in game class, I moved the code in runner. In addition, I make `LD_PRELOAD` and `LD_LIBRARY_PATH` modifiable in system config (before system config were overwritten). The `full` parameter is changed for `os_env` more meaningful.