### PR TITLE
Fix compositor only being disabled once per game

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -180,6 +180,7 @@ class Game(GObject.Object):
         """Enables or disables compositing"""
         if enable:
             system.execute(self.start_compositor, shell=True)
+            self.compositor_disabled = False
         else:
             (
                 self.start_compositor,


### PR DESCRIPTION
This bug has been annoying me for a very long time and I finally snapped and made the one line fix.

In my opinion the compositor state should be checked on every game start/end, or at least kept globally instead of per-game, but that's a PR for another day.