### PR TITLE
[next] Clear wine version cache on uninstall

### DIFF
--- a/lutris/gui/runnerinstalldialog.py
+++ b/lutris/gui/runnerinstalldialog.py
@@ -141,6 +141,10 @@ class RunnerInstallDialog(Dialog):
         arch = row[self.COL_ARCH]
         system.remove_folder(self.get_runner_path(version, arch))
         row[self.COL_INSTALLED] = False
+        if self.runner == "wine":
+            logger.debug("Clearing wine version cache")
+            from lutris.util.wine.wine import get_wine_versions
+            get_wine_versions.cache_clear()
 
     def install_runner(self, row):
         url = row[2]


### PR DESCRIPTION
Right now if you uninstall a wine version, it does not disappear from runner config dropdown. This fixes that.