### PR TITLE
Implemented search feature in LogWindow (#1395)

### DIFF
--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -1,5 +1,5 @@
 """Window to show game logs"""
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from lutris.gui.widgets.log_text_view import LogTextView
 
 
@@ -13,9 +13,54 @@ class LogWindow(Gtk.ApplicationWindow):
         self.buffer = buffer
         self.logtextview = LogTextView(self.buffer)
 
+        self.vbox = Gtk.VBox(spacing=6)
+        self.add(self.vbox)
+
         scrolledwindow = Gtk.ScrolledWindow(
             hexpand=True, vexpand=True, child=self.logtextview
         )
+        self.vbox.pack_start(scrolledwindow, True, True, 0)
 
-        self.add(scrolledwindow)
+        self.search_entry = Gtk.SearchEntry()
+        self.search_entry.props.placeholder_text = "Search..."
+        self.search_entry.connect("stop-search", self.dettach_search_entry)
+        self.search_entry.connect("search-changed", self.logtextview.find_first)
+        self.search_entry.connect("next-match", self.logtextview.find_next)
+        self.search_entry.connect("previous-match", self.logtextview.find_previous)
+
+        self.connect("key-press-event", self.on_key_press_event)
+
         self.show_all()
+
+    def on_key_press_event(self, widget, event):
+        if event.keyval == Gdk.KEY_Escape:
+            self.search_entry.emit("stop-search")
+            return
+
+        ctrl = (event.state & Gdk.ModifierType.CONTROL_MASK)
+        if ctrl and event.keyval == Gdk.KEY_f:
+            self.attach_search_entry()
+            return
+
+        shift = (event.state & Gdk.ModifierType.SHIFT_MASK)
+        if event.keyval == Gdk.KEY_Return:
+            if shift:
+                self.search_entry.emit("previous-match")
+            else:
+                self.search_entry.emit("next-match")
+
+    def attach_search_entry(self):
+        if self.search_entry.props.parent is None:
+            self.vbox.pack_start(self.search_entry, False, False, 0)
+            self.show_all()
+            self.search_entry.grab_focus()
+            if len(self.search_entry.get_text()) > 0:
+                self.logtextview.find_first(self.search_entry)
+
+    def dettach_search_entry(self, searched_entry):
+        if self.search_entry.props.parent is not None:
+            self.logtextview.reset_search()
+            self.vbox.remove(self.search_entry)
+            # Replace to bottom of log
+            adj = self.logtextview.get_vadjustment()
+            self.logtextview.scroll_max = adj.get_lower()

--- a/lutris/gui/widgets/log_text_view.py
+++ b/lutris/gui/widgets/log_text_view.py
@@ -7,11 +7,15 @@ class LogTextView(Gtk.TextView):
 
         self.set_buffer(buffer)
         self.set_editable(False)
+        self.set_cursor_visible(False)
         self.set_monospace(True)
         self.set_left_margin(10)
         self.scroll_max = 0
         self.set_wrap_mode(Gtk.WrapMode.CHAR)
         self.get_style_context().add_class("lutris-logview")
+
+        self.mark = self.create_new_mark(self.props.buffer.get_start_iter())
+
         if autoscroll:
             self.connect("size-allocate", self.autoscroll)
 
@@ -22,3 +26,67 @@ class LogTextView(Gtk.TextView):
             self.scroll_max = adj.get_value()
         else:
             self.scroll_max = adj.get_upper() - adj.get_page_size()
+
+    def create_new_mark(self, buffer_iter):
+        return self.props.buffer.create_mark(
+            None,
+            buffer_iter,
+            True
+        )
+
+    def reset_search(self):
+        self.props.buffer.delete_mark(self.mark)
+        self.mark = self.create_new_mark(self.props.buffer.get_start_iter())
+        self.props.buffer.place_cursor(self.props.buffer.get_iter_at_mark(self.mark))
+
+    def find_first(self, searched_entry):
+        self.reset_search()
+        self.find_next(searched_entry)
+
+    def find_next(self, searched_entry):
+        buffer_iter = self.props.buffer.get_iter_at_mark(self.mark)
+        next_occurence = buffer_iter.forward_search(
+            searched_entry.get_text(),
+            Gtk.TextSearchFlags.CASE_INSENSITIVE,
+            None)
+
+        # Found nothing try from the beginning
+        if next_occurence is None:
+            next_occurence = self.props.buffer.get_start_iter().forward_search(
+                searched_entry.get_text(),
+                Gtk.TextSearchFlags.CASE_INSENSITIVE,
+                None)
+
+        # Highlight if result
+        if next_occurence is not None:
+            self.highlight(next_occurence[0], next_occurence[1])
+            self.props.buffer.delete_mark(self.mark)
+            self.mark = self.create_new_mark(next_occurence[1])
+
+    def find_previous(self, searched_entry):
+        # First go to the beginning of searched_entry string
+        buffer_iter = self.props.buffer.get_iter_at_mark(self.mark)
+        buffer_iter.backward_chars(len(searched_entry.get_text()))
+
+        previous_occurence = buffer_iter.backward_search(
+            searched_entry.get_text(),
+            Gtk.TextSearchFlags.CASE_INSENSITIVE,
+            None)
+
+        # Found nothing ? Try from the end
+        if previous_occurence is None:
+            previous_occurence = self.props.buffer.get_end_iter().backward_search(
+                searched_entry.get_text(),
+                Gtk.TextSearchFlags.CASE_INSENSITIVE,
+                None)
+
+        # Highlight if result
+        if previous_occurence is not None:
+            self.highlight(previous_occurence[0], previous_occurence[1])
+            self.props.buffer.delete_mark(self.mark)
+            self.mark = self.create_new_mark(previous_occurence[1])
+
+    def highlight(self, range_start, range_end):
+        self.props.buffer.select_range(range_start, range_end)
+        # Focus
+        self.scroll_mark_onscreen(self.mark)


### PR DESCRIPTION
Hi,
I may be new around here but I wanted to give it a shot anyway.

I wasn't sure about the coding conventions, so I used exclusively spaces and followed snake_case syntax to stay consistent with the code in place, I just didn't set up the lint yet. :disappointed: 

But here's a proposition of an implementation of the search feature for the `LogWindow` class in order to adress issue #1395 .
It massively relies on the Gtk implementation to do the actual search, using the various signals of `Gtk.SearchEntry` but also the `Gtk.TextIter` `forward_search` and `backward_search` functions while using `Gtk.TextMark` because the buffer is constantly mutated and we can't rely on `Gtk.TextIter` alone.

The event part stays in the view/controller part (`LogWindow(Gtk.ApplicationWindow)`) and the search/algorithmic part stays in the model part (`LogTextView(Gtk.TextView)`).

There is just a slightly front-end correction to add so highlighted text near the edges of the window stay visible and maybe better support the already existing autoscroll function but aside from it should be 100% functional.

**How-to**:

- **Ctrl + F** on log window brings the `SearchEntry`
- **Escape** while there's the `SearchEntry` hides it
- Typing in the `SearchEntry` searches for the first occurrence
- **Ctrl + G** (default) and **Return** hops to next occurrence (while in `SearchEntry`)
- **Ctrl + Shift + G** (default) and **Shift + Return** hops to previous occurrence (while in `SearchEntry`)

Finally, I wasn't sure if I should have added a `Gtk.SearchBar` and/or `Gtk.Button`'s but there's definitely room for improvement.