### PR TITLE
steam: Add Flatpak's Steam path as a candidate

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -175,7 +175,12 @@ class steam(Runner):
     @property
     def steam_data_dir(self):
         """Return dir where Steam files lie."""
-        candidates = ("~/.steam", "~/.local/share/steam", "~/.steam/steam")
+        candidates = (
+            "~/.steam",
+            "~/.local/share/steam",
+            "~/.steam/steam",
+            "~/.var/app/com.valvesoftware.Steam/data/steam",
+        )
         for candidate in candidates:
             path = system.fix_path_case(
                 os.path.join(os.path.expanduser(candidate), "SteamApps")


### PR DESCRIPTION
This is a patch, put together by @gasinvein, to allow Lutris to detect Steam games that were installed through Flatpak. If you are running [Steam installed through Flatpak](https://flathub.org/apps/details/com.valvesoftware.Steam), and run Lutris, Lutris will now detect games installed through your Flatpak-ed Steam.

Seems like a worthy diff to push upstream.

## References

- https://github.com/RobLoach/net.lutris.Lutris/issues/13