### PR TITLE
Remove dead code for returning playtime in seconds

### DIFF
--- a/lutris/util/strings.py
+++ b/lutris/util/strings.py
@@ -136,9 +136,6 @@ def get_formatted_playtime(playtime):
     formatted_time = " and ".join([text for text in (hours_text, minutes_text) if text])
     if formatted_time:
         return formatted_time
-    seconds = int(hours * 3600)
-    if seconds:
-        return "%d seconds" % seconds
     return "No play time recorded"
 
 


### PR DESCRIPTION
`hours` is defined as `math.floor(playtime)`. The [python docs](https://docs.python.org/3.8/library/math.html#math.floor) say that `math.floor` returns an int. If `hours` are more than 0, the functions exits at line 138. Line 139 can only be reached with `hours` being 0. This causes the if-statement at line 140 to never trigger because `seconds` is always 0.

I decided to remove the code instead of fixing it because:
- seconds are too small of a unit to be used regularly
- fewer operations execute faster and are easier to maintain

Alternatively, this can be fixed by replacing `hours` with `playtime` in the line below.

https://github.com/lutris/lutris/blob/ddd18f33e9a07d2cfc23418e95e7e45ab53f4d45/lutris/util/strings.py#L139