### PR TITLE
Expose environment variables to scripts

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -446,6 +446,7 @@ class Game(GObject.Object):
         # Env vars
         game_env = gameplay_info.get("env") or self.runner.get_env()
         env.update(game_env)
+        env["game_name"] = self.name
 
         # LD_PRELOAD
         ld_preload = gameplay_info.get("ld_preload")
@@ -498,6 +499,7 @@ class Game(GObject.Object):
             self.prelaunch_executor = MonitoredCommand(
                 [prelaunch_command],
                 include_processes=[os.path.basename(prelaunch_command)],
+                env=self.game_runtime_config["env"],
                 cwd=self.directory,
             )
             self.prelaunch_executor.start()
@@ -620,6 +622,7 @@ class Game(GObject.Object):
             postexit_thread = MonitoredCommand(
                 [postexit_command],
                 include_processes=[os.path.basename(postexit_command)],
+                env=self.game_runtime_config["env"],
                 cwd=self.directory,
             )
             postexit_thread.start()


### PR DESCRIPTION
Hi there, hopefully this is a pretty minor change that won't have much friction. The pre-launch and post-exit scripts are very useful, but I would like to be able to use environment vars defined per-game > per-runner > global to influence the things that the scripts do. That way I can use existing GUI configuration for my specific use cases.

I did add another change as well: the name of the game being run is exported into the environment. That way, scripts can do intelligent things like adding the game's name to screenshot or recording filenames.