### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,57 +1,48 @@
-.PHONY: snap
 VERSION=`grep "__version__" lutris/__init__.py | cut -d" " -f 3 | sed 's|"\(.*\)"|\1|'`
 
-cover:
-	rm tests/fixtures/pga.db -f
-	rm tests/coverage/ -rf
-	nosetests --with-coverage --cover-package=lutris --cover-html --cover-html-dir=tests/coverage
+all:
+	export GITBRANCH=master
+	debuild
+	debclean
+
+build:
+	gbp buildpackage --git-debian-branch=${GITBRANCH}
+
+clean:
+	debclean
 
 test:
 	rm tests/fixtures/pga.db -f
 	nosetests
 	flake8 lutris
 
-deb-source: clean
-	gbp buildpackage -S --git-debian-branch=${GITBRANCH}
-	mkdir -p build
-	mv ../lutris_0* build
-
-deb: clean
-	gbp buildpackage --git-debian-branch=${GITBRANCH}
-	mkdir -p build
-	mv ../lutris_0* build
-
-changelog-add:
-	EDITOR=vim dch -i
-
-changelog-edit:
-	EDITOR=vim dch -e
-
-clean:
-	rm -rf build
-	debclean
-
-build-all: deb
-
-upload:
-	scp build/lutris_${VERSION}.tar.xz lutris.net:/srv/releases/
+cover:
+	rm tests/fixtures/pga.db -f
+	rm tests/coverage/ -rf
+	nosetests --with-coverage --cover-package=lutris --cover-html --cover-html-dir=tests/coverage
 
 pgp-renew:
 	osc signkey --extend home:strycore
 	osc rebuildpac home:strycore --all
 
-winetricks:
+update-winetricks:
 	wget https://raw.githubusercontent.com/Winetricks/winetricks/master/src/winetricks -O share/lutris/bin/winetricks
 
-snap:
-	snapcraft clean lutris -s pull
-	snapcraft
+changelog-add:
+	dch -i
+
+changelog-edit:
+	dch -e
+
+upload:
+	scp build/lutris_${VERSION}.tar.xz lutris.net:/srv/releases/
 
 upload-ppa:
 	dput ppa:lutris-team/lutris build/lutris_${VERSION}*_source.changes
 
 upload-staging:
-	gbp buildpackage -S --git-debian-branch=master
-	mkdir -p build
-	mv ../lutris_0* build
 	dput --force ppa:lutris-team/lutris-staging build/lutris_${VERSION}*_source.changes
+
+snap:
+	snapcraft clean lutris -s pull
+	snapcraft


### PR DESCRIPTION
- Default target always builds the master branch and cleans afterwards.
- Update clean target to use to debian/clean file.
- Remove editor variable as it should be done system-wide.
- Removed phony target from snap rule since it's not really necessary as far as I understand it.
- Some reordering to make the file easier to read