### PR TITLE
[dxvk] symlink to dxvk dlls instead of copying

### DIFF
--- a/lutris/util/dxvk.py
+++ b/lutris/util/dxvk.py
@@ -88,7 +88,7 @@ class DXVKManager:
                 shutil.move(wine_dll_path, wine_dll_path + ".orig")
         # Copying DXVK's version
         dxvk_dll_path = os.path.join(self.dxvk_path, dxvk_arch, "%s.dll" % dll)
-        shutil.copy(dxvk_dll_path, wine_dll_path)
+        os.symlink(dxvk_dll_path, wine_dll_path)
 
     def disable_dxvk_dll(self, system_dir, dxvk_arch, dll):
         """Remove DXVK DLL from Wine prefix"""


### PR DESCRIPTION
In the case of using system installed DXVK, symlinks will ensure the
files in the prefix are up to date with system version.