### PR TITLE
Added the option to restore the window position (fixes #2354)

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -106,6 +106,8 @@ class GameDialogCommon:
 
         prefs_box.pack_start(self._get_hide_on_game_launch_box(), False, False, 6)
 
+        prefs_box.pack_start(self._get_window_position(), False, False, 6)
+
         info_sw = self.build_scrolled_window(prefs_box)
         self._add_notebook_tab(info_sw, "Lutris preferences")
 
@@ -135,6 +137,19 @@ class GameDialogCommon:
     def _on_hide_client_change(self, widget):
         """Save setting for hiding the game on game launch"""
         settings.write_setting("hide_client_on_game_start", widget.get_active())
+
+    def _get_window_position(self):
+        box = Gtk.Box(spacing=12, margin_right=12, margin_left=12)
+        checkbox = Gtk.CheckButton(label="Remember the window position between launch")
+        if settings.read_setting("window_default_position") == "False":
+            checkbox.set_active(True)
+        checkbox.connect("toggled", self._on_switch_default_window_position)
+        box.pack_start(checkbox, True, True, 0)
+        return box
+
+    def _on_switch_default_window_position(self, widget):
+        """Save setting for restoring the window position on next launch"""
+        settings.write_setting("window_default_position", not widget.get_active())
 
     def _on_cache_path_set(self, entry):
         if self.timer_id:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -108,6 +108,14 @@ class LutrisWindow(Gtk.ApplicationWindow):
         self.connect("delete-event", self.on_window_delete)
         if self.maximized:
             self.maximize()
+        elif settings.read_setting("window_default_position") == "False":
+            #If we can't retreive the window coordinates from the config file, the window will stay at the center of the screen
+            try:
+                position = [int(i) for i in settings.read_setting("window_position").split(',')]
+                self.move(*position)
+            except ValueError:
+                pass
+
         self.init_template()
         self._init_actions()
         self._bind_zoom_adjustment()
@@ -592,6 +600,10 @@ class LutrisWindow(Gtk.ApplicationWindow):
             self.window_size = widget.get_size()
 
     def on_window_delete(self, *_args):
+        
+        if settings.read_setting("window_default_position") == "False":
+            settings.write_setting("window_position","{},{}".format(self.get_position().root_x,self.get_position().root_y))
+        
         if self.application.running_games.get_n_items():
             dlg = dialogs.QuestionDialog(
                 {


### PR DESCRIPTION
I implemented here the option to save the window position between launches. There is a new option in the lutris preferences. Fixes #2354 :)
![image](https://user-images.githubusercontent.com/10716685/66259974-90273c80-e7b8-11e9-9bbf-f1604c5675f5.png)

The logic might seems convoluted (storing the inverse of the checkbox) but with this way everything is still coherent when the option is not in the config file.
