### PR TITLE
Multiple fixes regarding the dxvk feature

### DIFF
--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -156,11 +156,9 @@ class DXVKManager:
     def disable_dxvk_dll(self, system_dir, dxvk_arch, dll):
         """Remove DXVK DLL from Wine prefix"""
         wine_dll_path = os.path.join(system_dir, "%s.dll" % dll)
-        if self.is_dxvk_dll(wine_dll_path):
+        if self.is_dxvk_dll(wine_dll_path) and system.path_exists(wine_dll_path + ".orig"):
             logger.info("Removing "+self.base_name.upper()+" dll %s/%s", system_dir, dll)
             os.remove(wine_dll_path)
-        # Restoring original version (may not be needed)
-        if system.path_exists(wine_dll_path + ".orig"):
             shutil.move(wine_dll_path + ".orig", wine_dll_path)
 
     def _iter_dxvk_dlls(self):

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -40,7 +40,7 @@ def init_dxvk_versions():
                     dxvk_versions.append(version_name)
         if not dxvk_versions:  # We don't want to set manager.DXVK_VERSIONS, if the list is empty
             raise IndexError
-        return dxvk_versions
+        return sorted(dxvk_versions, reverse=True)
 
     def init_versions(manager):
         try:


### PR DESCRIPTION
#### Improve dxvk fetcher behavior on missing internet connection:
When Lutris is launched without an internet connection only the hardcoded dxvk version is available. This commit adds some logic that checks, if dxvk versions were already downloaded and adds them to the version list.

#### Only remove d3d dlls when a backup exists:
This should fix #2198 by only deleting the normal d3d dll when the Lutris generated backup `.orig` exists.

#### Sort dxvk versions fetched via Github API:
This sorts the dxvk version list we get from the Github API. d9vk had a release which is called 0.13f and it is listed below 0.13 even though its a newer release. We might want to sort things in a more clever way some day, but the downloaded json file does not include any timestamps, so this is currently the simpler solution.