### PR TITLE
Rip out the game_options injection, no longer needed.  Put the discor…

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -162,11 +162,11 @@ class Game(GObject.Object):
         )
         self.runner = self._get_runner()
         if self.discord_presence.available:
-            self.discord_presence.client_id = self.config.game_config.get("discord_client_id") or DEFAULT_DISCORD_CLIENT_ID
-            self.discord_presence.game_name = self.config.game_config.get("discord_custom_game_name") or self.name
-            self.discord_presence.show_runner = self.config.game_config.get("discord_show_runner", True)
-            self.discord_presence.runner_name = self.config.game_config.get("discord_custom_runner_name") or self.runner_name
-            self.discord_presence.rpc_enabled = self.config.game_config.get("discord_rpc_enabled", True)
+            self.discord_presence.client_id = self.config.system_config.get("discord_client_id") or DEFAULT_DISCORD_CLIENT_ID
+            self.discord_presence.game_name = self.config.system_config.get("discord_custom_game_name") or self.name
+            self.discord_presence.show_runner = self.config.system_config.get("discord_show_runner", True)
+            self.discord_presence.runner_name = self.config.system_config.get("discord_custom_runner_name") or self.runner_name
+            self.discord_presence.rpc_enabled = self.config.system_config.get("discord_rpc_enabled", True)
 
     def set_desktop_compositing(self, enable):
         """Enables or disables compositing"""

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -12,7 +12,6 @@ from lutris.util.log import logger
 from lutris.util import system
 from lutris.util.http import Request
 from lutris.runners import RunnerInstallationError
-from lutris.discord import DiscordPresence
 
 
 class Runner:
@@ -27,41 +26,6 @@ class Runner:
     context_menu_entries = []
     depends_on = None
     runner_executable = None
-    common_game_options = []
-    discord_presence_options = [
-        {
-            "option": "discord_rpc_enabled",
-            "type": "bool",
-            "label": "Discord Rich Presence",
-            "default": True,
-            "help": "Enable notification to Discord of this game being played",
-        },
-        {
-            "option": "discord_show_runner",
-            "type": "bool",
-            "label": "Discord Show Runner",
-            "default": True,
-            "help": "Embed the runner name in the Discord notification",
-        },
-        {
-            "option": "discord_custom_game_name",
-            "type": "string",
-            "label": "Discord Custom Game Name",
-            "help": "Custom name to override with and send to Discord",
-        },
-        {
-            "option": "discord_custom_runner_name",
-            "type": "string",
-            "label": "Discord Custom Runner Name",
-            "help": "Custom runner name to override with and send to Discord",
-        },
-        {
-            "option": "discord_client_id",
-            "type": "string",
-            "label": "Discord Client ID",
-            "help": "Custom Discord Client ID for sending notifications",
-        },
-    ]
 
     def __init__(self, config=None):
         """Initialize runner."""
@@ -72,10 +36,6 @@ class Runner:
             self.game_data = pga.get_game_by_field(
                 self.config.game_config_id, "configpath"
             )
-        self.discord_presence = DiscordPresence()
-        if self.discord_presence.available:
-            self.common_game_options = self.common_game_options + self.discord_presence_options
-        self.inject_common_game_options()
 
     def __lt__(self, other):
         return self.name < other.name
@@ -430,9 +390,3 @@ class Runner:
         runner_path = os.path.join(settings.RUNNER_DIR, self.name)
         if os.path.isdir(runner_path):
             system.remove_folder(runner_path)
-
-    def inject_common_game_options(self):
-        """Dynamically add all the common game options to all runner classes"""
-        for item in self.common_game_options:
-            if item not in self.game_options:
-                self.game_options.append(item)

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 
 from lutris import runners
 from lutris.util import display, system
+from lutris.discord import DiscordPresence
 
 
 def get_optirun_choices():
@@ -384,6 +385,45 @@ system_options = [  # pylint: disable=invalid-name
         "help": "Open Xephyr in fullscreen (at the desktop resolution)",
     },
 ]
+
+discord_options = [
+    {
+        "option": "discord_rpc_enabled",
+        "type": "bool",
+        "label": "Discord Rich Presence",
+        "default": False,
+        "help": "Enable notification to Discord of this game being played",
+    },
+    {
+        "option": "discord_show_runner",
+        "type": "bool",
+        "label": "Discord Show Runner",
+        "default": True,
+        "help": "Embed the runner name in the Discord notification",
+    },
+    {
+        "option": "discord_custom_game_name",
+        "type": "string",
+        "label": "Discord Custom Game Name",
+        "help": "Custom name to override with and send to Discord",
+    },
+    {
+        "option": "discord_custom_runner_name",
+        "type": "string",
+        "label": "Discord Custom Runner Name",
+        "help": "Custom runner name to override with and send to Discord",
+    },
+    {
+        "option": "discord_client_id",
+        "type": "string",
+        "label": "Discord Client ID",
+        "help": "Custom Discord Client ID for sending notifications",
+    },
+]
+
+discord_presence = DiscordPresence()
+if discord_presence.available:
+    system_options = system_options + discord_options
 
 
 def with_runner_overrides(runner_slug):

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -35,6 +35,8 @@ def get_vk_icd_choices():
     return choices
 
 
+discord_presence = DiscordPresence()
+
 system_options = [  # pylint: disable=invalid-name
     {
         "option": "game_path",
@@ -384,46 +386,44 @@ system_options = [  # pylint: disable=invalid-name
         "advanced": True,
         "help": "Open Xephyr in fullscreen (at the desktop resolution)",
     },
-]
-
-discord_options = [
     {
         "option": "discord_rpc_enabled",
         "type": "bool",
         "label": "Discord Rich Presence",
         "default": False,
-        "help": "Enable notification to Discord of this game being played",
+        "condition": discord_presence.available,
+        "help": "Enable status to Discord of this game being played",
     },
     {
         "option": "discord_show_runner",
         "type": "bool",
         "label": "Discord Show Runner",
         "default": True,
-        "help": "Embed the runner name in the Discord notification",
+        "condition": discord_presence.available,
+        "help": "Embed the runner name in the Discord status",
     },
     {
         "option": "discord_custom_game_name",
         "type": "string",
         "label": "Discord Custom Game Name",
-        "help": "Custom name to override with and send to Discord",
+        "condition": discord_presence.available,
+        "help": "Custom name to override with and pass to Discord",
     },
     {
         "option": "discord_custom_runner_name",
         "type": "string",
         "label": "Discord Custom Runner Name",
-        "help": "Custom runner name to override with and send to Discord",
+        "condition": discord_presence.available,
+        "help": "Custom runner name to override with and pass to Discord",
     },
     {
         "option": "discord_client_id",
         "type": "string",
         "label": "Discord Client ID",
-        "help": "Custom Discord Client ID for sending notifications",
+        "condition": discord_presence.available,
+        "help": "Custom Discord Client ID for passing status",
     },
 ]
-
-discord_presence = DiscordPresence()
-if discord_presence.available:
-    system_options = system_options + discord_options
 
 
 def with_runner_overrides(runner_slug):


### PR DESCRIPTION
…d_options block into system options for full inheritance.

Moved the options to system options at the request of @tannisroot and @telanus.  Also set the default to disable the feature, so it's explicitly opt-in.  This allows users to change it globally, at the runner level, and at the game level.  Opting in at the global level turns it on for all games, you can then explicitly opt out for a specific runner (say, LibRetro), and still opt-in for an individual game under that runner.  @strycore, what are your thoughts on this?  