### PR TITLE
Add call to ldconfig to check for libvulkan, keep file search as backup.

### DIFF
--- a/lutris/util/vulkan.py
+++ b/lutris/util/vulkan.py
@@ -16,10 +16,10 @@ def vulkan_check():
     for line in subprocess.check_output(["ldconfig", "-p"]).splitlines():
         line = str(line)
         if 'libvulkan' in line:
-            if not 'x86-64' in line:
-                has_32_bit = True
-            else:
+            if 'x86-64' in line:
                 has_64_bit = True
+            else:
+                has_32_bit = True
 
     if not (has_64_bit or has_32_bit):
         return vulkan_available.NONE

--- a/lutris/util/vulkan.py
+++ b/lutris/util/vulkan.py
@@ -1,6 +1,8 @@
 """Vulkan helper module"""
 import os
 import re
+import subprocess
+import io
 from enum import Enum
 
 class vulkan_available(Enum):
@@ -19,12 +21,24 @@ def search_for_file(directory):
     return False
 
 def vulkan_check():
-    vulkan_lib = search_for_file("/usr/lib")
-    vulkan_lib32 = search_for_file("/usr/lib32")
-    vulkan_lib_multi = search_for_file("/usr/lib/x86_64-linux-gnu")
-    vulkan_lib32_multi =  search_for_file("/usr/lib32/i386-linux-gnu")
-    has_32_bit = vulkan_lib32 or vulkan_lib32_multi
-    has_64_bit = vulkan_lib or vulkan_lib_multi
+    has_32_bit = False
+    has_64_bit = False
+    pattern = re.compile(r'^libvulkan\.so')
+    proc = subprocess.Popen("ldconfig -p", shell=True, stdout=subprocess.PIPE)
+    for line in io.TextIOWrapper(proc.stdout, encoding="utf-8"):
+        if line.find('libvulkan') != -1:
+            if line.find('x86-64') != -1:
+                has_32_bit = True
+            else:
+                has_64_bit = True
+
+    if not (has_32_bit or has_64_bit):
+        vulkan_lib = search_for_file("/usr/lib")
+        vulkan_lib32 = search_for_file("/usr/lib32")
+        vulkan_lib_multi = search_for_file("/usr/lib/x86_64-linux-gnu")
+        vulkan_lib32_multi =  search_for_file("/usr/lib/i386-linux-gnu")
+        has_32_bit = vulkan_lib32 or vulkan_lib32_multi
+        has_64_bit = vulkan_lib or vulkan_lib_multi
 
     if not (has_64_bit or has_32_bit):
         return vulkan_available.NONE

--- a/lutris/util/vulkan.py
+++ b/lutris/util/vulkan.py
@@ -11,34 +11,16 @@ class vulkan_available(Enum):
     SIXTY_FOUR = 2
     ALL = 3
 
-def search_for_file(directory):
-    if os.path.isdir(directory):
-        pattern = re.compile(r'^libvulkan\.so')
-        files = [f for f in os.listdir(directory) if os.path.isfile(os.path.join(directory, f))]
-        files = [os.path.join(directory, f) for f in files if pattern.search(f)]
-        if files:
-            return True
-    return False
-
 def vulkan_check():
-    has_32_bit = False
     has_64_bit = False
-    pattern = re.compile(r'^libvulkan\.so')
-    proc = subprocess.Popen("ldconfig -p", shell=True, stdout=subprocess.PIPE)
-    for line in io.TextIOWrapper(proc.stdout, encoding="utf-8"):
-        if line.find('libvulkan') != -1:
-            if line.find('x86-64') != -1:
+    has_32_bit = False
+    for line in subprocess.check_output(["ldconfig", "-p"]).splitlines():
+        line = str(line)
+        if 'libvulkan' in line:
+            if 'x86-64' in line:
                 has_32_bit = True
             else:
                 has_64_bit = True
-
-    if not (has_32_bit or has_64_bit):
-        vulkan_lib = search_for_file("/usr/lib")
-        vulkan_lib32 = search_for_file("/usr/lib32")
-        vulkan_lib_multi = search_for_file("/usr/lib/x86_64-linux-gnu")
-        vulkan_lib32_multi =  search_for_file("/usr/lib/i386-linux-gnu")
-        has_32_bit = vulkan_lib32 or vulkan_lib32_multi
-        has_64_bit = vulkan_lib or vulkan_lib_multi
 
     if not (has_64_bit or has_32_bit):
         return vulkan_available.NONE

--- a/lutris/util/vulkan.py
+++ b/lutris/util/vulkan.py
@@ -16,7 +16,7 @@ def vulkan_check():
     for line in subprocess.check_output(["ldconfig", "-p"]).splitlines():
         line = str(line)
         if 'libvulkan' in line:
-            if 'x86-64' in line:
+            if not 'x86-64' in line:
                 has_32_bit = True
             else:
                 has_64_bit = True

--- a/lutris/util/vulkan.py
+++ b/lutris/util/vulkan.py
@@ -2,7 +2,6 @@
 import os
 import re
 import subprocess
-import io
 from enum import Enum
 
 class vulkan_available(Enum):


### PR DESCRIPTION
As suggested on #1227 added call to ldconfig for more robust check, keeping the search for the files as backup. Tested working on Ubuntu 18.10 and Arch.
Fixes #1231