### PR TITLE
scummvm: Add custom data dir runner option

### DIFF
--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -89,6 +89,13 @@ class scummvm(Runner):
             ("The algorithm used to scale up the game's base "
              "resolution, resulting in different visual styles. "),
         },
+        {
+            "option": "datadir",
+            "label": "Data directory",
+            "type": "directory_chooser",
+            "help": "Defaults to share/scummvm if unspecified.",
+            "advanced": True,
+        },
     ]
 
     @property
@@ -108,8 +115,13 @@ class scummvm(Runner):
         ]
 
     def get_scummvm_data_dir(self):
-        root_dir = os.path.dirname(os.path.dirname(self.get_executable()))
-        return os.path.join(root_dir, "share/scummvm")
+        data_dir = self.runner_config.get("datadir")
+
+        if data_dir is None:
+            root_dir = os.path.dirname(os.path.dirname(self.get_executable()))
+            data_dir = os.path.join(root_dir, "share/scummvm")
+
+        return data_dir
 
     def get_run_data(self):
         env = {"LD_LIBRARY_PATH": "%s;$LD_LIBRARY_PATH" % self.libs_dir}

--- a/tests/test_scummvm.py
+++ b/tests/test_scummvm.py
@@ -1,0 +1,14 @@
+from unittest import TestCase
+
+from lutris.config import LutrisConfig
+from lutris.runners.scummvm import scummvm
+
+
+class TestScummvm(TestCase):
+    def test_custom_data_dir(self):
+        scummvm_runner = scummvm()
+        scummvm_runner.config = LutrisConfig()
+        scummvm_runner.config.runner_config["datadir"] = "~/custom/scummvm"
+
+        self.assertEqual(scummvm_runner.get_scummvm_data_dir(), "~/custom/scummvm")
+        self.assertEqual(scummvm_runner.get_command()[1], "--extrapath=~/custom/scummvm")


### PR DESCRIPTION
By default, the scummvm runner looks up the data directory relative to
the executable. It expects it to be at ../share/scummvm. That works
for a system-installed version of scummvm, where the binary is in
/usr/bin and the data is in /usr/share/scummvm. However, we shouldn't
make assumptions about the directory structure for a custom executable.

This allows setting a custom data directory in addition to the custom
executable.

This is based on a request in the forums: https://forums.lutris.net/t/scummvm-custom-executable/9458