### PR TITLE
Fix LogTextView loosing lock to bottom (fixes #1213)

### DIFF
--- a/lutris/gui/logwindow.py
+++ b/lutris/gui/logwindow.py
@@ -19,7 +19,9 @@ class LogTextView(Gtk.TextView):
         adj = self.get_vadjustment()
         if adj.get_value() == self.scroll_max or self.scroll_max == 0:
             adj.set_value(adj.get_upper() - adj.get_page_size())
-        self.scroll_max = adj.get_upper() - adj.get_page_size()
+            self.scroll_max = adj.get_value()
+        else:
+            self.scroll_max = adj.get_upper() - adj.get_page_size()
 
 
 class LogWindow(Dialog):


### PR DESCRIPTION
If the value passed to `adj.set_value()` is too big the biggest possible number will be set instead. For reasons that are unknown to me `adj.get_upper() - adj.get_page_size()` sometimes produces a number that is too big. This caused `self.scroll_max` and `adj.get_value()` to be different the next time `autoscroll()` is called resulting in the log no longer sticking to the bottom.

This PR fixes this by using `adj.get_value()` to assign `self.scroll_max` which ensures that the biggest possible number is used if `adj.get_upper() - adj.get_page_size()` is too big.