### PR TITLE
Better installation guide

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -1,6 +1,16 @@
 Installing Lutris
 =================
 
+* Ubuntu
+    ``sudo apt-get install lutris``
+* Arch Linux
+    ``sudo pacman -S lutris``
+* Other distro
+    Find lutris package in your distribution's repositories. Do not use guide bellow, it's for distro maintainers
+
+For distribution maintainers
+============================
+
 Requirements
 ------------
 


### PR DESCRIPTION
Current installation guide may break some distros. Warning about that it's not recommended way to install lutris written too late, some people may execute apt command.