### PR TITLE
Fix the zdoom runner not working

### DIFF
--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -80,11 +80,6 @@ class zdoom(Runner):
         },
     ]
 
-    @property
-    def working_dir(self):
-        # Run in the installed game's directory.
-        return self.game_path
-
     def get_executable(self):
         executable = super(zdoom, self).get_executable()
         executable_dir = os.path.dirname(executable)


### PR DESCRIPTION
Since the game's directory is never set in game_data, since it's kinda hard to tell with Doom, self.game_path doesn't return anything, causing the runner to stop without anyone ever knowing. Simply using the default for working working_dir works fine. This could be changed to possibly use the WAD directory as the working directory, but I'm not sure