### PR TITLE
Add 5px margin to all sides of search entry

### DIFF
--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -614,6 +614,10 @@
                             <property name="can_focus">True</property>
                             <property name="halign">center</property>
                             <property name="valign">center</property>
+                            <property name="margin_left">5</property>
+                            <property name="margin_right">5</property>
+                            <property name="margin_top">5</property>
+                            <property name="margin_bottom">5</property>
                             <property name="hexpand">True</property>
                             <property name="width_chars">50</property>
                             <property name="placeholder_text" translatable="yes">Filter the list of games</property>


### PR DESCRIPTION
The search entry has currently no margin, making it look baked to the sides. This adds 5px margin to all sides.

Before:
![before_lutris_search_entry](https://user-images.githubusercontent.com/15329494/54073440-6ab86b80-4287-11e9-874e-707a6ce2772d.png)

After:
![after_lutris_search_entry](https://user-images.githubusercontent.com/15329494/54073441-6e4bf280-4287-11e9-9604-9dd2e093e97a.png)
