### PR TITLE
Add SteamWorks and Proton 3.16 AppIDs to blacklist

### DIFF
--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -228,7 +228,7 @@ def sync_appmanifest_state(appmanifest_path, name=None, slug=None):
 def sync_with_lutris(platform='linux'):
     steamapps_paths = get_steamapps_paths()
     steam_games_in_lutris = pga.get_games_where(steamid__isnull=False, steamid__not='')
-    proton_ids = ["858280", "930400"]
+    proton_ids = ["858280", "930400", "961940", "228980"]
     steamids_in_lutris = set([str(game['steamid']) for game in steam_games_in_lutris])
     seen_ids = set()  # Set of Steam appids seen while browsing AppManifests
 


### PR DESCRIPTION
To make them not appear in the game library when importing.