### PR TITLE
Manage runner win to fit on common laptop screens

### DIFF
--- a/share/lutris/ui/runners-dialog.ui
+++ b/share/lutris/ui/runners-dialog.ui
@@ -4,7 +4,7 @@
   <requires lib="gtk+" version="3.10"/>
   <object class="GtkWindow" id="runners_dialog">
     <property name="width_request">800</property>
-    <property name="height_request">800</property>
+    <property name="height_request">740</property>
     <property name="can_focus">False</property>
     <property name="destroy_with_parent">True</property>
     <signal name="configure-event" handler="on_resize" swapped="no"/>


### PR DESCRIPTION
Change to allow the manage runners window to fit on common laptop screens (the most common is 1366x768) without negatively affecting anything else.