### PR TITLE
rpm: correct macro names and dependencies

### DIFF
--- a/lutris.spec
+++ b/lutris.spec
@@ -19,11 +19,13 @@ BuildArch:      noarch
 BuildRequires:  desktop-file-utils
 BuildRequires:  python3-devel
 
-%if 0%{?fedora_version}
+%if 0%{?fedora}
 BuildRequires:  python3-gobject, python3-wheel, python3-setuptools, python3-gobject
 Requires:       python3-gobject, python3-PyYAML, cabextract
+Requires:       gtk3, psmisc, xorg-x11-server-Xephyr, xorg-x11-server-utils
+Recommends:     wine
 %endif
-%if 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?rhel} || 0%{?centos}
 BuildRequires:  python3-gobject
 Requires:       python3-gobject, python3-PyYAML, cabextract
 %endif
@@ -36,7 +38,7 @@ BuildRequires:  polkit
 BuildRequires:  python3-setuptools
 Requires:       python3-gobject, python3-PyYAML, cabextract
 %endif
-%if 0%{?fedora_version} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version}
 BuildRequires: fdupes
 %endif
 
@@ -60,7 +62,7 @@ on Linux.
 
 %install
 %py3_install
-%if 0%{?fedora_version} || 0%{?suse_version}
+%if 0%{?fedora} || 0%{?suse_version}
 %fdupes %{buildroot}%{python3_sitelib}
 %endif
 
@@ -69,7 +71,7 @@ on Linux.
 %suse_update_desktop_file -r -i %{name} Network FileTransfer
 %endif
 
-%if 0%{?fedora_version} || 0%{?rhel_version} || 0%{?centos_version}
+%if 0%{?fedora} || 0%{?rhel} || 0%{?centos}
 desktop-file-install --dir=%{buildroot}%{_datadir}/applications share/applications/%{name}.desktop
 desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 %endif


### PR DESCRIPTION
I recently installed lutris on my Fedora system and realized that
it's not pulling any dependencies.

The reason for that was that you have incorrect macros used. Macros
for Red Hat-based systems don't contain the `_version` suffix.

I'm not sure about OpenSuse since I'm not familiar with it.