### PR TITLE
speed up detection of wine process exit

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -1022,8 +1022,6 @@ Sysoptions
 
 ``disable_runtime`` (example: ``true``)
 
-``monitor_max_cycles`` adjusts the number of cycles the monitor will wait until declaring a game as exited (example: 10)
-
 ``disable_compositor`` (example: ``true``)
 
 ``reset_pulse`` (example: ``true``)

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -443,8 +443,6 @@ class Game(GObject.Object):
         if system_config.get("disable_compositor"):
             self.set_desktop_compositing(False)
 
-        monitor_max_cycles = int(system_config.get("monitor_max_cycles")) or 5
-
         prelaunch_command = self.runner.system_config.get("prelaunch_command")
         if system.path_exists(prelaunch_command):
             self.prelaunch_thread = MonitoredCommand(
@@ -464,7 +462,6 @@ class Game(GObject.Object):
             log_buffer=self.log_buffer,
             include_processes=include_processes,
             exclude_processes=exclude_processes,
-            max_cycles=monitor_max_cycles
         )
         if hasattr(self.runner, "stop"):
             self.game_thread.stop_func = self.runner.stop

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -270,18 +270,6 @@ system_options = [  # pylint: disable=invalid-name
         ),
     },
     {
-        "option": "monitor_max_cycles",
-        "type": "string",
-        "label": "Maximum number of empty monitor cycles",
-        "advanced": True,
-        "default": "5",
-        "help": (
-            "Number of cycles to wait before the game is considered as exited. "
-            "Each cycle is 2 seconds. Increasing the value will increase the "
-            "time Lutris take to update the exit status."
-        )
-    },
-    {
         "option": "single_cpu",
         "type": "bool",
         "label": "Restrict to single core",


### PR DESCRIPTION
This changeset installs a `SIGCHLD` signal handler which reaps child processes, and on successful child process reaping, triggers an early execution of `watch_children` to evaluate the new process state. This also removes the cycle count requirement for marking a process as exited since we now have more reliable ways to determine the state of the application. It also adds more background wine processes to the exclude list by default. Combined, these changes mean much more rapid detection of an exited wine game.

This should significantly help #1012.