### PR TITLE
Add support for toggling column visibility

### DIFF
--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -39,7 +39,7 @@ class GameListView(Gtk.TreeView, GameView):
         name_cell = self.set_text_cell()
         name_cell.set_padding(5, 0)
 
-        self.set_column(name_cell, _("Name"), COL_NAME, 200)
+        self.set_column(name_cell, _("Name"), COL_NAME, 200, always_visible=True)
         self.set_column(default_text_cell, _("Year"), COL_YEAR, 60)
         self.set_column(default_text_cell, _("Runner"), COL_RUNNER_HUMAN_NAME, 120)
         self.set_column(default_text_cell, _("Platform"), COL_PLATFORM, 120)
@@ -63,7 +63,7 @@ class GameListView(Gtk.TreeView, GameView):
         text_cell.set_property("ellipsize", Pango.EllipsizeMode.END)
         return text_cell
 
-    def set_column(self, cell, header, column_id, default_width, sort_id=None):
+    def set_column(self, cell, header, column_id, default_width, always_visible=False, sort_id=None):
         column = Gtk.TreeViewColumn(header, cell, markup=column_id)
         column.set_sort_indicator(True)
         column.set_sort_column_id(column_id if sort_id is None else sort_id)
@@ -71,7 +71,9 @@ class GameListView(Gtk.TreeView, GameView):
         column.set_resizable(True)
         column.set_reorderable(True)
         width = settings.read_setting("%s_column_width" % COLUMN_NAMES[column_id], "list view")
+        is_visible = settings.read_setting("%s_visible" % COLUMN_NAMES[column_id], "list view")
         column.set_fixed_width(int(width) if width else default_width)
+        column.set_visible(is_visible == "True" or always_visible if is_visible else True)
         self.append_column(column)
         column.connect("notify::width", self.on_column_width_changed)
         column.get_button().connect('button-press-event', self.on_column_header_button_pressed)
@@ -105,7 +107,8 @@ class GameListView(Gtk.TreeView, GameView):
     def on_column_header_button_pressed(self, button, event):
         """Handles column header button press events"""
         if event.button == 3:
-            # TODO: Trigger column selection popup menu here!
+            menu = GameListColumnToggleMenu(self.get_columns())
+            menu.popup_at_pointer(None)
             return True
 
     def on_row_activated(self, widget, line=None, column=None):
@@ -134,3 +137,37 @@ class GameListView(Gtk.TreeView, GameView):
                 col.get_fixed_width(),
                 "list view",
             )
+
+
+class GameListColumnToggleMenu(Gtk.Menu):
+
+    def __init__(self, columns):
+        super().__init__()
+        self.columns = columns
+        self.column_map = {}
+        self.create_menuitems()
+        self.show_all()
+
+    def create_menuitems(self):
+        for column in self.columns:
+            title = column.get_title()
+            if title == "":
+                continue
+            checkbox = Gtk.CheckMenuItem(title)
+            checkbox.set_active(column.get_visible())
+            if title == _("Name"):
+                checkbox.set_sensitive(False)
+            else:
+                checkbox.connect("toggled", self.on_toggle_column)
+            self.column_map[checkbox] = column
+            self.append(checkbox)
+
+    def on_toggle_column(self, check_menu_item):
+        column = self.column_map[check_menu_item]
+        is_visible = check_menu_item.get_active()
+        column.set_visible(is_visible)
+        settings.write_setting(
+            column.get_title().replace(" ", "") + "_visible",
+            str(is_visible),
+            "list view",
+        )

--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -74,6 +74,7 @@ class GameListView(Gtk.TreeView, GameView):
         column.set_fixed_width(int(width) if width else default_width)
         self.append_column(column)
         column.connect("notify::width", self.on_column_width_changed)
+        column.get_button().connect('button-press-event', self.on_column_header_button_pressed)
         return column
 
     def set_column_sort(self, col):
@@ -100,6 +101,12 @@ class GameListView(Gtk.TreeView, GameView):
         row = self.game_store.get_row_by_id(game_id, filtered=True)
         if row:
             self.set_cursor(row.path)
+
+    def on_column_header_button_pressed(self, button, event):
+        """Handles column header button press events"""
+        if event.button == 3:
+            # TODO: Trigger column selection popup menu here!
+            return True
 
     def on_row_activated(self, widget, line=None, column=None):
         """Handles double clicks"""


### PR DESCRIPTION
The first commit disables the right click issue that selects the first row as described in #2581. The second commit allows showing a column toggle menu (similar to the one in GNOME Files) upon right clicking the column header. It also handles the user's column visibility preferences in the config file. Also, under this implementation, the "Name" column will always be visible and cannot be toggled off.

Fixes #2581 