### PR TITLE
Improve behaviour of Lutris background process

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -279,6 +279,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
         This must be called each time the view is rebuilt.
         """
+        self.connect('delete-event', lambda *x: self.hide_on_delete())
         self.view.connect('game-installed', self.on_game_installed)
         self.view.connect("game-activated", self.on_game_run)
         self.view.connect("game-selected", self.game_selection_changed)


### PR DESCRIPTION
This commit adresses the following issues:
 * Closing the Lutris main window kills games started by Lutris
 * Starting a game using `lutris:rungameid` closes the lutris main window
 * Opening the main window after starting a game with `lutris:rungameid` quits Lutris when that game closes.

With this commit Lutris won't shut down anymore when using the close button of the main window. The main window will simply be hidden (it can still be shut down via Lutris->Quit). It can be made visible again by re-launching Lutris. This allows the Game to continue to run and be monitored by Lutris even though that window is gone. If the window is made visible again it will show up in the proper state - showing which game is currently running and able to provide the logs of that game).

Shutting down Lutris now works by polling two conditions: If the game is stopped and if the window is hidden. If both conditions are true Lutris will shut down. For this polling I reused the existing polling mechanism for quitting the background process launched by `lutris:rungameid`.

I skimmed the code of #1117 (tray icon support) and think both PRs should play nicely with each other, however I didn't test that so far.