### PR TITLE
Remove bufsize argument from subprocess.Popen

### DIFF
--- a/lutris/command.py
+++ b/lutris/command.py
@@ -225,7 +225,6 @@ class MonitoredCommand:
 
             return subprocess.Popen(
                 command,
-                bufsize=1,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 cwd=self.cwd,


### PR DESCRIPTION
bufsize=1 is only valid for text mode. The default changed in version 3.3.1: bufsize now defaults to -1 to enable buffering by default to match the behavior that most code expects ([source](https://docs.python.org/3.8/library/subprocess.html#popen-constructor)). 

Python 3.8 throws a warning when doing I/O in binary mode ([source](https://bugs.python.org/issue32236)). This causes the message below to appear when applications are launched through lutris:
```
/usr/lib/python3.8/subprocess.py:844: RuntimeWarning: line buffering (buffering=1) isn't supported in binary mode, the default buffer size will be used
  self.stdout = io.open(c2pread, 'rb', bufsize)
```

Also reported in https://github.com/lutris/lutris/issues/2479