### PR TITLE
Restore "Ctrl+Q key to quit" Lutris behaviour

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -148,6 +148,7 @@ class Application(Gtk.Application):
         action = Gio.SimpleAction.new('quit')
         action.connect('activate', lambda *x: self.quit())
         self.add_action(action)
+        self.add_accelerator('<Primary>q', 'app.quit')
 
         builder = Gtk.Builder.new_from_file(
             os.path.join(datapath.get(), 'ui', 'menus.ui')


### PR DESCRIPTION
This functionality was removed in 0.4.16 but is incredibly useful, this PR restores it.