### PR TITLE
Try to find wine prefix if none is provided

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -34,7 +34,7 @@ from lutris.util.wine.wine import (
 )
 from lutris.util.wine.x360ce import X360ce
 
-MIN_SAFE_VERSION = "4.0"  # Wine installers must run with at least this version
+MIN_SAFE_VERSION = "5.0"  # Wine installers must run with at least this version
 
 
 class wine(Runner):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -25,7 +25,7 @@ from lutris.util.jobs import thread_safe_call
 from lutris.util.log import logger
 from lutris.util.strings import parse_version, split_arguments
 from lutris.util.wine import dxvk, nine
-from lutris.util.wine.prefix import WinePrefixManager
+from lutris.util.wine.prefix import WinePrefixManager, find_prefix
 from lutris.util.wine.wine import (
     POL_PATH, WINE_DIR, WINE_PATHS, detect_arch, display_vulkan_error, esync_display_limit_warning,
     esync_display_version_warning, fsync_display_support_warning, fsync_display_version_warning, get_default_version,
@@ -581,13 +581,15 @@ class wine(Runner):
     @property
     def prefix_path(self):
         """Return the absolute path of the Wine prefix"""
-        _prefix_path = self.game_config.get("prefix")
+        _prefix_path = self.game_config.get("prefix") \
+            or os.environ.get("WINEPREFIX") \
+            or find_prefix(self.game_exe)
         if not _prefix_path:
             logger.warning(
-                "Wine prefix not provided, defaulting to $WINEPREFIX then ~/.wine."
+                "Wine prefix not provided, defaulting to ~/.wine."
                 " This is probably not the intended behavior."
             )
-            _prefix_path = os.environ.get("WINEPREFIX") or "~/.wine"
+            _prefix_path = "~/.wine"
         return os.path.expanduser(_prefix_path)
 
     @property

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -13,10 +13,12 @@ DESKTOP_KEYS = ["Desktop", "Personal", "My Music", "My Videos", "My Pictures"]
 DEFAULT_DESKTOP_FOLDERS = ["Desktop", "My Documents", "My Music", "My Videos", "My Pictures"]
 DESKTOP_XDG = ["DESKTOP", "DOCUMENTS", "MUSIC", "VIDEOS", "PICTURES"]
 
+
 def is_prefix(path):
     """Return True if the path is prefix"""
     return os.path.isdir(os.path.join(path, "drive_c")) \
         and os.path.exists(os.path.join(path, "user.reg"))
+
 
 def find_prefix(path):
     """Given an executable path, try to find a Wine prefix associated with it."""

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -13,6 +13,26 @@ DESKTOP_KEYS = ["Desktop", "Personal", "My Music", "My Videos", "My Pictures"]
 DEFAULT_DESKTOP_FOLDERS = ["Desktop", "My Documents", "My Music", "My Videos", "My Pictures"]
 DESKTOP_XDG = ["DESKTOP", "DOCUMENTS", "MUSIC", "VIDEOS", "PICTURES"]
 
+def is_prefix(path):
+    """Return True if the path is prefix"""
+    return os.path.isdir(os.path.join(path, "drive_c")) \
+        and os.path.exists(os.path.join(path, "user.reg"))
+
+def find_prefix(path):
+    """Given an executable path, try to find a Wine prefix associated with it."""
+    dir_path = path
+    if not dir_path:
+        logger.info("No path given, unable to guess prefix location")
+        return
+    while dir_path != "/" and dir_path:
+        dir_path = os.path.dirname(dir_path)
+        if is_prefix(dir_path):
+            return dir_path
+        for prefix_dir in ("prefix", "pfx"):
+            prefix_path = os.path.join(dir_path, prefix_dir)
+            if is_prefix(prefix_path):
+                return prefix_path
+
 
 class WinePrefixManager:
 


### PR DESCRIPTION
This makes the client smarter about defaulting to a wine prefix. If the prefix field is empty, it will look back in parent directories for a valid prefix and default to that one. It also looks for "prefix" and "pfx" sigling folders.