### PR TITLE
Fix Issues #2358 and Issues#2376

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -38,6 +38,11 @@ To install all those dependencies on Ubuntu based systems, you can run::
       gir1.2-notify-0.7 psmisc cabextract unzip p7zip curl fluid-soundfont-gs \
       x11-xserver-utils python3-evdev libc6-i386 lib32gcc1 libgirepository1.0-dev
 
+Note :
+If you use OpenSUSE, some dependencies are missing. You need to install python3-gobject-Gdk and typelib-1_0-Gtk-3_0
+
+``sudo apt install python3-gobject-Gdk typelib-1_0-Gtk-3_0``
+
 Installation
 ------------
 

--- a/debian/control
+++ b/debian/control
@@ -20,7 +20,7 @@ Maintainer: Mathieu Comandon <strider@strycore.com>
 Standards-Version: 3.9.5
 Vcs-Git: https://github.com/lutris/lutris
 Homepage: https://lutris.net
-X-Python-Version: >= 3.4
+X-Python3-Version: >= 3.4
 
 Package: lutris
 Architecture: any


### PR DESCRIPTION
- Issues #2358 (gtk critical error on 0.5.3, fails to launch)

add missing dependencies said in issue #2358 in INSTALL.rst (gtk critical error on 0.5.3, fails to launch)

- Issues #2376 (Some problems with the debian/control file in the source)

Change X-Python-Version: >= 3.4 ======> X-Python3-Version: >= 3.4 in debian/control file (line 23)