### PR TITLE
Add ScriptError to game folder creation

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -251,8 +251,12 @@ class ScriptInterpreter(CommandsMixin):
                 os.mkdir(self.cache_path)
 
             if self.target_path and self.should_create_target:
-                os.makedirs(self.target_path)
+                try:
+                    os.makedirs(self.target_path)
+                except PermissionError:
+                    raise ScriptingError("Lutris does not have necessary permissions to install to choosen game dir:", self.target_path)
                 self.reversion_data['created_main_dir'] = True
+
 
         if len(self.game_files) < len(self.files):
             logger.info(


### PR DESCRIPTION
This should close #930 

I simply raised an ScriptError, if lutris does not have the permission to create target path.

Is there a better way to report an error to the user in the installation process?
I'm not happy with the installer not to close completely but show the message and then stay open and stuck.

(I hope this is the right branch to merge to)