### PR TITLE
Hide running bar when prelaunch fails

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -265,6 +265,7 @@ class Game(GObject.Object):
             logger.error("Game prelaunch unsuccessful")
             dialogs.ErrorDialog("An error prevented the game from running")
             self.state = self.STATE_STOPPED
+            self.emit('game-stop')
             return
         system_config = self.runner.system_config
         self.original_outputs = sorted(

--- a/lutris/running_game.py
+++ b/lutris/running_game.py
@@ -45,6 +45,10 @@ class RunningGame:
             InstallerWindow(
                 game_slug=self.game.slug, parent=self.window, application=self.application
             )
+
+        if self.game.state == Game.STATE_STOPPED:
+            return
+
         self.running_game_box = RunningGameBox(self.game)
         self.running_game_box.stop_button.connect("clicked", self.on_stop)
         self.running_game_box.log_button.connect("clicked", self.on_show_logs)


### PR DESCRIPTION
If a game fails to do its prelaunch procedure, hide the "game is running" bar.