### PR TITLE
keep title as a string

### DIFF
--- a/lutris/command.py
+++ b/lutris/command.py
@@ -61,7 +61,7 @@ class MonitoredCommand:
 
         self._stdout = io.StringIO()
 
-        self._title = title if title else command
+        self._title = title if title else command[0]
 
     @property
     def stdout(self):


### PR DESCRIPTION
as mentioned in #2556 an error was introduced that added self._title to a list thats joined but if no title is provided when creating a instance of that class _title is set to command which is a list not a string