### PR TITLE
travis: Cache the pip dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ install:
   - sudo apt-get install -y python3-yaml python3-gi python3-pil gir1.2-gtk-3.0 psmisc gir1.2-glib-2.0 libgirepository1.0-dev gir1.2-gnomedesktop-3.0 gir1.2-webkit2-4.0 gir1.2-notify-0.7
 script: nosetests
 
+# Cache the pip dependencies
+cache: pip


### PR DESCRIPTION
This will speed up initialization of some of the dependency chain. Could do more of this elsewhere too, but pip is a good start:
https://docs.travis-ci.com/user/caching/#pip-cache