### PR TITLE
Finalize gentoo incompatibility fix

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -277,19 +277,20 @@ class LinuxSystem:
     def iter_lib_folders(self):
         """Loop over existing 32/64 bit library folders"""
         exported_lib_folders = set()
+        for lib_folder in self.get_lib_folders():
+            exported_lib_folders.add(lib_folder)
+            yield lib_folder
         for lib_paths in self.multiarch_lib_folders:
             if self.arch != 'x86_64':
                 # On non amd64 setups, only the first element is relevant
                 lib_paths = [lib_paths[0]]
             if all([os.path.exists(path) for path in lib_paths]):
-                exported_lib_folders.add(lib_paths[0])
-                yield lib_paths[0]
-                exported_lib_folders.add(lib_paths[1])
-                yield lib_paths[1]
-        for lib_folder in self.get_lib_folders():
-            if lib_folder not in exported_lib_folders:
-                yield lib_folder
-
+                if lib_paths[0] not in exported_lib_folders:
+                        yield lib_paths[0]
+                if len(lib_paths) != 1:
+                    if lib_paths[1] not in exported_lib_folders:
+                        yield lib_paths[1]
+    
     def get_ldconfig_libs(self):
         """Return a list of available libraries, as returned by `ldconfig -p`."""
         ldconfig = self.get("ldconfig")


### PR DESCRIPTION
The issue with the gentoo crash is because the generator places the prioritized list (sorted from ldconfig) directories after the directories from multiarch_lib_folders in `path` (line 268 runtime.py) This does not work on gentoo with nvidia because mesa is still installed at /usr/lib/ and /usr/lib64. (not problem for AMD users)

`"LD_LIBRARY_PATH": "/home/user/.local/share/lutris/runners/wine/lutris-4.13-x86_64/lib:/home/user/.local/share/lutris/runners/wine/lutris-4.13-x86_64/lib64:`**/lib:/lib64:/usr/lib:/usr/lib64**`:/usr/lib/OpenCL/vendors/nvidia:/usr/lib64/OpenCL/vendors/nvidia:/opt/cuda/nvvm/lib64:/usr/lib64/fltk:/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/32:`**/usr/lib/opengl/nvidia/lib:/usr/lib64/opengl/nvidia/lib**`:/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0/32:/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/32:/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0:/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0:/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0:/usr/lib64/rust-1.37.0:/opt/cuda/lib64:/usr/lib/llvm/8/lib:/usr/lib/llvm/8/lib64:/home/user/.local/share/lutris/runtime/Ubuntu-18.04-i686:/home/user/.local/share/lutris/runtime/steam/i386/lib/i386-linux-gnu:/home/user/.local/share/lutris/runtime/steam/i386/lib:/home/user/.local/share/lutris/runtime/steam/i386/usr/lib/i386-linux-gnu:/home/user/.local/share/lutris/runtime/steam/i386/usr/lib:/home/user/.local/share/lutris/runtime/Ubuntu-18.04-x86_64:/home/user/.local/share/lutris/runtime/steam/amd64/lib/x86_64-linux-gnu:/home/user/.local/share/lutris/runtime/steam/amd64/lib:/home/user/.local/share/lutris/runtime/steam/amd64/usr/lib/x86_64-linux-gnu:/home/user/.local/share/lutris/runtime/steam/amd64/usr/lib:$LD_LIBRARY_PATH",`

This does work on gentoo. 

`LD_LIBRARY_PATH="/home/ren/.local/share/lutris/runners/wine/lutris-4.13-x86_64/lib:/home/ren/.local/share/lutris/runners/wine/lutris-4.13-x86_64/lib64:/usr/lib/OpenCL/vendors/nvidia:/usr/lib64/OpenCL/vendors/nvidia:/opt/cuda/nvvm/lib64:/usr/lib64/fltk:`**/lib**`:/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0/32:`**/usr/lib/opengl/nvidia/lib:/usr/lib64/opengl/nvidia/lib**`:/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0/32:/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/32:/usr/lib/gcc/x86_64-pc-linux-gnu/8.3.0:/usr/lib/gcc/x86_64-pc-linux-gnu/9.1.0:/usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0:/usr/lib64/rust-1.37.0:/opt/cuda/lib64:`**/lib64**`:/usr/lib/llvm/8/lib:/usr/lib/llvm/8/lib64:`**/usr/lib:/usr/lib64**`:/home/ren/.local/share/lutris/runtime/Ubuntu-18.04-i686:/home/ren/.local/share/lutris/runtime/steam/i386/lib/i386-linux-gnu:/home/ren/.local/share/lutris/runtime/steam/i386/lib:/home/ren/.local/share/lutris/runtime/steam/i386/usr/lib/i386-linux-gnu:/home/ren/.local/share/lutris/runtime/steam/i386/usr/lib:/home/ren/.local/share/lutris/runtime/Ubuntu-18.04-x86_64:/home/ren/.local/share/lutris/runtime/steam/amd64/lib/x86_64-linux-gnu:/home/ren/.local/share/lutris/runtime/steam/amd64/lib:/home/ren/.local/share/lutris/runtime/steam/amd64/usr/lib/x86_64-linux-gnu:/home/ren/.local/share/lutris/runtime/steam/amd64/usr/lib:$LD_LIBRARY_PATH"
`

I tested manjaro in a VM and it worked (I ran Xonotic and the game launched and was playable)