### PR TITLE
Add auto-hide-launcher option

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -342,6 +342,9 @@ class Application(Gtk.Application):
         game.load_config()  # Reload the config before launching it.
         game.play()
 
+        if settings.read_setting("auto_hide_launcher").lower() == "true":
+            self.window.hide()  # Hide launcher window
+
     def get_game_by_id(self, game_id):
         for i in range(self.running_games.get_n_items()):
             game = self.running_games.get_item(i)
@@ -360,6 +363,9 @@ class Application(Gtk.Application):
         if game_index is not None:
             self.running_games.remove(game_index)
         game.emit("game-stopped", game.id)
+        
+        if settings.read_setting("auto_hide_launcher").lower() == "true":
+            self.window.show()  # Show launcher window
 
     @staticmethod
     def get_lutris_action(url):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -196,6 +196,11 @@ class LutrisWindow(Gtk.ApplicationWindow):
                 default=self.filter_installed,
                 accel="<Primary>h",
             ),
+            "auto-hide-launcher": Action(
+                self.on_auto_hide_launcher,
+                type="b",
+                default=self.auto_hide_launcher,
+            ),
             "show-installed-first": Action(
                 self.on_show_installed_first_state_change,
                 type="b",
@@ -290,6 +295,10 @@ class LutrisWindow(Gtk.ApplicationWindow):
     @property
     def show_installed_first(self):
         return settings.read_setting("show_installed_first") == "true"
+
+    @property
+    def auto_hide_launcher(self):
+        return settings.read_setting("auto_hide_launcher", default="false").lower() == "true"
 
     @property
     def view_sorting(self):
@@ -638,6 +647,11 @@ class LutrisWindow(Gtk.ApplicationWindow):
         action.set_state(value)
         self.set_show_installed_first_state(value.get_boolean())
 
+    def on_auto_hide_launcher(self, action, value):
+        """Hide launcher on game startup"""
+        action.set_state(value)
+        settings.write_setting("auto_hide_launcher", "true" if value.get_boolean() else "false")
+    
     def set_show_installed_first_state(self, show_installed_first):
         """Shows the installed games first in the view"""
         settings.write_setting("show_installed_first", "true" if show_installed_first else "false")

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -299,6 +299,21 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="receives_default">False</property>
+            <property name="action_name">win.auto-hide-launcher</property>
+            <property name="text" translatable="yes">Auto _Hide Launcher</property>
+            <accelerator key="0xffffff" signal="clicked"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="action_name">win.show-right-side-panel</property>
             <property name="text" translatable="yes">Show _Right Side Panel</property>
             <accelerator key="0xffffff" signal="clicked"/>
@@ -306,7 +321,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -317,7 +332,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -331,7 +346,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -346,7 +361,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">7</property>
+            <property name="position">8</property>
           </packing>
         </child>
         <child>
@@ -361,7 +376,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">8</property>
+            <property name="position">9</property>
           </packing>
         </child>
         <child>
@@ -376,7 +391,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">9</property>
+            <property name="position">10</property>
           </packing>
         </child>
         <child>
@@ -391,7 +406,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">10</property>
+            <property name="position">11</property>
           </packing>
         </child>
         <child>
@@ -406,7 +421,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">11</property>
+            <property name="position">12</property>
           </packing>
         </child>
         <child>
@@ -417,7 +432,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">12</property>
+            <property name="position">13</property>
           </packing>
         </child>
         <child>
@@ -431,7 +446,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">13</property>
+            <property name="position">14</property>
           </packing>
         </child>
         <child>
@@ -445,7 +460,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">14</property>
+            <property name="position">15</property>
           </packing>
         </child>
         <child>
@@ -459,7 +474,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">15</property>
+            <property name="position">16</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
This pull request adds an auto-hide-launcher option. If enabled, it hides lutris when a game is running and appears again when the game is closed.