### PR TITLE
Lower open file limits to those of systemd-240

### DIFF
--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -102,7 +102,7 @@ class LinuxSystem:
         '/usr/share/soundfonts',
     ]
 
-    recommended_no_file_open = 1048576
+    recommended_no_file_open = 524288
     required_components = ["OPENGL"]
     optional_components = ["VULKAN", "WINE", "GAMEMODE"]
 


### PR DESCRIPTION
Since systemd 240 raised the limits to 512K, we should probably lower the value that is required for activation of esync toggle so it would be less of a hassle to use the option.
According @zfigura: 
> through testing we found at least one application (Google Earth VR) that had a bad leak and used 300k handles. after that I think we set the limit on the test rigs to 1M after Debian-based distributions, so I don't know if any other application suffers from the same or worse
most people here seem to set their limits to 1M, I'm pretty sure I've heard some people set theirs to 200k and have no problems. I'm not positive though
this is what I told to fedora and then systemd when that discussion happened

So this change should be relatively safe.
