### PR TITLE
Fix for bare PICO-8 invocation.

### DIFF
--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -154,6 +154,8 @@ class pico8(Runner):
         return system.path_exists(os.path.join(settings.RUNNER_DIR, "pico8/web/player.html"))
 
     def prelaunch(self):
+        if not self.game_config.get("main_file") and self.is_installed():
+            return True
         if os.path.exists(os.path.join(settings.RUNNER_DIR, "pico8/cartridges", "tmp.p8.png")):
             os.remove(os.path.join(settings.RUNNER_DIR, "pico8/cartridges", "tmp.p8.png"))
 


### PR DESCRIPTION
Closes #2859

This is a fairly trivial change. It enables the existing PICO-8 runner "play" button to invoke PICO-8 directly without throwing an error.

Oddly I wasn't able to successfully run `make dev` or `make sc` on my machine (I'm running Pop!_OS 20.04) as the former was unable to build wheels for pygobject and the latter threw a ton of `Unable to import 'gi.repository'` sorts of errors. I'll have to dig into both of these to see what's happening, but in the meanwhile this particular fix passes `pep8`, `pylint`, and `flake8` when they are run manually.