### PR TITLE
Preferences Refresh

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -29,6 +29,7 @@ import gi
 gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 gi.require_version("GnomeDesktop", "3.0")
+gi.require_version("Handy", "0.0")
 
 from gi.repository import Gio, GLib, Gtk
 from lutris import pga

--- a/lutris/gui/config/add_game.py
+++ b/lutris/gui/config/add_game.py
@@ -24,12 +24,8 @@ class AddGameDialog(Dialog, GameDialogCommon):
             runner_slug=self.runner_name,
             level="game",
         )
-        self.build_notebook()
         self.build_tabs("game")
         self.build_action_area(self.on_save)
         self.name_entry.grab_focus()
         self.connect("delete-event", self.on_cancel_clicked)
-        self.build_headerbar()
-        self.viewswitcher.set_stack(self.stack)
-        self.set_titlebar(self.header)
         self.show_all()

--- a/lutris/gui/config/add_game.py
+++ b/lutris/gui/config/add_game.py
@@ -25,7 +25,6 @@ class AddGameDialog(Dialog, GameDialogCommon):
             level="game",
         )
         self.build_tabs("game")
-        self.build_action_area(self.on_save)
         self.name_entry.grab_focus()
-        self.connect("delete-event", self.on_cancel_clicked)
+        self.connect("delete-event", self.on_save)
         self.show_all()

--- a/lutris/gui/config/add_game.py
+++ b/lutris/gui/config/add_game.py
@@ -29,4 +29,7 @@ class AddGameDialog(Dialog, GameDialogCommon):
         self.build_action_area(self.on_save)
         self.name_entry.grab_focus()
         self.connect("delete-event", self.on_cancel_clicked)
+        self.build_headerbar()
+        self.viewswitcher.set_stack(self.stack)
+        self.set_titlebar(self.header)
         self.show_all()

--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -89,6 +89,8 @@ class ConfigBox(VBox):
             self.option_widget = None
             self.call_widget_generator(option, option_key, value, default)
 
+            self.wrapper.set_activatable_widget(self.option_widget)
+
             placeholder = Gtk.Box()
             placeholder.set_size_request(32, 32)
 

--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -593,8 +593,10 @@ class GameBox(ConfigBox):
             logger.warning("No runner in game supplied to GameBox")
         self.generate_widgets("game")
         print(len(self.basic.get_children()))
-        len(self.basic.get_children()) >= 1 and self.add(self.basic)
-        len(self.advanced.get_children()) >= 1 and self.add(self.advanced)
+        if len(self.basic.get_children()) >= 1:
+            self.add(self.basic)
+        if len(self.advanced.get_children()) >= 1:
+            self.add(self.advanced)
 
 
 class RunnerBox(ConfigBox):
@@ -615,8 +617,10 @@ class RunnerBox(ConfigBox):
                 "the base runner configuration."
             )
         self.generate_widgets("runner")
-        len(self.basic.get_children()) >= 1 and self.add(self.basic)
-        len(self.advanced.get_children()) >= 1 and self.add(self.advanced)
+        if len(self.basic.get_children()) >= 1:
+            self.add(self.basic)
+        if len(self.advanced.get_children()) >= 1:
+            self.add(self.advanced)
 
 
 class SystemBox(ConfigBox):
@@ -643,5 +647,7 @@ class SystemBox(ConfigBox):
             )
 
         self.generate_widgets("system")
-        len(self.basic.get_children()) >= 1 and self.add(self.basic)
-        len(self.advanced.get_children()) >= 1 and self.add(self.advanced)
+        if len(self.basic.get_children()) >= 1:
+            self.add(self.basic)
+        if len(self.advanced.get_children()) >= 1:
+            self.add(self.advanced)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -22,7 +22,7 @@ from lutris.gui.widgets.utils import (
 from lutris.util.strings import slugify
 from lutris.util import resources
 from lutris.util.linux import gather_system_info_str
-
+from lutris.util import datapath
 
 # pylint: disable=too-many-instance-attributes
 class GameDialogCommon:
@@ -147,6 +147,8 @@ class GameDialogCommon:
         self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         self._clipboard_buffer = sysinfo_str
 
+        build = Gtk.Builder()
+        build.add_from_file(os.path.join(datapath.get(), "ui", "copy-button.ui"))
         button_copy = Gtk.Button("Copy System Info")
         button_copy.connect("clicked", self._copy_text)
 
@@ -562,7 +564,6 @@ class GameDialogCommon:
 
         self.game.config = self.lutris_config
         self.game.save()
-        self.destroy()
         self.saved = True
 
     def on_custom_image_select(self, _widget, image_type):

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -478,7 +478,8 @@ class GameDialogCommon:
                 for ii in i.get_children()[0].get_children():
                     if Gtk.Buildable.get_name(ii) == "pages_stack":
                         for iii in ii.get_children():
-                            if not ii.get_visible_child() == iii: ii.remove(iii)
+                            if not ii.get_visible_child() == iii:
+                                ii.remove(iii)
 
         self._build_game_tab()
         self._build_runner_tab("game")

--- a/lutris/gui/config/edit_game.py
+++ b/lutris/gui/config/edit_game.py
@@ -15,11 +15,7 @@ class EditGameConfigDialog(Dialog, GameDialogCommon):
 
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
 
-        self.build_notebook()
         self.build_tabs("game")
         self.build_action_area(self.on_save)
         self.connect("delete-event", self.on_cancel_clicked)
-        self.build_headerbar()
-        self.viewswitcher.set_stack(self.stack)
-        self.set_titlebar(self.header)
         self.show_all()

--- a/lutris/gui/config/edit_game.py
+++ b/lutris/gui/config/edit_game.py
@@ -19,4 +19,7 @@ class EditGameConfigDialog(Dialog, GameDialogCommon):
         self.build_tabs("game")
         self.build_action_area(self.on_save)
         self.connect("delete-event", self.on_cancel_clicked)
+        self.build_headerbar()
+        self.viewswitcher.set_stack(self.stack)
+        self.set_titlebar(self.header)
         self.show_all()

--- a/lutris/gui/config/edit_game.py
+++ b/lutris/gui/config/edit_game.py
@@ -16,6 +16,5 @@ class EditGameConfigDialog(Dialog, GameDialogCommon):
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
 
         self.build_tabs("game")
-        self.build_action_area(self.on_save)
-        self.connect("delete-event", self.on_cancel_clicked)
+        self.connect("delete-event", self.on_save)
         self.show_all()

--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -18,7 +18,7 @@ class RunnerConfigDialog(Dialog, GameDialogCommon):
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
 
         self.build_tabs("runner")
-        self.build_action_area(self.on_save)
+        self.connect("delete-event", self.on_save)
         self.show_all()
 
     def on_save(self, wigdet, data=None):

--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -17,12 +17,8 @@ class RunnerConfigDialog(Dialog, GameDialogCommon):
 
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
 
-        self.build_notebook()
         self.build_tabs("runner")
         self.build_action_area(self.on_save)
-        self.build_headerbar()
-        self.viewswitcher.set_stack(self.stack)
-        self.set_titlebar(self.header)
         self.show_all()
 
     def on_save(self, wigdet, data=None):

--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -20,6 +20,9 @@ class RunnerConfigDialog(Dialog, GameDialogCommon):
         self.build_notebook()
         self.build_tabs("runner")
         self.build_action_area(self.on_save)
+        self.build_headerbar()
+        self.viewswitcher.set_stack(self.stack)
+        self.set_titlebar(self.header)
         self.show_all()
 
     def on_save(self, wigdet, data=None):

--- a/lutris/gui/config/system.py
+++ b/lutris/gui/config/system.py
@@ -15,7 +15,7 @@ class SystemConfigDialog(Dialog, GameDialogCommon):
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
 
         self.build_tabs("system")
-        self.build_action_area(self.on_save)
+        self.connect("delete-event", self.on_save)
         self.show_all()
 
     def on_save(self, _widget):

--- a/lutris/gui/config/system.py
+++ b/lutris/gui/config/system.py
@@ -14,12 +14,8 @@ class SystemConfigDialog(Dialog, GameDialogCommon):
 
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
 
-        self.build_notebook()
         self.build_tabs("system")
         self.build_action_area(self.on_save)
-        self.build_headerbar()
-        self.viewswitcher.set_stack(self.stack)
-        self.set_titlebar(self.header)
         self.show_all()
 
     def on_save(self, _widget):

--- a/lutris/gui/config/system.py
+++ b/lutris/gui/config/system.py
@@ -17,6 +17,9 @@ class SystemConfigDialog(Dialog, GameDialogCommon):
         self.build_notebook()
         self.build_tabs("system")
         self.build_action_area(self.on_save)
+        self.build_headerbar()
+        self.viewswitcher.set_stack(self.stack)
+        self.set_titlebar(self.header)
         self.show_all()
 
     def on_save(self, _widget):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -11,12 +11,12 @@ from lutris.util.log import logger
 import gi
 gi.require_version("WebKit2", "4.0")
 
-from gi.repository import GLib, GObject, Gtk, WebKit2
+from gi.repository import GLib, GObject, Gtk, WebKit2, Handy
 
 
-class Dialog(Gtk.Dialog):
+class Dialog(Handy.PreferencesWindow):
     def __init__(self, title=None, parent=None, flags=0, buttons=None):
-        super().__init__(title, parent, flags, buttons)
+        super().__init__()
         self.connect("delete-event", self.on_destroy)
         self.set_destroy_with_parent(True)
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -17,7 +17,6 @@ from gi.repository import GLib, GObject, Gtk, WebKit2
 class Dialog(Gtk.Dialog):
     def __init__(self, title=None, parent=None, flags=0, buttons=None):
         super().__init__(title, parent, flags, buttons)
-        self.set_border_width(10)
         self.connect("delete-event", self.on_destroy)
         self.set_destroy_with_parent(True)
 

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -2,7 +2,7 @@
 import os
 import random
 
-from gi.repository import GLib, Gtk
+from gi.repository import GLib, Gtk, Handy
 from lutris import api, settings
 from lutris.gui.dialogs import Dialog, ErrorDialog, QuestionDialog
 from lutris.util import jobs, system
@@ -26,15 +26,6 @@ class RunnerInstallDialog(Dialog):
 
         self.runner = runner
 
-        self.label = Gtk.Label("Waiting for response from %s" % (settings.SITE_URL))
-        self.vbox.pack_start(self.label, False, False, 18)
-
-        # Display a wait icon.
-        self.spinner = Gtk.Spinner()
-        self.vbox.pack_start(self.spinner, False, False, 18)
-        self.spinner.show()
-        self.spinner.start()
-
         self.show_all()
 
         jobs.AsyncCall(api.get_runners, self.display_all_versions, self.runner)
@@ -51,23 +42,22 @@ class RunnerInstallDialog(Dialog):
             )
             return
 
-        for child_widget in self.vbox.get_children():
-            if child_widget.get_name() not in "GtkBox":
-                child_widget.destroy()
+        page = Handy.PreferencesPage()
+        group = Handy.PreferencesGroup()
 
-        label = Gtk.Label("%s version management" % self.runner_info["name"])
-        self.vbox.add(label)
         self.runner_store = self.get_store()
         scrolled_window = Gtk.ScrolledWindow()
         self.treeview = self.get_treeview(self.runner_store)
         self.installing = {}
-        self.connect("response", self.on_destroy)
 
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        scrolled_window.set_shadow_type(Gtk.ShadowType.ETCHED_OUT)
-        scrolled_window.add(self.treeview)
+        page.set_title("%s Version Management" % self.runner_info["name"])
+        page.set_icon_name("system-software-install-symbolic")
+        
+        group.add(self.treeview)
 
-        self.vbox.pack_start(scrolled_window, True, True, 14)
+        page.add(group)
+
+        self.add(page)
         self.show_all()
 
     def get_treeview(self, model):

--- a/lutris/gui/widgets/common.py
+++ b/lutris/gui/widgets/common.py
@@ -34,7 +34,7 @@ class NumberEntry(Gtk.Entry, Gtk.Editable):
         return position
 
 
-class FileChooserEntry(Gtk.Box):
+class FileChooserEntry(Gtk.Bin):
     """Editable entry with a file picker button"""
 
     max_completion_items = 15  # Maximum number of items to display in the autocompletion dropdown.
@@ -49,8 +49,7 @@ class FileChooserEntry(Gtk.Box):
             warn_if_ntfs=False
     ):
         super().__init__(
-            orientation=Gtk.Orientation.VERTICAL,
-            spacing=12,
+            valign=Gtk.Align.CENTER,
             visible=True
         )
         self.title = title

--- a/share/lutris/ui/copy-button.ui
+++ b/share/lutris/ui/copy-button.ui
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.1 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkButton" id="copy_sys_info">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="receives_default">True</property>
+    <property name="halign">center</property>
+    <property name="valign">center</property>
+    <property name="relief">none</property>
+    <signal name="clicked" handler="on_copy" swapped="no"/>
+    <signal name="leave" handler="on_leave" swapped="no"/>
+    <child>
+      <object class="GtkStack" id="stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="transition_type">slide-up-down</property>
+        <child>
+          <object class="GtkImage" id="image2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">emblem-ok-symbolic</property>
+          </object>
+          <packing>
+            <property name="name">ok</property>
+            <property name="title" translatable="yes">page0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">edit-copy-symbolic</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Copy System Information</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">page0</property>
+            <property name="title" translatable="yes">page0</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <style>
+      <class name="flat"/>
+    </style>
+  </object>
+</interface>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -352,6 +352,7 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'name'</property>
             <property name="text" translatable="yes">_Name</property>
           </object>
           <packing>
@@ -366,6 +367,7 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'year'</property>
             <property name="text" translatable="yes">_Year</property>
           </object>
           <packing>
@@ -380,6 +382,7 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'lastplayed'</property>
             <property name="text" translatable="yes">Last _Played</property>
           </object>
           <packing>
@@ -394,6 +397,7 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'installed_at'</property>
             <property name="text" translatable="yes">In_stalled at</property>
           </object>
           <packing>
@@ -408,6 +412,7 @@
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'playtime'</property>
             <property name="text" translatable="yes">Play _time</property>
           </object>
           <packing>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -271,6 +271,46 @@
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">win.show-installed-only</property>
+            <property name="text" translatable="yes">_Installed Games Only</property>
+            <accelerator key="h" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">win.show-hidden-games</property>
+            <property name="text">Show Hidden Games</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
             <property name="action_name">win.view-sorting-ascending</property>
@@ -279,7 +319,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -294,7 +334,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -309,7 +349,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -324,7 +364,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">8</property>
           </packing>
         </child>
         <child>
@@ -339,7 +379,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">9</property>
           </packing>
         </child>
         <child>
@@ -354,7 +394,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">7</property>
+            <property name="position">10</property>
           </packing>
         </child>
       </object>
@@ -387,35 +427,6 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.show-installed-only</property>
-            <property name="text" translatable="yes">_Installed Games Only</property>
-            <accelerator key="h" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">1</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.show-hidden-games</property>
-            <property name="text">Show Hidden Games</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">2</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
             <property name="action_name">win.use-dark-theme</property>
             <property name="text" translatable="yes">Use _Dark Theme</property>
           </object>
@@ -423,89 +434,6 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.show-left-side-panel</property>
-            <property name="text" translatable="yes">Show _Left Side Panel</property>
-            <accelerator key="0xffffff" signal="clicked"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">4</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.show-right-side-panel</property>
-            <property name="text" translatable="yes">Show _Right Side Panel</property>
-            <accelerator key="0xffffff" signal="clicked"/>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">5</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">6</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.open-forums</property>
-            <property name="text" translatable="yes">Lutris forums</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">7</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.open-discord</property>
-            <property name="text" translatable="yes">Discord</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">8</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.donate</property>
-            <property name="text" translatable="yes">Support Lutris!</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">9</property>
           </packing>
         </child>
         <child>
@@ -570,20 +498,6 @@
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">14</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.show-tray-icon</property>
-            <property name="text" translatable="yes">Show Tray Icon</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">15</property>
           </packing>
         </child>
       </object>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -204,6 +204,162 @@
       </object>
     </child>
   </object>
+  <object class="GtkPopover" id="view_adjust_menu">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="width_request">160</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">9</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">3</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Zoom:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScale">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="adjustment">zoom_adjustment</property>
+                <property name="restrict_to_fill_level">False</property>
+                <property name="draw_value">False</property>
+                <property name="has_origin">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">win.view-sorting-ascending</property>
+            <property name="text" translatable="yes">Sort Ascending</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'name'</property>
+            <property name="text" translatable="yes">Name</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="action-target">'year'</property>
+            <property name="action_name">win.view-sorting</property>
+            <property name="text" translatable="yes">Year</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">4</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="action-target">'lastplayed'</property>
+            <property name="action_name">win.view-sorting</property>
+            <property name="text" translatable="yes">Last Played</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="action-target">'installed_at'</property>
+            <property name="action_name">win.view-sorting</property>
+            <property name="text" translatable="yes">Installed at</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">6</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">False</property>
+            <property name="action_name">win.view-sorting</property>
+            <property name="action-target">'playtime'</property>
+            <property name="text" translatable="yes">Play time</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">7</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </object>
   <object class="GtkImage" id="view_grid_symbolic">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
@@ -216,12 +372,6 @@
     <property name="pixel_size">16</property>
     <property name="icon_name">view-list-symbolic</property>
   </object>
-  <object class="GtkAdjustment" id="zoom_adjustment">
-    <property name="upper">3</property>
-    <property name="value">1</property>
-    <property name="step_increment">1</property>
-    <property name="page_increment">1</property>
-  </object>
   <object class="GtkPopover" id="view_menu_widget">
     <property name="can_focus">False</property>
     <child>
@@ -232,24 +382,6 @@
         <property name="border_width">9</property>
         <property name="orientation">vertical</property>
         <property name="spacing">3</property>
-        <child>
-          <object class="GtkScale">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="hexpand">True</property>
-            <property name="vexpand">True</property>
-            <property name="adjustment">zoom_adjustment</property>
-            <property name="restrict_to_fill_level">False</property>
-            <property name="round_digits">0</property>
-            <property name="draw_value">False</property>
-            <property name="has_origin">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">0</property>
-          </packing>
-        </child>
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
@@ -268,6 +400,8 @@
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="receives_default">False</property>
             <property name="action_name">win.show-hidden-games</property>
             <property name="text">Show Hidden Games</property>
           </object>
@@ -284,20 +418,6 @@
             <property name="receives_default">False</property>
             <property name="action_name">win.use-dark-theme</property>
             <property name="text" translatable="yes">Use _Dark Theme</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.show-tray-icon</property>
-            <property name="text" translatable="yes">Show Tray Icon</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -351,8 +471,8 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.view-sorting-ascending</property>
-            <property name="text" translatable="yes">Sort _Ascending</property>
+            <property name="action_name">win.open-forums</property>
+            <property name="text" translatable="yes">Lutris forums</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -365,9 +485,8 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.view-sorting</property>
-            <property name="action-target">'name'</property>
-            <property name="text" translatable="yes">_Name</property>
+            <property name="action_name">win.open-discord</property>
+            <property name="text" translatable="yes">Discord</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -380,9 +499,8 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.view-sorting</property>
-            <property name="action-target">'year'</property>
-            <property name="text" translatable="yes">_Year</property>
+            <property name="action_name">win.donate</property>
+            <property name="text" translatable="yes">Support Lutris!</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -391,13 +509,9 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkSeparator">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.view-sorting</property>
-            <property name="action-target">'lastplayed'</property>
-            <property name="text" translatable="yes">Last _Played</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -410,9 +524,8 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.view-sorting</property>
-            <property name="action-target">'installed_at'</property>
-            <property name="text" translatable="yes">In_stalled at</property>
+            <property name="action_name">win.manage-runners</property>
+            <property name="text" translatable="yes">Manage runners</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -425,9 +538,8 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.view-sorting</property>
-            <property name="action-target">'playtime'</property>
-            <property name="text" translatable="yes">Play _time</property>
+            <property name="action_name">win.preferences</property>
+            <property name="text" translatable="yes">Preferences</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -449,10 +561,10 @@
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.open-forums</property>
-            <property name="text" translatable="yes">Lutris forums</property>
+            <property name="action_name">win.about</property>
+            <property name="text" translatable="yes">About Lutris</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -463,107 +575,15 @@
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can_focus">True</property>
             <property name="receives_default">False</property>
-            <property name="action_name">win.open-discord</property>
-            <property name="text" translatable="yes">Discord</property>
+            <property name="action_name">win.show-tray-icon</property>
+            <property name="text" translatable="yes">Show Tray Icon</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">15</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.donate</property>
-            <property name="text" translatable="yes">Support Lutris!</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">16</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">17</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.manage-runners</property>
-            <property name="text" translatable="yes">Manage runners</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">18</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.preferences</property>
-            <property name="text" translatable="yes">Preferences</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">19</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkSeparator">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">20</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">win.about</property>
-            <property name="text" translatable="yes">About Lutris</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">21</property>
-          </packing>
-        </child>
-        <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can_focus">True</property>
-            <property name="receives_default">False</property>
-            <property name="action_name">app.quit</property>
-            <property name="text" translatable="yes">Quit</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">22</property>
           </packing>
         </child>
       </object>
@@ -659,19 +679,49 @@
               </packing>
             </child>
             <child>
-              <object class="GtkButton">
+              <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Toggle View</property>
-                <property name="action_name">win.toggle-viewtype</property>
+                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkImage" id="viewtype_icon">
+                  <object class="GtkButton">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">view-list-symbolic</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">False</property>
+                    <property name="tooltip_text" translatable="yes">Toggle View</property>
+                    <property name="action_name">win.toggle-viewtype</property>
+                    <child>
+                      <object class="GtkImage" id="viewtype_icon">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">view-list-symbolic</property>
+                      </object>
+                    </child>
                   </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
                 </child>
+                <child>
+                  <object class="GtkMenuButton">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="popover">view_adjust_menu</property>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <style>
+                  <class name="linked"/>
+                </style>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -778,12 +828,9 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkToggleButton" id="website_search_toggle">
+                              <object class="GtkSpinner" id="search_spinner">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">True</property>
-                                <property name="always_show_image">True</property>
-                                <signal name="toggled" handler="on_website_search_toggle_toggled" swapped="no"/>
+                                <property name="can_focus">False</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -792,9 +839,12 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkSpinner" id="search_spinner">
+                              <object class="GtkToggleButton" id="website_search_toggle">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">True</property>
+                                <property name="always_show_image">True</property>
+                                <signal name="toggled" handler="on_website_search_toggle_toggled" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -900,4 +950,10 @@
       </object>
     </child>
   </template>
+  <object class="GtkAdjustment" id="zoom_adjustment">
+    <property name="upper">3</property>
+    <property name="value">1</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">1</property>
+  </object>
 </interface>


### PR DESCRIPTION
- libhandy widgets are now used for preferences windows
- editable grids are put in their own popover
- some icons are changed
- reset button is removed due to technical issues (plus they're mostly pointless from a UX perspective considering the vast majority of options can be reset either via blanking a text field, clicking the option labelled default, or triggering a switch)
- clicking anywhere in a row will trigger a switch
- preferences windows now have search and are adaptive

![image](https://user-images.githubusercontent.com/20326855/71328300-0cd9d500-24e3-11ea-8ae0-6d721196ed54.png)
![image](https://user-images.githubusercontent.com/20326855/71328302-15321000-24e3-11ea-851a-d38691353730.png)
![image](https://user-images.githubusercontent.com/20326855/71328304-1c591e00-24e3-11ea-83a4-8bdd22c1f47d.png)
![image](https://user-images.githubusercontent.com/20326855/71328306-25e28600-24e3-11ea-85b7-6f0debb8e292.png)



