### PR TITLE
Add option to launch script at game start

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -164,7 +164,6 @@ system_options = [
     {
         'option': 'pre_script',
         'type': 'file',
-        'default': os.path.expanduser('~/Games'),
         'label': 'Script to launch at game start',
         'advanced': True,
         'help': ("Path to a script to execute at game start")

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -162,6 +162,14 @@ system_options = [
         'help': "Environment variables loaded at run time"
     },
     {
+        'option': 'pre_script',
+        'type': 'file',
+        'default': os.path.expanduser('~/Games'),
+        'label': 'Script to launch at game start',
+        'advanced': True,
+        'help': ("Path to a script to execute at game start")
+    },
+    {
         'option': 'prefix_command',
         'type': 'string',
         'label': 'Command prefix',


### PR DESCRIPTION
1 - this have some handy side effects, the script actually stops when the game stops so it can be used as one-shot or daemon
2 - Didn't want to add an option to launch script at game stop because it felt like its unnecessary:
if someone for example  wants a function to execute when a game exit he can use the bash trap function 