### PR TITLE
Make file limit and process monitor warnings dismissible

### DIFF
--- a/lutris/util/wine.py
+++ b/lutris/util/wine.py
@@ -19,6 +19,9 @@ WINE_PATHS = {
     'wine-development': '/usr/lib/wine-development/wine',
     'system': 'wine',
 }
+
+ESYNC_LIMIT_CHECK=os.environ.get('ESYNC_LIMIT_CHECK', '').lower()
+
 def get_proton():
     """Get the Folder that contains all the Proton versions. Can probably be improved"""
     for path in [os.path.join(p,'common') for p in steam().get_steamapps_dirs() ]:
@@ -147,6 +150,9 @@ def is_version_installed(version):
 
 def is_esync_limit_set():
     """Checks if the number of files open is acceptable for esync usage."""
+    if ESYNC_LIMIT_CHECK in ('0', 'off'):
+        logger.info("fd limit check for esync was manually disabled")
+        return True
     nolimit = subprocess.Popen("ulimit -Hn", shell=True, stdout=subprocess.PIPE).stdout.read()
     return int(nolimit) >= MIN_NUMBER_FILES_OPEN
 


### PR DESCRIPTION
Someone on irc complained that Lutris doesn't allow him to launch an esync game because he doesn't want to increase the file descriptor limit. Turns out that the file limit warning was indeed not dismissible so I changed it.
The process monitor warning is dismissible per game. So if someone ticks the box for one game, the warning will still appear for other games. But it's saved in lutris.conf. It would probably be better to make that a game config option, but I'm keeping it that way because it's simpler.

I also removed a double import in dialogs.py