### PR TITLE
Small fixes for the service window and installer dialog

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -52,7 +52,6 @@ class InstallerWindow(Gtk.ApplicationWindow):
         self.set_size_request(420, 420)
         self.set_default_size(600, 480)
         self.set_position(Gtk.WindowPosition.CENTER)
-        self.set_show_menubar(False)
 
         self.vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=12)
         self.vbox.set_margin_top(18)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -70,6 +70,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
     sync_button = GtkTemplate.Child()
     sync_label = GtkTemplate.Child()
     sync_spinner = GtkTemplate.Child()
+    add_popover = GtkTemplate.Child()
     viewtype_icon = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs):
@@ -532,6 +533,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
     def open_sync_dialog(self):
         """Opens the service sync dialog"""
+        self.add_popover.hide()
         SyncServiceWindow(application=self.application)
 
     def update_existing_games(self, added, updated, first_run=False):
@@ -806,6 +808,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
     @GtkTemplate.Callback
     def on_add_game_button_clicked(self, *_args):
         """Add a new game manually with the AddGameDialog."""
+        self.add_popover.hide()
         init_dxvk_versions()
         dialog = AddGameDialog(
             self,

--- a/lutris/gui/sync.py
+++ b/lutris/gui/sync.py
@@ -126,9 +126,11 @@ class ServiceSyncBox(Gtk.Box):
         return False
 
     def _connect_button_toggle(self):
+        is_connected = self.service.is_connected()
         icon_name = "user-offline-symbolic" \
-            if self.service.is_connected() \
+            if is_connected \
             else "user-available-symbolic"
+        self.connect_button.set_tooltip_text('Disconnect' if is_connected else 'Connect')
         self.connect_button.set_image(Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU))
 
     def on_sync_button_clicked(self, _button, sync_with_lutris_method):
@@ -291,6 +293,7 @@ class SyncServiceWindow(Gtk.ApplicationWindow):
     def __init__(self, application):
         super().__init__(title="Import games", application=application)
         self.application = application
+        self.set_show_menubar(False)
         self.connect("delete-event", lambda *x: self.destroy())
 
         self.set_border_width(10)

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -21,3 +21,9 @@
 row:selected {
   background: transparent;
 }
+row:hover {
+  background: rgba(0, 0, 0, 0.1);
+}
+row:selected, row:selected button label, row:selected label {
+  color: inherit;
+}


### PR DESCRIPTION
Hide popovers when actions are clicked.
Improve theme compatibility for installer selection screen
Show toolbar on connect/disconnect button in service window
Don't show a menubar in service window