### PR TITLE
Fix prelaunch_beat referencing no prelaunch_extractor

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -575,7 +575,7 @@ class Game(GObject.Object):
 
     def prelaunch_beat(self):
         """Watch the prelaunch command"""
-        if self.prelaunch_executor.is_running:
+        if self.prelaunch_executor and self.prelaunch_executor.is_running:
             return True
         self.start_game()
         return False


### PR DESCRIPTION
Was getting the following error in game.py....

```
File "lutris/game.py", line 578, in prelaunch_beat
    if self.prelaunch_executor.is_running:
AttributeError: 'NoneType' object has no attribute 'is_running'
```