### PR TITLE
Fix #2080 by adding a "Remove game files" checkbox

### DIFF
--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -99,6 +99,9 @@ class QuestionDialog(Gtk.MessageDialog):
         )
         self.set_markup(dialog_settings["question"])
         self.set_title(dialog_settings["title"])
+        if "widgets" in dialog_settings:
+            for widget in dialog_settings["widgets"]:
+                self.get_message_area().add(widget)
         self.result = self.run()
         self.destroy()
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -474,10 +474,15 @@ class InstallerWindow(BaseApplicationWindow):
 
     def cancel_installation(self, widget=None):
         """Ask a confirmation before cancelling the install"""
+        remove_checkbox = Gtk.CheckButton.new_with_label("Remove game files")
+        if self.interpreter:
+            remove_checkbox.set_active(self.interpreter.game_dir_created)
+            remove_checkbox.show()
         confirm_cancel_dialog = QuestionDialog(
             {
                 "question": "Are you sure you want to cancel the installation?",
                 "title": "Cancel installation?",
+                "widgets": [remove_checkbox]
             }
         )
         if confirm_cancel_dialog.result != Gtk.ResponseType.YES:
@@ -486,6 +491,7 @@ class InstallerWindow(BaseApplicationWindow):
             system.execute([system.find_executable("wineserver"), "-k9"])
             return True
         if self.interpreter:
+            self.interpreter.game_dir_created = remove_checkbox.get_active()
             self.interpreter.revert()
             self.interpreter.cleanup()
         self.destroy()


### PR DESCRIPTION
I tried to solve the issue #2080 by adding a checkbox in the cancel window.

I slightly edited `QuestionDialog()` which now accept a list of widgets to append, avoiding creation of a new widget and can be reused in other places.