### PR TITLE
Support change of $HOME in system environment variables preference.

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -226,10 +226,16 @@ class Game(object):
             self.state = self.STATE_STOPPED
             return
 
+        # Init env
         env = {}
+        game_env = gameplay_info.get('env') or self.runner.get_env()
+        os_env = {}
+        os_env.update(os.environ)
+        os_env.update(game_env)
+        
         sdl_gamecontrollerconfig = system_config.get('sdl_gamecontrollerconfig')
         if sdl_gamecontrollerconfig:
-            path = os.path.expanduser(sdl_gamecontrollerconfig)
+            path = system.expanduser(sdl_gamecontrollerconfig, os_env)
             if os.path.exists(path):
                 with open(path, "r") as f:
                     sdl_gamecontrollerconfig = f.read()
@@ -316,7 +322,6 @@ class Game(object):
                 return
 
         # Env vars
-        game_env = gameplay_info.get('env') or self.runner.get_env()
         env.update(game_env)
 
         ld_preload = gameplay_info.get('ld_preload')

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -3,6 +3,7 @@ import os
 import shlex
 import stat
 from lutris.runners.runner import Runner
+from lutris.util import system
 
 
 class linux(Runner):
@@ -114,7 +115,7 @@ class linux(Runner):
 
         ld_library_path = self.game_config.get('ld_library_path')
         if ld_library_path:
-            launch_info['ld_library_path'] = os.path.expanduser(ld_library_path)
+            launch_info['ld_library_path'] = system.expanduser(ld_library_path, self.get_env(os_env=True))
 
         command = [self.get_relative_exe()]
 

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -28,7 +28,7 @@ class mame(Runner):
 
     @property
     def config_dir(self):
-        return os.path.join(os.path.expanduser("~"), ".mame")
+        return os.path.join(system.expanduser("~", self.get_env(os_env=True)), ".mame")
 
     @property
     def working_dir(self):

--- a/lutris/runners/mess.py
+++ b/lutris/runners/mess.py
@@ -2,6 +2,7 @@ import os
 from lutris import settings
 from lutris.util.log import logger
 from lutris.runners.runner import Runner
+from lutris.util import system
 
 
 class mess(Runner):
@@ -213,7 +214,7 @@ class mess(Runner):
 
     @property
     def working_dir(self):
-        return os.path.join(os.path.expanduser("~"), ".mame")
+        return os.path.join(system.expanduser("~", self.get_env(os_env=True)), ".mame")
 
     def play(self):
         rompath = self.runner_config.get('rompath') or ''

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from lutris.runners.runner import Runner
+from lutris.util import system
 
 
 class o2em(Runner):
@@ -12,7 +13,6 @@ class o2em(Runner):
         'Phillips Videopac+',
         'Brandt Jopac',
     )
-    bios_path = os.path.expanduser("~/.o2em/bios")
     runner_executable = 'o2em/o2em'
 
     checksums = {
@@ -78,6 +78,10 @@ class o2em(Runner):
                      "the displays of yesteryear.")
         }
     ]
+
+    @property
+    def bios_path(self):
+        return system.expanduser("~/.o2em/bios", get_env(os_env=True))
 
     def get_platform(self):
         bios = self.runner_config.get('bios')

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -105,7 +105,7 @@ class reicast(Runner):
     def write_config(self, config):
         parser = ConfigParser()
 
-        config_path = os.path.expanduser('~/.reicast/emu.cfg')
+        config_path = system.expanduser('~/.reicast/emu.cfg', self.get_env(os_env=True))
         if os.path.exists(config_path):
             with open(config_path, 'r') as config_file:
                 parser.read(config_file)

--- a/lutris/runners/residualvm.py
+++ b/lutris/runners/residualvm.py
@@ -3,9 +3,7 @@ import os
 import subprocess
 
 from lutris.runners.runner import Runner
-
-RESIDUALVM_CONFIG_FILE = os.path.join(os.path.expanduser("~"), ".residualvmrc")
-
+from lutris.util import system
 
 class residualvm(Runner):
     human_name = "ResidualVM"
@@ -51,6 +49,10 @@ class residualvm(Runner):
             'default': False,
         }
     ]
+
+    @property
+    def config_file(self):
+        return os.path.join(system.expanduser("~", self.get_env(os_env=True)), ".residualvmrc")
 
     @property
     def game_path(self):

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -121,7 +121,7 @@ class Runner:
     @property
     def working_dir(self):
         """Return the working directory to use when running the game."""
-        return os.path.expanduser("~/")
+        return system.expanduser("~/", self.get_env(os_env=True))
 
     def killall_on_exit(self):
         return True

--- a/lutris/runners/snes9x.py
+++ b/lutris/runners/snes9x.py
@@ -53,8 +53,12 @@ class snes9x(Runner):
         }
     ]
 
+    @property
+    def config_file(self):
+        return system.expanduser("~/.snes9x/snes9x.xml", self.get_env(os_env=True))
+
     def set_option(self, option, value):
-        config_file = os.path.expanduser("~/.snes9x/snes9x.xml")
+        config_file = self.config_file
         if not os.path.exists(config_file):
             subprocess.Popen([self.get_executable(), '-help'])
         if not os.path.exists(config_file):

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -172,7 +172,7 @@ class steam(Runner):
         for candidate in candidates:
             path = system.fix_path_case(
                 os.path.join(
-                    os.path.expanduser(candidate),
+                    system.expanduser(candidate, self.get_env(os_env=True)),
                     "SteamApps"
                 )
             )
@@ -211,8 +211,8 @@ class steam(Runner):
 
         return args
 
-    def get_env(self):
-        env = super(steam, self).get_env()
+    def get_env(self, os_env=False):
+        env = super(steam, self).get_env(os_env)
 
         if(
                 not self.runner_config.get('lsi_steam') and

--- a/lutris/runners/winesteam.py
+++ b/lutris/runners/winesteam.py
@@ -201,7 +201,7 @@ class winesteam(wine.wine):
             steamless_binary = self.game_config.get('steamless_binary')
             if (os.path.isfile(steamless_binary)):
                 return os.path.dirname(steamless_binary)
-        return os.path.expanduser("~/")
+        return super(self, winesteam).working_dir
 
     @property
     def launch_args(self):
@@ -254,7 +254,7 @@ class winesteam(wine.wine):
         candidates = [
             self.get_default_prefix(arch='win64'),
             self.get_default_prefix(arch='win32'),
-            os.path.expanduser("~/.wine")
+            system.expanduser("~/.wine", self.get_env(os_env=True))
         ]
         for prefix in candidates:
             # Try the default install path

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -341,12 +341,24 @@ def get_default_terminal():
         return terms[0]
     logger.error("Couldn't find a terminal emulator.")
 
+def expanduser(path, env=None):
+    if (env is not None):
+        _environ = dict(os.environ)
+        os.environ.clear()
+        os.environ.update(env)
 
-def reverse_expanduser(path):
+    try:
+        return os.path.expanduser(path)
+    finally:
+        if (env is not None):
+            os.environ.clear()
+            os.environ.update(_environ)
+
+def reverse_expanduser(path, env=None):
     """Replace '/home/username' with '~' in given path."""
     if not path:
         return path
-    user_path = os.path.expanduser('~')
+    user_path = expanduser('~', env)
     if path.startswith(user_path):
         path = path[len(user_path):].strip('/')
         return '~/' + path


### PR DESCRIPTION
You can change the $HOME env vars but lutris do not fully take it into consideration. I created a modified expanduser function which take game environments as parameters and I use it everywhere $HOME vars need to be the $HOME game. This is truly experimental.

Tested only with steam. I didn't have other runners :
MAME
MESS
O2EM
REICAST
SNES9X
WINESTEAM
