### PR TITLE
residualvm: options to `--renderer` are strings, not numbers

### DIFF
--- a/lutris/runners/residualvm.py
+++ b/lutris/runners/residualvm.py
@@ -36,7 +36,7 @@ class residualvm(Runner):
             "option": "renderer",
             "label": "Renderer",
             "type": "choice",
-            "choices": (("OpenGL", "0"), ("OpenGL shaders", "1"), ("Software", "2")),
+            "choices": (("OpenGL", "opengl"), ("OpenGL shaders", "opengl_shaders"), ("Software", "software")),
             "default": "OpenGL",
         },
         {


### PR DESCRIPTION
I'm... not really sure what I was thinking at the time, but this should be the proper way to specify renderer types to residualvm.