### PR TITLE
Added a tic-80, MicroM8 & Redream Runner

### DIFF
--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -30,6 +30,7 @@ __all__ = [
     # Sony
     "pcsx2",
     "rpcs3",
+    "redream",
     # Sega
     "osmose",
     "reicast",

--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -30,10 +30,10 @@ __all__ = [
     # Sony
     "pcsx2",
     "rpcs3",
-    "redream",
     # Sega
     "osmose",
     "reicast",
+    "redream",
     # Fantasy consoles
     "pico8",
     # Misc legacy systems

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -10,7 +10,7 @@ class redream(Runner):
     description = "Sega Dreamcast emulator"
     platforms = ["Sega Dreamcast"]
     runner_executable = "redream/redream"
-    download_url = "https://redream.io/download/redream.x86_64-linux-v1.5.0.tar.gz",
+    download_url = "https://redream.io/download/redream.x86_64-linux-v1.5.0.tar.gz"
     game_options = [
         {
             "option": "main_file",

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -1,0 +1,146 @@
+import shutil
+import os
+from lutris.runners.runner import Runner
+from lutris.gui.dialogs import QuestionDialog, FileDialog
+from lutris import settings
+
+
+class redream(Runner):
+    human_name = "Redream"
+    description = "Sega Dreamcast emulator"
+    platforms = ["Sega Dreamcast"]
+    runner_executable = "redream/redream"
+    download_url = "https://redream.io/download/redream.x86_64-linux-v1.5.0.tar.gz",
+    game_options = [
+        {
+            "option": "main_file",
+            "type": "file",
+            "label": "Disc image file",
+            "help": ("Game data file\n" "Supported formats: GDI, CDI, CHD"),
+        }
+    ]
+    runner_options = [
+        {"option": "fs", "type": "bool", "label": "Fullscreen", "default": False},
+        {
+            "option": "ar",
+            "type": "choice",
+            "label": "Aspect Ratio",
+            "choices": [("4:3", "4:3"), ("Stretch", "stretch")],
+            "default": "4:3",
+        },
+        {
+            "option": "region",
+            "type": "choice",
+            "label": "Region",
+            "choices": [("USA", "usa"), ("Europe", "europe"), ("Japan", "japan")],
+            "default": "usa",
+        },
+        {
+            "option": "language",
+            "type": "choice",
+            "label": "System Language",
+            "choices": [
+                ("English", "english"),
+                ("German", "german"),
+                ("French", "french"),
+                ("Spanish", "spanish"),
+                ("Italian", "italian"),
+                ("Japanese", "japanese"),
+            ],
+            "default": "english",
+        },
+        {
+            "option": "broadcast",
+            "type": "choice",
+            "label": "Television System",
+            "choices": [
+                ("NTSC", "ntsc"),
+                ("PAL", "pal"),
+                ("PAL-M (Brazil)", "pal_m"),
+                ("PAL-N (Argentina, Paraguay, Uruguay)", "pal_n"),
+            ],
+            "default": "ntsc",
+        },
+        {
+            "option": "time_sync",
+            "type": "choice",
+            "label": "Time Sync",
+            "choices": [
+                ("Audio and video", "audio and video"),
+                ("Audio", "audio"),
+                ("Video", "video"),
+                ("None", "none"),
+            ],
+            "default": "audio and video",
+            "advanced": True,
+        },
+        {
+            "option": "int_res",
+            "type": "choice",
+            "label": "Internal Video Resolution Scale",
+            "choices": [
+                ("×1", "1"),
+                ("×2", "2"),
+                ("×3", "3"),
+                ("×4", "4"),
+                ("×5", "5"),
+                ("×6", "6"),
+                ("×7", "7"),
+                ("×8", "8"),
+            ],
+            "default": "2",
+            "advanced": True,
+            "help": "Only available in premium version.",
+        },
+    ]
+
+    def install(self, version=None, downloader=None, callback=None):
+        def on_runner_installed(*args):
+            dlg = QuestionDialog(
+                {
+                    "question": "Do you want to select a premium license file?",
+                    "title": "Use premium version?",
+                }
+            )
+            if dlg.result == dlg.YES:
+                license_dlg = FileDialog("Select a license file")
+                license_filename = license_dlg.filename
+                if not license_filename:
+                    return
+                shutil.copy(
+                    license_filename, os.path.join(settings.RUNNER_DIR, "redream")
+                )
+
+        super(redream, self).install(
+            version=version, downloader=downloader, callback=on_runner_installed
+        )
+
+    def play(self):
+        command = [self.get_executable()]
+
+        if self.runner_config.get("fs") is True:
+            command.append("--fullscreen=1")
+        else:
+            command.append("--fullscreen=0")
+
+        if self.runner_config.get("ar"):
+            command.append("--aspect=" + self.runner_config.get("ar"))
+
+        if self.runner_config.get("region"):
+            command.append("--region=" + self.runner_config.get("region"))
+
+        if self.runner_config.get("language"):
+            command.append("--language=" + self.runner_config.get("language"))
+
+        if self.runner_config.get("broadcast"):
+            command.append("--broadcast=" + self.runner_config.get("broadcast"))
+
+        if self.runner_config.get("time_sync"):
+            command.append("--time_sync=" + self.runner_config.get("time_sync"))
+
+        if self.runner_config.get("int_res"):
+            command.append("--res=" + self.runner_config.get("int_res"))
+
+        command.append(self.game_config.get("main_file"))
+
+        return {"command": command}

--- a/share/lutris/json/microm8.json
+++ b/share/lutris/json/microm8.json
@@ -1,0 +1,46 @@
+{
+    "human_name": "MicroM8",
+    "description": "microM8 is an Apple II emulator",
+    "platforms": ["Apple IIe"],
+    "runner_executable": "microm8/microm8",
+    "download_url": "http://paleotronic.com/download/microm8-linux.zip",
+    "game_options": [
+        {
+            "option": "main_file",
+            "type": "file",
+            "label": "Apple II disk file",
+            "help": "An Apple II disk file"
+        }
+    ],
+    "runner_options": [
+
+        {
+            "option": "fullscreen",
+            "type": "bool",
+            "label": "Fullscreen",
+            "default": false,
+            "argument": "-fullscreen"
+        },
+        {
+            "option": "bw",
+            "type": "bool",
+            "label": "Black and White",
+            "default": false,
+            "argument": "-bw"
+        },
+        {
+            "option": "wp",
+            "type": "bool",
+            "label": "Drive 1 in write protect mode",
+            "default": false,
+            "argument": "-drive1wp"
+        },
+        {
+            "option": "config",
+            "type": "bool",
+            "label": "Disk 1",
+            "default": true,
+            "argument": "-drive1"
+        }
+    ]
+}

--- a/share/lutris/json/pcem.json
+++ b/share/lutris/json/pcem.json
@@ -1,0 +1,33 @@
+{
+    "human_name": "PCem",
+    "description": "PCem is an IBM PC emulator",
+    "platforms": ["MS-DOS"],
+    "runnable_alone": "True",
+    "runner_executable": "pcem/pcem",
+    "download_url": "http://pcem-emulator.co.uk/files/PCemV16Linux.tar.gz",
+    "game_options": [
+        {
+            "option": "main_file",
+            "type": "file",
+            "label": "Config file",
+            "help": "PCem's Configuration file"
+        }
+    ],
+    "runner_options": [
+
+        {
+            "option": "config",
+            "type": "bool",
+            "label": "Fullscreen",
+            "default": true,
+            "argument": "--fullscreen"
+        },
+        {
+            "option": "config",
+            "type": "bool",
+            "label": "Config",
+            "default": true,
+            "argument": "--config"
+        }
+    ]
+}

--- a/share/lutris/json/tic80.json
+++ b/share/lutris/json/tic80.json
@@ -1,0 +1,38 @@
+{
+    "human_name": "TIC-80",
+    "description": "TIC-80 tiny computer",
+    "platforms": ["TIC-80"],
+    "runner_executable": "tic80/tic80",
+    "download_url": "https://github.com/nesbox/tic.computer/releases/download/v0.70.6/tic80_0.70.6.tar.gz",
+    "game_options": [
+        {
+            "option": "main_file",
+            "type": "file",
+            "label": "ROM file",
+            "default_path": "game_path"
+        }
+    ],
+    "runner_options": [
+        {
+            "option": "surf",
+            "type": "bool",
+            "label": "Start in Surf",
+            "default": false,
+            "argument": "-surf"
+        },
+        {
+            "option": "skip",
+            "type": "bool",
+            "label": "Skip startup animation",
+            "default": false,
+            "argument": "-skip"
+        },
+        {
+            "option": "nosound",
+            "type": "bool",
+            "label": "Start in silent mode",
+            "default": false,
+            "argument": "-nosound"
+        }
+    ]
+}


### PR DESCRIPTION
Can be merged once https://github.com/lutris/lutris/issues/3020 gets fully resolved.

The Redream runner was previously in lutris, but was removed due to not being available on the Lutris download server, with the new "download_url" option this can go back, as the removal reason is no longer valid. I tried jsonfied the redream runner, but it opened way more corner cases than what it's worth, so I'm leaving it as is