### PR TITLE
flake8 fixes

### DIFF
--- a/lutris/migrations/d9vk_to_dxvk.py
+++ b/lutris/migrations/d9vk_to_dxvk.py
@@ -1,8 +1,5 @@
-from lutris.pga import PGA_DB, get_games
+from lutris.pga import get_games
 from lutris.game import Game
-from lutris.util import sql
-from lutris.util.log import logger
-
 
 
 def migrate():
@@ -22,4 +19,3 @@ def migrate():
         game.config.runner_config["dxvk"] = True
         game.config.save()
         print("Migrated %s" % game)
-

--- a/lutris/migrations/fix_playtime.py
+++ b/lutris/migrations/fix_playtime.py
@@ -15,6 +15,7 @@ def fix_playtime(game):
                    game["name"])
     sql.db_update(PGA_DB, "games", {"playtime": playtime}, ("id", game["id"]))
 
+
 def migrate():
     for game in get_games():
         if not game["playtime"]:

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -120,7 +120,7 @@ class DXVKManager:
             with open(dll_path, 'rb') as file:
                 prev_block_end = b''
                 while True:
-                    block = file.read(2*1024*1024)  # 2 MiB
+                    block = file.read(2 * 1024 * 1024)  # 2 MiB
                     if not block:
                         break
 


### PR DESCRIPTION
This PR fixes these flake8 errors:
- unused imports
- incorrect amount of blank lines
- missing whitespace around arithmetic operator


These are all flake8 errors except:
- all lines too long lines with less than 100 characters. 
- imports which are not on top, because the GLib-Interface version has to be defined before importing (E402)
- line breaks before binary operator, because they are somewhat inconsistently linted for compatibility reasons (W503).

Maybe we should add a flake8 test to the PR checks with the following config:
```
[flake8]
ignore = E402, W503
max-line-length = 100
```