### PR TITLE
Tiny fix to make certain wine installers and games work again

### DIFF
--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -98,6 +98,8 @@ class WinePrefixManager:
         _desktop_folders = self.get_desktop_folders()
         if _desktop_folders:
             DESKTOP_FOLDERS = _desktop_folders  # pylint: disable=invalid-name
+        else
+            DESKTOP_FOLDERS = []
 
         if not desktop_dir:
             desktop_dir = user_dir

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -98,7 +98,7 @@ class WinePrefixManager:
         _desktop_folders = self.get_desktop_folders()
         if _desktop_folders:
             DESKTOP_FOLDERS = _desktop_folders  # pylint: disable=invalid-name
-        else
+        else:
             DESKTOP_FOLDERS = []
 
         if not desktop_dir:


### PR DESCRIPTION
This should fix #2501 at least to the extent of lutris being able to install and run certain games with wine. This may have unintended side effects, I am not familiar enough with the entirety of the code to say for sure; this should probably only be a temporary fix.

I was personally experiencing this bug and made this tiny change in my own copy of lutris, which allowed me to install and play games again.