### PR TITLE
Fix missing parentheses in default value of gamemode option.

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -250,7 +250,7 @@ system_options = [  # pylint: disable=invalid-name
     {
         "option": "gamemode",
         "type": "bool",
-        "default": system.LINUX_SYSTEM.gamemode_available,
+        "default": system.LINUX_SYSTEM.gamemode_available(),
         "condition": system.LINUX_SYSTEM.gamemode_available,
         "label": _("Enable Feral gamemode"),
         "help": _("Request a set of optimisations be temporarily applied to the host OS"),


### PR DESCRIPTION
Feral GameMode support in Lutris seemed to be always enabled since some time ago. This probably fixes that.