### PR TITLE
fix game_mode

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -341,10 +341,9 @@ class Game:
         if gamemode:
             env['LD_PRELOAD'] = ':'.join([
                 path for path in
-                [env.get('LD_PRELOAD'), system.GAMEMODE_PATH]
+                [env.get('LD_PRELOAD'), "/usr/$LIB/libgamemodeauto.so.0"]
                 if path
             ])
-
         # LD_LIBRARY_PATH
         game_ld_libary_path = gameplay_info.get('ld_library_path')
         if game_ld_libary_path:


### PR DESCRIPTION
preloading https://github.com/lutris/lutris/blob/master/lutris/util/system.py#L50 is based on luck, to get the correct library for the game we can use $LIB see this insightful comment https://github.com/FeralInteractive/gamemode/issues/64#issuecomment-404779034,
