### PR TITLE
Correct Runtime for new library search.

### DIFF
--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -236,8 +236,8 @@ def get_system_paths():
     # This prioritizes system libraries over
     # the Lutris and Steam runtimes.
     for lib_paths in LINUX_SYSTEM.iter_lib_folders():
-        for index, _arch in enumerate(LINUX_SYSTEM.runtime_architectures):
-            paths.append(lib_paths[index])
+        for path in lib_paths:
+            paths.append(path)
     return paths
 
 


### PR DESCRIPTION
Fixes #1969.

Tested distro: ubuntu, manjaro, gentoo