### PR TITLE
Fix Steam not starting when clicking the play-button next to the runner in 0.5.1

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -165,11 +165,12 @@ class steam(Runner):
 
     @property
     def game_path(self):
-        for apps_path in self.get_steamapps_dirs():
-            game_path = get_path_from_appmanifest(apps_path, self.appid)
-            if game_path:
-                return game_path
-        logger.info("Data path for SteamApp %s not found.", self.appid)
+        if self.appid:
+            for apps_path in self.get_steamapps_dirs():
+                game_path = get_path_from_appmanifest(apps_path, self.appid)
+                if game_path:
+                    return game_path
+            logger.info("Data path for SteamApp %s not found.", self.appid)
 
     @property
     def steam_data_dir(self):


### PR DESCRIPTION
runners/steam.py: game_path is expected to return None, when called without an appid set according to working_dir in runners/runner.py - this fixes Steam not starting when clicking the play-button next to the runner in 0.5.1