### PR TITLE
Add missing columns in listview

### DIFF
--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -81,8 +81,11 @@ class GameStore(GObject.Object):
         "runner": COL_RUNNER_HUMAN_NAME,
         "platform": COL_PLATFORM,
         "lastplayed": COL_LASTPLAYED,
+        "lastplayed_text": COL_LASTPLAYED_TEXT,
         "installed_at": COL_INSTALLED_AT,
+        "installed_at_text": COL_INSTALLED_AT_TEXT,
         "playtime": COL_PLAYTIME,
+        "playtime_text": COL_PLAYTIME_TEXT,
     }
 
     def __init__(


### PR DESCRIPTION
This fixes these issues with the "Last Played", "Installed At", "Play Time": 
- Showing the following exception in the logs, when clicking one of the columns.
```pytb
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/lutris/gui/views/store.py", line 271, in on_sort_column_changed
    raise ValueError("Invalid sort key for col %s" % col)
ValueError: Invalid sort key for col 14
```
- The selecting column does not get saved. This is a symptom of the previous issue. The cause is that `self.prevent_sort_updat` is still true  because the function did not exiting correctly.
- Either clicking on the column and restarting or selecting the column in the view adjust menu does not show an arrow.

I forgot to check if the each column sorts correctly and not as a string. I will probably do that within the next day.