### PR TITLE
add PrimusVK as a bumblebee option (adds Vulkan functionality)

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -353,6 +353,8 @@ class Game(GObject.Object):
             launch_arguments.insert(0, "virtualgl")
             launch_arguments.insert(0, "-b")
             launch_arguments.insert(0, "optirun")
+        elif optimus == "pvkrun" and system.find_executable("pvkrun"):
+            launch_arguments.insert(0, "pvkrun")
 
         xephyr = system_config.get("xephyr") or "off"
         if xephyr != "off":

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -13,6 +13,8 @@ def get_optirun_choices():
         choices.append(("primusrun", "primusrun"))
     if system.find_executable("optirun"):
         choices.append(("optirun/virtualgl", "optirun"))
+    if system.find_executable("pvkrun"):
+        choices.append(("primus vk", "pvkrun"))
     return choices
 
 
@@ -129,6 +131,7 @@ system_options = [  # pylint: disable=invalid-name
             "activating your NVIDIA graphic chip for high 3D "
             "performance. primusrun normally has better performance, but"
             "optirun/virtualgl works better for more games."
+            "Primus VK provide vulkan support under bumblebee."
         ),
     },
     {

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -17,6 +17,7 @@ SYSTEM_COMPONENTS = {
         "vulkaninfo",
         "optirun",
         "primusrun",
+        "pvkrun",
         "xboxdrv",
         "pulseaudio",
         "lsi-steam",


### PR DESCRIPTION
Implements PrimusVK as another option for Vulkan support for those that have it installed on their system with bumblebee. This is mostly because it is a viable option now for those that take advantage of bumblebee. The project itself can be found here. https://github.com/felixdoerre/primus_vk