### PR TITLE
Create desktop folder/applications folder if they don't exist

### DIFF
--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -74,9 +74,13 @@ def create_launcher(game_slug, game_id, game_name, desktop=False, menu=False):
     )
 
     if desktop:
+        if not os.path.exists(desktop_dir):
+            os.mkdir(desktop_dir)
         shutil.copy(tmp_launcher_path, os.path.join(desktop_dir, launcher_filename))
     if menu:
         menu_path = os.path.join(GLib.get_user_data_dir(), "applications")
+        if not os.path.exists(menu_path):
+            os.mkdir(menu_path)
         shutil.copy(tmp_launcher_path, os.path.join(menu_path, launcher_filename))
     os.remove(tmp_launcher_path)
 


### PR DESCRIPTION
Create desktop folder/applications folder if they don't exist when using "Create desktop shortcut"/"Create application menu shortcut"