### PR TITLE
use custom steam executable for game installation

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -279,7 +279,7 @@ class steam(Runner):
             if is_running():
                 shutdown()
                 time.sleep(5)
-        command = ["steam", "steam://install/%s" % (appid)]
+        command = [self.get_executable(), "steam://install/%s" % (appid)]
         subprocess.Popen(command)
 
     def prelaunch(self):


### PR DESCRIPTION
When someone has set a custom Steam executable in the Steam runner configuration, Lutris would still run the non-custom steam executable when installing a Steam game. This PR should fix that. I also thought about always respecting user-set arguments whenever steam is ran, but I'm not sure if this is wanted (But it certainly would ease up running Lutris + flatpak Steam as it was discussed [here](https://forums.lutris.net/t/lutris-and-flatpak-ed-steam-solved/3393), because no one would have to write a short script to get it working).