### PR TITLE
Fix copy paste issue in auth webviews

### DIFF
--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -279,7 +279,8 @@ def connect(parent=None):
     """Connect to GOG"""
     logger.debug("Connecting to GOG")
     dialog = WebConnectDialog(SERVICE, parent)
-    dialog.run()
+    dialog.set_modal(True)
+    dialog.show()
 
 
 def disconnect():

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -152,7 +152,8 @@ def is_connected():
 def connect(parent=None):
     """Connect to Humble Bundle"""
     dialog = WebConnectDialog(SERVICE, parent)
-    dialog.run()
+    dialog.set_modal(True)
+    dialog.show()
 
 
 def disconnect():


### PR DESCRIPTION
I have tried debugging with `Gtk.Clipboard`'s `owner-change` signal, and copying text from other apps, including KeePassXC, triggers this signal. Calling `Gtk.Clipboard.wait_for_text()` from inside the signal handler does output the copied text in other parts of Lutris except in these auth webviews where I get `None` if I copy from KeePassXC.

I also tried replacing the `WebConnectDialog`'s content with a simple `Gtk.Entry`, and I can copy paste fine from KeePassXC. There is really something that interferes with the GTK clipboard if a `WebKit2.WebView` is inside a `Gtk.Dialog`, and if the containing dialog was displayed with `Gtk.Dialog.run()`. Using `Gtk.Dialog.set_modal(True)` and `Gtk.Dialog.show()` instead works fine, even copy pasting from KeePassXC.

Fixes #2132 