### PR TITLE
Fix exception after steam game install

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -666,6 +666,8 @@ class ScriptInterpreter(CommandsMixin):
                 config[key] = {k: self._substitute(v) for (k, v) in value.items()}
             elif isinstance(value, bool):
                 config[key] = value
+            elif isinstance(value, int):
+                config[key] = value
             else:
                 config[key] = self._substitute(value)
         return config


### PR DESCRIPTION
This fixes a regression introduced by c8f25309 where installing a steam game caused an exception making the ui behave weird (also the config was probably not properly written).

The regeression was caused by the fact that integers previously ran through the variable substitution that was implemented for strings. Since the passed variable is converted to a string midway through this wasn't a problem until now. c8f25309 however introduced a `lower`-call right at the start of the substitution function where the value is still an int. This PR fixes the issue by giving integers their own path (like all the other data types have as well).

**There is one thing you might want to check before merging this**: Previously all integers were converted to strings by the substitution function. I assumed this was a bug to begin with, so I didn't perform that conversion in my fix. Note however that with this fix the behaviour is slightly different from how it was before c8f25309, so if something depends on `config` not containing integers they might break down the line (However that behaviour would be worth investigating as well imo).