### PR TITLE
Adding a switch to enable NVIDIA Prime render offload

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -457,6 +457,12 @@ class Game(GObject.Object):
         env.update(game_env)
         env["game_name"] = self.name
 
+        # Prime vars
+        prime = system_config.get("prime")
+        if prime:
+            env["__NV_PRIME_RENDER_OFFLOAD"] = "1"
+            env["__GLX_VENDOR_LIBRARY_NAME"] = "nvidia"
+
         # LD_PRELOAD
         ld_preload = gameplay_info.get("ld_preload")
         if ld_preload:

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -194,6 +194,19 @@ system_options = [  # pylint: disable=invalid-name
         "help": "Request a set of optimisations be temporarily applied to the host OS",
     },
     {
+        "option": "prime",
+        "type": "bool",
+        "default": False,
+        "condition": True,
+        "label": "Enable NVIDIA Prime render offload",
+        "help": (
+            "If you have the latest NVIDIA driver and the properly patched xorg-server "
+            "(see https://download.nvidia.com/XFree86/Linux-x86_64/435.17/README/primerenderoffload.html), "
+            "you can launch a game on your NVIDIA GPU by toggling this switch (this will apply "
+            "__NV_PRIME_RENDER_OFFLOAD=1 and __GLX_VENDOR_LIBRARY_NAME=nvidia environment variables)"
+        )
+    },
+    {
         "option": "dri_prime",
         "type": "bool",
         "default": display.USE_DRI_PRIME,


### PR DESCRIPTION
This feature adds a switch to enable NVIDIA Prime render offload. It just adds the proper environment variables to the game when enabled.