### PR TITLE
 Add 'Primary' option to 'Turn off monitors except'.

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -274,9 +274,24 @@ class Game(GObject.Object):
 
         restrict_to_display = system_config.get('display')
         if restrict_to_display != 'off':
-            display.turn_off_except(restrict_to_display)
-            time.sleep(3)
-            self.resolution_changed = True
+            if restrict_to_display == 'primary':
+                restrict_to_display = None
+                for output in self.original_outputs:
+                    if output.primary:
+                        restrict_to_display = output.name
+                        break
+            else:
+                found = False
+                for output in self.original_outputs:
+                    if output.name == restrict_to_display:
+                        found = True
+                        break
+                if not found:
+                    restrict_to_display = None
+            if restrict_to_display:
+                display.turn_off_except(restrict_to_display)
+                time.sleep(3)
+                self.resolution_changed = True
 
         resolution = system_config.get('resolution')
         if resolution != 'off':

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -280,6 +280,8 @@ class Game(GObject.Object):
                     if output.primary:
                         restrict_to_display = output.name
                         break
+                if not restrict_to_display:
+                    logger.warning('No primary display set')
             else:
                 found = False
                 for output in self.original_outputs:
@@ -287,6 +289,7 @@ class Game(GObject.Object):
                         found = True
                         break
                 if not found:
+                    logger.warning('Selected display %s not found', restrict_to_display)
                     restrict_to_display = None
             if restrict_to_display:
                 display.turn_off_except(restrict_to_display)

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -249,7 +249,7 @@ class Game(GObject.Object):
         system_config = self.runner.system_config
         self.original_outputs = sorted(
             display.get_outputs(),
-            key=lambda e: e[0] == system_config.get('display')
+            key=lambda e: e.name == system_config.get('display')
         )
 
         gameplay_info = self.runner.play()

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -6,7 +6,6 @@ from lutris import runners
 # from lutris.util.log import logger
 from lutris.util import display, system
 
-
 def get_optirun_choices():
     choices = [('Off', 'off')]
     if system.find_executable('primusrun'):

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -6,6 +6,7 @@ from lutris import runners
 # from lutris.util.log import logger
 from lutris.util import display, system
 
+
 def get_optirun_choices():
     choices = [('Off', 'off')]
     if system.find_executable('primusrun'):

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -286,6 +286,7 @@ def get_output_choices():
     displays = DISPLAY_MANAGER.get_display_names()
     output_choices = list(zip(displays, displays))
     output_choices.insert(0, ("Off", 'off'))
+    output_choices.insert(0, ("Primary", 'primary'))
     return output_choices
 
 

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -286,7 +286,7 @@ def get_output_choices():
     displays = DISPLAY_MANAGER.get_display_names()
     output_choices = list(zip(displays, displays))
     output_choices.insert(0, ("Off", 'off'))
-    output_choices.insert(0, ("Primary", 'primary'))
+    output_choices.insert(1, ("Primary", 'primary'))
     return output_choices
 
 

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -149,7 +149,7 @@ def change_resolution(resolution):
                 rotation = display.rotation
             else:
                 rotation = "normal"
-            logger.info("Switching resolution of %s to %s", display_name, display_resolution)
+            logger.info("Switching resolution of %s to %s", display.name, display_resolution)
             subprocess.Popen([
                 "xrandr",
                 "--output", display.name,


### PR DESCRIPTION
I have a laptop that I use at two locations, one of which has an external monitor.  
I don't want to always change the 'Turn off monitors except' option, so I added the option to turn off all monitors except the primary one.