### PR TITLE
prevent DXVK overrides from appearing in config

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -680,10 +680,17 @@ class wine(Runner):
 
     def get_dll_overrides(self):
         """Return the DLLs overriden at runtime"""
-        overrides = self.runner_config.get("overrides") or {}
-        if not isinstance(overrides, dict):
-            logger.warning("DLL overrides is not a mapping: %s", overrides)
+        try:
+            overrides = self.runner_config['overrides']
+        except KeyError:
             overrides = {}
+        else:
+            if not isinstance(overrides, dict):
+                logger.warning("DLL overrides is not a mapping: %s", overrides)
+                overrides = {}
+            else:
+                overrides = overrides.copy()
+
         overrides.update(self.dll_overrides)
         return overrides
 


### PR DESCRIPTION
Fixes #1590.

The essential change here was using `.copy()` to create a new dictionary before modifying it with DXVK overrides.