### PR TITLE
Add file_glob command, aliases in input_menu

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -616,6 +616,39 @@ selected is French, the "$INPUT_LANG" alias would be available in
 following directives and would correspond to "fr". "$INPUT" would work as well,
 up until the next input directive.
 
+Finding one or more files with wildcards
+----------------------------------------
+
+Files can be searched for with the ``file_glob`` directive.
+The ``filespec`` parameter holds a file path including wildcards as follows:
+
+- ? matches any single character (file? matches file1 and fileX)
+- \* matches zero or more characters (file\* matches file1 and fileXYZ)
+- \*\* matches zero or more levels of directory nesting (dir/\*\*/file matches dir/file and dir/dir2/dir3/file)
+- [abc] matches a single a, b, or c
+- [!abc] matches a single character that is not a, b, or c
+
+Zero matches are an error by default, set the ``missing`` parameter to ``blank`` to yield an empty string or ``raw`` to yield the filespec itself.
+By default the first match will be returned, set the ``multiple`` parameter to get a list. By default the list will be separated by spaces, use the ``delimiter`` parameter to specify an alternative.
+
+The result of the last file_glob directive is available with the ``$GLOB`` alias.
+If need be, you can add an ``id`` parameter to the directive which will make the
+selected value available with ``$GLOB_<id>``. The id must contain only numbers, letters and underscores.
+
+Example:
+
+::
+
+    - file_glob:
+        filespec: "/usr/share/**/*Mono*.ttf"
+        id: MONOFONTS
+        multiple: true
+        delimiter: ","
+
+This example will find some semblance of all of the fonts with "Mono" in their name
+and put them in the "$GLOB_MONOFONTS" alias for following directives. If there are more
+than one result, they will be separated by commas.
+
 
 Trying the installer locally
 ============================

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -113,6 +113,7 @@ class ScriptInterpreter(CommandsMixin):
         self.cancelled = False
         self.abort_current_task = None
         self.user_inputs = []
+        self.file_globs = []
         self.steam_data = {}
         self.gog_data = {}
         self.script = installer.get("script")
@@ -733,6 +734,7 @@ class ScriptInterpreter(CommandsMixin):
             "STEAM_DATA_DIR": steam.steam().steam_data_dir,
             "DISC": self.game_disc,
             "USER": os.getenv("USER"),
+            "GLOB": self._get_last_file_glob(),
             "INPUT": self._get_last_user_input(),
             "VERSION": self.version,
             "RESOLUTION": "x".join(self.current_resolution),
@@ -741,7 +743,8 @@ class ScriptInterpreter(CommandsMixin):
 
         }
         # Add 'INPUT_<id>' replacements for user inputs with an id
-        for input_data in self.user_inputs:
+        # and 'GLOB_<id>' replacements for file globs with an id
+        for input_data in self.user_inputs + self.file_globs:
             alias = input_data["alias"]
             if alias:
                 replacements[alias] = input_data["value"]
@@ -751,6 +754,9 @@ class ScriptInterpreter(CommandsMixin):
 
     def _get_last_user_input(self):
         return self.user_inputs[-1]["value"] if self.user_inputs else ""
+
+    def _get_last_file_glob(self):
+        return self.file_globs[-1]["value"] if self.file_globs else ""
 
     def eject_wine_disc(self):
         """Use Wine to eject a CD, otherwise Wine can have problems detecting disc changes"""


### PR DESCRIPTION
Per discussion on Discord, this PR adds a new installer directive `file_glob` which allows searching the filesystem for files and putting them in an alias to be referenced later. The immediate use case is to locate Vulkan json files that have slightly different naming schemes on different distros.

For testing purposes I also added alias substitution to input_menu keys and values, and that feels like a useful feature to keep. I can take it out, if necessary.