### PR TITLE
Update DXVK versions & Fix DXVK URL

### DIFF
--- a/lutris/util/dxvk.py
+++ b/lutris/util/dxvk.py
@@ -8,8 +8,8 @@ from lutris.util.log import logger
 from lutris.util.extract import extract_archive
 from lutris.util.downloader import Downloader
 
-DXVK_LATEST = "0.52"
-DXVK_PAST_RELEASES = ["0.51", "0.50", "0.42", "0.31", "0.21"]
+DXVK_LATEST = "0.62"
+DXVK_PAST_RELEASES = ["0.61", "0.52", "0.51", "0.42"]
 
 
 class DXVKManager:

--- a/lutris/util/dxvk.py
+++ b/lutris/util/dxvk.py
@@ -2,6 +2,7 @@
 import os
 import time
 import shutil
+import re
 
 from lutris.settings import RUNTIME_DIR
 from lutris.util.log import logger
@@ -61,6 +62,7 @@ class DXVKManager:
         # There's a glitch in one of the archive's names
         fixed_version = 'v0.40' if self.version == '0.40' else self.version
         dxvk_url = self.base_url.format(self.version, fixed_version)
+        dxvk_url = re.sub(r"\s+\(default\)","", dxvk_url)
         if self.is_available():
             logger.warning("DXVK already available at %s", self.dxvk_path)
 


### PR DESCRIPTION
Good day, 

There is currently a bug where dxvk.py's self.version returns the full string "0.**  (default)", which is displayed to the user through the UI. This has prevented lutris from downloading the default selected version of dxvk. 

A simple fix which I have made has been to simply regex/substitute the dxvk_url string.

I've also added an update to DXVK versions.
