### PR TITLE
Fix rpcs3 runner to run games on launch

### DIFF
--- a/lutris/runners/rpcs3.py
+++ b/lutris/runners/rpcs3.py
@@ -12,7 +12,7 @@ class rpcs3(Runner):
             "option": "main_file",
             "type": "file",
             "default_path": "game_path",
-            "label": "Full path to EBOOT.BIN (/home/...)"
+            "label": "Path to EBOOT.BIN"
         }
     ]
 

--- a/lutris/runners/rpcs3.py
+++ b/lutris/runners/rpcs3.py
@@ -10,9 +10,9 @@ class rpcs3(Runner):
     game_options = [
         {
             "option": "main_file",
-            "type": "directory_chooser",
+            "type": "file",
             "default_path": "game_path",
-            "label": "Game folder"
+            "label": "Full path to EBOOT.BIN (/home/...)"
         }
     ]
 


### PR DESCRIPTION
The previous fix to this was slightly incorrect. This changes the main file argument from the game folder to the **full** path of the EBOOT.BIN file. 

Previously lutris would run the command `rpcs3 "/dir/to/gamefolder"`
This is now `rpcs3 "/full/dir/to/EBOOT.BIN"`

This now launches the game when the emulator launchs.

[Changes in action](https://gfycat.com/gifs/detail/OldShyChimpanzee)

If you want to keep the game folder solution, the change needs to add "USRDIR/EBOOT.BIN" to the end of the directory and check for it to be a full directory path but this seemed a simpler solution.