### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -92,7 +92,7 @@ class pico8(Runner):
 
     @property
     def is_native(self):
-        return self.runner_config.get("runner_executable", "") is not ""
+        return self.runner_config.get("runner_executable", "") != ""
 
     @property
     def engine_path(self):
@@ -126,7 +126,7 @@ class pico8(Runner):
                 args.append("-splore")
 
             size = self.runner_config.get("window_size").split("x")
-            if len(size) is 2:
+            if len(size) == 2:
                 args.append("-width")
                 args.append(size[0])
                 args.append("-height")


### PR DESCRIPTION
Use ==/!= to compare str, bytes, and int literals because identity is not the same thing as equality in Python. These instances will raise SyntaxWarnings on Python >= 3.8 so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

[flake8](http://flake8.pycqa.org) testing of https://github.com/lutris/lutris on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./lutris/runners/pico8.py:95:16: F632 use ==/!= to compare str, bytes, and int literals
        return self.runner_config.get("runner_executable", "") is not ""
               ^
./lutris/runners/pico8.py:129:16: F632 use ==/!= to compare str, bytes, and int literals
            if len(size) is 2:
               ^
2     F632 use ==/!= to compare str, bytes, and int literals
2
```