### PR TITLE
convert dict_keys to str before concatenating.

### DIFF
--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -22,7 +22,8 @@ def get_xdg_entry(directory):
     }
     directory = directory.upper()
     if directory not in special_dir.keys():
-        raise ValueError("Only those folders are supported " + special_dir.keys())
+        raise ValueError(directory + " not supported. Only those folders are supported: " +
+                         ", ".join(special_dir.keys()))
     return GLib.get_user_special_dir(special_dir[directory])
 
 


### PR DESCRIPTION
Calling `get_xdg_entry` with an invalid option gives a `TypeError`, even tho it should be a `ValueError`. This Happens because `dict_keys` cannot be concatenated to strings.

Traceback:
```pytb
Traceback (most recent call last):
  File "/home/nect/PycharmProjects/lutris/bin/debug-main.py", line 5, in <module>
    get_xdg_entry("INVALID")
  File "/home/nect/PycharmProjects/lutris/lutris/util/xdgshortcuts.py", line 25, in get_xdg_entry
    raise ValueError("Only those folders are supported " + special_dir.keys())
TypeError: can only concatenate str (not "dict_keys") to str
```

This PR converts the `dict_keys` strings before concatenating.
This PR also adds the invalid directory name, so that one could see which directory was given.

Traceback with this changes:
```pytb
Traceback (most recent call last):
  File "/home/nect/PycharmProjects/lutris/bin/debug-main.py", line 5, in <module>
    get_xdg_entry("INVALID")
  File "/home/nect/PycharmProjects/lutris/lutris/util/xdgshortcuts.py", line 26, in get_xdg_entry
    ", ".join(special_dir.keys()))
ValueError: INVALID not supported. Only those folders are supported: DESKTOP, MUSIC, PICTURES, VIDEOS, DOCUMENTS
```