### PR TITLE
Added new esync option, which adds the WINEESYNC environment variable.

### DIFF
--- a/lutris/gui/config_boxes.py
+++ b/lutris/gui/config_boxes.py
@@ -152,6 +152,9 @@ class ConfigBox(VBox):
         elif option_type == 'bool':
             self.generate_checkbox(option, value)
             self.tooltip_default = 'Enabled' if default else 'Disabled'
+        elif option_type == 'extended_bool':
+            self.generate_checkbox_with_callback(option, value)
+            self.tooltip_default = 'Enabled' if default else 'Disabled'
         elif option_type == 'range':
             self.generate_range(option_key,
                                 option["min"],
@@ -197,9 +200,31 @@ class ConfigBox(VBox):
         self.wrapper.pack_start(checkbox, True, True, 5)
         self.option_widget = checkbox
 
+    #Checkbox with callback
+    def generate_checkbox_with_callback(self, option, value=None):
+        """Generate a checkbox. With callback"""
+        checkbox = Gtk.CheckButton(label=option["label"])
+        if option['active'] is True:
+            checkbox.set_sensitive(True)
+        else:
+            checkbox.set_sensitive(False)
+        if value is True:
+            checkbox.set_active(value)
+        checkbox.connect("toggled", self.checkbox_toggle_with_callback, option['option'], option['callback'], option['callback_on'])
+        self.wrapper.pack_start(checkbox, True, True, 5)
+        self.option_widget = checkbox
+
     def checkbox_toggle(self, widget, option_name):
         """Action for the checkbox's toggled signal."""
         self.option_changed(widget, option_name, widget.get_active())
+
+    def checkbox_toggle_with_callback(self, widget, option_name, callback, callback_on=None):
+        """Action for the checkbox's toggled signal. With callback method"""
+        if widget.get_active() == callback_on or callback_on == None:
+            if callback(self.config):
+                self.option_changed(widget, option_name, widget.get_active())
+            else:
+                widget.set_active(False)
 
     # Entry
     def generate_entry(self, option_name, label, value=None):

--- a/lutris/gui/config_boxes.py
+++ b/lutris/gui/config_boxes.py
@@ -220,7 +220,7 @@ class ConfigBox(VBox):
 
     def checkbox_toggle_with_callback(self, widget, option_name, callback, callback_on=None):
         """Action for the checkbox's toggled signal. With callback method"""
-        if widget.get_active() == callback_on or callback_on == None:
+        if widget.get_active() == callback_on or callback_on is None:
             if callback(self.config):
                 self.option_changed(widget, option_name, widget.get_active())
             else:

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -628,10 +628,9 @@ class wine(Runner):
                             " <a href='https://github.com/lutris/lutris/wiki/How-to:-Esync'>"
                             "https://github.com/lutris/lutris/wiki/How-to:-Esync</a>")
                 return False
-            else:
-                if is_version_esync(config['version']):
-                    ErrorDialog("Your wine version may not support esync, if you are unsure please check.")
-                return True
+            if is_version_esync(config['version']):
+                ErrorDialog("Your wine version may not support esync, if you are unsure please check.")
+            return True
 
         self.runner_options = [
             {
@@ -1098,7 +1097,6 @@ class wine(Runner):
         env['WINEDEBUG'] = self.runner_config.get('show_debug', '-all')
         env['WINEARCH'] = self.wine_arch
         env['WINE'] = self.get_executable()
-        print(self.get_executable())
         if self.prefix_path:
             env['WINEPREFIX'] = self.prefix_path
 


### PR DESCRIPTION
Added checkbox with callback to allow for checks when enabling esync.

The checkbox will not enable, if ulimit -Hn does not return correctly. There is also a warning displayed if the user tries to enable it with a wine version without 'esync' in the title, to remind them to check that it is esync capable. This does not stop them enabling it however, to allow for custom versions.

Fixes #1131 