### PR TITLE
libretro: Update configuration and core detection

### DIFF
--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -141,10 +141,9 @@ class libretro(Runner):
                     return core[2]
         return ""
 
-    @staticmethod
-    def get_core_path(core):
+    def get_core_path(self, core):
         return os.path.join(
-            settings.RUNNER_DIR, "retroarch/cores/{}_libretro.so".format(core)
+            settings.RUNNER_DIR, "retroarch", "cores", "{}_libretro.so".format(core)
         )
 
     def get_version(self, use_default=True):
@@ -158,6 +157,7 @@ class libretro(Runner):
             core = self.game_config["core"]
         if not core or self.runner_config.get("runner_executable"):
             return self.is_retroarch_installed()
+
         is_core_installed = system.path_exists(self.get_core_path(core))
         return self.is_retroarch_installed() and is_core_installed
 
@@ -304,6 +304,10 @@ class libretro(Runner):
                 "text": "No core has been selected for this game",
             }
         command.append("--libretro={}".format(self.get_core_path(core)))
+
+        # Ensure the core is available
+        if not self.is_installed(core):
+            self.install(core)
 
         # Main file
         file = self.game_config.get("main_file")

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -116,16 +116,22 @@ class libretro(Runner):
 
     runner_options = [
         {
+            "option": "config_file",
+            "type": "file",
+            "label": "Config file",
+            "default": get_default_config_path("retroarch.cfg"),
+        },
+        {
             "option": "fullscreen",
             "type": "bool",
             "label": "Fullscreen",
             "default": True,
         },
         {
-            "option": "config_file",
-            "type": "file",
-            "label": "Config file",
-            "default": get_default_config_path("retroarch.cfg"),
+            "option": "verbose",
+            "type": "bool",
+            "label": "Verbose logging",
+            "default": False,
         },
     ]
 
@@ -208,28 +214,16 @@ class libretro(Runner):
             retro_config = RetroConfig(config_file)
             retro_config["libretro_directory"] = get_default_config_path("cores")
             retro_config["libretro_info_path"] = get_default_config_path("info")
-            retro_config["content_database_path"] = get_default_config_path(
-                "database/rdb"
-            )
-            retro_config["cheat_database_path"] = get_default_config_path(
-                "database/cht"
-            )
-            retro_config["cursor_directory"] = get_default_config_path(
-                "database/cursors"
-            )
-            retro_config["screenshot_directory"] = get_default_config_path(
-                "screenshots"
-            )
-            retro_config["input_remapping_directory"] = get_default_config_path(
-                "remaps"
-            )
+            retro_config["content_database_path"] = get_default_config_path("database/rdb")
+            retro_config["cheat_database_path"] = get_default_config_path("database/cht")
+            retro_config["cursor_directory"] = get_default_config_path("database/cursors")
+            retro_config["screenshot_directory"] = get_default_config_path("screenshots")
+            retro_config["input_remapping_directory"] = get_default_config_path("remaps")
             retro_config["video_shader_dir"] = get_default_config_path("shaders")
             retro_config["core_assets_directory"] = get_default_config_path("downloads")
             retro_config["thumbnails_directory"] = get_default_config_path("thumbnails")
             retro_config["playlist_directory"] = get_default_config_path("playlists")
-            retro_config["joypad_autoconfig_dir"] = get_default_config_path(
-                "autoconfig"
-            )
+            retro_config["joypad_autoconfig_dir"] = get_default_config_path("autoconfig")
             retro_config["rgui_config_directory"] = get_default_config_path("config")
             retro_config["overlay_directory"] = get_default_config_path("overlay")
             retro_config["assets_directory"] = get_default_config_path("assets")
@@ -283,10 +277,16 @@ class libretro(Runner):
 
     def get_runner_parameters(self):
         parameters = []
+
         # Fullscreen
         fullscreen = self.runner_config.get("fullscreen")
         if fullscreen:
             parameters.append("--fullscreen")
+
+        # Verbose
+        verbose = self.runner_config.get("verbose")
+        if verbose:
+            parameters.append("--verbose")
 
         parameters.append("--config={}".format(self.get_config_file()))
         return parameters

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -254,6 +254,7 @@ class Runner:
         request = Request(runner_api_url)
         response = request.get()
         response_content = response.json
+
         if response_content:
             versions = response_content.get("versions") or []
             arch = self.arch
@@ -274,6 +275,9 @@ class Runner:
                 default_version = [v for v in versions if v["default"] is True]
                 if default_version:
                     return default_version[0]
+            # If we didn't find a proper version yet, return the first available.
+            if len(versions_for_arch) >= 1:
+                return versions_for_arch[0]
 
     def install(self, version=None, downloader=None, callback=None):
         """Install runner using package management systems."""

--- a/lutris/util/libretro.py
+++ b/lutris/util/libretro.py
@@ -13,11 +13,16 @@ class RetroConfig:
         self.config = []
         with open(config_path, "r") as config_file:
             for line in config_file.readlines():
-                try:
-                    key, value = line.strip().split(" = ", 1)
-                except ValueError:
+                if not line:
                     continue
-                value = value.strip('"')
+                line = line.strip()
+                if line == "" or line.startswith('#'):
+                    continue
+                key, value = line.split("=")
+                key = key.strip()
+                value = value.strip().strip('"')
+                if not key or not value:
+                    continue
                 self.config.append((key, value))
 
     def save(self):
@@ -43,8 +48,8 @@ class RetroConfig:
                 return self.deserialize_value(value)
 
     def __setitem__(self, key, value):
-        for index, k, _ in enumerate(self.config):
-            if key == k:
+        for index, conf in enumerate(self.config):
+            if key == conf[0]:
                 self.config[index] = (key, self.serialize_value(value))
                 return
         self.config.append((key, self.serialize_value(value)))


### PR DESCRIPTION
This does a few things for RetroArch/libretro...

- Check for a core to be installed before running its content
- Allows for getting runner information on individual cores, when the core has multiple versions
- Adds `verbose` option
- Fixes some of the configuration parsing