### PR TITLE
Vkd3d changes

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -247,13 +247,6 @@ class wine(Runner):
             #     "help": _("Use DXVK to handle DirectX9 games")
             # },
             {
-                "option": "vkd3d",
-                "label": _("Enable VKD3D"),
-                "type": "bool",
-                "default": False,
-                "help": _("Enable DX12 support with VKD3D. This requires a compatible Wine build.")
-            },
-            {
                 "option": "esync",
                 "label": _("Enable Esync"),
                 "type": "extended_bool",
@@ -847,9 +840,7 @@ class wine(Runner):
         self.sandbox(prefix_manager)
         self.set_regedit_keys()
         self.setup_x360ce(self.runner_config.get("x360ce-path"))
-        if self.runner_config.get("vkd3d"):
-            dxvk_manager = dxvk.VKD3DManager
-        elif not self.runner_config.get("dxvk_d3d9", True):
+        if self.runner_config.get("dxvk_d3d9", True):
             dxvk_manager = dxvk.DXVKManagerNoD3D9
         else:
             dxvk_manager = dxvk.DXVKManager

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -219,16 +219,16 @@ class wine(Runner):
             },
             {
                 "option": "dxvk",
-                "label": _("Enable DXVK"),
+                "label": _("Enable DXVK/VKD3D"),
                 "type": "extended_bool",
                 "callback": dxvk_vulkan_callback,
                 "callback_on": True,
                 "default": True,
                 "active": True,
                 "help": _(
-                    "Use DXVK to increase compatibility and performance "
-                    "in Direct3D 11 and 10 applications by translating "
-                    "their calls to Vulkan."),
+                    "Use DXVK and VKD3D to enable support for Direct3D 12 and "
+                    "increase compatibility and performance in Direct3D 11, 10 "
+                    "and 9 applications by translating their calls to Vulkan."),
             },
             {
                 "option": "dxvk_version",

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -79,7 +79,7 @@ class DXVKManager:
     """Utility class to install DXVK dlls to a Wine prefix"""
 
     DXVK_TAGS_URL = "https://api.github.com/repos/lutris/dxvk/releases"
-    DXVK_VERSIONS = ["1.6"]
+    DXVK_VERSIONS = ["1.7L-84bb768"]
     DXVK_LATEST, DXVK_PAST_RELEASES = DXVK_VERSIONS[0], DXVK_VERSIONS[1:9]
 
     init_started = False

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -223,12 +223,6 @@ class DXVKManager:
             self.disable_dxvk_dll(system_dir, dxvk_arch, dll)
 
 
-class VKD3DManager(DXVKManager):
-
-    """Modified DXVKManager for supporting VKD3D"""
-    dxvk_dlls = ("d3d11", "d3d10core", "d3d9", "dxvk_config")
-
-
 class DXVKManagerNoD3D9(DXVKManager):
 
     """Modified DXVKManager without D3D9 support"""

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -88,7 +88,7 @@ class DXVKManager:
     base_url = "https://github.com/lutris/dxvk/releases/download/v{}/dxvk-{}.tar.gz"
     base_name = "dxvk"
     base_dir = os.path.join(RUNTIME_DIR, base_name)
-    dxvk_dlls = ("dxgi", "d3d11", "d3d10core", "d3d9")
+    dxvk_dlls = ("dxgi", "d3d11", "d3d10core", "d3d9", "d3d12")
     latest_version = DXVK_LATEST
 
     def __init__(self, prefix, arch="win64", version=None):


### PR DESCRIPTION
This will:
-  Disable the Vkd3d option (and also the d3d9 option), even for those people who still have it enabled in the configuration.
- Bump DXVK version
- Add override for d3d12.dll
- Rename DXVK option to DXVK/VKD3D as the opiton now handles VKD3D as well.