### PR TITLE
Add more Vulkan ICD dirs

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -33,13 +33,11 @@ def get_optirun_choices():
 
 def get_vk_icd_choices():
     """Return available Vulkan ICD loaders"""
-    loader_paths = []
-    for data_dir in VULKAN_DATA_DIRS:
-        loader_paths.append(os.path.join(data_dir, "icd.d", "*.json"))
     choices = [("Auto", "")]
 
     # Add loaders
-    for path in loader_paths:
+    for data_dir in VULKAN_DATA_DIRS:
+        path = os.path.join(data_dir, "icd.d", "*.json")
         for loader in glob.glob(path):
             choices.append((os.path.basename(loader), loader))
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -23,6 +23,8 @@ def get_optirun_choices():
 def get_vk_icd_choices():
     """Return available Vulkan ICD loaders"""
     loader_paths = ["/usr/share/vulkan/icd.d/*.json",  # standard location
+                    "/usr/lib/x86_64-linux-gnu/GL/vulkan/icd.d/*.json", # Flatpak GL extension
+                    "/usr/lib/i386-linux-gnu/GL/vulkan/icd.d/*.json", # Flatpak GL32 extension
                     "/opt/amdgpu-pro/etc/vulkan/icd.d/*.json",  # AMD GPU Pro - TkG
                     "/etc/vulkan/icd.d/*.json"]  # AMDVLK - Ubuntu
     choices = [("Auto", "")]

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -8,6 +8,17 @@ from lutris.util import display, system
 from lutris.discord import DiscordPresence
 
 
+VULKAN_DATA_DIRS = [
+    "/usr/local/etc/vulkan",  # standard site-local location
+    "/usr/local/share/vulkan",  # standard site-local location
+    "/etc/vulkan",  # standard location
+    "/usr/share/vulkan",  # standard location
+    "/usr/lib/x86_64-linux-gnu/GL/vulkan",  # Flatpak GL extension
+    "/usr/lib/i386-linux-gnu/GL/vulkan",  # Flatpak GL32 extension
+    "/opt/amdgpu-pro/etc/vulkan"  # AMD GPU Pro - TkG
+]
+
+
 def get_optirun_choices():
     """Return menu choices (label, value) for Optimus"""
     choices = [("Off", "off")]
@@ -22,11 +33,9 @@ def get_optirun_choices():
 
 def get_vk_icd_choices():
     """Return available Vulkan ICD loaders"""
-    loader_paths = ["/usr/share/vulkan/icd.d/*.json",  # standard location
-                    "/usr/lib/x86_64-linux-gnu/GL/vulkan/icd.d/*.json", # Flatpak GL extension
-                    "/usr/lib/i386-linux-gnu/GL/vulkan/icd.d/*.json", # Flatpak GL32 extension
-                    "/opt/amdgpu-pro/etc/vulkan/icd.d/*.json",  # AMD GPU Pro - TkG
-                    "/etc/vulkan/icd.d/*.json"]  # AMDVLK - Ubuntu
+    loader_paths = []
+    for data_dir in VULKAN_DATA_DIRS:
+        loader_paths.append(os.path.join(data_dir, "icd.d", "*.json"))
     choices = [("Auto", "")]
 
     # Add loaders


### PR DESCRIPTION
Fixes #2337, also adds `/usr/local` paths.
vulkan-loader still searches way more paths for ICDs. I wonder if Lutris could somehow get those paths dynamically.