### PR TITLE
Install/Remove/Uninstall from Command line without GUI

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -209,7 +209,7 @@ class Application(Gtk.Application):
     def do_startup(self):  # pylint: disable=arguments-differ
         Gtk.Application.do_startup(self)
         signal.signal(signal.SIGINT, signal.SIG_DFL)
-        
+
         action = Gio.SimpleAction.new("quit")
         action.connect("activate", lambda *x: self.quit())
         self.add_action(action)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -125,6 +125,22 @@ class Application(Gtk.Application):
             None,
         )
         self.add_main_option(
+            "uninstall",
+            ord("u"),
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING,
+            _("Uninstall a game. Keep files on the disk"),
+            None,
+        )
+        self.add_main_option(
+            "remove",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING,
+            _("Uninstall and remove game"),
+            None,
+        )
+        self.add_main_option(
             "bin_path",
             0,
             GLib.OptionFlags.NONE,
@@ -409,13 +425,12 @@ class Application(Gtk.Application):
                     or pga.get_game_by_field(game_slug, "installer_slug")
                 )
 
-<<<<<<< HEAD
         if action == "write-script":
             if not db_game or not db_game["id"]:
                 logger.warning("No game provided to generate the script")
                 return 1
             self.generate_script(db_game, options.lookup_value("output-script").get_string())
-=======
+            return 0
         # check if path is provided with install
         if (options.contains("bin_path") or options.contains("install_path")) and not options.contains("install"):
             self._print(command_line, _("No installer provided!"))
@@ -445,7 +460,22 @@ class Application(Gtk.Application):
                     cmd_print=self._print,
                     commandline=command_line
                 )
->>>>>>> a294b699... Added option to install from command line
+            return 0
+        
+        if action == "uninstall":
+            if not db_game or not db_game["id"]:
+                logger.warning("No game found in library")
+                return 1
+            self._print(command_line, _("Uninstall Game %s") % db_game["slug"])
+            Game(db_game["id"]).remove(True, False)
+            return 0
+        
+        if action == "remove":
+            if not db_game or not db_game["id"]:
+                logger.warning("No game found in library")
+                return 1
+            self._print(command_line, _("Remove Game %s") % db_game["slug"])
+            Game(db_game["id"]).remove(True, True)
             return 0
 
         # Graphical commands

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -7,6 +7,7 @@ from gettext import gettext as _
 
 # Third Party Libraries
 from gi.repository import Gtk
+from gi.repository import GLib
 
 # Lutris Modules
 from lutris import api, pga, settings
@@ -527,3 +528,12 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         self.widget_box.pack_end(scrolledwindow, True, True, 10)
         scrolledwindow.show()
         self.log_textview.show()
+
+    def set_cancle_butten_sensitive(self, sensitivity):
+        GLib.idle_add(self.cancel_button.set_sensitive, sensitivity)
+
+    def continue_button_hide(self):
+        self.continue_button.hide()
+
+    def eject_button_show(self):
+        GLib.idle_add(self.eject_button.show)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -7,7 +7,6 @@ from gettext import gettext as _
 
 # Third Party Libraries
 from gi.repository import Gtk
-from gi.repository import GLib
 
 # Lutris Modules
 from lutris import api, pga, settings
@@ -529,11 +528,11 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         scrolledwindow.show()
         self.log_textview.show()
 
-    def set_cancle_butten_sensitive(self, sensitivity):
-        GLib.idle_add(self.cancel_button.set_sensitive, sensitivity)
+    def set_cancel_butten_sensitive(self, sensitivity):
+        self.cancel_button.set_sensitive(sensitivity)
 
     def continue_button_hide(self):
         self.continue_button.hide()
 
     def eject_button_show(self):
-        GLib.idle_add(self.eject_button.show)
+        self.eject_button.show()

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -198,7 +198,7 @@ class CommandsMixin:
         choosen_option = menu.get_active_id()
         if choosen_option:
             self.user_inputs.append({"alias": alias, "value": choosen_option})
-            self.parent.continue_button_hide()
+            GLib.idle_add(self.parent.continue_button_hide)
             self._iter_commands()
 
     def insert_disc(self, data):
@@ -216,7 +216,7 @@ class CommandsMixin:
               "<i>%s</i>") % requires
         )
         if self.runner == "wine":
-            self.parent.eject_button_show()
+            GLib.idle_add(self.parent.eject_button_show)
         GLib.idle_add(self.parent.ask_for_disc, message, self._find_matching_disc, requires)
         return "STOP"
 
@@ -365,7 +365,7 @@ class CommandsMixin:
         """
         self._check_required_params("name", data, "task")
         if self.parent:
-            GLib.idle_add(self.parent.cancel_button_set_sensitive, False)
+            GLib.idle_add(self.parent.set_cancel_butten_sensitiv, False)
         runner_name, task_name = self._get_task_runner_and_name(data.pop("name"))
 
         wine_version = None
@@ -397,7 +397,7 @@ class CommandsMixin:
 
         task = import_task(runner_name, task_name)
         thread = task(**data)
-        GLib.idle_add(self.parent.cancel_button_set_sensitive, True)
+        GLib.idle_add(self.parent.set_cancel_butten_sensitive, True)
         if isinstance(thread, MonitoredCommand):
             # Monitor thread and continue when task has executed
             GLib.idle_add(self.parent.attach_logger, thread)

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -198,7 +198,7 @@ class CommandsMixin:
         choosen_option = menu.get_active_id()
         if choosen_option:
             self.user_inputs.append({"alias": alias, "value": choosen_option})
-            GLib.idle_add(self.parent.continue_button.hide)
+            self.parent.continue_button_hide()
             self._iter_commands()
 
     def insert_disc(self, data):
@@ -216,7 +216,7 @@ class CommandsMixin:
               "<i>%s</i>") % requires
         )
         if self.runner == "wine":
-            GLib.idle_add(self.parent.eject_button.show)
+            self.parent.eject_button_show()
         GLib.idle_add(self.parent.ask_for_disc, message, self._find_matching_disc, requires)
         return "STOP"
 
@@ -365,7 +365,7 @@ class CommandsMixin:
         """
         self._check_required_params("name", data, "task")
         if self.parent:
-            GLib.idle_add(self.parent.cancel_button.set_sensitive, False)
+            GLib.idle_add(self.parent.cancel_button_set_sensitive, False)
         runner_name, task_name = self._get_task_runner_and_name(data.pop("name"))
 
         wine_version = None
@@ -397,7 +397,7 @@ class CommandsMixin:
 
         task = import_task(runner_name, task_name)
         thread = task(**data)
-        GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
+        GLib.idle_add(self.parent.cancel_button_set_sensitive, True)
         if isinstance(thread, MonitoredCommand):
             # Monitor thread and continue when task has executed
             GLib.idle_add(self.parent.attach_logger, thread)

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -492,7 +492,7 @@ class ScriptInterpreter(CommandsMixin):
         try:
             runner = import_runner(runner_name)
         except InvalidRunner:
-            GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
+            self.parent.set_cancle_butten_sensitive()
             raise ScriptingError("Invalid runner provided %s" % runner_name)
         return runner
 
@@ -535,7 +535,7 @@ class ScriptInterpreter(CommandsMixin):
 
         self.parent.set_status("Installing game data")
         self.parent.add_spinner()
-        self.parent.continue_button.hide()
+        self.parent.continue_button_hide()
 
         commands = self.script.get("installer", [])
         if exception:

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -492,7 +492,7 @@ class ScriptInterpreter(CommandsMixin):
         try:
             runner = import_runner(runner_name)
         except InvalidRunner:
-            self.parent.set_cancle_butten_sensitive()
+            GLib.idle_add(self.parent.set_cancel_butten_sensitive, True)
             raise ScriptingError("Invalid runner provided %s" % runner_name)
         return runner
 

--- a/lutris/installer/silient_install.py
+++ b/lutris/installer/silient_install.py
@@ -1,0 +1,219 @@
+"""Install games without GUI"""
+# Standard Library
+import os
+import time
+from gettext import gettext as _
+
+# Lutris Modules
+from lutris import settings
+from lutris.installer import interpreter
+from lutris.installer.errors import MissingGameDependency, ScriptingError
+from lutris.util import jobs, system
+from lutris.util.log import logger
+from lutris.util.downloader import Downloader
+
+
+class SilenInstall:
+
+    """silent install process."""
+
+    def __init__(
+            self,
+            game_slug=None,
+            installer_file=None,
+            revision=None,
+            binary_path=None,
+            install_path=None,
+            cmd_print=None,  # get commandline output from application.py
+            commandline=None
+    ):
+
+        self.interpreter = None
+        self.game_slug = game_slug
+        self.installer_file = installer_file
+        self.revision = revision
+        self.binary_path = binary_path
+        self.install_path = install_path
+        self.downloader = None
+        self.bin_path_coutner = 0  # iterating throught the files
+        self._print = cmd_print
+        self.commandline = commandline
+
+        if system.path_exists(self.installer_file):
+            self.on_scripts_obtained(interpreter.read_script(self.installer_file))
+        else:
+            self._print(self.commandline, _("Waiting for response from %s" % settings.SITE_URL))
+            logger.info(_("Waiting for response from %s" % settings.SITE_URL))
+            jobs.AsyncCall(
+                interpreter.fetch_script,
+                self.on_scripts_obtained,
+                self.game_slug,
+                self.revision
+            )
+
+    def on_scripts_obtained(self, scripts, _error=None):
+        if not scripts:
+            self._print(self.commandline, "No install script found")
+            logger.error("No install script found")
+            return
+
+        if isinstance(scripts, list):  # if scripts is a list longer than one element
+            if len(scripts) != 1:
+                self._print(self.commandline, "Please provide single installer")
+                logger.error("No install script found")
+                return
+            self.script = scripts[0]
+        else:
+            self.script = scripts
+
+        self.validate_scripts()
+        self.prepare_install(self.script)
+
+    def validate_scripts(self):
+        """Auto-fixes some script aspects and checks for mandatory fields"""
+
+        for item in ["description", "notes"]:
+            self.script[item] = self.script.get(item) or ""
+        for item in ["name", "runner", "version"]:
+            if item not in self.script:
+                self._print(self.commandline, _("Invalid script: %s" % self.script))
+                raise ScriptingError('Missing field "%s" in install script' % item)
+
+    def prepare_install(self, script):
+
+        install_script = script
+        if not install_script:
+            raise ValueError("Could not find script %s" % install_script)
+        try:
+            self.interpreter = interpreter.ScriptInterpreter(install_script, self)
+        except MissingGameDependency as ex:
+            # call recursive dependencies
+            SilenInstall(
+                game_slug=ex.slug
+            )
+
+        self.select_install_folder()
+
+    def select_install_folder(self):
+        """Stage where we select the install directory."""
+        if self.interpreter.creates_game_folder:
+            if self.install_path is None:
+                self.install_path = self.interpreter.get_default_target()
+
+            self.interpreter.target_path = self.install_path
+            self._print(self.commandline, _("install Folder %s" % self.interpreter.target_path))
+            logger.info("No install script found")
+
+        try:
+            self.interpreter.check_runner_install()
+        except ScriptingError as ex:
+            self._print(self.commandline, ex.__str__)
+            logger.error(ex.__str__)
+            return
+
+    def set_status(self, text):
+        self._print(self.commandline, text)
+
+    # required by interpreter
+    def clean_widgets(self):
+        pass
+
+    # required by interpreter
+    def add_spinner(self):
+        pass
+
+    # required by interpreter
+    def set_cancle_butten_sensitive(self):
+        pass
+
+    # required by interpreter
+    def continue_button_hide(self):
+        pass
+
+    def attach_logger(self, command):
+        pass
+
+    def on_install_error(self, message):
+        self._print(self.commandline, message)
+        logger.error(message)
+        exit()
+        # end program
+
+    def on_install_finished(self):
+        self._print(self.commandline, "finished install")
+        logger.info("finished install")
+        exit()
+        # end program
+
+    def input_menu(self, alias, options, preselect, has_entry, callback):
+        """Display an input request as a dropdown menu with options."""
+        # not sure what to do here...
+        self._print(self.commandline, "input menu not supported for silent install")
+        logger.error("input menu not supported for silent install")
+        return
+
+    def ask_user_for_file(self, message):
+        if not os.path.isfile(self.binary_path[self.bin_path_coutner]):
+            self._print(self.commandline, _("%s is not a file" % self.binary_path[self.bin_path_coutner]))
+            logger.warning("%s is not a file", self.binary_path[self.bin_path_coutner])
+            return
+        logger.info("use %s", self.binary_path[self.bin_path_coutner])
+        self.interpreter.file_selected(self.binary_path[self.bin_path_coutner])
+        self.bin_path_coutner += 1
+
+    def start_download(self, file_uri, dest_file, callback=None, data=None, referer=None):
+        try:
+            self.downloader = Downloader(file_uri, dest_file, referer=referer, overwrite=True)
+        except RuntimeError as ex:
+            self._print(self.commandline, _("Downloading  %s to %s has an error: %s") %
+                        (file_uri, dest_file, ex.__str__))
+            logger.error(_("Downloading  %s to %s has an error: %s") % (file_uri, dest_file, ex.__str__))
+            return None
+
+        self._print(self.commandline, _("Downloading %s to %s") % (file_uri, dest_file))
+        logger.info(_("Downloading %s to %s") % (file_uri, dest_file))
+        self.downloader.start()
+
+        while self.downloader.check_progress() != 1.0:
+            self.download_progress()
+            time.sleep(0.5)
+
+        self.on_download_complete(callback, data)
+
+    def download_progress(self):
+        """Show download progress."""
+        if self.downloader.state in [self.downloader.CANCELLED, self.downloader.ERROR]:
+            if self.downloader.state == self.downloader.CANCELLED:
+                self._print(self.commandline, "Download interrupted")
+                logger.error("Download interrupted")
+            else:
+                self._print(self.commandline, self.downloader.error)
+            if self.downloader.state == self.downloader.CANCELLED:
+                self._print(self.commandline, "Download canceled")
+                logger.error("Download canceled")
+            return
+        megabytes = 1024 * 1024
+        self._print(self.commandline, _((
+            "{downloaded:0.2f} / {size:0.2f}MB ({speed:0.2f}MB/s), {time} remaining"
+        ).format(
+            downloaded=float(self.downloader.downloaded_size) / megabytes,
+            size=float(self.downloader.full_size) / megabytes,
+            speed=float(self.downloader.average_speed) / megabytes,
+            time=self.downloader.time_left,
+        )))
+
+    def on_download_complete(self, callback=None, callback_data=None):
+        """Action called on a completed download."""
+        if callback:
+            try:
+                callback_data = callback_data or {}
+                callback(**callback_data)
+            except Exception as ex:  # pylint: disable:broad-except
+                raise ScriptingError(str(ex))
+
+        self.interpreter.abort_current_task = None
+        self.interpreter.iter_game_files()
+
+    def ask_for_disc(self, message, callback, requires):
+        """Ask the user to do insert a CD-ROM."""
+        callback(requires)

--- a/lutris/installer/silient_install.py
+++ b/lutris/installer/silient_install.py
@@ -167,11 +167,11 @@ class SilenInstall:
         except RuntimeError as ex:
             self._print(self.commandline, _("Downloading  %s to %s has an error: %s") %
                         (file_uri, dest_file, ex.__str__))
-            logger.error(_("Downloading  %s to %s has an error: %s") % (file_uri, dest_file, ex.__str__))
+            logger.error("Downloading  %s to %s has an error: %s", file_uri, dest_file, ex.__str__)
             return None
 
         self._print(self.commandline, _("Downloading %s to %s") % (file_uri, dest_file))
-        logger.info(_("Downloading %s to %s") % (file_uri, dest_file))
+        logger.info("Downloading %s to %s", file_uri, dest_file)
         self.downloader.start()
 
         while self.downloader.check_progress() != 1.0:

--- a/lutris/installer/unattended_install.py
+++ b/lutris/installer/unattended_install.py
@@ -9,13 +9,13 @@ from lutris import settings
 from lutris.installer import interpreter
 from lutris.installer.errors import MissingGameDependency, ScriptingError
 from lutris.util import jobs, system
-from lutris.util.log import logger
 from lutris.util.downloader import Downloader
+from lutris.util.log import logger
 
 
-class SilenInstall:
+class UnattendedInstall:
 
-    """silent install process."""
+    """unattended install process."""
 
     def __init__(
             self,
@@ -24,9 +24,11 @@ class SilenInstall:
             revision=None,
             binary_path=None,
             install_path=None,
+            install_options=None,
             cmd_print=None,  # get commandline output from application.py
-            commandline=None
-    ):
+            commandline=None,
+            quit_callback=None
+    ):  # pylint: disable=too-many-arguments
 
         self.interpreter = None
         self.game_slug = game_slug
@@ -34,16 +36,19 @@ class SilenInstall:
         self.revision = revision
         self.binary_path = binary_path
         self.install_path = install_path
+        self.install_options = install_options
         self.downloader = None
         self.bin_path_coutner = 0  # iterating throught the files
+        self.options_coutner = 0   # iterating throught the options
         self._print = cmd_print
         self.commandline = commandline
+        self.quit_callback = quit_callback
 
         if system.path_exists(self.installer_file):
             self.on_scripts_obtained(interpreter.read_script(self.installer_file))
         else:
             self._print(self.commandline, _("Waiting for response from %s" % settings.SITE_URL))
-            logger.info(_("Waiting for response from %s" % settings.SITE_URL))
+            logger.debug(_("Waiting for response from %s" % settings.SITE_URL))
             jobs.AsyncCall(
                 interpreter.fetch_script,
                 self.on_scripts_obtained,
@@ -53,42 +58,73 @@ class SilenInstall:
 
     def on_scripts_obtained(self, scripts, _error=None):
         if not scripts:
-            self._print(self.commandline, "No install script found")
-            logger.error("No install script found")
-            return
+            self.on_install_error("No install script found")
 
         if isinstance(scripts, list):  # if scripts is a list longer than one element
             if len(scripts) != 1:
-                self._print(self.commandline, "Please provide single installer")
-                logger.error("No install script found")
-                return
+                self.on_install_error("Please provide single installer")
+
             self.script = scripts[0]
         else:
             self.script = scripts
 
-        self.validate_scripts()
+        if self.validate_scripts() != 0:
+            return
         self.prepare_install(self.script)
 
     def validate_scripts(self):
         """Auto-fixes some script aspects and checks for mandatory fields"""
-
+        # check correct syntax
         for item in ["description", "notes"]:
             self.script[item] = self.script.get(item) or ""
         for item in ["name", "runner", "version"]:
             if item not in self.script:
-                self._print(self.commandline, _("Invalid script: %s" % self.script))
-                raise ScriptingError('Missing field "%s" in install script' % item)
+                self.on_install_error(_("Invalid script: %s" % self.script))
+                return -1
+
+        # Check if given files match the number of needed files in the skript. Also test if the files available
+        if "files" in self.script["script"]:
+            req_files = list(filter(lambda file: "N/A" in file[next(iter(file))], self.script["script"]["files"]))
+            if len(req_files) != 0:  # do we need an argument
+                if len(req_files) != len(self.binary_path):  # is the number of arguments correct
+                    self.on_install_error(_("Number of provided files is wrong. %s instead of %s")
+                                          % (len(self.binary_path), len(req_files)))
+                    return -1
+                # check if files available
+                for f in self.binary_path:
+                    if not system.path_exists(f):
+                        self.on_install_error(_("File %s does not exist") % f)
+                        return -1
+
+        # Check if given options match the number of needed options in the skript
+        # Also test if the options are valid. The Options must be provided in correct order required from the skript
+        menus = list(filter(lambda file: "input_menu" in file, self.script["script"]["installer"]))
+        if len(menus) != 0:   # do we need an option
+            if len(menus) != len(self.install_options):  # is the number of arguments correct
+                self.on_install_error(_("Number of provided options is wrong. %s instead of %s")
+                                      % (len(self.install_options), len(menus)))
+                return -1
+
+            # check content
+            for count, menu in enumerate(menus):
+                if len(list(filter(lambda file, i=count: self.install_options[i] in file,
+                                   menu["input_menu"]["options"]))) == 0:
+                    self.on_install_error(_("Option %s not available for menu %s")
+                                          % (self.install_options[count], count))
+                    return -1
+        return 0
 
     def prepare_install(self, script):
 
         install_script = script
         if not install_script:
-            raise ValueError("Could not find script %s" % install_script)
+            self.on_install_error(_("Could not find script %s" % install_script))
+            return
         try:
             self.interpreter = interpreter.ScriptInterpreter(install_script, self)
         except MissingGameDependency as ex:
             # call recursive dependencies
-            SilenInstall(
+            UnattendedInstall(
                 game_slug=ex.slug
             )
 
@@ -102,13 +138,12 @@ class SilenInstall:
 
             self.interpreter.target_path = self.install_path
             self._print(self.commandline, _("install Folder %s" % self.interpreter.target_path))
-            logger.info("No install script found")
+            logger.debug(_("install Folder %s" % self.interpreter.target_path))
 
         try:
             self.interpreter.check_runner_install()
         except ScriptingError as ex:
-            self._print(self.commandline, ex.__str__)
-            logger.error(ex.__str__)
+            self.on_install_error(ex.__str__)
             return
 
     def set_status(self, text):
@@ -123,39 +158,40 @@ class SilenInstall:
         pass
 
     # required by interpreter
-    def set_cancle_butten_sensitive(self):
+    def set_cancel_butten_sensitive(self, sensitivity):
         pass
 
     # required by interpreter
     def continue_button_hide(self):
         pass
 
+    # required by interpreter
     def attach_logger(self, command):
         pass
 
     def on_install_error(self, message):
         self._print(self.commandline, message)
         logger.error(message)
-        exit()
+        self.quit_callback()
         # end program
 
     def on_install_finished(self):
         self._print(self.commandline, "finished install")
-        logger.info("finished install")
-        exit()
+        logger.debug("finished install")
+        self.quit_callback()
         # end program
 
     def input_menu(self, alias, options, preselect, has_entry, callback):
         """Display an input request as a dropdown menu with options."""
-        # not sure what to do here...
-        self._print(self.commandline, "input menu not supported for silent install")
-        logger.error("input menu not supported for silent install")
-        return
+
+        # if values are valid is checked in validate_scripts() function
+        self.interpreter.user_inputs.append({"alias": alias, "value": self.install_options[self.options_coutner]})
+        self.options_coutner += 1
+        self.interpreter._iter_commands()
 
     def ask_user_for_file(self, message):
         if not os.path.isfile(self.binary_path[self.bin_path_coutner]):
-            self._print(self.commandline, _("%s is not a file" % self.binary_path[self.bin_path_coutner]))
-            logger.warning("%s is not a file", self.binary_path[self.bin_path_coutner])
+            self.on_install_error(_("%s is not a file" % self.binary_path[self.bin_path_coutner]))
             return
         logger.info("use %s", self.binary_path[self.bin_path_coutner])
         self.interpreter.file_selected(self.binary_path[self.bin_path_coutner])
@@ -165,13 +201,12 @@ class SilenInstall:
         try:
             self.downloader = Downloader(file_uri, dest_file, referer=referer, overwrite=True)
         except RuntimeError as ex:
-            self._print(self.commandline, _("Downloading  %s to %s has an error: %s") %
-                        (file_uri, dest_file, ex.__str__))
-            logger.error("Downloading  %s to %s has an error: %s", file_uri, dest_file, ex.__str__)
+            self.on_install_error(_("Downloading  %s to %s has an error: %s") %
+                                  (file_uri, dest_file, ex.__str__))
             return None
 
         self._print(self.commandline, _("Downloading %s to %s") % (file_uri, dest_file))
-        logger.info("Downloading %s to %s", file_uri, dest_file)
+        logger.debug("Downloading %s to %s", file_uri, dest_file)
         self.downloader.start()
 
         while self.downloader.check_progress() != 1.0:
@@ -184,13 +219,11 @@ class SilenInstall:
         """Show download progress."""
         if self.downloader.state in [self.downloader.CANCELLED, self.downloader.ERROR]:
             if self.downloader.state == self.downloader.CANCELLED:
-                self._print(self.commandline, "Download interrupted")
-                logger.error("Download interrupted")
+                self.on_install_error("Download interrupted")
             else:
-                self._print(self.commandline, self.downloader.error)
+                self.on_install_error(self.downloader.error)
             if self.downloader.state == self.downloader.CANCELLED:
-                self._print(self.commandline, "Download canceled")
-                logger.error("Download canceled")
+                self.on_install_error("Download canceled")
             return
         megabytes = 1024 * 1024
         self._print(self.commandline, _((
@@ -209,7 +242,8 @@ class SilenInstall:
                 callback_data = callback_data or {}
                 callback(**callback_data)
             except Exception as ex:  # pylint: disable:broad-except
-                raise ScriptingError(str(ex))
+                self.on_install_error(str(ex))
+                return
 
         self.interpreter.abort_current_task = None
         self.interpreter.iter_game_files()


### PR DESCRIPTION
Fixes #2907

Currently it works like
**Silent Install**
lutris --install (game slug / url) --bin_path path_to_binary1; path_to_binary2 [--install_path path_to_install_folder]

If install folder is not given, the default one is used.


**Silent Remove**
lutris --remove id/game_slug

**Silent Uninstall**
lutris --uninstall id/game_slug

Missing Runners are installed without asking
Disks are searched in the standard search paths

I don't know how to handle input menus for this case. So the program prints an error and stops.
Any suggestions?


