### PR TITLE
Read Reicast config file properly and don't override mixed-case (fixes #2505)

### DIFF
--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -1,7 +1,7 @@
 import re
 import os
 import shutil
-from configparser import ConfigParser
+from configparser import RawConfigParser
 from collections import Counter
 from lutris import settings
 from lutris.runners.runner import Runner
@@ -106,12 +106,16 @@ class reicast(Runner):
 
     @staticmethod
     def write_config(config):
-        parser = ConfigParser()
+        # use RawConfigParser to preserve case-sensitive configs written by Reicast
+        # otherwise, Reicast will write with mixed-case and Lutris will overwrite with all lowercase
+        #   which will confuse Reicast
+        parser = RawConfigParser()
+        parser.optionxform = lambda option: option
 
         config_path = os.path.expanduser("~/.reicast/emu.cfg")
         if system.path_exists(config_path):
             with open(config_path, "r") as config_file:
-                parser.read(config_file)
+                parser.read_file(config_file)
 
         for section in config:
             if not parser.has_section(section):


### PR DESCRIPTION
* Properly reads Reicast config file with `read_file` rather than `read`
* Preserves mixed-case config keys that Reicast uses rather than blindly overwriting with all lowercase (which causes Reicast to ignore keys with changed case)

Tested locally, works properly. Existing config files are properly parsed and preserved without issue. New config files work well too.