### PR TITLE
Switched PC-Engine module from pce to pce_fast (Mednafen)

### DIFF
--- a/lutris/runners/mednafen.py
+++ b/lutris/runners/mednafen.py
@@ -35,7 +35,7 @@ class mednafen(Runner):
         ("Master System", "sms"),
         ("Neo Geo Pocket (Color)", "gnp"),
         ("NES", "nes"),
-        ("PC Engine", "pce"),
+        ("PC Engine", "pce_fast"),
         ("PC-FX", "pcfx"),
         ("PlayStation", "psx"),
         ("Saturn", "ss"),


### PR DESCRIPTION
Switch made for better emulation speeds and also to have the possibility to turn on square pixels ('pce_fast.correct_aspect 0') in the configuration file, which is missing in the pce module. The following is from mednafens pce_fast module description:

"The "pce_fast" emulation module is an experimental alternative to the pce emulation module. It is a fork of 0.8.x modified for speed at the expense of (usually) unneeded accuracy(this compares to the "pce" module, which traded speed away in favor of accuracy).
To use this module rather than the "pce" module, you must either set the "pce.enable" setting to "0", or pass "-force_module pce_fast" to Mednafen each time it is invoked."
(Found at: https://mednafen.github.io/documentation/pce_fast.html)

Even though it is less accurate, it prevents some issues like sound crackling and slow downs when using 'sound.driver sdl' or 'sound.driver alsa'. However when ALSA is used the 'sound.device' has to be 'sexyal-literal-default' instead of 'default'.