### PR TITLE
Update get_game_by_id() to check for game.id

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -374,7 +374,7 @@ class Application(Gtk.Application):
 
     def get_game_by_id(self, game_id):
         for game in self.running_games:
-            if game.id == game_id:
+            if hasattr(game, 'id') and game.id == game_id:
                 return game
 
     @staticmethod


### PR DESCRIPTION
There were cases where running_games objects didn't have `id` properties, running into python errors. Checking to ensure the property exists first keeps it from breaking.