### PR TITLE
Add more system processes to be excluded from monitor

### DIFF
--- a/lutris/util/monitor.py
+++ b/lutris/util/monitor.py
@@ -15,6 +15,12 @@ SYSTEM_PROCESSES = {
     "services.exe",
     "winedevice.exe",
     "plugplay.exe",
+    "explorer.exe",
+    "wineconsole",
+    "svchost.exe",
+    "rpcss.exe",
+    "rundll32.exe",
+    "mscorsvw.exe",
 }
 
 


### PR DESCRIPTION
Otherwise Battle.Net and MTGA installers don't finish properly