### PR TITLE
Symlink restoration when disabling wine sandbox

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -923,6 +923,8 @@ class wine(Runner):
             wine_prefix.desktop_integration(
                 desktop_dir=self.runner_config.get("sandbox_dir")
             )
+        else:
+            wine_prefix.desktop_integration(restore=True)
 
     def play(self):
         game_exe = self.game_exe

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -10,6 +10,18 @@ from gi.repository import GLib
 from lutris.util import system
 from lutris.settings import CACHE_DIR
 
+def get_xdg_entry(directory):
+    """Return the path for specific user folders"""
+    special_dir = { "DESKTOP":  GLib.UserDirectory.DIRECTORY_DESKTOP,
+                    "MUSIC":    GLib.UserDirectory.DIRECTORY_MUSIC,
+                    "PICTURES": GLib.UserDirectory.DIRECTORY_PICTURES,
+                    "VIDEOS":   GLib.UserDirectory.DIRECTORY_VIDEOS,
+                    "DOCUMENTS":GLib.UserDirectory.DIRECTORY_DOCUMENTS }
+    directory = directory.upper()
+    if directory not in special_dir.keys():
+        raise ValueError("Only those folders are supported "+special_dir.keys())
+    return GLib.get_user_special_dir(special_dir[directory])
+
 
 def get_xdg_basename(game_slug, game_id, base_dir=None):
     """Return the filename for .desktop shortcuts"""
@@ -86,7 +98,6 @@ def get_menu_launcher_path(game_slug, game_id):
     return os.path.join(
         menu_dir, get_xdg_basename(game_slug, game_id, base_dir=menu_dir)
     )
-
 
 def desktop_launcher_exists(game_slug, game_id):
     return system.path_exists(get_launcher_path(game_slug, game_id))


### PR DESCRIPTION
This pull request add restoration of wine's symlinks to the user's folder when you disable the sanbox in the runner option.
It uses xdg to get the right folders, and leverage most of existing code especially the existing "folder.winecfg" backup when there are files in the folder instead of deleting it.
Tested and working, but more tests are welcomed :)