### PR TITLE
Do nothing when trying to create a symlink to desktop-integration-folders and one is already there. (closes #2598)

### DIFF
--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -117,7 +117,11 @@ class WinePrefixManager:
                     except OSError:
                         os.rename(path, old_path)
 
-                if restore and not os.path.isdir(path):
+                # if we want to create a symlink and one is already there, just skip to the next item.
+                # this also makes sure the elif doesn't find a dir (isdir only looks at the target of the symlink).
+                if restore and os.path.islink(path):
+                    continue
+                elif restore and not os.path.isdir(path):
                     os.symlink(xdgshortcuts.get_xdg_entry(DESKTOP_XDG[i]), path)
                     # We don't need all the others process of the loop
                     continue


### PR DESCRIPTION
When you start the game a second time (with sandboxing disabled), lutris tries to restore the sandbox folders over the symlinks (to the user's home folders). This creates the error but is indeed not the problem.
The problem is that lutris tries to restore sandboxing folders when sandboxing is disabled in the first place. This happens because the if-statement in `desktop_integration` which checks if symlinks get created tests for a directory. But `isdir` inspects the target of the symlink, which indeed is a directory.

**I don't entirely understand, what the `isdir` in line 120 (124 in this PR) is for. Maybe it's a failed attempt to do the same this PR does?**

This PR checks for a symlink before testing for the directory. And if a symlink is present, it skips to the next desktop-integration-folder.
(closes #2598)

The sandbox directorys get created every start. We could also create the symlinks everytime. They could point to the wrong path, because of user manipulation. This would be slower and make it impossible for users to use a custom link endpoints.
