### PR TITLE
add Ubuntu's AMDVLK path to Vulkan ICD loader search

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -22,16 +22,16 @@ def get_optirun_choices():
 
 def get_vk_icd_choices():
     """Return available Vulkan ICD loaders"""
+    loader_paths = ["/usr/share/vulkan/icd.d/*.json",  # standard location
+                    "/opt/amdgpu-pro/etc/vulkan/icd.d/*.json",  # AMD GPU Pro - TkG
+                    "/etc/vulkan/icd.d/*.json"]  # AMDVLK - Ubuntu
     choices = [("Auto", "")]
 
-    # Add loaders from standard location
-    for loader in glob.glob("/usr/share/vulkan/icd.d/*.json"):
-        choices.append((os.path.basename(loader), loader))
+    # Add loaders
+    for path in loader_paths:
+        for loader in glob.glob(path):
+            choices.append((os.path.basename(loader), loader))
 
-    # Also add loaders for the AMD GPU Pro driver
-    # https://github.com/Tk-Glitch/PKGBUILDS/tree/master/amdgpu-pro-vulkan-only
-    for loader in glob.glob("/opt/amdgpu-pro/etc/vulkan/icd.d/*.json"):
-        choices.append((os.path.basename(loader), loader))
     return choices
 
 


### PR DESCRIPTION
This removes some duplicated code and fixes #2157.