### PR TITLE
make LutrisThread not a thread

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -43,6 +43,7 @@ from lutris.thread import exec_in_thread
 from lutris.util import datapath
 from lutris.util.log import logger, console_handler, DEBUG_FORMATTER
 from lutris.util.resources import parse_installer_url
+from lutris.util.monitor import set_child_subreaper
 
 from .lutriswindow import LutrisWindow
 from lutris.gui.lutristray import LutrisTray
@@ -55,6 +56,7 @@ class Application(Gtk.Application):
             flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
         )
         logger.info("Running Lutris %s", settings.VERSION)
+        set_child_subreaper()
         gettext.bindtextdomain("lutris", "/usr/share/locale")
         gettext.textdomain("lutris")
 


### PR DESCRIPTION
`LutrisThread` doesn't actually do anything threaded because the body of `run` method doesn't block. Make it no longer threaded. Also move `set_child_subreaper` to application initialization so that we don't have to keep calling it over and over again on every game launch for no reason, and because I originally put it there because I wasn't sure if it was a per-thread setting (which is now irrelevant).

Also, I noticed that `attach_thread` is dead code so I removed it.