### PR TITLE
Refresh functionality when clicking on create/remove shortcut button

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -737,6 +737,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
             self.game_actions.set_game(game=game)
             self.game_panel = GamePanel(self.game_actions)
             self.game_panel.connect("panel-closed", self.on_panel_closed)
+            self.view.contextual_menu.connect("shortcut-edited", self.game_panel.on_shortcut_edited)
         self.game_scrolled.add(self.game_panel)
         return True
 

--- a/lutris/gui/views/game_panel.py
+++ b/lutris/gui/views/game_panel.py
@@ -149,13 +149,6 @@ class GamePanel(GenericPanel):
                 buttons[name] = button
         return buttons
 
-    def on_shortcut_edited(self, widget, action_id):
-        self.buttons[action_id].hide()
-        if 'rm' == action_id[0:2]:
-            self.buttons[action_id[3:]].show()
-        else:
-            self.buttons['rm-' + action_id].show()
-
     def place_buttons(self, base_height):
         play_x_offset = 87
         icon_offset = 6
@@ -200,6 +193,13 @@ class GamePanel(GenericPanel):
                 extra_button_index += 1
 
             self.put(button, position[0], position[1])
+
+    def on_shortcut_edited(self, widget, action_id):
+        self.buttons[action_id].hide()
+        if 'rm' == action_id[0:2]:
+            self.buttons[action_id[3:]].show()
+        else:
+            self.buttons['rm-' + action_id].show()
 
     def on_game_start(self, widget):
         self.buttons["play"].set_label("Launching...")

--- a/lutris/gui/views/game_panel.py
+++ b/lutris/gui/views/game_panel.py
@@ -128,13 +128,17 @@ class GamePanel(GenericPanel):
                     button.set_size_request(146, 42)
                 else:
                     button = get_link_button(label)
-            button.connect("clicked", callback)
 
             if displayed.get(action_id):
                 button.show()
             else:
                 button.hide()
             buttons[action_id] = button
+
+            if action_id in ('desktop-shortcut', 'rm-desktop-shortcut', 'menu-shortcut', 'rm-menu-shortcut'):
+                callback = self.shortcut_button_refresh(action_id, callback)
+
+            button.connect("clicked", callback)
 
         if self.game.runner_name and self.game.is_installed:
             for entry in self.get_runner_entries(self.game):
@@ -144,6 +148,20 @@ class GamePanel(GenericPanel):
                 button.connect("clicked", callback)
                 buttons[name] = button
         return buttons
+
+    def shortcut_button_refresh(self, action_id, callback):
+        """Decorates callback to enable visibility toggling of shortcut buttons"""
+        def refresh_wrapper(*_args):
+            if action_id[0:2] == 'rm':
+                self.buttons[action_id].hide()
+                self.buttons[action_id[3:]].show()
+            else:
+                self.buttons[action_id].hide()
+                self.buttons['rm-' + action_id].show()
+
+            callback()
+
+        return refresh_wrapper
 
     def place_buttons(self, base_height):
         play_x_offset = 87

--- a/lutris/gui/views/game_panel.py
+++ b/lutris/gui/views/game_panel.py
@@ -136,7 +136,7 @@ class GamePanel(GenericPanel):
             buttons[action_id] = button
 
             if action_id in ('desktop-shortcut', 'rm-desktop-shortcut', 'menu-shortcut', 'rm-menu-shortcut'):
-                callback = self.shortcut_button_refresh(action_id, callback)
+                button.connect("clicked", self.on_shortcut_edited, action_id)
 
             button.connect("clicked", callback)
 
@@ -149,19 +149,12 @@ class GamePanel(GenericPanel):
                 buttons[name] = button
         return buttons
 
-    def shortcut_button_refresh(self, action_id, callback):
-        """Decorates callback to enable visibility toggling of shortcut buttons"""
-        def refresh_wrapper(*_args):
-            if action_id[0:2] == 'rm':
-                self.buttons[action_id].hide()
-                self.buttons[action_id[3:]].show()
-            else:
-                self.buttons[action_id].hide()
-                self.buttons['rm-' + action_id].show()
-
-            callback()
-
-        return refresh_wrapper
+    def on_shortcut_edited(self, widget, action_id):
+        self.buttons[action_id].hide()
+        if 'rm' == action_id[0:2]:
+            self.buttons[action_id[3:]].show()
+        else:
+            self.buttons['rm-' + action_id].show()
 
     def place_buttons(self, base_height):
         play_x_offset = 87

--- a/lutris/gui/views/menu.py
+++ b/lutris/gui/views/menu.py
@@ -1,5 +1,5 @@
 # pylint: disable=no-member
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 from lutris.game import Game
 
@@ -10,6 +10,10 @@ from lutris.util.log import logger
 
 
 class ContextualMenu(Gtk.Menu):
+    __gsignals__ = {
+        "shortcut-edited": (GObject.SIGNAL_RUN_FIRST, None, (str,)),
+    }
+
     def __init__(self, main_entries):
         super().__init__()
         self.main_entries = main_entries
@@ -26,6 +30,10 @@ class ContextualMenu(Gtk.Menu):
         name, label, callback = entry
         action = Gtk.Action(name=name, label=label)
         action.connect("activate", callback)
+
+        if name in ("desktop-shortcut", "rm-desktop-shortcut", "menu-shortcut", "rm-menu-shortcut"):
+            action.connect("activate", lambda a: self.emit('shortcut-edited', name))
+
         menu_item = action.create_menu_item()
         menu_item.action_id = name
         self.append(menu_item)

--- a/lutris/gui/views/menu.py
+++ b/lutris/gui/views/menu.py
@@ -32,7 +32,7 @@ class ContextualMenu(Gtk.Menu):
         action.connect("activate", callback)
 
         if name in ("desktop-shortcut", "rm-desktop-shortcut", "menu-shortcut", "rm-menu-shortcut"):
-            action.connect("activate", lambda a: self.emit('shortcut-edited', name))
+            action.connect("activate", self.on_shortcut_edited)
 
         menu_item = action.create_menu_item()
         menu_item.action_id = name
@@ -83,3 +83,6 @@ class ContextualMenu(Gtk.Menu):
             menuitem.set_visible(displayed.get(menuitem.action_id, True))
 
         super().popup(None, None, None, None, event.button, event.time)
+
+    def on_shortcut_edited(self, action):
+        self.emit('shortcut-edited', action.get_name())


### PR DESCRIPTION
I took at stab at the issue #1948 to familiarise myself with lutris code base(first time working on lutris) as this seemed relatively simple thing to do.

This solution achieves the original purpose, but creates one problem, clicking the same option in the context menu doesn't update the buttons on the panel.

@strycore I'm willing to devote some time on this and rewrite it using GObject signals, it will probably also solve the context menu problem.

Pardon my code style and other errors, as I'm creating this PR in order to get feedback.