### PR TITLE
Don't hide installation notes scrollbar when the notes are longer than the view.

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -239,6 +239,7 @@ class InstallerWindow(Gtk.ApplicationWindow):
         except AttributeError:
             logger.debug("set_propagate_natural_height not available")
         notes_scrolled_area.set_min_content_height(100)
+        notes_scrolled_area.set_overlay_scrolling(False)
         notes_scrolled_area.add(self.notes_label)
         self.installer_choice_box.pack_start(notes_scrolled_area, True, True, 10)
 


### PR DESCRIPTION
This way you can always see when there are more notes to read. Even when the notes have a line break exactly where the scrolled window ends.

![scrollbaralwaysvisible](https://user-images.githubusercontent.com/7442115/47255202-6ffa5280-d46d-11e8-801a-3a8298afc25a.png)

(Closes #959 )