### PR TITLE
change to arch: all

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -37,8 +37,6 @@ Recommends: python3-evdev,
             gvfs-backends,
             libwine-development,
             winetricks,
-            libc6-i386 [amd64],
-            lib32gcc1 [amd64] | lib32gcc-s1 [amd64],
 Suggests: gamemode,
 Description: open source gaming platform
  Lutris goal is to make gaming on Linux as easy as possible by taking care of

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/lutris/lutris
 Vcs-Git: https://github.com/lutris/lutris.git
 
 Package: lutris
-Architecture: any
+Architecture: all
 Depends: ${misc:Depends},
          ${python3:Depends},
          python3-yaml,


### PR DESCRIPTION
Related to #3005.
@strycore to mark it as `arch: all` no arch specific recommends are allowed (don't really get it but nothing one can do about it).
This means all the 32bit gcc libs have to be removed - obviously one should only do this if they are really required, but I'm not sure why they are in the recommends field in the first place.