### PR TITLE
fix race condition with init_dxvk_versions (closes #2522)

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -49,7 +49,7 @@ from lutris.util.log import logger
 from lutris.util.http import Request, HTTPError
 from lutris.api import parse_installer_url
 from lutris.startup import init_lutris, run_all_checks
-from lutris.util.wine.dxvk import init_dxvk_versions
+from lutris.util.wine.dxvk import init_dxvk_versions, wait_for_dxvk_init
 
 from .lutriswindow import LutrisWindow
 
@@ -370,6 +370,7 @@ class Application(Gtk.Application):
         logger.debug("Launching %s (%s)", game, id(game))
         self.running_games.append(game)
         game.connect("game-stop", self.on_game_stop)
+        wait_for_dxvk_init()
         game.load_config()  # Reload the config before launching it.
         game.play()
 


### PR DESCRIPTION
`init_dxvk_versions` is called asynchronous.
Sometimes the asynchronous call finishes after `DXVKManager.DXVK_LATEST` was read for starting a game. This causes games to start with the DXVK fallback version. 

This PR adds a function to dxvk.py, which waits for `init_dxvk_versions` to finish.
If `AsyncCall` has not gotten around to starting `init_dxvk_versions`, `wait_for_dxvk_init` calls `init_dxvk_versions` instead, because processing this synchronus will finish the initialization faster. (Closes #2522)

I'm not sure about the changes made in this PR, because sometimes you wait for `init_dxvk_versions`, even for none wine games.
It's kind of weird that `init_dxvk_versions` is always called in `do_command_line` for all games (even the once that do not use wine).