### PR TITLE
Fix wrong order of tuple for assigning soft- and hardlimits value

### DIFF
--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -116,7 +116,7 @@ class LinuxSystem:
 
         self.populate_libraries()
         self.populate_sound_fonts()
-        self.hard_limit, self.soft_limit = self.get_file_limits()
+        self.soft_limit, self.hard_limit = self.get_file_limits()
 
     @staticmethod
     def get_sbin_path(command):


### PR DESCRIPTION
Here is the documentation of the method:
https://docs.python.org/3/library/resource.html#resource.getrlimit

> Returns a tuple (soft, hard) with the current soft and hard limits of resource. Raises ValueError if an invalid resource is specified, or error if the underlying system call fails unexpectedly.