### PR TITLE
Fixed #2367 by assuming true by default for showing the panels

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -266,12 +266,12 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
     @property
     def left_side_panel_visible(self):
-        show_left_panel = settings.read_setting("left_side_panel_visible").lower() == "true"
+        show_left_panel = settings.read_setting("left_side_panel_visible").lower() != "false"
         return show_left_panel or self.sidebar_visible
 
     @property
     def right_side_panel_visible(self):
-        show_right_panel = settings.read_setting("right_side_panel_visible").lower() == "true"
+        show_right_panel = settings.read_setting("right_side_panel_visible").lower() != "false"
         return show_right_panel or self.sidebar_visible
 
     @property


### PR DESCRIPTION
I simply changed the way the check is done to show the panels. I assume true by default (instead of false by default) which means that if the value is not in the config file, the panels are indeed displayed.