### PR TITLE
debian: use dh-sequence-python3

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,14 +2,14 @@ Source: lutris
 Section: games
 Priority: optional
 Maintainer: Mathieu Comandon <strider@strycore.com>
-Build-Depends: debhelper-compat (= 11),
+Build-Depends: debhelper-compat (= 12),
+ dh-sequence-python3,
  python3,
  python3-yaml,
  python3-setuptools,
  python3-requests,
  python3-pil,
  python3-gi,
- dh-python,
  gir1.2-gtk-3.0,
  gir1.2-glib-2.0,
  gir1.2-gnomedesktop-3.0,

--- a/debian/rules
+++ b/debian/rules
@@ -2,4 +2,4 @@
 export PYBUILD_INSTALL_ARGS_python3=--install-scripts=/usr/games/
 
 %:
-	dh $@ --with python3 --buildsystem=pybuild
+	dh $@ --buildsystem=pybuild


### PR DESCRIPTION
This is how projects with pybuild should be build now (basically dh-sequence-python3 is dh-python but already has --with python3). dh-sequence-python3 was introduced in with debhlper 12 (Ubuntu 19.04 / disco), so maybe merge this a bit later once more people moved from 18.04 LTS to 20.04 LTS.