### PR TITLE
libretro: Add ChaiLove core

### DIFF
--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -14,6 +14,7 @@ LIBRETRO_CORES = [
     ('atari800 (Atari 800/5200)', 'atari800', 'Atari 800/5200'),
     ('blueMSX (MSX/MSX2/MSX+)', 'bluemsx', 'MSX/MSX2/MSX+'),
     ('Caprice32 (Amstrad CPC)', 'cap32', 'Amstrad CPC'),
+    ('ChaiLove', 'chailove', 'ChaiLove'),
     ('Citra (Nintendo 3DS)', 'citra', 'Nintendo 3DS'),
     ('Citra Canary (Nintendo 3DS)', 'citra_canary', 'Nintendo 3DS'),
     ('CrocoDS (Amstrad CPC)', 'crocods', 'Amstrad CPC'),


### PR DESCRIPTION
This change adds the [ChaiLove](https://github.com/libretro/libretro-chailove) libretro core, which is a 2D game framework. It's similar to [Love2D](https://love2d.org/), but using [ChaiScript](http://chaiscript.com/).

Added a game to Lutris that uses it over at: https://lutris.net/games/floppy-bird/