### PR TITLE
give every installer cache dir a unique name

### DIFF
--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -9,7 +9,8 @@ from lutris.util import system
 
 class InstallerFile:
     """Representation of a file in the `files` sections of an installer"""
-    def __init__(self, game_slug, file_id, file_meta):
+    def __init__(self, game_slug, file_id, file_meta, launch_time):
+        self.launch_time = launch_time
         self.game_slug = game_slug
         self.id = file_id  # pylint: disable=invalid-name
         self.dest_file = None
@@ -67,7 +68,7 @@ class InstallerFile:
             else:
                 folder = self.id
             return os.path.join(settings.read_setting("pga_cache_path"), self.game_slug, folder)
-        return os.path.join(settings.CACHE_DIR, "installer/%s" % self.game_slug)
+        return os.path.join(settings.CACHE_DIR, "installer/%s-%d" % (self.game_slug, self.launch_time))
 
     def get_download_info(self):
         """Retrieve the file locally"""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -102,6 +102,7 @@ class ScriptInterpreter(CommandsMixin):
     """
 
     def __init__(self, installer, parent):
+        self.launch_time = int(time.time() * 1000)
         self.error = None
         self.errors = []
         self.target_path = None
@@ -142,7 +143,7 @@ class ScriptInterpreter(CommandsMixin):
             )
 
         self.files = [
-            InstallerFile(self.game_slug, file_id, file_meta)
+            InstallerFile(self.game_slug, file_id, file_meta, self.launch_time)
             for file_desc in self.script.get("files", [])
             for file_id, file_meta in file_desc.items()
         ]
@@ -171,7 +172,7 @@ class ScriptInterpreter(CommandsMixin):
     @property
     def cache_path(self):
         """Return the directory used as a cache for the duration of the installation"""
-        return os.path.join(settings.CACHE_DIR, "installer/%s" % self.game_slug)
+        return os.path.join(settings.CACHE_DIR, "installer/%s-%d" % (self.game_slug, self.launch_time))
 
     @property
     def creates_game_folder(self):
@@ -321,7 +322,7 @@ class ScriptInterpreter(CommandsMixin):
                 InstallerFile(self.game_slug, file_id, {
                     "url": link,
                     "filename": filename,
-                })
+                }, self.launch_time)
             )
 
     def prepare_game_files(self):


### PR DESCRIPTION
Fixes #1773 
This patch gives every cache directory of every installer its own unique name by appending the start time of the installer in milliseconds to the directory name. I have done some basic testing with two different games and it seems to work just fine.