### PR TITLE
Reverse the log lines, as they were added incorrectly

### DIFF
--- a/lutris/discord.py
+++ b/lutris/discord.py
@@ -20,10 +20,10 @@ class Presence(object):
 
     def __init__(self):
         if PyPresence is not None:
-            logger.debug('Discord Rich Presence not available due to lack of pypresence')
+            logger.debug('Discord Rich Presence enabled')
             self.rich_presence_available = True
         else:
-            logger.debug('Discord Rich Presence enabled')
+            logger.debug('Discord Rich Presence not available due to lack of pypresence')
             self.rich_presence_available = False
         self.last_rpc = 0
         self.rpc_interval = 60


### PR DESCRIPTION
This partially addresses concerns raised in #2148 but there is more work which could be done depending on the team's input.

The actual logic for checking for the existence of the pypresence library works, from my testing, I just had mistakenly added the false log line to the true block and vice versa.