### PR TITLE
Unify tips in configuration

### DIFF
--- a/lutris/gui/config_boxes.py
+++ b/lutris/gui/config_boxes.py
@@ -618,7 +618,7 @@ class RunnerBox(ConfigBox):
         if lutris_config.level == "game":
             self.generate_top_info_box(
                 "If modified, these options supersede the same options from "
-                "the base runner configuration."
+                "the base runner configuration and global preferences."
             )
         self.generate_widgets("runner")
 
@@ -637,8 +637,7 @@ class SystemBox(ConfigBox):
         if lutris_config.game_config_id and runner_slug:
             self.generate_top_info_box(
                 "If modified, these options supersede the same options from "
-                "the base runner configuration, which themselves supersede "
-                "the global preferences."
+                "the base runner configuration and global preferences."
             )
         elif runner_slug:
             self.generate_top_info_box(


### PR DESCRIPTION
Closes https://github.com/lutris/lutris/issues/1537
Now the text is this one for both tabs:
>If modified, these options supersede the same options from the base runner configuration and global preferences.

Looks pretty too:
![image](https://user-images.githubusercontent.com/10602045/51069067-00919a80-1639-11e9-877f-4b2590b3ac64.png)
