### PR TITLE
GH-578 Hide GUI window on rungame command

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -174,7 +174,6 @@ class Application(Gtk.Application):
             Gtk.StyleContext.add_provider_for_screen(
                 screen, self.css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             )
-        self.window.present()  # EXPLAIN YOURSELF BEFORE MESSING WITH THAT LINE
 
     @staticmethod
     def _print(command_line, string):
@@ -310,6 +309,7 @@ class Application(Gtk.Application):
                 action = "install"
 
         if action == "install":
+            self.window.present()
             InstallerWindow(
                 game_slug=game_slug,
                 installer_file=installer_file,


### PR DESCRIPTION
Instead of showing the window unconditionally in the do_activate method,
move the window.present() into the install action, the full behavior
should then be:
* not show the window for rungame/rungameid action, unless the provided
game is not installed
* show the window in any other cases