### PR TITLE
Add System Info (Closes #1782)

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -19,6 +19,7 @@ from lutris.gui.widgets.utils import (
 )
 from lutris.util.strings import slugify
 from lutris.util import resources
+from lutris.util.linux import gather_system_info_str
 
 
 # pylint: disable=too-many-instance-attributes
@@ -70,6 +71,7 @@ class GameDialogCommon:
             self._build_runner_tab(config_level)
         if config_level == "system":
             self._build_prefs_tab()
+            self._build_sysinfo_tab()
         self._build_system_tab(config_level)
 
     def _build_info_tab(self):
@@ -106,6 +108,17 @@ class GameDialogCommon:
 
         info_sw = self.build_scrolled_window(prefs_box)
         self._add_notebook_tab(info_sw, "Lutris preferences")
+
+    def _build_sysinfo_tab(self):
+        sysinfo_view = Gtk.TextView()
+        sysinfo_view.set_editable(False)
+        sysinfo_view.set_cursor_visible(False)
+
+        text_buffer = sysinfo_view.get_buffer()
+        text_buffer.set_text(gather_system_info_str())
+
+        info_sw = self.build_scrolled_window(sysinfo_view)
+        self._add_notebook_tab(info_sw, "System Information")
 
     def _get_game_cache_box(self):
         box = Gtk.Box(spacing=12, margin_right=12, margin_left=12)

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -461,11 +461,10 @@ def gather_system_info_str():
         graphics_dict["Vulkan"] = "Not Supported"
     system_info_readable["Graphics"] = graphics_dict
     #format output
-    def number_of_tab(str, maxt=5):
-        if int(len(str)/4) > maxt:
+    def number_of_tab(string, maxt=5):
+        if int(len(string)/4) > maxt:
             return 0
-        else:
-            return maxt-int(len(str)/4)
+        return maxt-int(len(str)/4)
     output = ''
     for section in system_info_readable:
         output += '{}:\n'.format(section)

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -171,7 +171,7 @@ class LinuxSystem:
             drive for drive in json.loads(output)["blockdevices"]
             if drive["fstype"] != "squashfs"
         ]
-    
+
     @staticmethod
     def get_ram_info():
         """Parse the output of /proc/meminfo and return RAM information in kB"""
@@ -408,8 +408,8 @@ def gather_system_info_str():
     system_dict["OS"] = ' '.join(system_info["dist"])
     system_dict["Arch"] = system_info["arch"]
     system_dict["Kernel"] = system_info["kernel"]
-    system_dict["Desktop"] = system_info["env"]["XDG_CURRENT_DESKTOP"]
-    system_dict["Display Server"] = system_info["env"]["XDG_SESSION_TYPE"]
+    system_dict["Desktop"] = system_info["env"].get("XDG_CURRENT_DESKTOP", "Not found")
+    system_dict["Display Server"] = system_info["env"].get("XDG_SESSION_TYPE", "Not found")
     system_info_readable["System"] = system_dict
     #Add CPU information
     cpu_dict = {}

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -402,10 +402,6 @@ def gather_system_info():
 def gather_system_info_str():
     """Get all relevant system information already formatted as a string"""
     system_info = gather_system_info()
-    print("Gpus:")
-    print(system_info["gpus"])
-    print("GLX:")
-    print(system_info["glxinfo"])
     system_info_readable = {}
     #Add system information
     system_dict = {}
@@ -425,7 +421,7 @@ def gather_system_info_str():
     #Add memory information
     ram_dict = {}
     ram_dict["RAM"] = system_info["ram"]["MemTotal"] + " kB"
-    ram_dict["Swap"] = system_info["ram"]["SwapTotal"] + "kB"
+    ram_dict["Swap"] = system_info["ram"]["SwapTotal"] + " kB"
     system_info_readable["Memory"] = ram_dict
     #Add graphics information
     graphics_dict = {}


### PR DESCRIPTION
This is a initial commit to try and add the system information to lutris as proposed in #1782 
It's not complete as of yet.
When the Preferences are opened on a system level (not on a game level) a new tab appears which contains the system information.
I also changed the `get_mem_info()` function to read from `/proc/meminfo` as the keys were localized in the old function. The old function was deleted. Another possibility to have the keys always in english would be  to export the system locale before running the `free` command with `export LANG=en_US.UTF-8 && free`.

Missing features / issues:
* Only displays information about the first CPU socket, could be problematic with server boards which have two or more CPU sockets.
* Needs testing on different hardware configurations, especially with amdgpu drivers.

![Bildschirmfoto vom 2019-05-22 13-47-29](https://user-images.githubusercontent.com/6241018/58173070-a49bea00-7c9a-11e9-9f23-6c83d2ce9290.png)


As this is my first commit to this project I'm happy about feedback.
