### PR TITLE
Add vulkan check

### DIFF
--- a/lutris/gui/config_boxes.py
+++ b/lutris/gui/config_boxes.py
@@ -230,6 +230,8 @@ class ConfigBox(VBox):
                 self.option_changed(widget, option_name, widget.get_active())
             else:
                 widget.set_active(False)
+        else:
+            self.option_changed(widget, option_name, widget.get_active())
 
     # Entry
     def generate_entry(self, option_name, label, value=None):

--- a/lutris/gui/dialogs.py
+++ b/lutris/gui/dialogs.py
@@ -361,7 +361,7 @@ class NoInstallerDialog(Gtk.MessageDialog):
 
 class DontShowAgainDialog(Gtk.MessageDialog):
     """Display a message to the user and offer an option not to display this dialog again."""
-    def __init__(self, setting, message, secondary_message=None, parent=None):
+    def __init__(self, setting, message, secondary_message=None, parent=None, checkbox_message=None):
         super().__init__(type=Gtk.MessageType.WARNING, buttons=Gtk.ButtonsType.OK, parent=parent)
 
         if settings.read_setting(setting) == 'True':
@@ -375,7 +375,10 @@ class DontShowAgainDialog(Gtk.MessageDialog):
             self.props.secondary_use_markup = True
             self.props.secondary_text = secondary_message
 
-        dont_show_checkbutton = Gtk.CheckButton("Do not display this message again.")
+        if not checkbox_message:
+            checkbox_message = "Do not display this message again."
+
+        dont_show_checkbutton = Gtk.CheckButton(checkbox_message)
         dont_show_checkbutton.props.halign = Gtk.Align.CENTER
         dont_show_checkbutton.show()
 

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -522,11 +522,12 @@ def build_vulkan_error(option, on_launch):
         checkbox_message = "Enable anyway and do not show this message again."
 
     DontShowAgainDialog('hide-no-vulkan-warning',
-        message,
-        secondary_message="Please follow the installation procedures as described in\n"
-        "<a href='https://github.com/lutris/lutris/wiki/How-to:-DXVK'>"
-        "How-to:-DXVK(https://github.com/lutris/lutris/wiki/How-to:-DXVK)</a>",
-        checkbox_message = checkbox_message)
+                        message,
+                        secondary_message="Please follow the installation "
+                        "procedures as described in\n"
+                        "<a href='https://github.com/lutris/lutris/wiki/How-to:-DXVK'>"
+                        "How-to:-DXVK(https://github.com/lutris/lutris/wiki/How-to:-DXVK)</a>",
+                        checkbox_message=checkbox_message)
 
 def dxvk_vulkan_check(on_launch):
     vulkan_lib = os.path.isfile("/usr/lib/libvulkan.so")

--- a/lutris/util/vulkan.py
+++ b/lutris/util/vulkan.py
@@ -1,0 +1,19 @@
+"""Vulkan helper module"""
+import os
+from enum import Enum
+
+def vulkan_check():
+    vulkan_lib = os.path.isfile("/usr/lib/libvulkan.so")
+    vulkan_lib32 = os.path.isfile("/usr/lib32/libvulkan.so")
+    vulkan_lib_multi = os.path.isfile("/usr/lib/x86_64-linux-gnu/libvulkan.so")
+    vulkan_lib32_multi = os.path.isfile("/usr/lib32/i386-linux-gnu/libvulkan.so")
+    has_32_bit = vulkan_lib32 or vulkan_lib32_multi
+    has_64_bit = vulkan_lib or vulkan_lib_multi
+
+    if not (has_64_bit or has_32_bit):
+        return 0
+    if has_64_bit and not has_32_bit:
+        return 1
+    if not (vulkan_lib or vulkan_lib_multi) and has_32_bit:
+        return 2
+    return 3


### PR DESCRIPTION
Fixes #1038
Add warning messages to be shown to user, if vulkan libraries are not found in the expected locations. This warning is dismissible (don't show again option) so that advanced users or users with unusual system setups can get rid of it.