### PR TITLE
Use get_env() return as default environments.

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -297,7 +297,7 @@ class Game(object):
                 return
 
         # Env vars
-        game_env = gameplay_info.get('env') or {}
+        game_env = gameplay_info.get('env') or self.runner.get_env()
         env.update(game_env)
 
         ld_preload = gameplay_info.get('ld_preload')


### PR DESCRIPTION
Set et_env() return as default environments. Because a lot of play function don't set the environment. Avoid empty environments.