### PR TITLE
runner: Fix lutris.gui.dialogs.runners

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -233,7 +233,7 @@ class Runner:
         )
         if Gtk.ResponseType.YES == dialog.result:
 
-            from lutris.gui.runnersdialog import simple_downloader
+            from lutris.gui.dialogs.runners import simple_downloader
             if hasattr(self, "get_version"):
                 self.install(downloader=simple_downloader,
                              version=self.get_version(use_default=False))


### PR DESCRIPTION
The `simple_downloader` function now lives in `lutris/guid/dialogs/runners`.