### PR TITLE
Various fixes for winesteam for Linux game data download and wine game execution

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -699,7 +699,7 @@ class ScriptInterpreter(CommandsMixin):
         appid = self.steam_data['appid']
         if not steam_runner.get_game_path_from_appid(appid):
             logger.debug("Installing steam game %s", appid)
-            steam_runner.config = LutrisConfig(runner_slug=self.runner)
+            steam_runner.config = LutrisConfig(runner_slug=steam_runner.name)
             if 'arch' in self.steam_data:
                 steam_runner.config.game_config['arch'] = self.steam_data['arch']
             AsyncCall(steam_runner.install_game, None, appid, is_game_files)

--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -372,7 +372,7 @@ class winesteam(wine.wine):
 
     def get_or_create_default_prefix(self, arch=None):
         """Return the default prefix' path. Create it if it doesn't exist"""
-        if not arch:
+        if not arch or arch == "auto":
             arch = self.default_arch
         prefix = self.get_default_prefix(arch=arch)
         if not os.path.exists(prefix):

--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -119,10 +119,11 @@ class LutrisThread(threading.Thread):
             self.game_process = self.execute_process(self.command, env)
         if not self.game_process:
             return
-
         if self.watch:
             GLib.timeout_add(HEARTBEAT_DELAY, self.watch_children)
             self.stdout_monitor = GLib.io_add_watch(self.game_process.stdout, GLib.IO_IN | GLib.IO_HUP, self.on_stdout_output)
+        else:
+            self.game_process.stdout.close()
 
     def on_stdout_output(self, fd, condition):
         if condition == GLib.IO_HUP:


### PR DESCRIPTION
1. Use proper runner config data when downloading Linux game data from Steam for Windows otherwise no wine prefix is detected (ex. Doom 3 BFG); Lutris was attempting to use linux runner data so no prefix keys were found in the runner_config dict.

https://lutris.net/games/doom-3-bfg-edition/

2. For default winesteam install, use default_arch if auto is set for the prefix architecture when no explicit prefix is set (ex. Warhammer 40K: Dawn of War 1).

https://lutris.net/games/warhammer-40000-dawn-of-war/

3. Steam for Windows install can get stuck when output from stdout is not read. If watch is not set, just close the stdout stream. This problem mainly occurred on my Xubuntu 16.04 and SteamOS installs but I think it has happened sometimes while testing on Xubuntu 17.10. The tweak fixes the problem on all my Linux installations.