### PR TITLE
Revert "Send kill signal to game PID"

### DIFF
--- a/lutris/gui/game_panel.py
+++ b/lutris/gui/game_panel.py
@@ -166,6 +166,7 @@ class GamePanel(Gtk.Fixed):
                 self.put(button, position[0], position[1])
 
     def on_game_start(self, widget):
+        print("Game has started")
         self.buttons["play"].hide()
         self.buttons["stop"].show()
         self.buttons["show_logs"].set_sensitive(True)


### PR DESCRIPTION
This reverts commit 2945e1198319e8516b2ceb15ba39dbdd82f60aa8.

This makes the "stop" button end processes again. Mentioned in #1497 but maybe not related to the original issue.