### PR TITLE
forbid overwriting prefixes and fix a bug

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -309,7 +309,7 @@ class InstallerWindow(Gtk.ApplicationWindow):
         
         # replace ~ with full path so os.path.exists and listdir work correctly
         if path.startswith("~/"):
-            path = path.replace("~",os.path.expanduser('~'),1)
+            path = path.replace("~", os.path.expanduser('~'), 1)
 
         if os.path.exists(path) and os.listdir(path):
             self.non_empty_label.show()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -260,7 +260,7 @@ class InstallerWindow(Gtk.ApplicationWindow):
     def on_installer_selected(self, widget):
         self.prepare_install(self.installer_choice)
         self.installer_choice_box.destroy()
-        self.show_non_empty_warning()
+        self.forbid_non_empty_pfx_overwrite()
 
     def prepare_install(self, script_index):
         script = self.scripts[script_index]
@@ -284,7 +284,7 @@ class InstallerWindow(Gtk.ApplicationWindow):
             self.non_empty_label = Gtk.Label()
             self.non_empty_label.set_markup(
                 "<b>Warning!</b> The selected path "
-                "contains files, installation might not work properly."
+                "contains files, Please change the directory."
             )
             self.widget_box.pack_start(self.non_empty_label, False, False, 10)
         else:
@@ -299,17 +299,24 @@ class InstallerWindow(Gtk.ApplicationWindow):
         """Set the installation target for the game."""
         path = text_entry.get_text()
         self.interpreter.target_path = os.path.expanduser(path)
-        self.show_non_empty_warning()
+        self.forbid_non_empty_pfx_overwrite()
 
-    def show_non_empty_warning(self):
+    def forbid_non_empty_pfx_overwrite(self):
         """Display a warning if destination folder is not empty."""
         if not self.location_entry:
             return
         path = self.location_entry.get_text()
+        
+        # replace ~ with full path so os.path.exists and listdir work correctly
+        if path.startswith("~/"):
+            path=path.replace("~",os.path.expanduser('~'),1)
+
         if os.path.exists(path) and os.listdir(path):
             self.non_empty_label.show()
+            self.install_button.hide()
         else:
             self.non_empty_label.hide()
+            self.install_button.show()
 
     # ---------------------
     # "Get the files" stage

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -309,7 +309,7 @@ class InstallerWindow(Gtk.ApplicationWindow):
         
         # replace ~ with full path so os.path.exists and listdir work correctly
         if path.startswith("~/"):
-            path=path.replace("~",os.path.expanduser('~'),1)
+            path = path.replace("~",os.path.expanduser('~'),1)
 
         if os.path.exists(path) and os.listdir(path):
             self.non_empty_label.show()


### PR DESCRIPTION
1- I think overwriting pfx should be not be allowed at all, I cant think of a good use case where its necessary to overwrite a pfx and on the other-hand if a user installs a game on the root of a windows partition and deletes it he will delete the whole partition, obviously there are a lot of warnings but its a big deal and it happened [https://forums.lutris.net/t/lutris-deleted-my-whole-partition-data/3853](https://forums.lutris.net/t/lutris-deleted-my-whole-partition-data/3853) and I don't see the benefit.
2-  os.path.exists(path) and os.listdir(path) cant detect paths with "~" correctly they will always output false , we have to expand username first