### PR TITLE
util.monitor mini-cleanup

### DIFF
--- a/lutris/util/monitor.py
+++ b/lutris/util/monitor.py
@@ -51,6 +51,10 @@ class ProcessMonitor:
         # process names from /proc only contain 15 characters
         return {p[0:15] for p in process_list}
 
+    @staticmethod
+    def iterate_all_processes():
+        return Process(os.getpid()).iter_children()
+
     def iterate_game_processes(self):
         for child in self.iterate_all_processes():
             if child.state == 'Z':
@@ -67,16 +71,9 @@ class ProcessMonitor:
             if child.name not in self.unmonitored_processes:
                 yield child
 
-    def iterate_all_processes(self):
-        return Process(os.getpid()).iter_children()
-
     def is_game_alive(self):
-        "Returns whether at least one nonexcluded process exists"
-        for _child in self.iterate_game_processes():
-            return True
-        return False
+        """Returns whether at least one nonexcluded process exists"""
+        return next(self.iterate_game_processes(), None) is not None
 
     def are_monitored_processes_alive(self):
-        for _child in self.iterate_monitored_processes():
-            return True
-        return False
+        return next(self.iterate_monitored_processes(), None) is not None


### PR DESCRIPTION
This PR is a tiny cleanup of lutris.util.monitor.
Is this needed? probably not, feel free to close this PR.

In this PR `iterate_all_processes` is made static, the docstring in `is_game_alive` is defined correctly with 3 quotations marks.
The thing I am most split about is using `return next(ITER, None) is None` to check if an iterator returns something instead of using a for loop. I think this increases readability, but I am not certain about it.