### PR TITLE
Add supporting functionality to fetch and install mod files from https://www.moddb.com/

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -293,8 +293,6 @@ class ScriptInterpreter(CommandsMixin):
 
         if file_uri.startswith("/"):
             file_uri = "file://" + file_uri
-        elif file_uri.startswith("https://www.moddb.com/downloads/start/"):
-            file_uri = self._moddb_ultimate_download_uri(file_uri)
         elif file_uri.startswith(("$WINESTEAM", "$STEAM")):
             # Download Steam data
             self._download_steam_data(file_uri, file_id)
@@ -374,25 +372,6 @@ class ScriptInterpreter(CommandsMixin):
             self.parent.set_status('Getting Steam game data')
             self.steam_data['platform'] = "linux"
             self.install_steam_game(steam.steam, is_game_files=True)
-
-    def _moddb_ultimate_download_uri(self, permanent_uri):
-        """Permalinks to ModDB mod files redirect to one of several mirrors
-        with a time-limited token in the URL.  This function takes the
-        permalink and returns the proper download URL.
-
-        permanent_uri: The permanent/canonical download URL for the mod file
-        """
-        import re
-
-        request = Request(permanent_uri)
-        request.get()
-
-        transient_uri = re.findall("/downloads/mirror/[a-f0-9/]+", request.text)[0]
-
-        if transient_uri is None:
-            raise RuntimeError("Couldn't get mirror for %s" % permanent_uri)
-        else:
-             return "https://www.moddb.com"+transient_uri
 
     def check_runner_install(self):
         """Check if the runner is installed before starting the installation

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -293,6 +293,8 @@ class ScriptInterpreter(CommandsMixin):
 
         if file_uri.startswith("/"):
             file_uri = "file://" + file_uri
+        elif file_uri.startswith("https://www.moddb.com/downloads/start/"):
+            file_uri = self._moddb_ultimate_download_uri(file_uri)
         elif file_uri.startswith(("$WINESTEAM", "$STEAM")):
             # Download Steam data
             self._download_steam_data(file_uri, file_id)
@@ -372,6 +374,25 @@ class ScriptInterpreter(CommandsMixin):
             self.parent.set_status('Getting Steam game data')
             self.steam_data['platform'] = "linux"
             self.install_steam_game(steam.steam, is_game_files=True)
+
+    def _moddb_ultimate_download_uri(self, permanent_uri):
+        """Permalinks to ModDB mod files redirect to one of several mirrors
+        with a time-limited token in the URL.  This function takes the
+        permalink and returns the proper download URL.
+
+        permanent_uri: The permanent/canonical download URL for the mod file
+        """
+        import re
+
+        request = Request(permanent_uri)
+        request.get()
+
+        transient_uri = re.findall("/downloads/mirror/[a-f0-9/]+", request.text)[0]
+
+        if transient_uri is None:
+            raise RuntimeError("Couldn't get mirror for %s" % permanent_uri)
+        else:
+             return "https://www.moddb.com"+transient_uri
 
     def check_runner_install(self):
         """Check if the runner is installed before starting the installation
@@ -692,6 +713,7 @@ class ScriptInterpreter(CommandsMixin):
             "GAMEDIR": self.target_path,
             "CACHE": self.cache_path,
             "HOME": os.path.expanduser("~"),
+            "STEAM_DATA_DIR": steam.steam().steam_data_dir,
             "DISC": self.game_disc,
             "USER": os.getenv('USER'),
             "INPUT": self._get_last_user_input(),


### PR DESCRIPTION
I added a game to the Lutris database that is a Source engine mod that isn't available from Steam but is available from https://www.moddb.com/.  In order to install the mod, the mod files must be downloaded and unpacked in Steam's sourcemods directory.

I attempted to write an installer to do this but found that I needed an extra bit of functionality to make it work, which is included in this pull request.

The additions are:
- A function to follow the ModDB permalink for the download through to an appropriate mirror.
- An additional variable available in the installer script that expands to the Steam data directory.

I'm not sure if this is a good idea for a number of reasons, including;
- It is likely to be fragile, depending on ModDB specifics.
- The addition of third-party-site specific code into Lutris, which would perhaps be better pulled out in some sort of configuration file, addon or similar structure, particularly if there were more similar additions in the future.
- Security issues associated with downloads from random sources.
- Problematic legalities / Mod DB T&Cs.
- I'm new to the Lutris codebase, and have possibly missed existing functionality or established conventions.

I'd welcome any comments/discussion.  Additionally, I would be happy to recreate this pull request as a branch on the main repository if required, in order to avoid any issues when I delete this repository in the future.

For reference, the following is the installer that would make use of these changes;


```
files:
- archive: https://www.moddb.com/downloads/start/126529
installer:
- execute:
        file: p7zip
        args: --decompress $archive
        working_dir: $STEAM_DATA_DIR/steamapps/sourcemods/
- rename:
        src: Portal-StillAlive
        dst: Portal-stillalive
        working_dir: $STEAM_DATA_DIR/steamapps/sourcemods/
game:
        appid: '400'
        args: -game $STEAM_DATA_DIR/steamapps/sourcemods/Portal-stillalive
requires: portal
requires-binaries: p7zip
steam: {}
```