### PR TITLE
Add support for dxvk_config.dll to DXVKManager

### DIFF
--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -228,4 +228,4 @@ class DXVKManager:
 
 class VKD3DManager(DXVKManager):
     """Modified DXVKManager for supporting VKD3D"""
-    dxvk_dlls = ("d3d11", "d3d10core", "d3d9")
+    dxvk_dlls = ("d3d11", "d3d10core", "d3d9", "dxvk_config")


### PR DESCRIPTION
It's needed for DXVK compatibility with our Vkd3d-enabled wine builds.