### PR TITLE
Improve names of UI elements

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -79,7 +79,7 @@ class InstallerWindow(BaseApplicationWindow):
         self.source_button = self.add_button("_View source", self.on_source_clicked)
         self.install_button = self.add_button("_Install", self.on_install_clicked)
         self.continue_button = self.add_button("_Continue")
-        self.play_button = self.add_button("_Launch game", self.launch_game)
+        self.play_button = self.add_button("_Launch", self.launch_game)
         self.close_button = self.add_button("_Close", self.on_destroy)
 
         self.continue_handler = None

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -21,7 +21,7 @@ def get_optirun_choices():
 
 def get_vk_icd_choices():
     """Return available Vulkan ICD loaders"""
-    choices = [("None", "")]
+    choices = [("Auto", "")]
 
     # Add loaders from standard location
     for loader in glob.glob("/usr/share/vulkan/icd.d/*.json"):


### PR DESCRIPTION
- Default value for Vulkan ICD Loader  is now `Auto` instead of `None` (as the latter implies that no ICD loader is going to be used, which is not true at all)
- `Launch Game` in installation window is renamed to `Launch` as Lutris can install and launch far more than just games.
![Screenshot from 2019-04-24 14-49-51](https://user-images.githubusercontent.com/10602045/56657542-f6a01e80-66a0-11e9-8109-3789952541cd.png)
![Screenshot from 2019-04-24 14-46-15](https://user-images.githubusercontent.com/10602045/56657545-f9027880-66a0-11e9-97e1-f54a70c4bcbc.png)
