### PR TITLE
Added large_image at Discord Presence

### DIFF
--- a/lutris/discord.py
+++ b/lutris/discord.py
@@ -95,7 +95,7 @@ class DiscordPresence(object):
             try:
                 state_text = "via %s" % self.runner_name if self.show_runner else "  "
                 logger.info("Attempting to update Discord status: %s, %s", self.game_name, state_text)
-                self.rpc_client.update(details="Playing %s" % self.game_name, state=state_text)
+                self.rpc_client.update(details="Playing %s" % self.game_name, state=state_text, large_image="large_image", large_text="Using Lutris")
             except PyPresenceException as ex:
                 logger.error("Unable to update Discord: %s", ex)
 

--- a/lutris/discord.py
+++ b/lutris/discord.py
@@ -95,7 +95,8 @@ class DiscordPresence(object):
             try:
                 state_text = "via %s" % self.runner_name if self.show_runner else "  "
                 logger.info("Attempting to update Discord status: %s, %s", self.game_name, state_text)
-                self.rpc_client.update(details="Playing %s" % self.game_name, state=state_text, large_image="large_image", large_text="Using Lutris")
+                self.rpc_client.update(details="Playing %s" % self.game_name, state=state_text, \
+                                       large_image="large_image", large_text="Using Lutris")
             except PyPresenceException as ex:
                 logger.error("Unable to update Discord: %s", ex)
 


### PR DESCRIPTION
Its Possible to show two images at the discord rich presence. 

- "large_image" stands for the large image and "large_text" is the text when hovering over the large image. 
- There is also "small_image" and "small_text" for the small image but i couldn't think of an use case for the small image. 

The creator of the Discord Application needs to add the image on https://discord.com/developers/applications/<ApplicaitonID\>/rich-presence/assets and name it large_image so it can be displayed correctly.

The code provided doesn't generate errors when there is no image uploaded to discord so everything should be ok.

Here is an Image of the rich Presence generated by the code provided: https://cdn.bigbotnetwork.com/030720184156.png (Note that lutris-patch is the name given the Application on the discord dev page)