### PR TITLE
RFC: Gallium Nine

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -739,7 +739,10 @@ class wine(Runner):
         self.sandbox(prefix_manager)
         self.set_regedit_keys()
         self.setup_x360ce(self.runner_config.get("x360ce-path"))
-        self.setup_nine(self.runner_config.get("gallium_nine"))
+        try:
+            self.setup_nine(self.runner_config.get("gallium_nine"))
+        except nine.NineUnavailable as e:
+            raise GameConfigError("Unable to configure GalliumNine: " + str(e))
         try:
             dxvk_version = self.runner_config.get("dxvk_version")
             self.toggle_dxvk(

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -17,6 +17,7 @@ from lutris.util.graphics.vkquery import is_vulkan_supported
 from lutris.util.wine.prefix import WinePrefixManager
 from lutris.util.wine.x360ce import X360ce
 from lutris.util.wine import dxvk
+from lutris.util.wine import nine
 from lutris.util.wine.wine import (
     POL_PATH,
     WINE_DIR,
@@ -222,6 +223,19 @@ class wine(Runner):
                 "callback": esync_limit_callback,
                 "callback_on": True,
                 "active": True,
+            },
+            {
+                "option": "gallium_nine",
+                "label": "Enable Gallium Nine",
+                "type": "bool",
+                "default": False,
+                "condition": nine.NineManager.is_available(),
+                "advanced": True,
+                "help": (
+                    "Gallium Nine allows to run any Direct3D 9 application with nearly "
+                    "no CPU overhead. Make sure your active graphics card supports "
+                    "Gallium Nine state tracker before enabling this options."
+                ),
             },
             {
                 "option": "x360ce-path",
@@ -725,6 +739,7 @@ class wine(Runner):
         self.sandbox(prefix_manager)
         self.set_regedit_keys()
         self.setup_x360ce(self.runner_config.get("x360ce-path"))
+        self.setup_nine(self.runner_config.get("gallium_nine"))
         try:
             dxvk_version = self.runner_config.get("dxvk_version")
             self.toggle_dxvk(
@@ -850,6 +865,17 @@ class wine(Runner):
             self.dll_overrides["xinput9_1_0"] = "native"
         if self.runner_config.get("x360ce-dinput"):
             self.dll_overrides["dinput8"] = "native"
+
+    def setup_nine(self, enable):
+        nine_manager = nine.NineManager(
+            self.prefix_path,
+            self.wine_arch,
+        )
+
+        if enable:
+            nine_manager.enable()
+        else:
+            nine_manager.disable()
 
     def sandbox(self, wine_prefix):
         if self.runner_config.get("sandbox", True):

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -264,6 +264,10 @@ class LinuxSystem:
             if self.arch != 'x86_64':
                 # On non amd64 setups, only the first element is relevant
                 lib_paths = [lib_paths[0]]
+            else:
+                # Ignore paths where 64-bit path is link to supposed 32-bit path
+                if os.path.realpath(lib_paths[0]) == os.path.realpath(lib_paths[1]):
+                    continue
             if all([os.path.exists(path) for path in lib_paths]):
                 yield lib_paths
 

--- a/lutris/util/wine/nine.py
+++ b/lutris/util/wine/nine.py
@@ -1,0 +1,116 @@
+"""Gallium Nine helper module"""
+import os
+import shutil
+
+from lutris.util import system
+from lutris.runners.commands.wine import wineexec
+
+class NineManager:
+    """Utility class to install and manage Gallium Nine to a Wine prefix"""
+
+    nine_files = ("d3d9-nine.dll", "ninewinecfg.exe")
+    mesa_files = ("d3dadapter9.so.1",)
+
+    def __init__(self, prefix, arch):
+        self.prefix = prefix
+        self.wine_arch = arch
+
+    @staticmethod
+    def nine_is_supported():
+        """Check if MESA is built with Gallium Nine state tracker support
+
+        basic check for presence of d3dadapter9 library in 'd3d' subdirectory
+        of system library directory
+        """
+        for mesa_file in NineManager.mesa_files:
+            if not any([os.path.exists(os.path.join(lib[0], "d3d", mesa_file))
+            for lib in system.LINUX_SYSTEM.iter_lib_folders()]):
+                return False
+
+            if system.LINUX_SYSTEM.is_64_bit:
+                if not any([os.path.exists(os.path.join(lib[1], "d3d", mesa_file))
+                for lib in system.LINUX_SYSTEM.iter_lib_folders()]):
+                    return False
+
+        return True
+
+    @staticmethod
+    def nine_is_installed():
+        """Check if Gallium Nine standalone is installed on this system
+
+        check 'wine/fakedlls' subdirectory of system library directory for Nine binaries
+        """
+        for nine_file in NineManager.nine_files:
+            if not any([os.path.exists(os.path.join(lib[0], "wine/fakedlls", nine_file))
+            for lib in system.LINUX_SYSTEM.iter_lib_folders()]):
+                return False
+
+            if system.LINUX_SYSTEM.is_64_bit:
+                if not any([os.path.exists(os.path.join(lib[1], "wine/fakedlls", nine_file))
+                for lib in system.LINUX_SYSTEM.iter_lib_folders()]):
+                    return False
+
+        return True
+
+    @staticmethod
+    def is_available():
+        """Check if Gallium Nine can be enabled on this system"""
+        return NineManager.nine_is_supported() and NineManager.nine_is_installed()
+
+    def get_system_path(self, arch):
+        """Return path of Windows system directory with binaries of chosen architecture"""
+        windows_path = os.path.join(self.prefix, "drive_c/windows")
+
+        if self.wine_arch == "win32" and arch == "x32":
+            return os.path.join(windows_path, "system32")
+        if self.wine_arch == "win64" and arch == "x32":
+            return os.path.join(windows_path, "syswow64")
+        if self.wine_arch == "win64" and arch == "x64":
+            return os.path.join(windows_path, "system32")
+
+        return None
+
+    def is_prefix_prepared(self):
+        if not all(system.path_exists(os.path.join(self.get_system_path("x32"), nine_file))
+        for nine_file in self.nine_files):
+            return False
+
+        if self.wine_arch == "win64":
+            if not all(system.path_exists(os.path.join(self.get_system_path("x64"), nine_file))
+            for nine_file in self.nine_files):
+                return False
+
+        return True
+
+    def prepare_prefix(self):
+        for nine_file in NineManager.nine_files:
+            for lib in system.LINUX_SYSTEM.iter_lib_folders():
+                nine_file_32 = os.path.join(lib[0], "wine/fakedlls", nine_file)
+                if os.path.exists(nine_file_32):
+                    shutil.copy(nine_file_32, self.get_system_path("x32"))
+
+                if self.wine_arch == "win64":
+                    nine_file_64 = os.path.join(lib[1], "wine/fakedlls", nine_file)
+                    if os.path.exists(nine_file_64):
+                        shutil.copy(nine_file_64, self.get_system_path("x64"))
+
+    def enable(self):
+        if not self.is_prefix_prepared():
+            self.prepare_prefix()
+
+        wineexec(
+            "ninewinecfg",
+            args="-e",
+            prefix=self.prefix,
+            blocking=True,
+        )
+
+    def disable(self):
+        if self.is_prefix_prepared():
+            wineexec(
+                "ninewinecfg",
+                args="-d",
+                prefix=self.prefix,
+                blocking=True,
+            )
+

--- a/lutris/util/wine/nine.py
+++ b/lutris/util/wine/nine.py
@@ -5,6 +5,9 @@ import shutil
 from lutris.util import system
 from lutris.runners.commands.wine import wineexec
 
+class NineUnavailable(RuntimeError):
+    """Exception raised when Gallium Nine is not available"""
+
 class NineManager:
     """Utility class to install and manage Gallium Nine to a Wine prefix"""
 
@@ -95,6 +98,10 @@ class NineManager:
                         shutil.copy(nine_file_64, self.get_system_path("x64"))
 
     def enable(self):
+        if not self.nine_is_supported():
+            raise NineUnavailable("Nine is not supported on this system")
+        if not self.nine_is_installed():
+            raise NineUnavailable("Nine Standalone is not installed")
         if not self.is_prefix_prepared():
             self.prepare_prefix()
 
@@ -113,4 +120,3 @@ class NineManager:
                 prefix=self.prefix,
                 blocking=True,
             )
-


### PR DESCRIPTION
This pull request adds Gallium Nine option to Wine runner, as requested in #1625 

So far this option rely on Gallium Nine standalone provided by system package (like Feral gamemode), but we may change it to pack it with Lutris or let it download (like DXVK) from Gallium Nine standalone Github project in the future.

Gallium Nine can be enabled if:
* MESA is built with gallium nine state tracker support (_d3dadapter9_ library is found)
* Gallium Nine standalone is installed on the system (_d3d9-nine.dll_ and _ninewinecfg.exe_ binaries are found)

First condition is checked every time the configuration window is opened. I tried to add info about MESA support into `LIBRARIES` in `util.linux.SYSTEM_COMPONENTS` and check Mesa for Gallium support by simple calling `system.LINUX_SYSTEM.is_feature_supported("GALLIUM_NINE")`, but _d3dadapter9_ is not detected by `ldconfig -p`. If we want to do it like this, we need to manually check system library paths (for example by _linux.iter_lib_folders()_).

Gallium Nine standalone provides _ninewinecfg.exe_, which is used for enabling and disabling Gallium Nine itself for active Wine prefix. But we can do it manually, as described in #1625

There is one problem - when you enable Gallium Nine on GPU which does not support it, game will not start. For example my setup - dedicated AMD GPU with MESA driver supporting Gallium Nine - everything works fine unless I switch GPU to integrated Intel. Probably the only way how to detect if chosen GPU supports Gallium Nine or not is by calling some executable which will try to initialize D3D9 device by calling _Direct3DCreate9Ex_. This detection is not part of this pull request - we will need to create custom exe file (or kindly ask GN standalone guys to add command line option to _ninewinecfg.exe_ for this?)