### PR TITLE
D3d9 fixes

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -845,7 +845,10 @@ class wine(Runner):
         )
 
         try:
-            self.setup_nine(self.runner_config.get("gallium_nine"))
+            self.setup_nine(
+                bool(self.runner_config.get("gallium_nine")),
+                bool(self.runner_config.get("dxvk"))
+            )
         except nine.NineUnavailable as ex:
             raise GameConfigError("Unable to configure GalliumNine: %s" % ex)
         return True
@@ -962,15 +965,16 @@ class wine(Runner):
         if self.runner_config.get("x360ce-dinput"):
             self.dll_overrides["dinput8"] = "native"
 
-    def setup_nine(self, enable):
+    def setup_nine(self, with_nine, with_dxvk):
         nine_manager = nine.NineManager(
             self.prefix_path,
             self.wine_arch,
         )
 
-        if enable:
+        # Do not restore D3D9 settings if DXVK is using it
+        if with_nine:
             nine_manager.enable()
-        else:
+        elif not with_dxvk:
             nine_manager.disable()
 
     def sandbox(self, wine_prefix):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -967,6 +967,7 @@ class wine(Runner):
 
     def setup_nine(self, with_nine, with_dxvk):
         nine_manager = nine.NineManager(
+            self.get_executable(),
             self.prefix_path,
             self.wine_arch,
         )

--- a/lutris/util/wine/nine.py
+++ b/lutris/util/wine/nine.py
@@ -21,7 +21,8 @@ class NineManager:
     nine_files = ("d3d9-nine.dll", "ninewinecfg.exe")
     mesa_files = ("d3dadapter9.so.1", )
 
-    def __init__(self, prefix, arch):
+    def __init__(self, path, prefix, arch):
+        self.wine_path = path
         self.prefix = prefix
         self.wine_arch = arch
 
@@ -120,6 +121,7 @@ class NineManager:
         wineexec(
             "ninewinecfg",
             args="-e",
+            wine_path=self.wine_path,
             prefix=self.prefix,
             blocking=True,
         )
@@ -129,6 +131,7 @@ class NineManager:
             wineexec(
                 "ninewinecfg",
                 args="-d",
+                wine_path=self.wine_path,
                 prefix=self.prefix,
                 blocking=True,
             )

--- a/lutris/util/wine/nine.py
+++ b/lutris/util/wine/nine.py
@@ -6,6 +6,7 @@ import shutil
 # Lutris Modules
 from lutris.runners.commands.wine import wineexec
 from lutris.util import system
+from lutris.util.log import logger
 from lutris.util.wine.cabinstall import CabInstaller
 
 
@@ -20,6 +21,7 @@ class NineManager:
 
     nine_files = ("d3d9-nine.dll", "ninewinecfg.exe")
     mesa_files = ("d3dadapter9.so.1", )
+    nine_dll = "d3d9"
 
     def __init__(self, path, prefix, arch):
         self.wine_path = path
@@ -110,6 +112,28 @@ class NineManager:
                 if not os.path.exists(os.path.join(self.get_system_path("x64"), nine_file)):
                     raise NineUnavailable("could not install " + nine_file + " (x64)")
 
+    def move_dll(self, backup):
+        """ Backup or restore dll used by Gallium Nine"""
+        src_suff = "" if backup else ".orig"
+        dst_suff = ".orig" if backup else ""
+
+        wine_dll_path = os.path.join(self.get_system_path("x32"), NineManager.nine_dll + ".dll")
+        if (
+            os.path.exists(wine_dll_path + src_suff)
+            and not os.path.islink(wine_dll_path + src_suff)
+        ):
+            shutil.move(wine_dll_path + src_suff, wine_dll_path + dst_suff)
+            logger.debug("Moving file %s (x32)", wine_dll_path + src_suff)
+
+        if self.wine_arch == "win64":
+            wine_dll_path = os.path.join(self.get_system_path("x64"), NineManager.nine_dll + ".dll")
+            if (
+                os.path.exists(wine_dll_path + src_suff)
+                and not os.path.islink(wine_dll_path + src_suff)
+            ):
+                shutil.move(wine_dll_path + src_suff, wine_dll_path + dst_suff)
+                logger.debug("Moving file %s (x64)", wine_dll_path + src_suff)
+
     def enable(self):
         if not self.nine_is_supported():
             raise NineUnavailable("Nine is not supported on this system")
@@ -117,6 +141,8 @@ class NineManager:
             raise NineUnavailable("Nine Standalone is not installed")
         if not self.is_prefix_prepared():
             self.prepare_prefix()
+
+        self.move_dll(True)
 
         wineexec(
             "ninewinecfg",
@@ -128,6 +154,9 @@ class NineManager:
 
     def disable(self):
         if self.is_prefix_prepared():
+            # DXVK might to restore the dll - backup it again before calling ninewinecfg
+            self.move_dll(True)
+
             wineexec(
                 "ninewinecfg",
                 args="-d",
@@ -135,3 +164,5 @@ class NineManager:
                 prefix=self.prefix,
                 blocking=True,
             )
+
+            self.move_dll(False)


### PR DESCRIPTION
Several fixes for D3D9/GalliumNine
Commit 233b12d fixes #2591 
Commit 0eb4161 probably fixes  #2526 and possibly #2229 and #2414 (closed, but not fixed), since they all seems related to me, but I am not sure.
Commit 60f01b0 fixes non-fatal, but maybe unwanted behavior mentioned also in #2526 where original d3d9.dll is replaced by link to d3d9-nine.dll and later deleted (when the option is disabled).