### PR TITLE
Fix deletion of Registry keys and change the default SampleCount to auto

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -682,7 +682,7 @@ class wine(Runner):
         for key, path in self.reg_keys.items():
             value = self.runner_config.get(key) or "auto"
             if not value or value == "auto" and key not in managed_keys.keys():
-                prefix_manager.clear_registry_key(path)
+                prefix_manager.clear_registry_subkeys(path, key)
             elif key in self.runner_config:
                 if key in managed_keys.keys():
                     # Do not pass fallback 'auto' value to managed keys

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -351,13 +351,14 @@ class wine(Runner):
                 "label": "Anti-aliasing Sample Count",
                 "type": "choice",
                 "choices": [
-                    ("0", "0 (disabled)"),
+                    ("Auto", "auto"),
+                    ("0", "0"),
                     ("2", "2"),
                     ("4", "4"),
                     ("8", "8"),
                     ("16", "16")
                 ],
-                "default": "0",
+                "default": "auto",
                 "advanced": True,
                 "help": (
                     "Override swapchain sample count. It can be used to force enable multisampling "


### PR DESCRIPTION
### Fixes:
Clearing the whole Registry key (folder) when one of its entries is set to `auto` or `None` in the Lutris config looks like the wrong thing to do.

### Additions:
Disabling AA globally for every wined3d application is not a good idea as the default behavior use `auto` instead.
This fixes #2083 