### PR TITLE
Call the correct method for creating TreeModelSort (Closes #2554)

### DIFF
--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -140,7 +140,7 @@ class GameStore(GObject.Object):
         self.prevent_sort_update = False  # prevent recursion with signals
         self.modelfilter = self.store.filter_new()
         self.modelfilter.set_visible_func(self.filter_view)
-        self.modelsort = Gtk.TreeModelSort.sort_new_with_model(self.modelfilter)
+        self.modelsort = Gtk.TreeModelSort.new_with_model(self.modelfilter)
         self.modelsort.connect("sort-column-changed", self.on_sort_column_changed)
         self.modelsort.set_sort_func(sort_col, sort_func, sort_col)
         self.sort_view(sort_key, sort_ascending)


### PR DESCRIPTION
`Gtk.TreeModelSort.new_with_model()` instead of `Gtk.TreeModelSort.sort_new_with_model()`