### PR TITLE
Launch with the correct Game object using the found ID

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -327,7 +327,7 @@ class Application(Gtk.Application):
             # If game is not installed, show the GUI before running. Otherwise leave the GUI closed.
             if not db_game["installed"]:
                 self.window.present()
-            self.launch(db_game["id"])
+            self.launch(Game(db_game["id"]))
 
         else:
             self.window.present()


### PR DESCRIPTION
Encountered this issue when I was trying to add a non-steam game with the shortcut generated by Lutris. 

The wrong type was being passed to `launch`, and causing it to crash. Small fix to allow shortcut to be run correctly.

This was tested using the `lutris-git` AUR package pointing to my repository. 