### PR TITLE
Don't use DXVK's d3d10 and d3d10_1 dlls

### DIFF
--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -90,7 +90,7 @@ class DXVKManager:
     base_url = "https://github.com/doitsujin/dxvk/releases/download/v{}/dxvk-{}.tar.gz"
     base_name = "dxvk"
     base_dir = os.path.join(RUNTIME_DIR, base_name)
-    dxvk_dlls = ("dxgi", "d3d11", "d3d10core", "d3d10_1", "d3d10", "d3d9")
+    dxvk_dlls = ("dxgi", "d3d11", "d3d10core", "d3d9")
     latest_version = DXVK_LATEST
 
     def __init__(self, prefix, arch="win64", version=None):


### PR DESCRIPTION
It's needed to make use of Wine's implementation of the D3D10 effects framework.
This follows the changes made in DXVK 1.6 (https://github.com/doitsujin/dxvk/releases/tag/v1.6).