### PR TITLE
Improve UX when the Lutris API is slow

### DIFF
--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -25,13 +25,37 @@ class RunnerInstallDialog(Dialog):
         self.set_default_size(width, height)
 
         self.runner = runner
-        self.runner_info = api.get_runners(self.runner)
+        self.runner_info = None
+
+        self.label = Gtk.Label("Waiting for response from %s" % (settings.SITE_URL))
+        self.vbox.pack_start(self.label, False, False, 18)
+        
+        # Display a wait icon.
+        self.spinner = Gtk.Spinner()        
+        self.vbox.pack_start(self.spinner, False, False, 18)
+        self.spinner.show()
+        self.spinner.start()
+
+        self.show_all()
+
+        jobs.AsyncCall(api.get_runners, self.display_all_versions, self.runner)
+
+    def display_all_versions(self, runner_info, error):
+        """Clear the box and display versions from runner_info"""
+        if error:
+            logger.error(error)
+
+        self.runner_info = runner_info
         if not self.runner_info:
             ErrorDialog(
-                "Unable to get runner versions. Check your internet connection.",
-                parent=parent,
+                "Unable to get runner versions. Check your internet connection."
             )
             return
+
+        for child_widget in self.vbox.get_children():
+            if child_widget.get_name() not in "GtkBox":
+                child_widget.destroy()
+            
         label = Gtk.Label("%s version management" % self.runner_info["name"])
         self.vbox.add(label)
         self.runner_store = self.get_store()

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -25,8 +25,7 @@ class RunnerInstallDialog(Dialog):
         self.set_default_size(width, height)
 
         self.runner = runner
-        self.runner_info = None
-
+        
         self.label = Gtk.Label("Waiting for response from %s" % (settings.SITE_URL))
         self.vbox.pack_start(self.label, False, False, 18)
         

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -86,6 +86,11 @@ class InstallerWindow(BaseApplicationWindow):
 
         self.get_scripts()
 
+        self.set_status("Waiting for response from %s" % (settings.SITE_URL))
+        self.add_spinner()
+        self.widget_box.show()
+        self.status_label.show()
+
         self.present()
 
     def add_button(self, label, handler=None):
@@ -115,8 +120,10 @@ class InstallerWindow(BaseApplicationWindow):
 
         if not isinstance(scripts, list):
             scripts = [scripts]
+        self.clean_widgets()
         self.scripts = scripts
         self.show_all()
+        self.status_label.hide()
         self.close_button.hide()
         self.play_button.hide()
         self.install_button.hide()


### PR DESCRIPTION
For some reason the Lutris API takes a very long time to respond for me. While the client is doing most calls asynchronously now, there are still a few parts left where that's not the case. This PR prevents the client from locking up while it fetches the available runner versions (can be seen in the wine version management window) and displays a small loading circle to show that it is currently doing something. I also added the loading circle to the installer window, because otherwise it's just empty while Lutris is getting the available installers of a game.

Feel free to tell me why my code is bad (and how it can be improved 😄)