### PR TITLE
Use fallback locale if locale is configured incorrectly (fixes #2341)

### DIFF
--- a/bin/lutris
+++ b/bin/lutris
@@ -24,7 +24,11 @@ if os.path.isdir(os.path.join(LAUNCH_PATH,"../lutris")):
 else:
     sys.path.insert(0, os.path.normpath(os.path.join(LAUNCH_PATH, "../lib/lutris")))
 
-locale.setlocale(locale.LC_ALL, "")
+try:
+    locale.setlocale(locale.LC_ALL, "")
+except locale.Error:
+    sys.stderr.write("Unsupported locale setting. Using 'C' as fallback locale.\n")
+    locale.setlocale(locale.LC_ALL, "C")
 
 from lutris.gui.application import Application
 


### PR DESCRIPTION
e0b39596 introduced a regression that would prevent Lutris from starting if the locale configured via the environment variables is invalid. This commit caches that error, prints a warning and falls back to the 'C' locale (this is the same behavior that the gtk tookit uses when encountering an invalid locale).