### PR TITLE
GH-578 Hide GUI window on rungame command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,8 @@ build
 .pydevproject
 .settings
 .ropeproject
+.idea
 tags
-.ropeproject
 *.pyc
 *.pyo
 PYSMELLTAGS

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -178,7 +178,6 @@ class Application(Gtk.Application):
             Gtk.StyleContext.add_provider_for_screen(
                 screen, self.css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             )
-        self.window.present()
 
     @staticmethod
     def _print(command_line, string):
@@ -321,6 +320,8 @@ class Application(Gtk.Application):
         elif action in ("rungame", "rungameid"):
             if not db_game or not db_game["id"]:
                 logger.warning("No game found in library")
+                if not self.window.is_visible():
+                    self.do_shutdown()
                 return 0
 
             logger.info("Launching %s", db_game["name"])


### PR DESCRIPTION
Prevent Lutris window to open when running a game from command line.
The opening window seems to be a regression introduced by commit dabf7ef
which was a revert of commit 7ca5f6c9. Adding back chunks of commit
7ca5f6c9 prevent the Lutris window from opening when running game from
command line.

Also removing a duplicate entry from the .gitignore file and adding
JetBrains IDE projet directory.