### PR TITLE
Change Use Prime option to Use discrete graphics

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -11,7 +11,7 @@ lutris (0.5.1) cosmic; urgency=medium
   * Fix GOG games not being installable without being connected to GOG
   * Improve performance of log handling
   * Remove winecfg if Proton is used
-  * Enable Prime by default for compatible systems
+  * Use discrete graphics by default with compatible systems
   * Various fixes
 
  -- Mathieu Comandon <strycore@gmail.com>  Wed, 20 Mar 2019 00:24:27 -0700

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -156,7 +156,7 @@ system_options = [  # pylint: disable=invalid-name
         "type": "bool",
         "default": display.USE_DRI_PRIME,
         "condition": display.USE_DRI_PRIME,
-        "label": "Use PRIME (hybrid graphics on laptops)",
+        "label": "Use discrete graphics",
         "advanced": True,
         "help": (
             "If you have open source graphic drivers (Mesa), selecting this "


### PR DESCRIPTION
Regular people don't know what the hell "PRIME" is. "Use discrete graphics" is much more obvious and also quite shorter than "Use PRIME (hybrid graphics on laptops)"