### PR TITLE
Fixed one lintian error when building deb

### DIFF
--- a/debian/lintian-overrides
+++ b/debian/lintian-overrides
@@ -1,2 +1,0 @@
-# not a game but a gaming platform
-lutris: package-section-games-but-has-usr-bin

--- a/debian/lutris.links
+++ b/debian/lutris.links
@@ -1,2 +1,0 @@
-/usr/bin/lutris /usr/games/lutris
-/usr/bin/lutris-wrapper /usr/games/lutris-wrapper

--- a/debian/rules
+++ b/debian/rules
@@ -1,4 +1,5 @@
 #!/usr/bin/make -f
+export PYBUILD_INSTALL_ARGS_python3=--install-scripts=/usr/games/
 
 %:
 	dh $@ --with python3 --buildsystem=pybuild


### PR DESCRIPTION
This fixes the package-section-games-but-has-usr-bin error which was
shown when running debuild.

With this change, there will no longer be any binaries in the /usr/bin
directory in the deb package.

There are a couple more errors when building the deb package. I'll try to look into those too.