### PR TITLE
replace absolute symlink with a relative one

### DIFF
--- a/share/lutris/icons/hicolor/symbolic/apps/amiga500+-symbolic.svg
+++ b/share/lutris/icons/hicolor/symbolic/apps/amiga500+-symbolic.svg
@@ -1,1 +1,1 @@
-/home/strider/Projects/lutris/share/lutris/icons/hicolor/symbolic/apps/amiga-symbolic.svg
+amiga-symbolic.svg

--- a/share/lutris/icons/hicolor/symbolic/apps/amiga500-symbolic.svg
+++ b/share/lutris/icons/hicolor/symbolic/apps/amiga500-symbolic.svg
@@ -1,1 +1,1 @@
-/home/strider/Projects/lutris/share/lutris/icons/hicolor/symbolic/apps/amiga-symbolic.svg
+amiga-symbolic.svg


### PR DESCRIPTION
replaces the absolute symlinks introduced in fec9fbf750e81e96bea3f47c4f3d7ace519f951b with relative ones