### PR TITLE
Convert playtime to float from string (closes #2659)

### DIFF
--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -126,7 +126,7 @@ class GameStore(GObject.Object):
             bool,
             int,
             str,
-            str,
+            float,
             str,
         )
         sort_col = COL_NAME

--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -2,7 +2,7 @@ import importlib
 from lutris import settings
 from lutris.util.log import logger
 
-MIGRATION_VERSION = 6  # Never decrease this number
+MIGRATION_VERSION = 7  # Never decrease this number
 
 # Replace deprecated migrations with empty lists
 MIGRATIONS = [
@@ -11,7 +11,8 @@ MIGRATIONS = [
     [],
     [],
     ["fix_playtime"],
-    ["d9vk_to_dxvk"]
+    ["d9vk_to_dxvk"],
+    ["fix_playtime_type"]
 ]
 
 

--- a/lutris/migrations/fix_playtime_type.py
+++ b/lutris/migrations/fix_playtime_type.py
@@ -1,0 +1,67 @@
+from lutris.util.sql import cursor_execute, db_cursor
+
+from lutris.pga import PGA_DB
+
+SQL_STATEMENTS = [
+    """
+    create table games_tmp
+    (
+        id INTEGER primary key,
+        name TEXT,
+        slug TEXT,
+        installer_slug TEXT,
+        parent_slug TEXT,
+        platform TEXT,
+        runner TEXT,
+        executable TEXT,
+        directory TEXT,
+        updated DATETIME,
+        lastplayed INTEGER,
+        installed INTEGER,
+        installed_at INTEGER,
+        year INTEGER,
+        steamid INTEGER,
+        gogid INTEGER,
+        configpath TEXT,
+        has_custom_banner INTEGER,
+        has_custom_icon INTEGER,
+        playtime REAL,
+        humblestoreid TEXT
+    );
+    """,
+    """
+    insert into games_tmp select
+        id,
+        name,
+        slug,
+        installer_slug,
+        parent_slug,
+        platform,
+        runner,
+        executable,
+        directory,
+        updated,
+        lastplayed,
+        installed,
+        installed_at,
+        year,
+        steamid,
+        gogid,
+        configpath,
+        has_custom_banner,
+        has_custom_icon,
+        playtime,
+        humblestoreid
+    from games;
+    """,
+    "drop table games;",
+    "alter table games_tmp rename to games;"
+]
+
+
+def migrate():
+    """Convert the playtime to float from text, to allow sorting correctly"""
+
+    with db_cursor(PGA_DB) as cursor:
+        for sql_statement in SQL_STATEMENTS:
+            cursor_execute(cursor, sql_statement)

--- a/lutris/pga.py
+++ b/lutris/pga.py
@@ -34,7 +34,7 @@ DATABASE = {
         {"name": "configpath", "type": "TEXT"},
         {"name": "has_custom_banner", "type": "INTEGER"},
         {"name": "has_custom_icon", "type": "INTEGER"},
-        {"name": "playtime", "type": "TEXT"},
+        {"name": "playtime", "type": "REAL"},
     ],
     "store_games": [
         {"name": "id", "type": "INTEGER", "indexed": True},


### PR DESCRIPTION
The playtime column in `GTK.ListStore` uses `str` for a float. The PGA also uses a text for the playtime column, which prevents just setting the `GTK.ListStore` column to a float (see #2659). This also creates the need for another migration.

This PR convert the playtime column in the `GTK.ListStore` from `str` to `float` to fix the sorting.
Also, when the new games table gets created. The new playtime column type is a `real` (SQLite float?).
As far as I know, SQLite does not allow converting column types. So this PR creates a new temporary Games table with correct playtime type, copies all the data over, **DROPS** the current games table and renames the temporary one to the current one.

**PLEASE REVIEW THIS PR THOROUGHLY, because:**
I don't know whether or not I should have replaced the old migrations with empty lists.
Old migrations should be removed: I already have a [change in my repo](https://github.com/connectety/lutris/commit/531b58cf73e729a9dc8c431dfe8c767a9d921cce) for this (even [changes based on this PR](https://github.com/connectety/lutris/commit/df555999694f11f42df89f1f7ee468618086887c)) .
Old migrations should stay like they are: there are some flake8 errors in them, I will create a PR with [changes from my repo](https://github.com/connectety/lutris/commit/6b1ee978af962f93c4e5c8331a76cf75e931bb1e).

I am not certain if using a `real` is the best option and why a `text` was used before.

If the migration process gets stopped right after the games table gets dropped, there is no current games table anymore. 
Maybe we should make the process unkillable or extend the migration so that:
If no games table is found, but a temporary games table. Rename the temporary one to "games".
If a games table is found, but also a temporary one. Drop the temporary one and restart the process.
But these side effects can also happen inside the DB driver and would cause worse problems, which are less fixable. I'd guess at maximum 2 people would have problems with this and in that case, it might be easier to help those people directly instead of creating a fix for an artificial problem.
Or maybe there is an easier way to migrate the DB entirely.