### PR TITLE
Improve sorting in gameviews

### DIFF
--- a/lutris/gui/gameviews.py
+++ b/lutris/gui/gameviews.py
@@ -312,14 +312,15 @@ class GameListView(Gtk.TreeView, GameView):
         default_text_cell = self.set_text_cell()
         name_cell = self.set_text_cell()
         name_cell.set_padding(5, 0)
+
         self.set_column(name_cell, "Name", COL_NAME, 200)
         self.set_column(default_text_cell, "Year", COL_YEAR, 60)
         self.set_column(default_text_cell, "Runner", COL_RUNNER_HUMAN_NAME, 120)
         self.set_column(default_text_cell, "Platform", COL_PLATFORM, 120)
-        self.set_column(default_text_cell, "Last played", COL_LASTPLAYED_TEXT, 120)
-        self.set_sort_with_column(COL_LASTPLAYED_TEXT, COL_LASTPLAYED)
-        self.set_column(default_text_cell, "Installed at", COL_INSTALLED_AT_TEXT, 120)
-        self.set_sort_with_column(COL_INSTALLED_AT_TEXT, COL_INSTALLED_AT)
+        self.set_column(default_text_cell, "Last played", COL_LASTPLAYED_TEXT, 120, sort_id=COL_LASTPLAYED)
+        # self.set_sort_with_column(COL_LASTPLAYED_TEXT, COL_LASTPLAYED)
+        self.set_column(default_text_cell, "Installed at", COL_INSTALLED_AT_TEXT, 120, sort_id=COL_INSTALLED_AT)
+        # self.set_sort_with_column(COL_INSTALLED_AT_TEXT, COL_INSTALLED_AT)
 
         self.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
 
@@ -333,10 +334,10 @@ class GameListView(Gtk.TreeView, GameView):
         text_cell.set_property("ellipsize", Pango.EllipsizeMode.END)
         return text_cell
 
-    def set_column(self, cell, header, column_id, default_width):
+    def set_column(self, cell, header, column_id, default_width, sort_id=None):
         column = Gtk.TreeViewColumn(header, cell, markup=column_id)
         column.set_sort_indicator(True)
-        column.set_sort_column_id(column_id)
+        column.set_sort_column_id(column_id if sort_id is None else sort_id)
         column.set_resizable(True)
         column.set_reorderable(True)
         width = settings.read_setting('%s_column_width' % COLUMN_NAMES[column_id], 'list view')

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -38,6 +38,7 @@ from lutris.gui.config_dialogs import (
 from lutris.gui.gameviews import (
     GameListView, GameGridView, ContextualMenu, GameStore
 )
+from lutris.gui.widgets.utils import IMAGE_SIZES
 
 
 @GtkTemplate(ui=os.path.join(datapath.get(), 'ui', 'lutris-window.ui'))
@@ -293,7 +294,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.view.connect("remove-game", self.on_remove_game)
 
     def _bind_zoom_adjustment(self):
-        SCALE = ('icon_small', 'icon', 'banner_small', 'banner')
+        SCALE = list(IMAGE_SIZES.keys())
         self.zoom_adjustment.props.value = SCALE.index(self.icon_type)
         self.zoom_adjustment.connect('value-changed',
                                      lambda adj: self._set_icon_type(SCALE[int(adj.props.value)]))
@@ -346,7 +347,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
         else:
             self.icon_type = settings.read_setting('icon_type_gridview')
             default = settings.ICON_TYPE_GRIDVIEW
-        if self.icon_type not in ("banner_small", "banner", "icon", "icon_small"):
+        if self.icon_type not in IMAGE_SIZES.keys():
             self.icon_type = default
         return self.icon_type
 
@@ -376,7 +377,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.set_show_installed_state(self.filter_installed)
         self.view.show_all()
 
-        SCALE = ('icon_small', 'icon', 'banner_small', 'banner')
+        SCALE = list(IMAGE_SIZES.keys())
         self.zoom_adjustment.props.value = SCALE.index(self.icon_type)
 
         settings.write_setting('view_type', view_type)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -67,6 +67,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
     sync_button = GtkTemplate.Child()
     sync_label = GtkTemplate.Child()
     sync_spinner = GtkTemplate.Child()
+    viewtype_icon = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs):
         self.application = application
@@ -95,6 +96,10 @@ class LutrisWindow(Gtk.ApplicationWindow):
             settings.read_setting('filter_installed') == 'true'
         self.sidebar_visible = \
             settings.read_setting('sidebar_visible') in ['true', None]
+        self.view_sorting = \
+            settings.read_setting('view_sorting') or 'name'
+        self.view_sorting_ascending = \
+            settings.read_setting('view_sorting_ascending') != 'false'
         self.use_dark_theme = settings.read_setting('dark_theme') == 'true'
 
         # Sync local lutris library with current Steam games and desktop games
@@ -103,8 +108,9 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
         # Window initialization
         self.game_list = pga.get_games()
-        self.game_store = GameStore([], self.icon_type, self.filter_installed)
+        self.game_store = GameStore([], self.icon_type, self.filter_installed, self.view_sorting, self.view_sorting_ascending)
         self.view = self.get_view(view_type)
+        self.game_store.connect('sorting-changed', self.on_game_store_sorting_changed)
         super().__init__(default_width=width,
                          default_height=height,
                          icon_name='lutris',
@@ -122,6 +128,11 @@ class LutrisWindow(Gtk.ApplicationWindow):
         # Load view
         self.games_scrollwindow.add(self.view)
         self.connect_signals()
+        other_view = 'list' if view_type is 'grid' else 'grid'
+        self.viewtype_icon.set_from_icon_name(
+            'view-' + other_view + '-symbolic',
+            Gtk.IconSize.BUTTON
+        )
         self.view.show()
 
         # Contextual menu
@@ -197,10 +208,13 @@ class LutrisWindow(Gtk.ApplicationWindow):
             'show-installed-only': Action(self.on_show_installed_state_change, type='b',
                                           default=self.filter_installed,
                                           accel='<Primary>h'),
-            'view-type': Action(self.on_viewtype_state_change, type='s',
-                                default=self.current_view_type),
+            'toggle-viewtype': Action(self.on_toggle_viewtype),
             'icon-type': Action(self.on_icontype_state_change, type='s',
                                 default=self.icon_type),
+            'view-sorting': Action(self.on_view_sorting_state_change, type='s',
+                                   default=self.view_sorting),
+            'view-sorting-ascending': Action(self.on_view_sorting_direction_change, type='b',
+                                             default=self.view_sorting_ascending),
             'use-dark-theme': Action(self.on_dark_theme_state_change, type='b',
                                      default=self.use_dark_theme),
             'show-side-bar': Action(self.on_sidebar_state_change, type='b',
@@ -377,6 +391,11 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.set_show_installed_state(self.filter_installed)
         self.view.show_all()
 
+        other_view = 'list' if view_type is 'grid' else 'grid'
+        self.viewtype_icon.set_from_icon_name(
+            'view-' + other_view + '-symbolic',
+            Gtk.IconSize.BUTTON
+        )
         SCALE = list(IMAGE_SIZES.keys())
         self.zoom_adjustment.props.value = SCALE.index(self.icon_type)
 
@@ -538,6 +557,8 @@ class LutrisWindow(Gtk.ApplicationWindow):
     def invalidate_game_filter(self):
         """Refilter the game view based on current filters"""
         self.game_store.modelfilter.refilter()
+        self.game_store.modelsort.clear_cache()
+        self.game_store.sort_view(self.view_sorting, self.view_sorting_ascending)
         self.no_results_overlay.props.visible = len(self.game_store.modelfilter) == 0
 
     def on_show_installed_state_change(self, action, value):
@@ -779,11 +800,11 @@ class LutrisWindow(Gtk.ApplicationWindow):
         if game.is_installed:
             dialog = EditGameConfigDialog(self, game, on_dialog_saved)
 
-    def on_viewtype_state_change(self, action, val):
-        action.set_state(val)
-        view_type = val.get_string()
-        if view_type != self.current_view_type:
-            self.switch_view(view_type)
+    def on_toggle_viewtype(self, *args):
+        if self.current_view_type is 'grid':
+            self.switch_view('list')
+        else:
+            self.switch_view('grid')
 
     def _set_icon_type(self, icon_type):
         self.icon_type = icon_type
@@ -799,6 +820,24 @@ class LutrisWindow(Gtk.ApplicationWindow):
     def on_icontype_state_change(self, action, value):
         action.set_state(value)
         self._set_icon_type(value.get_string())
+
+    def on_view_sorting_state_change(self, action, value):
+        ascending = self.view_sorting_ascending
+        self.game_store.sort_view(value.get_string(), ascending)
+
+    def on_view_sorting_direction_change(self, action, value):
+        self.game_store.sort_view(self.view_sorting, value.get_boolean())
+
+    def on_game_store_sorting_changed(self, game_store, key, ascending):
+        self.view_sorting = key
+        self.view_sorting_ascending = ascending
+        self.actions['view-sorting'].set_state(GLib.Variant.new_string(key))
+        self.actions['view-sorting-ascending'].set_state(GLib.Variant.new_boolean(ascending))
+        settings.write_setting('view_sorting', self.view_sorting)
+        settings.write_setting(
+            'view_sorting_ascending',
+            'true' if self.view_sorting_ascending else 'false'
+        )
 
     def create_menu_shortcut(self, *args):
         """Add the selected game to the system's Games menu."""

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -376,6 +376,9 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.set_show_installed_state(self.filter_installed)
         self.view.show_all()
 
+        SCALE = ('icon_small', 'icon', 'banner_small', 'banner')
+        self.zoom_adjustment.props.value = SCALE.index(self.icon_type)
+
         settings.write_setting('view_type', view_type)
 
     def sync_library(self):

--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -17,10 +17,10 @@ DEFAULT_BANNER = os.path.join(datapath.get(), 'media/default_banner.png')
 DEFAULT_ICON = os.path.join(datapath.get(), 'media/default_icon.png')
 
 IMAGE_SIZES = {
-    'banner': BANNER_SIZE,
-    'banner_small': BANNER_SMALL_SIZE,
+    'icon_small': ICON_SMALL_SIZE,
     'icon': ICON_SIZE,
-    'icon_small': ICON_SMALL_SIZE
+    'banner_small': BANNER_SMALL_SIZE,
+    'banner': BANNER_SIZE
 }
 
 
@@ -75,10 +75,10 @@ def get_overlay(size):
 
 
 def get_pixbuf_for_game(game_slug, icon_type, is_installed=True):
-    if icon_type in ("banner", "banner_small"):
+    if icon_type.startswith("banner"):
         default_icon_path = DEFAULT_BANNER
         icon_path = datapath.get_banner_path(game_slug)
-    elif icon_type in ("icon", "icon_small"):
+    elif icon_type.startswith("icon"):
         default_icon_path = DEFAULT_ICON
         icon_path = datapath.get_icon_path(game_slug)
     else:

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -82,6 +82,20 @@
               </object>
             </child>
             <child>
+              <object class="GtkButton">
+                <property name="visible">1</property>
+                <property name="can_focus">1</property>
+                <property name="tooltip_text" translatable="yes">Toggle View</property>
+                <property name="action-name">win.toggle-viewtype</property>
+                <child>
+                  <object class="GtkImage" id="viewtype_icon">
+                    <property name="visible">1</property>
+                    <property name="icon-name">view-list-symbolic</property>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child>
               <object class="GtkMenuButton">
                 <property name="visible">1</property>
                 <property name="can_focus">1</property>
@@ -501,48 +515,7 @@
         <property name="orientation">vertical</property>
         <property name="width_request">160</property>
         <property name="spacing">3</property>
-        <property name="homogeneous">1</property>
-        <child>
-          <object class="GtkBox">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <child>
-              <object class="GtkToggleButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Grid View</property>
-                <property name="image">view_grid_symbolic</property>
-                <property name="draw_indicator">False</property>
-                <property name="action-name">win.view-type</property>
-                <property name="action-target">'grid'</property>
-                <property name="xalign">0.5</property>
-                <property name="hexpand">1</property>
-                <property name="vexpand">1</property>
-              </object>
-            </child>
-            <child>
-              <object class="GtkToggleButton">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">List View</property>
-                <property name="image">view_list_symbolic</property>
-                <property name="xalign">0.5</property>
-                <property name="hexpand">1</property>
-                <property name="vexpand">1</property>
-                <property name="draw_indicator">False</property>
-                <property name="action-name">win.view-type</property>
-                <property name="action-target">'list'</property>
-                <property name="hexpand">1</property>
-                <property name="vexpand">1</property>
-              </object>
-            </child>
-            <style>
-              <class name="linked"/>
-            </style>
-          </object>
-        </child>
+        <property name="homogeneous">0</property>
         <child>
           <object class="GtkScale">
             <property name="visible">1</property>
@@ -563,47 +536,97 @@
           </object>
         </child>
         <child>
-          <object class="GtkCheckButton">
+          <object class="GtkModelButton">
             <property name="visible">1</property>
-            <property name="can_focus">1</property>
             <property name="action-name">win.show-installed-only</property>
+            <property name="text" translatable="yes">_Installed Games Only</property>
             <accelerator key="h" modifiers="GDK_CONTROL_MASK" signal="clicked"/>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">_Installed Games Only</property>
-                <property name="use-underline">1</property>
-              </object>
-            </child>
+            <property name="use-underline">1</property>
           </object>
         </child>
         <child>
-          <object class="GtkCheckButton">
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">Sort _Ascending</property>
+            <property name="action-name">win.view-sorting-ascending</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Name</property>
+            <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'name'</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Year</property>
+            <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'year'</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Runner</property>
+            <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'runner'</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Platform</property>
+            <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'platform'</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">_Last played</property>
+            <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'lastplayed'</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="text" translatable="yes">Ins_talled at</property>
+            <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'installed_at'</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkSeparator">
             <property name="visible">1</property>
-            <property name="can_focus">1</property>
+            <property name="orientation">horizontal</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">1</property>
             <property name="action-name">win.use-dark-theme</property>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Use _Dark Theme</property>
-                <property name="use-underline">1</property>
-              </object>
-            </child>
+            <property name="text" translatable="yes">Use _Dark Theme</property>
+            <property name="use-underline">1</property>
           </object>
         </child>
         <child>
-          <object class="GtkCheckButton">
+          <object class="GtkModelButton">
             <property name="visible">1</property>
-            <property name="can_focus">1</property>
             <property name="action-name">win.show-side-bar</property>
             <accelerator key="f9" signal="clicked"/>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">1</property>
-                <property name="label" translatable="yes">Show _Side Panel</property>
-                <property name="use-underline">1</property>
-              </object>
-            </child>
+            <property name="text" translatable="yes">Show _Side Panel</property>
+            <property name="use-underline">1</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Adds sorting options to the menu, uses a single button to toggle between grid and list, sorting is synced with grid and remembered on save, sorting falls back to sort by name and runner if values are equal (if you sort by platform, year etc.), fix zoom/icon size slider.