### PR TITLE
bugfix

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -308,9 +308,8 @@ class InstallerWindow(Gtk.ApplicationWindow):
         path = self.location_entry.get_text()
         
         # replace ~ with full path so os.path.exists and os.listdir work correctly
-        if path.startswith("~/"):
-            path = path.replace("~", os.path.expanduser('~'), 1)
-            
+        path = os.path.expanduser(path)
+                 
         if os.path.exists(path) and os.listdir(path):
             self.non_empty_label.show()
         else:

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -306,6 +306,11 @@ class InstallerWindow(Gtk.ApplicationWindow):
         if not self.location_entry:
             return
         path = self.location_entry.get_text()
+        
+        # replace ~ with full path so os.path.exists and listdir work correctly
+        if path.startswith("~/"):
+            path = path.replace("~", os.path.expanduser('~'), 1)
+            
         if os.path.exists(path) and os.listdir(path):
             self.non_empty_label.show()
         else:

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -307,7 +307,7 @@ class InstallerWindow(Gtk.ApplicationWindow):
             return
         path = self.location_entry.get_text()
         
-        # replace ~ with full path so os.path.exists and listdir work correctly
+        # replace ~ with full path so os.path.exists and os.listdir work correctly
         if path.startswith("~/"):
             path = path.replace("~", os.path.expanduser('~'), 1)
             


### PR DESCRIPTION
os.path.exists(path) and os.listdir(path) cant detect paths with "~" correctly they will always output false , we have to expand username first, discssed here [https://github.com/lutris/lutris/pull/1200](https://github.com/lutris/lutris/pull/1200)