### PR TITLE
Add option to use system winetricks

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -337,12 +337,17 @@ def winetricks(
         disable_runtime=False,
 ):
     """Execute winetricks."""
-    winetricks_path = os.path.join(settings.RUNTIME_DIR, "winetricks/winetricks")
-    if not system.path_exists(winetricks_path):
-        logger.warning(
-            "Could not find local winetricks install, falling back to bundled version"
-        )
-        winetricks_path = os.path.join(datapath.get(), "bin/winetricks")
+    wine_config = config or LutrisConfig(runner_slug="wine")
+    system_winetricks = wine_config.get("system_winetricks")
+    if system_winetricks:
+        winetricks_path = "usr/bin/winetricks"
+    else:
+        winetricks_path = os.path.join(settings.RUNTIME_DIR, "winetricks/winetricks")
+        if not system.path_exists(winetricks_path):
+            logger.warning(
+                "Could not find local winetricks install, falling back to bundled version"
+            )
+            winetricks_path = os.path.join(datapath.get(), "bin/winetricks")
     if wine_path:
         winetricks_wine = wine_path
     else:

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -206,6 +206,14 @@ class wine(Runner):
                 ),
             },
             {
+                "option": "system_winetricks",
+                "label": "Use system winetricks",
+                "type": "bool",
+                "default": False,
+                "advanced": True,
+                "help": "Switch on to use /usr/bin/winetricks for winetricks.",
+            },
+            {
                 "option": "dxvk",
                 "label": "Enable DXVK",
                 "type": "extended_bool",


### PR DESCRIPTION
Closes #2445

Feature could be extended to check for example if winetricks is even on the system installed or to download the upstream version.

Signed-off-by: Stephan Lachnit <stephanlachnit@protonmail.com>