### PR TITLE
Allow underscore in identifier name (closes #2625)

### DIFF
--- a/lutris/gui/widgets/common.py
+++ b/lutris/gui/widgets/common.py
@@ -15,7 +15,7 @@ class SlugEntry(Gtk.Entry, Gtk.Editable):
 
     def do_insert_text(self, new_text, length, position):
         """Filter inserted characters to only accept alphanumeric and dashes"""
-        new_text = "".join([c for c in new_text if c.isalnum() or c == "-"]).lower()
+        new_text = "".join([c for c in new_text if c.isalnum() or c in "-_"]).lower()
         length = len(new_text)
         self.get_buffer().insert_text(position, new_text, length)
         return position + length


### PR DESCRIPTION
This PR aims at accepting underscores in identifier names.
(for why see #2625)

To do this the character replacement in `SlugEntry.do_insert_text` does not replace underscores. (closes #2625)

Alternatively, all underscores in identifier names could be removed.