### PR TITLE
Refresh right panel when a game is started

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -102,6 +102,7 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_updated)
+        GObject.add_emission_hook(Game, "game-started", self.on_game_started)
         GObject.add_emission_hook(GenericPanel,
                                   "running-game-selected",
                                   self.game_selection_changed)
@@ -710,6 +711,10 @@ class LutrisWindow(Gtk.ApplicationWindow):
         """Called when a game has sent the 'game-error' signal"""
         logger.error("%s crashed", game)
         dialogs.ErrorDialog(error, parent=self)
+
+    def on_game_started(self, game):
+        self.game_panel.refresh()
+        return True
 
     def on_game_updated(self, game):
         """Callback to refresh the view when a game is updated"""

--- a/lutris/gui/views/game_panel.py
+++ b/lutris/gui/views/game_panel.py
@@ -36,6 +36,9 @@ class GamePanel(GenericPanel):
         self.buttons = self.get_buttons()
         self.place_buttons(145)
 
+    def refresh(self):
+        self.place_content()
+
     @property
     def background_id(self):
         return self.game.slug

--- a/lutris/gui/views/generic_panel.py
+++ b/lutris/gui/views/generic_panel.py
@@ -81,6 +81,9 @@ class GenericPanel(Gtk.Fixed):
             self.put(running_label, 12, 355)
             self.put(self.get_running_games(), 12, 377)
 
+    def refresh(self):
+        self.place_content()
+
     def get_preferences_button(self):
         preferences_button = Gtk.Button.new_from_icon_name(
             "preferences-system-symbolic", Gtk.IconSize.MENU


### PR DESCRIPTION
Right now when a game is started using a slug (for example using an application menu entry) the ui won't change to reflect this change. The list of running games won't be updated in the GenericPanel and the "Play"-Button won't change to "Stop" in the GamePanel. This PR fixes this behaviour by hooking the `game-started` event and forcing a refresh on the panel when the event occurs.

The reason why I implemented a `refresh` function into the panels even tough it does nothing but invoke `place_content` is because I felt it would be a more clean api to call `refresh` in case there would be a need in the future to have different functionality implemented for refreshing than a simple `place_content` call.