### PR TITLE
fix RecursionError, when opening game settings (closes #2650)

### DIFF
--- a/lutris/gui/widgets/common.py
+++ b/lutris/gui/widgets/common.py
@@ -150,7 +150,7 @@ class FileChooserEntry(Gtk.Box):
             )
             self.pack_end(non_empty_label, False, False, 10)
         parent = system.get_existing_parent(path)
-        if not os.access(parent, os.W_OK):
+        if parent is not None and not os.access(parent, os.W_OK):
             non_writable_destination_label = Gtk.Label(visible=True)
             non_writable_destination_label.set_markup(
                 "<b>Warning</b> The destination folder "

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -343,7 +343,10 @@ def run_once(function):
 
 def get_existing_parent(path):
     """Return the 1st existing parent for a folder (or itself if the path
-    exists and is a directory)"""
+    exists and is a directory). returns None, when none of the parents exists.
+    """
+    if path == "":
+        return None
     if os.path.exists(path) and not os.path.isfile(path):
         return path
     return get_existing_parent(os.path.dirname(path))


### PR DESCRIPTION
When opening game configs of any game installed via a Lutris installer, I get a RecursionError. Everything still works as expected, but there is the RecursionError in the output. (see #2650 for more detail).

This fixes the issue by making `get_existing_parent` return `None` when no parent directory exists.
An extra check gets added to an if-statement in `on_entry_changed` to make sure the result of `get_existing_parent` only gets used if it is not none.

Alternatively `get_existing_parent` could return an empty string (`""`) which would make it possible to remove the extra check in the if-statement, but could cause issue later.