### PR TITLE
create case insensitive recursive lookup function for handling vdf (fixes #2605)

### DIFF
--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -26,18 +26,25 @@ def get_default_acf(appid, name):
 
 def read_config(steam_data_dir):
     """Read the Steam configuration and return it as an object"""
+
+    def get_entry_case_insensitive(config_dict, path):
+        for key, value in config_dict.items():
+            if key.lower() == path[0].lower():
+                if len(path) <= 1:
+                    return config_dict[key]
+
+                return get_entry_case_insensitive(config_dict[key], path[1:])
+        raise KeyError(path[0])
+
     config_filename = os.path.join(steam_data_dir, "config/config.vdf")
     if not system.path_exists(config_filename):
         return None
     with open(config_filename, "r") as steam_config_file:
         config = vdf_parse(steam_config_file, {})
     try:
-        return config["InstallConfigStore"]["Software"]["Valve"]["Steam"]
-    except KeyError:
-        try:
-            return config["InstallConfigStore"]["Software"]["valve"]["Steam"]
-        except KeyError as ex:
-            logger.error("Steam config %s is empty: %s", config_filename, ex)
+        return get_entry_case_insensitive(config, ["InstallConfigStore", "Software", "Valve", "Steam"])
+    except KeyError as ex:
+        logger.error("Steam config %s is empty: %s", config_filename, ex)
 
 
 def get_steamapps_paths_for_platform(platform_name):


### PR DESCRIPTION
Some keys in `config.vdf` seam to be case insensitive. Currently, Lutris tries `valve` in lowercase and camelcase, but doesn't handle `steam` equally.

To prevent some further Problems, this PR introduces a function that recursively looks through the VDF dictionary and matches keys case-insensitive. (closes #2605)