### PR TITLE
prevent buttons from showing null when hovering over them

### DIFF
--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -161,6 +161,7 @@
             <child>
               <object class="GtkLinkButton" id="connect_link">
                 <property name="label" translatable="yes">Connecting to your Lutris.net account to sync your library</property>
+                <property name="tooltip_text"></property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>
@@ -178,6 +179,7 @@
             <child>
               <object class="GtkLinkButton">
                 <property name="label" translatable="yes">Manually adding a game installed on your hard drive</property>
+                <property name="tooltip_text"></property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>


### PR DESCRIPTION
When starting lutris without having any games installed or being logged in, it shows three buttons. When hovering the mouse over two of them a little tooltip appears saying 'null'.
This pull request fixes that by adding an empty tooltip_text property to these buttons so no tooltip appears when the mouse is moved on them, which makes it look a bit better.

before:
![before](https://user-images.githubusercontent.com/40150792/42876888-59281422-8a88-11e8-8f09-b323276250bd.jpg)
after:
![after](https://user-images.githubusercontent.com/40150792/42876896-5da3a124-8a88-11e8-8daf-ff8f227063fd.jpg)
