### PR TITLE
Use PR_SET_CHILD_SUBREAPER to detect grandchildren

### DIFF
--- a/lutris/thread.py
+++ b/lutris/thread.py
@@ -11,6 +11,8 @@ import contextlib
 from collections import defaultdict
 from itertools import chain
 
+import ctypes
+from ctypes.util import find_library
 
 from textwrap import dedent
 from gi.repository import GLib
@@ -35,6 +37,9 @@ EXCLUDED_PROCESSES = [
 ]
 
 
+PR_SET_CHILD_SUBREAPER = 36
+
+
 class LutrisThread(threading.Thread):
     """Run the game in a separate thread."""
     debug_output = True
@@ -43,6 +48,9 @@ class LutrisThread(threading.Thread):
                  watch=True, cwd=None, include_processes=None, exclude_processes=None, log_buffer=None):
         """Thread init"""
         threading.Thread.__init__(self)
+        result = ctypes.CDLL(find_library('c')).prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0, 0)
+        if result == -1:
+            logger.warning("PR_SET_CHILD_SUBREAPER failed, process watching may fail")
         self.ready_state = True
         if env is None:
             self.env = {}
@@ -351,7 +359,7 @@ class LutrisThread(threading.Thread):
                 self.is_running = False
                 return False
 
-        if num_watched_children == 0:
+        if num_watched_children == 0 or num_watched_children == terminated_children:
             time_since_start = time.time() - self.startup_time
             if self.monitoring_started or time_since_start > WARMUP_TIME:
                 self.cycles_without_children += 1


### PR DESCRIPTION
Fixes #1413.

Lutris' process monitor right now cannot properly follow "fork-and-die" processes. The grandchild process is invisible to Lutris and then Lutris kills the runner.

This changeset sets [`PR_SET_CHILD_SUBREAPER`](http://man7.org/linux/man-pages/man2/prctl.2.html) so that these grandchild processes become child processes of Lutris instead, and Lutris can track them properly.

Note that fix will only be effective in Linux 3.4+ as that is when `PR_SET_CHILD_SUBREAPER` was introduced.