### PR TITLE
Fixed launching Steam from Lutris on Ubuntu 18.04

### DIFF
--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -132,8 +132,6 @@ class LutrisThread(threading.Thread):
             self.stdout_monitor = GLib.io_add_watch(self.game_process.stdout,
                                                     GLib.IO_IN | GLib.IO_HUP,
                                                     self.on_stdout_output)
-        else:
-            self.game_process.stdout.close()
 
     def on_stdout_output(self, fd, condition):
         if condition == GLib.IO_HUP:

--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -180,8 +180,14 @@ class LutrisThread(threading.Thread):
         try:
             if self.cwd and not system.path_exists(self.cwd):
                 os.makedirs(self.cwd)
+
+            if self.watch:
+                pipe=subprocess.PIPE
+            else:
+                pipe=None
+
             return subprocess.Popen(command, bufsize=1,
-                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+                                    stdout=pipe, stderr=subprocess.STDOUT,
                                     cwd=self.cwd, env=env)
         except OSError as ex:
             logger.exception("Failed to execute %s: %s", ' '.join(command), ex)


### PR DESCRIPTION
I ran into the issue that Steam and a couple of other native applications could no longer be launched through Lutris after recent updates. I've identified the commit responsible for my issue using git bisect and then partially reverted a single change from that commit that appeared to be the cause of my trouble. Steam and other apps work as expected again with this change.

The issue is further discussed in #869.