### PR TITLE
Registry fixes

### DIFF
--- a/lutris/util/wineregistry.py
+++ b/lutris/util/wineregistry.py
@@ -216,11 +216,11 @@ class WineRegistryKey(object):
             self.add_meta(line)
         elif line.startswith('"'):
             try:
-                key, value = re.split(re.compile(r"(?<![^\\]\\\")="), line, maxsplit=1)
+                key, value = re.split(re.compile(r"(?<![^\\]\\\")\"="), line, maxsplit=1)
             except ValueError as ex:
                 logger.error("Unable to parse line %s", line)
                 raise
-            key = key[1:-1]
+            key = key[1:]
             self.subkeys[key] = value
         elif line.startswith('@'):
             k, v = line.split('=', 1)


### PR DESCRIPTION
This first commit fixes a bug with registry parsing. Keys such as "HDA Intel PCH HDMI/DP,pcm=3 (js)" would fail to parse correctly and would in turn render incorrectly in the reg file.
The other commit fixes registry writing when a game is launched. Currently the values ShowCrashDialog and UseXVidMode gets overridden by regedit.exe which is running while Lutris tries to write to the registry too, causing those values to be lost. I have changed it so that it only uses Lutris' WineRegistry class to write when a game is launched. Note: This may cause issues if something is already running in the wineprefix! Please test it.