### PR TITLE
Fix error message in prepare_game_files

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -353,7 +353,7 @@ class ScriptInterpreter(CommandsMixin):
             try:
                 self.swap_humble_game_files()
             except UnavailableGame as ex:
-                logger.error("Unable to get the game from GOG: %s", ex)
+                logger.error("Unable to get the game from Humble Bundle: %s", ex)
         self.iter_game_files()
 
     def iter_game_files(self):


### PR DESCRIPTION
The prepare_game_files function has separate blocks for GOG and
Humble Bundle services, but the error messages print GOG for
both of them.