### PR TITLE
Add 'copy' as an alias for 'merge' in installers

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -212,7 +212,8 @@ Example:
 Copying and merging directories
 -------------------------------
 
-Both merging and copying actions are done with the ``merge`` directive.
+Both merging and copying actions are done with the ``merge`` or the ``copy`` directive.
+It is not important which of these directives is used because ``copy`` is just an alias for ``merge``.
 Whether the action does a merge or copy depends on the existence of the
 destination directory. When merging into an existing directory, original files
 with the same name as the ones present in the merged directory will be

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -263,6 +263,10 @@ class CommandsMixin:
             return
         self._killable_process(system.merge_folders, src, dst)
 
+    def copy(self, params):
+        """Alias for merge"""
+        self.merge(params)
+
     def move(self, params):
         """Move a file or directory into a destination folder."""
         self._check_required_params(['src', 'dst'], params, 'move')


### PR DESCRIPTION
Fixes #1061 