### PR TITLE
Remove lutris.settings reference from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import os
 import sys
 from setuptools import setup
-from lutris.settings import VERSION
 
 if sys.version_info < (3, 4):
     sys.exit('Python 3.4 is required to run Lutris')
@@ -21,7 +20,7 @@ for directory, _, filenames in os.walk(u'share'):
 
 setup(
     name='lutris',
-    version=VERSION,
+    version='0.4.18',
     license='GPL-3',
     author='Mathieu Comandon',
     author_email='strider@strycore.com',


### PR DESCRIPTION
Executing `python setup.py install` gets an error when importing lutris.settings....
```
Running: python setup.py install
Traceback (most recent call last):
  File "setup.py", line 5, in <module>
    from lutris.settings import VERSION
  File "/run/build/lutris/lutris/settings.py", line 4, in <module>
    from gi.repository import GLib
ImportError: No module named gi.repository
```
It's because gi.repository isn't installed, yet. Switching the version out for the actual version fixes it.