### PR TITLE
Add wine SampleCount option

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -102,6 +102,7 @@ class wine(Runner):
         "MouseWarpOverride": r"%s/DirectInput" % reg_prefix,
         "OffscreenRenderingMode": r"%s/Direct3D" % reg_prefix,
         "StrictDrawOrdering": r"%s/Direct3D" % reg_prefix,
+        "SampleCount": r"%s/Direct3D" % reg_prefix,
         "Desktop": "MANAGED",
         "WineDesktop": "MANAGED",
         "ShowCrashDialog": "MANAGED",
@@ -354,6 +355,25 @@ class wine(Runner):
                     "In general disabling GLSL is not recommended, "
                     "only use this for debugging purposes."
                 ),
+            },
+            {
+                'option': 'SampleCount',
+                'label': "Anti-aliasing Sample Count",
+                'type': 'choice',
+                'choices': [
+                            ('0', '0 (disabled)'),
+                            ('2', '2'),
+                            ('4', '4'),
+                            ('8', '8'),
+                            ('16', '16')],
+                'default': '0',
+                'advanced': True,
+                'help': (
+                    "Override swapchain sample count. It can be used to force enable multisampling"
+                    "with applications that otherwise don't support it, like the similar control panel setting"
+                    "available with some GPU drivers. This one might work in more cases than the driver setting though."
+                    " Not all applications are compatible with all sample counts. "
+                   )
             },
             {
                 "option": "UseXVidMode",
@@ -647,7 +667,11 @@ class wine(Runner):
                         value = None
                     managed_keys[key](value)
                     continue
-                prefix_manager.set_registry_key(path, key, value)
+                # Convert numeric strings to integers so they are saved as dword
+                if value.isdigit():
+                    value = int(value)
+
+                    prefix_manager.set_registry_key(path, key, value)
 
     def toggle_dxvk(self, enable, version=None):
         dxvk_manager = dxvk.DXVKManager(

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -357,18 +357,18 @@ class wine(Runner):
                 ),
             },
             {
-                'option': 'SampleCount',
-                'label': "Anti-aliasing Sample Count",
-                'type': 'choice',
-                'choices': [
-                            ('0', '0 (disabled)'),
-                            ('2', '2'),
-                            ('4', '4'),
-                            ('8', '8'),
-                            ('16', '16')],
-                'default': '0',
-                'advanced': True,
-                'help': (
+                "option": "SampleCount",
+                "label": "Anti-aliasing Sample Count",
+                "type": "choice",
+                "choices": [
+                            ("0", "0 (disabled)"),
+                            ("2", "2"),
+                            ("4", "4"),
+                            ("8", "8"),
+                            ("16", "16")],
+                "default": "0",
+                "advanced": True,
+                "help": (
                     "Override swapchain sample count. It can be used to force enable multisampling "
                     "with applications that otherwise don't support it, like the similar control panel setting "
                     "available with some GPU drivers. This one might work in more cases than the driver setting though. "

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -671,7 +671,7 @@ class wine(Runner):
                 if value.isdigit():
                     value = int(value)
 
-                    prefix_manager.set_registry_key(path, key, value)
+                prefix_manager.set_registry_key(path, key, value)
 
     def toggle_dxvk(self, enable, version=None):
         dxvk_manager = dxvk.DXVKManager(

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -369,9 +369,9 @@ class wine(Runner):
                 'default': '0',
                 'advanced': True,
                 'help': (
-                    "Override swapchain sample count. It can be used to force enable multisampling"
-                    "with applications that otherwise don't support it, like the similar control panel setting"
-                    "available with some GPU drivers. This one might work in more cases than the driver setting though."
+                    "Override swapchain sample count. It can be used to force enable multisampling "
+                    "with applications that otherwise don't support it, like the similar control panel setting "
+                    "available with some GPU drivers. This one might work in more cases than the driver setting though. "
                     " Not all applications are compatible with all sample counts. "
                    )
             },


### PR DESCRIPTION
A trivial change to expose WINE's registry option SampleCount in Lutris' GUI. This allows forcing MSAA in games. It's useful for older games that don't have an in-game option for anti-aliasing. 

I'm fairly sure this will also need adding in the code that parses installers so you can set the SampleCount in the installer, if it's required.