### PR TITLE
[wine] Restore Audio option

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -549,6 +549,7 @@ class wine(Runner):
     reg_prefix = "HKEY_CURRENT_USER/Software/Wine"
     reg_keys = {
         "RenderTargetLockMode": r"%s/Direct3D" % reg_prefix,
+        "Audio": r"%s/Drivers" % reg_prefix,
         "MouseWarpOverride": r"%s/DirectInput" % reg_prefix,
         "OffscreenRenderingMode": r"%s/Direct3D" % reg_prefix,
         "StrictDrawOrdering": r"%s/Direct3D" % reg_prefix,
@@ -779,6 +780,19 @@ class wine(Runner):
                 'help': (
                     'Set this to "Y" to allow wine switch the resolution using XVidMode extension.'
                 )
+            },
+            {
+                'option': 'Audio',
+                'label': 'Audio driver',
+                'type': 'choice',
+                'choices': [('Auto', 'auto'),
+                            ('ALSA', 'alsa'),
+                            ('PulseAudio', 'pulse'),
+                            ('OSS', 'oss')],
+                'default': 'auto',
+                'help': ("Which audio backend to use.\n"
+                         "By default, Wine automatically picks the right one "
+                         "for your system.")
             },
             {
                 'option': 'ShowCrashDialog',


### PR DESCRIPTION
Also replaces Jack with PulseAudio, because Jack is no longer supported. Winecfg no longer has an option to change audio driver, and some installer scripts depends on the Audio option.
Fixes https://github.com/lutris/lutris/issues/950