### PR TITLE
Add data and merge parameters to write_config installer command

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -321,9 +321,10 @@ Writing into an INI type config file
 Modify or create a config file with the ``write_config`` directive. A config file
 is a text file composed of key=value (or key: value) lines grouped under
 [sections]. Use the ``file`` (an absolute path or a ``file id``), ``section``,
-``key`` and ``value`` parameters. Note that the file is entirely rewritten and
-comments are left out; Make sure to compare the initial and resulting file
-to spot any potential parsing issues.
+``key`` and ``value`` parameters or the ``data`` parameter. Set ``merge: false``
+to first truncate the file. Note that the file is entirely rewritten and
+comments are left out; Make sure to compare the initial and resulting file to
+spot any potential parsing issues.
 
 Example:
 
@@ -334,6 +335,16 @@ Example:
         section: Engine
         key: Renderer
         value: OpenGL
+
+::
+
+    - write_config:
+        file: $GAMEDIR/myfile.ini
+        data:
+          General:
+            iNumHWThreads: 2
+            bUseThreadedAI: 1
+
 
 Writing into a JSON type file
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -491,7 +491,6 @@ class CommandsMixin:
                 parser.add_section(section)
             for key, value in keys.items():
                 value = self._substitute(value)
-                print(section, key, value)
                 parser.set(section, key, value)
 
         with open(config_file_path, 'wb') as config_file:

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -457,7 +457,10 @@ class CommandsMixin:
 
     def write_config(self, params):
         """Write a key-value pair into an INI type config file."""
-        self._check_required_params(['file', 'section', 'key', 'value'],
+        if params.get('data', None):
+            self._check_required_params(['file', 'data'], params, 'write_config')
+        else:
+            self._check_required_params(['file', 'section', 'key', 'value'],
                                     params, 'write_config')
         # Get file
         config_file_path = self._get_file(params['file'])
@@ -467,17 +470,29 @@ class CommandsMixin:
         if not os.path.exists(basedir):
             os.makedirs(basedir)
 
+        merge = params.get('merge', True)
+
         parser = EvilConfigParser(allow_no_value=True,
                                   dict_type=MultiOrderedDict,
                                   strict=False)
         parser.optionxform = str  # Preserve text case
-        parser.read(config_file_path)
+        if merge:
+            parser.read(config_file_path)
 
-        value = self._substitute(params['value'])
+        data = {}
+        if params.get('data', None):
+            data = params['data']
+        else:
+            data[params['section']] = {}
+            data[params['section']][params['key']] = params['value']
 
-        if not parser.has_section(params['section']):
-            parser.add_section(params['section'])
-        parser.set(params['section'], params['key'], value)
+        for section, keys in data.items():
+            if not parser.has_section(section):
+                parser.add_section(section)
+            for key, value in keys.items():
+                value = self._substitute(value)
+                print(section, key, value)
+                parser.set(section, key, value)
 
         with open(config_file_path, 'wb') as config_file:
             parser.write(config_file)


### PR DESCRIPTION
This lets you set multiple values with one write_config command:
```yaml
- write_config:
    file: $GAMEDIR/myfile.ini
    data:
      General:
        iNumHWThreads: 2
        bUseThreadedAI: 1
      Display:
        fDefaultWorldFOV: 90
```
Also adds a `merge` parameter, works the same as `write_json`. It lets you overwrite the contents and truncate the file first. Set `merge: false` to overwrite.