### PR TITLE
Fix Small Mistake in `installers.rst`

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -573,7 +573,7 @@ Example:
         - en: English
         - fr: French
         - "value and": "label can be anything, surround them with quotes to avoid issues"
-        preselect: fr
+        preselect: en
 
 In this example, English would be preselected. If the option eventually
 selected is French, the "$INPUT_LANG" alias would be available in


### PR DESCRIPTION
I just noticed a small mistake while reading through `docs/installers.rst`.
The description and example didn't match.
So this PR modifies the example to match the description and therefore fix the mistake.