### PR TITLE
Change default icon folder to 128x128

### DIFF
--- a/lutris.spec
+++ b/lutris.spec
@@ -127,6 +127,8 @@ desktop-file-validate %{buildroot}%{_datadir}/applications/%{appid}.desktop
 %{_datadir}/icons/hicolor/24x24/apps/lutris.png
 %{_datadir}/icons/hicolor/32x32/apps/lutris.png
 %{_datadir}/icons/hicolor/48x48/apps/lutris.png
+%{_datadir}/icons/hicolor/64x64/apps/lutris.png
+%{_datadir}/icons/hicolor/128x128/apps/lutris.png
 %{_datadir}/icons/hicolor/scalable/apps/lutris.svg
 %{_datadir}/polkit-1/actions/*
 %{python3_sitelib}/%{name}-*.egg-info

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -23,7 +23,7 @@ GAME_CONFIG_DIR = os.path.join(CONFIG_DIR, "games")
 TMP_PATH = os.path.join(CACHE_DIR, "tmp")
 BANNER_PATH = os.path.join(DATA_DIR, "banners")
 COVERART_PATH = os.path.join(DATA_DIR, "coverart")
-ICON_PATH = os.path.join(GLib.get_user_data_dir(), "icons", "hicolor", "32x32", "apps")
+ICON_PATH = os.path.join(GLib.get_user_data_dir(), "icons", "hicolor", "128x128", "apps")
 
 sio = SettingsIO(CONFIG_FILE)
 PGA_DB = sio.read_setting("pga_path") or os.path.join(DATA_DIR, "pga.db")


### PR DESCRIPTION
Fixes #1903
Btw, I noticed that even without my changes, I always see `gtk-update-icon-cache: The generated cache was invalid.` pop up in the log. Is that normal?