### PR TITLE
show warning when launching wine game without system wine installed

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -10,7 +10,7 @@ from gi.repository import GLib, Gtk
 from lutris import pga
 from lutris import runtime
 from lutris.services import xdg
-from lutris.runners import import_runner, InvalidRunner
+from lutris.runners import import_runner, InvalidRunner, wine
 from lutris.util import audio, display, jobs, system, strings
 from lutris.util.log import logger
 from lutris.config import LutrisConfig
@@ -191,6 +191,11 @@ class Game(object):
                 )
                 dialogs.ErrorDialog("Runtime currently updating",
                                     "Game might not work as expected")
+
+        if "wine" in self.runner_name:
+            if not "system" in wine.get_wine_versions():
+                dialogs.ErrorDialog("install wine")
+
         return True
 
     def play(self):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -3,6 +3,7 @@ import time
 import shlex
 import shutil
 import subprocess
+from functools import lru_cache
 from collections import OrderedDict
 
 from lutris import runtime
@@ -447,6 +448,7 @@ def get_default_version():
         return installed_versions[0]
 
 
+@lru_cache(maxsize=16)
 def get_system_wine_version(wine_path="wine"):
     """Return the version of Wine installed on the system."""
     if os.path.exists(wine_path) and os.path.isabs(wine_path):


### PR DESCRIPTION
It's not ready to merge yet. The pop-up just contains some placeholder text and I want to get some opinions on this first.

I'm not sure if this is a good workaround for the system wine problem. I guess it's better than nothing and could make the first time experience a lot better for new users who only came for wine.
The issues I see with my solution are that it does wine specific things in game.py and I'm not sure if that's an ok thing to do. It also doesn't show up during installers or during the download dialog, and I'm generally unsure what the best time would be to show/not show this pop-up.
It could also get a bit annoying for people who knowingly use Lutris without system wine. I thought about adding an option to disable the message but the only simple way I could quickly come up with is by adding it to the system options, which is not really the location this option should be in.

So, I'd be happy about some criticism. I'm aware that Lutris wine not working properly without system wine is not supposed to happen, but until that is fixed we need to somehow tell new users that they could experience issues without system wine.

Oh, and I added caching to the system wine version. It's already implemented in `next` but master could benefit from it as well.