### PR TITLE
Fix wine libs not being preferred for winetricks

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -256,6 +256,8 @@ def wineexec(executable, args="", wine_path=None, prefix=None, arch=None,
     if use_lutris_runtime(wine_path=wineenv['WINE'], force_disable=disable_runtime):
         if WINE_DIR in wine_path:
             wine_root_path = os.path.dirname(os.path.dirname(wine_path))
+        elif WINE_DIR in winetricks_wine:
+            wine_root_path = os.path.dirname(os.path.dirname(winetricks_wine))
         else:
             wine_root_path = None
         wineenv['LD_LIBRARY_PATH'] = ':'.join(runtime.get_paths(


### PR DESCRIPTION
Fixes #1100.

The issue was that when launching winetricks, wine_path pointed to the winetricks binary (instead of wine, which would usually be the case) and the wine libs are only preferred if WINE_DIR is in wine_path which isn't the case in this situation. When winetricks is launched, winetricks_wine is the variable that contains the actual wine path, so I added a check for it.