### PR TITLE
Remove unused attribute 'exit_main_loop'

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -81,7 +81,6 @@ class Game(GObject.Object):
         self.heartbeat = None
         self.killswitch = None
         self.state = self.STATE_IDLE
-        self.exit_main_loop = False
         self.xboxdrv_thread = None
         self.game_runtime_config = {}
         self.resolution_changed = False
@@ -708,8 +707,6 @@ class Game(GObject.Object):
             restore_gamma()
 
         self.process_return_codes()
-        if self.exit_main_loop:
-            exit()
 
     def process_return_codes(self):
         """Do things depending on how the game quitted."""


### PR DESCRIPTION
While going through lutris code trying to fix some issue, I discovered this unused attribute in `game.py`. I think it can be safely removed since doing a project-wide search yielded only these two occurrences, meaning it is never set to true.
This is one of my first contribution to FOSS. I made sure to read and follow the contribution guidelines, even though introduced changes are small. However, please feel free to refuse the PR and shortly explain why, so that the next one I make is better.