### PR TITLE
update fallback dxvk versions and fix a typo

### DIFF
--- a/lutris/util/dxvk.py
+++ b/lutris/util/dxvk.py
@@ -38,8 +38,9 @@ try:
 except Exception as ex:  # pylint: disable= broad-except
     logger.error(ex)
     DXVK_VERSIONS = [
-        "0.65", "0.64", "0.63",
-        "0.54", "0.53" "0.52",
+        "0.71", "0.70", "0.65",
+        "0.64", "0.63", "0.62",
+        "0.54", "0.53", "0.52",
         "0.42", "0.31", "0.21"
     ]
 DXVK_LATEST, DXVK_PAST_RELEASES = DXVK_VERSIONS[0], DXVK_VERSIONS[1:]


### PR DESCRIPTION
When Lutris gets to show the fallback DXVK versions (Because someone fell victim to #1106 or for some other reason), it shows `0.530.52` as available version which is caused by a missing comma in the code. I also used this opportunity to add 0.70 and 0.71 (and 0.62 to keep the code beautiful) to the list (Which will probably be outdated till the next Lutris release anyway).