### PR TITLE
Fix: Sandbox in non-english prefixes

### DIFF
--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -157,7 +157,7 @@ class WinePrefixManager:
             # Security: Remove other symlinks.
             for item in os.listdir(user_dir):
                 path = os.path.join(user_dir, item)
-                if item not in DEFAULT_DESKTOP_FOLDERS and os.path.islink(path):
+                if item not in desktop_folders and os.path.islink(path):
                     os.unlink(path)
                     os.makedirs(path)
 


### PR DESCRIPTION
I encountered a bug, where my "My Documents"-Folder got deleted every time i started a wine application, (German Prefix) because it would use the English folder names and remove all other symlinks.
This should fix it, works for me.