### PR TITLE
dxvk: Fix wine_dll_path check

### DIFF
--- a/lutris/util/dxvk.py
+++ b/lutris/util/dxvk.py
@@ -122,7 +122,7 @@ class DXVKManager:
         # Copying DXVK's version
         dxvk_dll_path = os.path.join(self.dxvk_path, dxvk_arch, "%s.dll" % dll)
         if os.path.exists(dxvk_dll_path):
-            if wine_dll_path:
+            if os.path.exists(wine_dll_path):
                 os.remove(wine_dll_path)
             os.symlink(dxvk_dll_path, wine_dll_path)
 


### PR DESCRIPTION
When a new wine prefix is being used the original wine_dll_path is moved (because of the optional backup),
so the removal failed.