### PR TITLE
Begin switch to meson build system

### DIFF
--- a/bin/lutris
+++ b/bin/lutris
@@ -17,10 +17,12 @@ import locale
 from os.path import realpath, dirname, normpath
 
 LAUNCH_PATH = dirname(realpath(__file__))
-if not LAUNCH_PATH.startswith("/usr"):
+if os.path.isdir(os.path.join(LAUNCH_PATH,"../lutris")):
     sys.dont_write_bytecode = True
     SOURCE_PATH = normpath(os.path.join(LAUNCH_PATH, '..'))
     sys.path.insert(0, SOURCE_PATH)
+else:
+    sys.path.insert(0, os.path.normpath(os.path.join(LAUNCH_PATH, "../lib/lutris")))
 
 try:
     locale_name = locale.getlocale()

--- a/bin/lutris-wrapper
+++ b/bin/lutris-wrapper
@@ -127,10 +127,12 @@ def main():
 
 if __name__ == "__main__":
     LAUNCH_PATH = os.path.dirname(os.path.realpath(__file__))
-    if not LAUNCH_PATH.startswith("/usr"):
+    if os.path.isdir(os.path.join(LAUNCH_PATH,"../lutris")):
         logger.setLevel(logging.DEBUG)
         sys.dont_write_bytecode = True
         SOURCE_PATH = os.path.normpath(os.path.join(LAUNCH_PATH, '..'))
         sys.path.insert(0, SOURCE_PATH)
+    else:
+        sys.path.insert(0, os.path.normpath(os.path.join(LAUNCH_PATH, "../lib/lutris")))
 
     main()

--- a/lutris/util/datapath.py
+++ b/lutris/util/datapath.py
@@ -13,6 +13,8 @@ def get():
         data_path = "/usr/share/lutris"
     elif system.path_exists(os.path.normpath(os.path.join(sys.path[0], "share"))):
         data_path = os.path.normpath(os.path.join(sys.path[0], "share/lutris"))
+    elif system.path_exists(os.path.normpath(os.path.join(launch_path, "../../share/lutris"))):
+        data_path = os.path.normpath(os.path.join(launch_path, "../../share/lutris"))
     else:
         import lutris
 

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,15 @@
+project('lutris')
+
+pymod = import('python')
+# Checking for Python
+python  = pymod.find_installation('python3', required: true, modules: ['yaml', 'gi', 'evdev', 'requests'])
+python_version     = python.language_version()
+python_version_min = '>=3.4'
+if not python_version.version_compare(python_version_min)
+  error('Python @0@ required, found Python @1@.'.format(python_version_min, python_version))
+endif
+
+# Do installation
+install_subdir('lutris', install_dir: 'lib/lutris')
+install_subdir('share',  install_dir: 'share', strip_directory: true)
+install_subdir('bin',    install_dir: 'bin'  , strip_directory: true, install_mode: 'rwxr-xr-x')


### PR DESCRIPTION
I just discovered Lutris... very good ! In your README, you was saying that the system-wide installation is not clean. I've learned *meson* and made a `meson.build` file, to use it :
```sh
meson build && cd build && sudo meson install
```
Lutris *python* files are now installed in `$DESTDIR/lib/lutris`.
I also edited some code about path searching (see the *commit* message for all changes), Lutris should be usable from any installation root (*/tmp/lutris* work for me).

With some additions, *translations* and *automated tests* should work.

This patch stay very minimalist and doesn't break old behaviors (running from source and *AUR makepkg* for `lutris-git` stays working).

Are you interested ?