### PR TITLE
Give more informative error message for unset USER

### DIFF
--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -95,6 +95,8 @@ class WinePrefixManager:
         # pylint: disable=too-many-branches
         # TODO: reduce complexity (18)
         user = os.getenv("USER")
+        if not user:
+            user = 'lutrisuser'
         user_dir = os.path.join(self.path, "drive_c/users/", user)
         desktop_folders = self.get_desktop_folders()
 


### PR DESCRIPTION
If USER is unset, this error in lutris/util/wine/prefix.py:98:
    `TypeError: expected str, bytes or os.PathLike object, not NoneType`
appears when attempting to install or launch a Wine game.
This changes that to manually raise a ValueError with appropriate message.

An alternative to this could be using the `subprocess` module to run `whoami` if USER is unset. I chose sticking with the error message because it is less complicated than running a subprocess, and USER should probably be set in the user's env anyway.

Note: the only other place this env var is used is lutris/installer/interpreter.py:745  
I don't know if that, or other uses of env vars, need null checks.
