### PR TITLE
Added check to Steam.py Sync() to fix #1999

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -426,7 +426,10 @@ class InstallerWindow(BaseApplicationWindow):
         self.play_button.show()
         self.close_button.grab_focus()
         self.close_button.show()
+        game_data = pga.get_game_by_field(self.game_slug, "slug")
 
+        game = Game(game_data["id"])
+        game.save(metadata_only=True)
         if not self.is_active():
             self.set_urgency_hint(True)  # Blink in taskbar
             self.connect("focus-in-event", self.on_window_focus)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -714,6 +714,9 @@ class LutrisWindow(Gtk.ApplicationWindow):
     def on_game_updated(self, game):
         """Callback to refresh the view when a game is updated"""
         logger.debug("Updating game %s", game)
+        if not game.is_installed:
+            game = Game(game_id=game.id)
+            self.game_selection_changed(None, None)
         game.load_config()
         try:
             self.game_store.update_game_by_id(game.id)
@@ -721,9 +724,8 @@ class LutrisWindow(Gtk.ApplicationWindow):
             self.game_store.add_game_by_id(game.id)
 
         self.view.set_selected_game(game.id)
-        self.game_selection_changed(None, game)
-        if not game.is_installed:
-            self.game_selection_changed(None, None)
+        if game.is_installed:
+            self.game_selection_changed(None, game)
         return True
 
     def on_search_games_fire(self, value):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -722,6 +722,8 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
         self.view.set_selected_game(game.id)
         self.game_selection_changed(None, game)
+        if not game.is_installed:
+            self.game_selection_changed(None, None)
         return True
 
     def on_search_games_fire(self, value):

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -139,8 +139,8 @@ class SteamSyncer:
         for game in games:
             steamid = game.appid
             available_ids.add(steamid)
-            # if game is on disk... and not shown as installed in Lutris...
             pga_game = self.get_pga_game(game)
+
             if pga_game:
                 if steamid in self.lutris_steamids and pga_game["installed"] != 1 and pga_game["installed"]:
                     added_games.append(game.install())

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -14,7 +14,7 @@ ONLINE = False
 
 
 class SteamGame(ServiceGame):
-    """SericeGame for Steam games"""
+    """ServiceGame for Steam games"""
     store = "steam"
     installer_slug = "steam"
     excluded_appids = [
@@ -139,10 +139,15 @@ class SteamSyncer:
         for game in games:
             steamid = game.appid
             available_ids.add(steamid)
+            # if game is on disk... and not shown as installed in Lutris...
+            pga_game = self.get_pga_game(game)
+            if pga_game:
+                if steamid in self.lutris_steamids and pga_game["installed"] != 1 and pga_game["installed"]:
+                    added_games.append(game.install())
+
             if steamid not in self.lutris_steamids:
                 added_games.append(game.install())
             else:
-                pga_game = self.get_pga_game(game)
                 if pga_game:
                     added_games.append(game.install(pga_game))
 


### PR DESCRIPTION
Fixes #1999 

Added a check for when a game is installed on disk, but is not shown as installed in the SQLite database. In such case we can safely run game.install() and append it to the list of games the Sync() method installed.

I've tested this with every variation I could come up with of multiple games installed in Lutris and on disk and other games not shown/installed in Lutris while being installed on disk. It appears to function as intended.

First ever commit to an OSS project, be gentle :D