### PR TITLE
Fix esync check on game launch

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -803,7 +803,7 @@ class wine(Runner):
 
         launch_info = {"env": self.get_env(os_env=False)}
 
-        if "WINEESYNC" in launch_info["env"].get("WINEESYNC") == "1":
+        if launch_info["env"].get("WINEESYNC") == "1":
             limit_set = is_esync_limit_set()
             wine_ver = is_version_esync(self.get_executable())
 


### PR DESCRIPTION
The esync check during game launch seems to have been broken. It simply got skipped on game launch because of a messed up if-statement