### PR TITLE
Fix xrandr parsing when SteamVR is open

### DIFF
--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -40,6 +40,8 @@ def get_outputs():
         return []
     for line in vid_modes:
         if "connected" in line:
+            if "disconnected" in line:
+                continue
             primary = "primary" in line
             try:
                 if primary:


### PR DESCRIPTION
When I try to run any game in Lutris when SteamVR is open, xrandr parsing will fail, as the output is different. This causes the game to never launch with the error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.7/site-packages/lutris/exceptions.py", line 26, in wrapper
    return function(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/lutris/game.py", line 296, in configure_game
    display.get_outputs(), key=lambda e: e.name == system_config.get("display")
  File "/usr/lib/python3.7/site-packages/lutris/util/display.py", line 47, in get_outputs
    name, _, geometry, rotate, *_ = line.split()
ValueError: not enough values to unpack (expected at least 4, got 2)
```
With the git master branch, this doesn't cause a crash but still prints that error.

xrandr output without SteamVR and with SteamVR are attached.
[xrandr_without_steamvr.txt](https://github.com/lutris/lutris/files/3541394/xrandr_without_steamvr.txt)
[xrandr_with_steamvr.txt](https://github.com/lutris/lutris/files/3541395/xrandr_with_steamvr.txt)

I solved the issue by checking if the display is "disconnected", since I assume we want to discard those anyway.