### PR TITLE
make lutris.util.downloader use monotonic time

### DIFF
--- a/lutris/util/downloader.py
+++ b/lutris/util/downloader.py
@@ -6,6 +6,10 @@ from lutris.util import http, jobs
 from lutris.util.log import logger
 
 
+# `time.time` can skip ahead or even go backwards if the current
+# system time is changed between invocations. Use `time.monotonic`
+# so we won't have screenshots making fun of us for showing negative
+# download speeds.
 get_time = time.monotonic
 
 


### PR DESCRIPTION
`time.time` can go backwards if the system clock time is changed. This makes it inappropriate for measuring the length of time between two events. Replace with `time.monotonic` inside `lutris.util.downloader`.