### PR TITLE
Fixing comment syntax of translations.

### DIFF
--- a/share/applications/lutris.desktop
+++ b/share/applications/lutris.desktop
@@ -2,10 +2,10 @@
 Version=1.0
 Name=Lutris
 Comment=Open gaming platform
-Comment=[pl]=Otwarta platforma dla graczy
-Comment=[pt-BR]=Plataforma de jogos de código aberto
-Comment=[es]=Plataforma de juegos de código abierto
-Comment=[id]=Platform permainan terbuka
+Comment[pl]=Otwarta platforma dla graczy
+Comment[pt-BR]=Plataforma de jogos de código aberto
+Comment[es]=Plataforma de juegos de código abierto
+Comment[id]=Platform permainan terbuka
 Categories=Game;
 Exec=lutris %U
 Icon=lutris


### PR DESCRIPTION
This is a small change to meet what I believe to be the proper syntax for translations of comments in .desktop files. This is currently causing Fedora (and I would guess other rpm based distros) to fail their builds.

-Bunny