### PR TITLE
Disconnect game hook after game has stopped

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -359,6 +359,7 @@ class Application(Gtk.Application):
 
     def on_game_stop(self, game):
         """Callback to remove the game from the running games"""
+        game.disconnect_by_func(self.on_game_stop)
         game_index = self.get_game_index(game.id)
         if game_index is not None:
             self.running_games.remove(game_index)


### PR DESCRIPTION
Everytime time application.launch a hook is added to the stop event of that game. This hook never gets removed. However sometimes a game instance gets reused, causing another hook being added to the stop event so that the event handler is called multiple times.

This PR removes the hook from the game instance once the game has quit ensuring that the quit hook is always called exactly once.