### PR TITLE
Fix sorting (Closes: #2046)

### DIFF
--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -30,6 +30,14 @@ from . import (
 )
 
 
+def try_lower(value):
+    try:
+        out = value.lower()
+    except AttributeError:
+        out = value
+    return out
+
+
 def sort_func(model, row1, row2, sort_col):
     """Sorting function for the GameStore"""
     value1 = model.get_value(row1, sort_col)
@@ -40,15 +48,23 @@ def sort_func(model, row1, row2, sort_col):
         value1 = type(value2)()
     elif value2 is None:
         value2 = type(value1)()
+    value1 = try_lower(value1)
+    value2 = try_lower(value2)
     diff = -1 if value1 < value2 else 0 if value1 == value2 else 1
     if diff == 0:
-        value1 = model.get_value(row1, COL_NAME)
-        value2 = model.get_value(row2, COL_NAME)
-        diff = -1 if value1 < value2 else 0 if value1 == value2 else 1
+        value1 = try_lower(model.get_value(row1, COL_NAME))
+        value2 = try_lower(model.get_value(row2, COL_NAME))
+        try:
+            diff = -1 if value1 < value2 else 0 if value1 == value2 else 1
+        except TypeError:
+            diff = 0
     if diff == 0:
-        value1 = model.get_value(row1, COL_RUNNER_HUMAN_NAME)
-        value2 = model.get_value(row2, COL_RUNNER_HUMAN_NAME)
-    return -1 if value1 < value2 else 0 if value1 == value2 else 1
+        value1 = try_lower(model.get_value(row1, COL_RUNNER_HUMAN_NAME))
+        value2 = try_lower(model.get_value(row2, COL_RUNNER_HUMAN_NAME))
+    try:
+        return -1 if value1 < value2 else 0 if value1 == value2 else 1
+    except TypeError:
+        return 0
 
 
 class GameStore(GObject.Object):

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -146,7 +146,7 @@ class TestSort(TestCase):
         row2 = self.FakeRow({'name': 1})
         model = self.FakeModel([row1, row2])
         with self.assertRaises(TypeError):
-            sort_func(model, 0, 1, 'name') == -1
+            assert sort_func(model, 0, 1, 'name') == -1
 
     def test_both_none(self):
         row1 = self.FakeRow({})

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -11,6 +11,7 @@ from lutris import pga
 from lutris.gui.config.common import GameDialogCommon
 from lutris.gui.config.add_game import AddGameDialog
 from lutris.gui.application import Application
+from lutris.gui.views.store import sort_func
 from unittest import TestCase
 from lutris import runners
 
@@ -102,3 +103,59 @@ class TestGameDialog(TestCase):
         game = Game(pga_game['id'])
         self.assertEqual(game.name, 'Test game')
         game.remove(from_library=True)
+
+
+class TestSort(TestCase):
+    class FakeModel(object):
+        def __init__(self, rows):
+            self.rows = rows
+
+        def get_value(self, row_index, col_name):
+            return self.rows[row_index].cols.get(col_name)
+
+    class FakeRow(object):
+        def __init__(self, coldict):
+            self.cols = coldict
+
+    def test_sort_strings_with_caps(self):
+        row1 = self.FakeRow({'name': 'Abc'})
+        row2 = self.FakeRow({'name': 'Def'})
+        model = self.FakeModel([row1, row2])
+        assert sort_func(model, 0, 1, 'name') == -1
+
+    def test_sort_strings_with_one_caps(self):
+        row1 = self.FakeRow({'name': 'abc'})
+        row2 = self.FakeRow({'name': 'Def'})
+        model = self.FakeModel([row1, row2])
+        assert sort_func(model, 0, 1, 'name') == -1
+
+    def test_sort_strings_with_no_caps(self):
+        row1 = self.FakeRow({'name': 'abc'})
+        row2 = self.FakeRow({'name': 'def'})
+        model = self.FakeModel([row1, row2])
+        assert sort_func(model, 0, 1, 'name') == -1
+
+    def test_sort_int(self):
+        row1 = self.FakeRow({'name': 1})
+        row2 = self.FakeRow({'name': 2})
+        model = self.FakeModel([row1, row2])
+        assert sort_func(model, 0, 1, 'name') == -1
+
+    def test_sort_mismatched_types(self):
+        row1 = self.FakeRow({'name': 'abc'})
+        row2 = self.FakeRow({'name': 1})
+        model = self.FakeModel([row1, row2])
+        with self.assertRaises(TypeError):
+            sort_func(model, 0, 1, 'name') == -1
+
+    def test_both_none(self):
+        row1 = self.FakeRow({})
+        row2 = self.FakeRow({})
+        model = self.FakeModel([row1, row2])
+        assert sort_func(model, 0, 1, 'name') == 0
+
+    def test_one_none(self):
+        row1 = self.FakeRow({})
+        row2 = self.FakeRow({'name': 'abc'})
+        model = self.FakeModel([row1, row2])
+        assert sort_func(model, 0, 1, 'name') == -1


### PR DESCRIPTION
I maybe overdid it on the test coverage here, and the try_lower() method is kinda an ugly hack, but it's way better than sticking a try/except around every attempt to lower things.  Also, this makes sure that if we somehow ever try to compare two rows that don't have a name/runner (okay, yeah, this should never happen, but stranger things have happened), we still return a value rather than raising an exception and just barfing.