### PR TITLE
Improve background behaviour

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -366,6 +366,9 @@ class Application(Gtk.Application):
 
         if settings.read_setting("hide_client_on_game_start") == "True":
             self.window.show()  # Show launcher window
+        elif not self.window.is_visible():
+            if self.running_games.get_n_items() == 0:
+                self.quit()
 
     @staticmethod
     def get_lutris_action(url):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -594,15 +594,8 @@ class LutrisWindow(Gtk.ApplicationWindow):
 
     def on_window_delete(self, *_args):
         if self.application.running_games.get_n_items():
-            dlg = dialogs.QuestionDialog(
-                {
-                    "question": ("Some games are still running. "
-                                 "Are you sure you want to quit Lutris?"),
-                    "title": "Quit Lutris?",
-                }
-            )
-            if dlg.result != Gtk.ResponseType.YES:
-                return True
+            self.hide()
+            return True
 
     @GtkTemplate.Callback
     def on_destroy(self, *_args):


### PR DESCRIPTION
(Note: This basically does the same for the new UI as I did in #1147 for the old UI)

This issue gives the background functionality of Lutris a more consistent feel. You can now close the main window and Lutris will continue running in the Background (given that any games are still running. If not lutris will simply quit as it has always done). When Lutris is in the background the lutris binary can be launched at any time to make the main window visible again. Should all games stop while the main window is hidden Lutris will detect this and quit.

Mainly this PR adresses two issues:

1. When launching a game using a slug Lutirs will be run in background without showing the main window. If the game quits the lutris process won't detect this and keep running.
2. Once the Lutris main window is shown it cannot be put into the background. The only option to get rid of the window is quitting lutris which will cause it to loose it's state and detach all games.