### PR TITLE
use wrapper processes to manage running games

### DIFF
--- a/lutris/child_wrapper.py
+++ b/lutris/child_wrapper.py
@@ -1,0 +1,77 @@
+# coding: utf-8
+import os
+import time
+import ctypes
+import sys
+import subprocess
+import signal
+from ctypes.util import find_library
+from lutris.util.log import logger
+from lutris.util.monitor import ProcessMonitor
+
+PR_SET_CHILD_SUBREAPER = 36
+def set_child_subreaper():
+    """Sets the current process to a subreaper.
+
+    A subreaper fulfills the role of init(1) for its descendant
+    processes.  When a process becomes orphaned (i.e., its
+    immediate parent terminates) then that process will be
+    reparented to the nearest still living ancestor subreaper.
+    Subsequently, calls to getppid() in the orphaned process will
+    now return the PID of the subreaper process, and when the
+    orphan terminates, it is the subreaper process that will
+    receive a SIGCHLD signal and will be able to wait(2) on the
+    process to discover its termination status.
+
+    The setting of this bit is not inherited by children created
+    by fork(2) and clone(2).  The setting is preserved across
+    execve(2).
+
+    Establishing a subreaper process is useful in session
+    management frameworks where a hierarchical group of processes
+    is managed by a subreaper process that needs to be informed
+    when one of the processes—for example, a double-forked daemon—
+    terminates (perhaps so that it can restart that process).
+    Some init(1) frameworks (e.g., systemd(1)) employ a subreaper
+    process for similar reasons.
+    """
+    result = ctypes.CDLL(find_library('c')).prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0, 0)
+    if result == -1:
+        print("PR_SET_CHILD_SUBREAPER failed, process watching may fail")
+
+
+def main():
+    set_child_subreaper()
+    _, include_proc_count, exclude_proc_count, *args = sys.argv
+
+    # So I'm too lazy to implement real argument parsing... sorry.
+    include_proc_count = int(include_proc_count)
+    exclude_proc_count = int(exclude_proc_count)
+    include_procs, args = args[:include_proc_count], args[include_proc_count:]
+    exclude_procs, args = args[:exclude_proc_count], args[exclude_proc_count:]
+
+    monitor = ProcessMonitor(include_procs, exclude_procs)
+
+    def sig_handler(signum, frame):
+        signal.signal(signal.SIGTERM, old_sigterm_handler)
+        signal.signal(signal.SIGINT, old_sigint_handler)
+        monitor.refresh_process_status()
+        for child in monitor.children:
+            os.kill(child.pid, signum)
+
+    old_sigterm_handler = signal.signal(signal.SIGTERM, sig_handler)
+    old_sigint_handler = signal.signal(signal.SIGINT, sig_handler)
+
+    returncode = subprocess.run(args).returncode
+    try:
+        while True:
+            os.wait3(0)
+            if not monitor.refresh_process_status():
+                break
+    except ChildProcessError:
+        pass
+    sys.exit(returncode)
+
+
+if __name__ == "__main__":
+    main()

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -16,9 +16,12 @@ from lutris.runners import import_runner, InvalidRunner, wine
 from lutris.util import audio, display, jobs, system, strings
 from lutris.util.log import logger
 from lutris.config import LutrisConfig
-from lutris.command import MonitoredCommand, HEARTBEAT_DELAY
+from lutris.command import MonitoredCommand
 from lutris.gui import dialogs
 from lutris.util.timer import Timer
+
+
+HEARTBEAT_DELAY = 2000
 
 
 def watch_lutris_errors(function):

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -44,7 +44,6 @@ from lutris.util.steam.config import get_steamapps_paths
 from lutris.util import datapath
 from lutris.util.log import logger, console_handler, DEBUG_FORMATTER
 from lutris.util.resources import parse_installer_url
-from lutris.util.monitor import set_child_subreaper
 from lutris.util.system import check_libs
 from lutris.util.drivers import check_driver
 from lutris.util.vkquery import check_vulkan
@@ -60,7 +59,6 @@ class Application(Gtk.Application):
             flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
         )
         logger.info("Running Lutris %s", settings.VERSION)
-        set_child_subreaper()
         gettext.bindtextdomain("lutris", "/usr/share/locale")
         gettext.textdomain("lutris")
 

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -205,6 +205,7 @@ def winekill(prefix, arch=WINE_DEFAULT_ARCH, wine_path=None, env=None, initial_p
             )
             break
         time.sleep(0.1)
+    logger.debug("Done waiting.")
 
 
 def wineexec(

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -126,6 +126,7 @@ class wine(Runner):
             ("wineexec", "Run EXE inside wine prefix", self.run_wineexec),
             ("winecfg", "Wine configuration", self.run_winecfg),
             ("wine-regedit", "Wine registry", self.run_regedit),
+            ("winekill", "Kill all wine processes", self.run_winekill),
             ("winetricks", "Winetricks", self.run_winetricks),
             ("joycpl", "Joystick Control Panel", self.run_joycpl),
         ]
@@ -623,6 +624,17 @@ class wine(Runner):
         self.prelaunch()
         joycpl(prefix=self.prefix_path, wine_path=self.get_executable(), config=self)
 
+    def run_winekill(self, *args):
+        """Runs wineserver -k."""
+        winekill(
+            self.prefix_path,
+            arch=self.wine_arch,
+            wine_path=self.get_executable(),
+            env=self.get_env(),
+            initial_pids=self.get_pids(),
+        )
+        return True
+
     def set_regedit_keys(self):
         """Reset regedit keys according to config."""
         prefix = self.prefix_path
@@ -833,14 +845,7 @@ class wine(Runner):
         return launch_info
 
     def stop(self):
-        """The kill command runs wineserver -k."""
-        winekill(
-            self.prefix_path,
-            arch=self.wine_arch,
-            wine_path=self.get_executable(),
-            env=self.get_env(),
-            initial_pids=self.get_pids(),
-        )
+        """Does nothing whatsoever."""
         return True
 
     @staticmethod

--- a/lutris/util/monitor.py
+++ b/lutris/util/monitor.py
@@ -2,13 +2,12 @@
 import os
 import shlex
 import ctypes
-from ctypes.util import find_library
 from collections import defaultdict
 
 from lutris.util import system
 from lutris.util.log import logger
+from lutris.util.process import Process
 
-PR_SET_CHILD_SUBREAPER = 36
 
 # List of process names that are ignored by the process monitoring
 EXCLUDED_PROCESSES = [
@@ -44,40 +43,10 @@ EXCLUDED_PROCESSES = [
 ]
 
 
-def set_child_subreaper():
-    """Sets the current process to a subreaper.
-
-    A subreaper fulfills the role of init(1) for its descendant
-    processes.  When a process becomes orphaned (i.e., its
-    immediate parent terminates) then that process will be
-    reparented to the nearest still living ancestor subreaper.
-    Subsequently, calls to getppid() in the orphaned process will
-    now return the PID of the subreaper process, and when the
-    orphan terminates, it is the subreaper process that will
-    receive a SIGCHLD signal and will be able to wait(2) on the
-    process to discover its termination status.
-
-    The setting of this bit is not inherited by children created
-    by fork(2) and clone(2).  The setting is preserved across
-    execve(2).
-
-    Establishing a subreaper process is useful in session
-    management frameworks where a hierarchical group of processes
-    is managed by a subreaper process that needs to be informed
-    when one of the processes—for example, a double-forked daemon—
-    terminates (perhaps so that it can restart that process).
-    Some init(1) frameworks (e.g., systemd(1)) employ a subreaper
-    process for similar reasons.
-    """
-    result = ctypes.CDLL(find_library('c')).prctl(PR_SET_CHILD_SUBREAPER, 1, 0, 0, 0, 0)
-    if result == -1:
-        logger.warning("PR_SET_CHILD_SUBREAPER failed, process watching may fail")
-
-
 class ProcessMonitor:
     """Class to keep track of a process and its children status"""
 
-    def __init__(self, include_processes, exclude_processes, exclusion_process):
+    def __init__(self, include_processes, exclude_processes):
         """Creates a process monitor
 
         All arguments accept process names like the ones in EXCLUDED_PROCESSES
@@ -85,7 +54,6 @@ class ProcessMonitor:
         Args:
             exclude_processes (str or list): list of processes that shouldn't be monitored
             include_processes (str or list): list of process that should be forced to be monitored
-            exclusion_process (str): If given, ignore all process before this one
         """
 
         # process names from /proc only contain 15 characters
@@ -95,11 +63,9 @@ class ProcessMonitor:
         self.exclude_processes = [
             x[0:15] for x in EXCLUDED_PROCESSES + self.parse_process_list(exclude_processes)
         ]
-        self.exclusion_process = exclusion_process
-        self.old_pids = system.get_all_pids()
         # Keep a copy of the monitored processes to allow comparisons
-        self.monitored_processes = defaultdict(list)
         self.children = []
+        self.ignored_children = []
 
     @staticmethod
     def parse_process_list(process_list):
@@ -119,13 +85,23 @@ class ProcessMonitor:
             if not topdown:
                 yield child
 
-    def get_process_status(self, process):
+    @staticmethod
+    def _log_changes(label, old, new):
+        newpids = {p.pid for p in new}
+        oldpids = {p.pid for p in old}
+        added = [p for p in new if p.pid not in oldpids]
+        removed = [p for p in old if p.pid not in newpids]
+        if added:
+            logger.debug("New %s processes: %s", label, ', '.join(map(str, added)))
+        if removed:
+            logger.debug("New %s processes: %s", label, ', '.join(map(str, removed)))
+
+    def refresh_process_status(self):
         """Return status of a process"""
-        self.children = []
-        num_watched_children = 0
-        has_passed_exclusion_process = False
-        processes = defaultdict(list)
-        for child in self.iter_children(process):
+        old_children, self.children = self.children, []
+        old_ignored_children, self.ignored_children = self.ignored_children, []
+
+        for child in self.iter_children(Process(os.getpid())):
             if child.state == 'Z':  # should never happen anymore...
                 logger.debug("Unexpected zombie process %s", child)
                 try:
@@ -134,40 +110,16 @@ class ProcessMonitor:
                     pass
                 continue
 
-            if self.exclusion_process:
-                if child.name == self.exclusion_process:
-                    has_passed_exclusion_process = True
-                if not has_passed_exclusion_process:
-                    continue
-
-            self.children.append(child)
-
-            if child.pid in self.old_pids:
-                processes["external"].append(str(child))
-                continue
-
             if (
                     child.name
                     and child.name in self.exclude_processes
                     and child.name not in self.include_processes
             ):
-                processes["excluded"].append(str(child))
-                continue
-            num_watched_children += 1
-
-        for child in self.monitored_processes["monitored"]:
-            if child not in processes["monitored"]:
+                self.ignored_children.append(child)
+            else:
                 self.children.append(child)
-                num_watched_children += 1
 
-        for key in processes:
-            if processes[key] != self.monitored_processes[key]:
-                process_pids = {p.split(":")[0] for p in processes[key]}
-                monitored_pids = {p.split(":")[0] for p in self.monitored_processes[key]}
-                self.monitored_processes[key] = processes[key]
-                if process_pids != monitored_pids:
-                    logger.debug(
-                        "Processes %s: %s", key, ", ".join(processes[key]) or "no process"
-                    )
+        self._log_changes('ignored', old_ignored_children, self.ignored_children)
+        self._log_changes('monitored', old_children, self.children)
 
-        return num_watched_children > 0
+        return len(self.children) > 0

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -365,11 +365,6 @@ def get_pid(program, multiple=False):
     return pids[0]
 
 
-def get_all_pids():
-    """Return all pids of currently running processes"""
-    return [int(pid) for pid in os.listdir("/proc") if pid.isdigit()]
-
-
 def kill_pid(pid):
     """Terminate a process referenced by its PID"""
     try:


### PR DESCRIPTION
This is attempting to address multiple issues involving running multiple games or multiple instances of the same game from the same `WINEPREFIX` at the same time. These issues include:

 * When a second application starts and the first one closes, lutris doesn't recognize that the first application has closed.
 * When a second application closes, the first still-running application is killed.
 * When one application is stopped, all applications using that prefix are stopped. This is because behind the scenes, stop is using `wineserver -k`.

All of these issues are addressed in the below PR.

Instead of Lutris directly setting `PR_SET_CHILD_SUBREAPER` and having lots of children running around whose original parents are unknown and unknowable, we add an intermediate daemon (here `child_wrapper.py`, invoked as `python3 -m lutris.child_wrapper`) who sets `PR_SET_CHILD_SUBREAPER` and watches a game's process and its child processes on Lutris' behalf. It basically has two responsibilities:

 * collect all of a game's processes, no matter how tragic their lineage is, while ignoring other processes.
 * when `SIGINT` or `SIGTERM` are received, propagate those signals *only* to those directly relevant processes. Do NOT send them to `wineserver`.
 * Exit when all of the game processes exit, giving Lutris a simple indication that the game has exited.

Extra care had to be taken to avoid breaking the "run in terminal" feature and it actually works better now (it doesn't spawn an extra shell anymore and the terminal closes timely when the game closes).

Wine applications no longer invoke `wineserver -k`. Users can invoke `wineserver -k` by right-clicking a game and clicking "Kill all wine processes". This context menu is getting a little crowded now, though.

I believe there may be significant amounts of dead code laying around the process monitoring system and the wine runner now as I tore out a lot of code based on the old paradigm. It may need a once-over to find unused code and remove it.

I changed the wine runner to have a prelaunch step where we launch the `wineserver` as well, so that none of the `child_wrapper` instances will have the `wineserver` inside their perview. This is technically unnecessary because of the exclude process system working just fine to accomplish the same thing, I figured the more we can isolate the process trees the better off we'll be. However, processes like `plugplay.exe` and `winedevice.exe` are still created inside the `child_wrapper` process tree, so I'm not sure if my efforts have done much here.