### PR TITLE
checks can crash the program when an unmigrated game needs to be provided a platform

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: games
 Priority: optional
 Build-Depends: debhelper,
  python3,
+ python3-yaml,
  python3-setuptools,
  python3-requests,
  python3-pil,
@@ -10,6 +11,9 @@ Build-Depends: debhelper,
  dh-python,
  gir1.2-gtk-3.0,
  gir1.2-glib-2.0,
+ gir1.2-gnomedesktop-3.0,
+ gir1.2-webkit2-4.0,
+ gir1.2-notify-0.7,
  libgirepository1.0-dev
 Maintainer: Mathieu Comandon <strider@strycore.com>
 Standards-Version: 3.9.5

--- a/lutris.spec
+++ b/lutris.spec
@@ -112,6 +112,7 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{name}.desktop
 
 %files
 %{_bindir}/%{name}
+%{_bindir}/lutris-wrapper
 %{_datadir}/%{name}/
 %{_datadir}/appdata/%{appid}.appdata.xml
 %{_datadir}/applications/%{appid}.desktop

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -220,8 +220,8 @@ class Application(Gtk.Application):
             return 0
 
         logger.info("Running Lutris %s", settings.VERSION)
-        run_all_checks()
         migrate()
+        run_all_checks()
         AsyncCall(init_dxvk_versions)
 
         # List game


### PR DESCRIPTION
if an un-migrated game needs to be provided a platform, lutris checks will crash the program when trying to save the game's data.  
this happens because `playtime` couldn't be initialized with un-migrated data and thus isn't an attribute in the Game object.  

so this PR should fix 3 issues:  
- `Game` object doesn't always have `playtime` attribute  
- `fill_missing_platforms` is called before migration, and tries to save un-migrated game data   
- `fill_missing_platforms` is saving data even when it fails to get platform

Log: https://pastebin.com/HBZN7R5c