### PR TITLE
Add option to use xdg-open instead of Gtk.show_uri for browsing files

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -1,6 +1,7 @@
 """Handle game specific actions"""
 import os
 import signal
+import subprocess
 from gi.repository import Gio
 from lutris.command import MonitoredCommand
 from lutris.game import Game
@@ -217,7 +218,10 @@ class GameActions:
         if not path:
             dialogs.NoticeDialog("This game has no installation directory")
         elif path_exists(path):
-            open_uri("file://%s" % path)
+            if self.game.runner.system_config.get("use_xdg_utils"):
+                subprocess.run(["xdg-open", path])
+            else:
+                open_uri("file://%s" % path)
         else:
             dialogs.NoticeDialog("Can't open %s \nThe folder doesn't exist." % path)
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -353,6 +353,14 @@ system_options = [  # pylint: disable=invalid-name
         "advanced": True,
         "help": "Open Xephyr in fullscreen (at the desktop resolution)",
     },
+    {
+        "option": "use_xdg_utils",
+        "type": "bool",
+        "label": "Use xdg utils",
+        "default": False,
+        "advanced": True,
+        "help": "Use xdg-open instead of Gtk.show_uri for browsing, and other xdg utils",
+    },
 ]
 
 


### PR DESCRIPTION
Implementation of #1869
Even if it's not welcome for merge, at least this makes it visible to other people having the same problem I did, with gtk opening a random program (as the spec indicates it should when no default has been configured with gtk tools).