### PR TITLE
wine:  find proton-tkg

### DIFF
--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -45,7 +45,7 @@ def get_proton_paths():
     """Get the Folder that contains all the Proton versions. Can probably be improved"""
     paths = set()
     for path in _iter_proton_locations():
-        proton_versions = [p for p in os.listdir(path) if "Proton" in p]
+        proton_versions = [p for p in os.listdir(path) if "Proton" or "proton" in p]
         for version in proton_versions:
             if system.path_exists(os.path.join(path, version, "dist/bin/wine")):
                 paths.add(path)
@@ -151,7 +151,7 @@ def get_wine_versions():
                 versions.append(dirname)
 
     for proton_path in get_proton_paths():
-        proton_versions = [p for p in os.listdir(proton_path) if "Proton" in p]
+        proton_versions = [p for p in os.listdir(proton_path) if "Proton" or "proton" in p]
         for version in proton_versions:
             path = os.path.join(proton_path, version, "dist/bin/wine")
             if os.path.isfile(path):


### PR DESCRIPTION
Just looks for a lowercase "Proton"

I'm sure I could do it in a better with a couple characters, but I don't know how. For the moment this just allows me to use a tkg proton build in lutris, like I use it in Steam.

https://github.com/lutris/lutris/pull/1928#issuecomment-475972587

Ignore 'test' in commit, it works