### PR TITLE
lutris.command: improve logging performance

### DIFF
--- a/lutris/command.py
+++ b/lutris/command.py
@@ -1,5 +1,6 @@
 """Threading module, used to launch games while monitoring them."""
 
+import io
 import os
 import sys
 import shlex
@@ -50,7 +51,6 @@ class MonitoredCommand:
         self.return_code = None
         self.terminal = system.find_executable(term)
         self.is_running = True
-        self.stdout = ""
         self.daemon = True
         self.error = None
         self.log_handlers = [
@@ -65,6 +65,12 @@ class MonitoredCommand:
 
         # Keep a copy of previously running processes
         self.cwd = self.get_cwd(cwd)
+
+        self._stdout = io.StringIO()
+
+    @property
+    def stdout(self):
+        return self._stdout.getvalue()
 
     @property
     def wrapper_command(self):
@@ -134,7 +140,7 @@ class MonitoredCommand:
 
     def log_handler_stdout(self, line):
         """Add the line to this command's stdout attribute"""
-        self.stdout += line
+        self._stdout.write(line)
 
     def log_handler_buffer(self, line):
         """Add the line to the associated LogBuffer object"""

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -84,10 +84,18 @@ class Game(GObject.Object):
         self.compositor_disabled = False
         self.stop_compositor = self.start_compositor = ""
         self.original_outputs = None
-        self.log_buffer = Gtk.TextBuffer()
-        self.log_buffer.create_tag("warning", foreground="red")
-
+        self._log_buffer = None
         self.timer = Timer()
+
+    @property
+    def log_buffer(self):
+        if self._log_buffer is None:
+            self._log_buffer = Gtk.TextBuffer()
+            self._log_buffer.create_tag("warning", foreground="red")
+            if self.game_thread:
+                self.game_thread.set_log_buffer(self._log_buffer)
+                self._log_buffer.set_text(self.game_thread.stdout)
+        return self._log_buffer
 
     def __repr__(self):
         return self.__unicode__()
@@ -500,7 +508,7 @@ class Game(GObject.Object):
             runner=self.runner,
             env=self.game_runtime_config["env"],
             term=self.game_runtime_config["terminal"],
-            log_buffer=self.log_buffer,
+            log_buffer=self._log_buffer,
             include_processes=self.game_runtime_config["include_processes"],
             exclude_processes=self.game_runtime_config["exclude_processes"],
         )


### PR DESCRIPTION
This improves logging performance by about 3x by avoiding expensive repeated string concatenation, instead using `StringIO`.