### PR TITLE
Config validation, base implementation.  Closes: #2081

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -1,5 +1,6 @@
 """Shared config dialog stuff"""
 # pylint: disable=no-member,not-an-iterable
+import importlib
 import os
 from gi.repository import Gtk, Pango, GLib
 from lutris.game import Game
@@ -440,6 +441,25 @@ class GameDialogCommon:
                 and self.lutris_config.game_config.get("appid") is None
         ):
             ErrorDialog("Steam AppId not provided")
+            return False
+        invalid_fields = []
+        runner_module = importlib.import_module("lutris.runners." + self.runner_name)
+        runner_class = getattr(runner_module, self.runner_name)
+        runner_instance = runner_class()
+        for config in ["game", "runner"]:
+            for k, v in getattr(self.lutris_config, config + "_config").items():
+                option = runner_instance.find_option(config + "_options", k)
+                if option is None:
+                    continue
+                validator = option.get("validator")
+                if validator is not None:
+                    try:
+                        res = validator(v)
+                        logger.debug("{} validated successfully: {}".format(k, res))
+                    except Exception:
+                        invalid_fields.append(option.get("label"))
+        if len(invalid_fields) > 0:
+            ErrorDialog("The following fields have invalid values: " + ", ".join(invalid_fields))
             return False
         return True
 

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -458,7 +458,7 @@ class GameDialogCommon:
                         logger.debug("{} validated successfully: {}".format(k, res))
                     except Exception:
                         invalid_fields.append(option.get("label"))
-        if len(invalid_fields) > 0:
+        if invalid_fields:
             ErrorDialog("The following fields have invalid values: " + ", ".join(invalid_fields))
             return False
         return True

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -436,3 +436,14 @@ class Runner:
         for item in self.common_game_options:
             if item not in self.game_options:
                 self.game_options.append(item)
+
+    def find_option(self, options_group, option_name):
+        """Retrieve an option dict if it exists in the group"""
+        if options_group not in ['game_options', 'runner_options']:
+            return None
+        output = None
+        for item in getattr(self, options_group):
+            if item["option"] == option_name:
+                output = item
+                break
+        return output

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -566,9 +566,9 @@ class wine(Runner):
                 # Update the version in the config
                 if version == self.runner_config.get("version"):
                     self.runner_config["version"] = default_version
-                    # TODO: runner_config is a dict so we have to instanciate a
+                    # TODO: runner_config is a dict so we have to instanciate a #  pylint: disable=fixme
                     # LutrisConfig object to save it.
-                    # XXX: The version key could be either in the game specific
+                    # XXX: The version key could be either in the game specific #  pylint: disable=fixme
                     # config or the runner specific config. We need to know
                     # which one to get the correct LutrisConfig object.
             return wine_path
@@ -583,8 +583,8 @@ class wine(Runner):
         wine_versions = get_wine_versions()
         if min_version:
             min_version_list, _, _ = parse_version(min_version)
-            for version in wine_versions:
-                version_list, _, _ = parse_version(version)
+            for wine_version in wine_versions:
+                version_list, _, _ = parse_version(wine_version)
                 if version_list > min_version_list:
                     return True
             logger.warning("Wine %s or higher not found", min_version)

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -66,7 +66,8 @@ class wine(Runner):
             "option": "args",
             "type": "string",
             "label": "Arguments",
-            "help": "Windows command line arguments used when launching the game"
+            "help": "Windows command line arguments used when launching the game",
+            "validator": shlex.split
         },
         {
             "option": "working_dir",


### PR DESCRIPTION
Only enabled for the args field of the wine runner.  Works by doing magic imports and enumerating fields, and if there is a validator for the field, we make sure it does not raise an exception.  If it does, refuse to save.  This does lean more heavily toward using custom validators than core functions, but should be acceptable, I think.