### PR TITLE
Fix info message of missing runner

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -460,7 +460,7 @@ class ScriptInterpreter(CommandsMixin):
                         logger.error("Failed to get default wine version (got %s)", default_wine)
 
             if not runner.is_installed(**params):
-                logger.info("Runner %s needs to be installed")
+                logger.info("Runner %s needs to be installed", runner)
                 self.runners_to_install.append(runner)
 
         if self.runner.startswith("wine") and not get_system_wine_version():


### PR DESCRIPTION
When checking the required runner prerequisites, the message that was
intended to show which runner is still missing did not actually show the
runner, but always showed "%s". Fixed by this commit.