### PR TITLE
ADD: system-wide steam dirs and env

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -139,6 +139,8 @@ class steam(Runner):
     system_options_override = [{"option": "disable_runtime", "default": True}]
 
     data_dir_candidates = (
+        "/usr/share/steam",
+        "/usr/local/share/steam/",
         "~/.steam",
         "~/.local/share/steam",
         "~/.steam/steam",
@@ -242,6 +244,9 @@ class steam(Runner):
     def get_steamapps_dirs(self):
         """Return a list of the Steam library main + custom folders."""
         dirs = []
+        # Extra colon-separated compatibility tools dirs environment variable
+        if 'STEAM_EXTRA_COMPAT_TOOLS_PATHS' in os.environ:
+            dirs += os.getenv('STEAM_EXTRA_COMPAT_TOOLS_PATHS').split(':')
         # Main steamapps dir and compatibilitytools.d dir
         for data_dir in self.data_dir_candidates:
             for _dir in ["SteamApps", "compatibilitytools.d"]:

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -140,7 +140,7 @@ class steam(Runner):
 
     data_dir_candidates = (
         "/usr/share/steam",
-        "/usr/local/share/steam/",
+        "/usr/local/share/steam",
         "~/.steam",
         "~/.local/share/steam",
         "~/.steam/steam",


### PR DESCRIPTION
Closes #2520.

My python-fu is not strong, so I hope I have not written anything wrong.
I tested the changes by making lutris find 2 custom Proton-GE versions in `/usr/share/steam/compatibilitytools.d` and another in a path inside the `STEAM_EXTRA_COMPAT_TOOLS_PATHS` environment variable.