### PR TITLE
Use correct desktop_folders for symlink removal

### DIFF
--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -157,7 +157,7 @@ class WinePrefixManager:
             # Security: Remove other symlinks.
             for item in os.listdir(user_dir):
                 path = os.path.join(user_dir, item)
-                if item not in DEFAULT_DESKTOP_FOLDERS and os.path.islink(path):
+                if item not in desktop_folders and os.path.islink(path):
                     os.unlink(path)
                     os.makedirs(path)
 


### PR DESCRIPTION
The same set of desktop folders used to create symlinks must be used to remove other symlinks.

This fixes issue  #2707.