### PR TITLE
fix gameboy(color) copyright

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -89,7 +89,7 @@ Copyright: matoro <https://github.com/matoro>
 License: CC0-1.0
 
 Files: share/lutris/icons/hicolor/symbolic/apps/msx_msx2_msx2+-symbolic.svg
- share/lutris/icons/hicolor/symbolic/apps/nintendogameboycolor-symbolic.svg
+ share/lutris/icons/hicolor/symbolic/apps/nintendogameboy(color)-symbolic.svg
 Copyright: Creaticca Ltd <https://www.flaticon.com/authors/creaticca-creative-agency>
 License: Flaticon
 


### PR DESCRIPTION
Lintian reported: `I: lutris source: wildcard-matches-nothing-in-dep5-copyright share/lutris/icons/hicolor/symbolic/apps/nintendogameboycolor-symbolic.svg (paragraph at line 91)`
Looks like the files was renamed in fec9fbf750e81e96bea3f47c4f3d7ace519f951b.