### PR TITLE
WIP: Only start game if prelaunch command returns 0

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -574,7 +574,8 @@ class Game(GObject.Object):
         """Watch the prelaunch command"""
         if self.prelaunch_executor.is_running:
             return True
-        self.start_game()
+        if self.prelaunch_executor.return_code == 0:
+            self.start_game()
         return False
 
     def beat(self):


### PR DESCRIPTION
## Context

The League of Legends wine appimage is hard-coded to use `~/.wine-appimage-lol` as its prefix. This is bad because:

- When uninstalling League through Lutris, the default prefix does not get wiped and the game does not get uninstalled.
    - This is the biggest issue. Lots of people try the d9vk version, find it doesn't work, then try the d3d9wine version and it still doesn't work — because they're *actually* still using the d9vk version, which was never uninstalled.
- Generally it's just unexpected behavior that the game would install somewhere other than $GAMEDIR
    - If your /home is on an SSD and you install games to a bigger HDD (as I do), League will be installed to the SSD.

To fix this, I'm working on a set of simple bash scripts to be included in the Lutris installer (I've spoken briefly with @tannisroot about this). There is a prelaunch script which symlinks the hard-coded prefix to $GAMEDIR, and a postexit script that removes the symlink.

## Problem

Symlinking fixes the two problems above, but causes a new one: launching both versions at the same time will cause one to overwrite the symlink. As long as the prefix is hard coded, the two versions can't be run simultaneously — that's unfixable. Fine.

Ideally, though, if one version is running, the other should refuse to start. To this end, my scripts use the symlink as a lock of sorts. If it exists (and doesn't point to $GAMEDIR), the prelaunch script will return a nonzero exit code (and print an appropriate message to stderr, so it's easy to diagnose in logs).

Unfortunately, I can't find a way to get lutris to respond to the exit code. I tried a command prefix of `/path/to/prelaunch_script.sh && `, and then the game just always fails to start, even when the command exits normally.

## Solution(s)

Ideally, Lutris would have a way to only launch the game if the pre-launch command succeeds. I can think of 3 ways to do this:

1. Change the behavior of the "wait for pre-launch command" setting, as this PR currently does
2. Add a new setting, "Do not launch game if pre-launch command fails". Grayed out or invisible if "wait for pre-launch command" is turned off.
3. Change the "wait for pre-launch command" from a toggle to a drop down with 3 options, "Start the game immediately", "Start the game when the pre-launch command finishes", and "Start the game when the pre-launch command succeeds" (or something like that, there might be better wording).

I implemented the first just for demonstration — sometimes 1 line of code is worth 2.5k characters of explanation, or something like that. I didn't test it and this PR is not intended to be merged (yet).

If none of these are feasible, I suppose I could also write a shell script that does the check and then launches League, but that's even more of a hack the current scripts are.