### PR TITLE
Add option to disable the screen saver while a game is running.

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -10,7 +10,7 @@ from gettext import gettext as _
 from lutris import runners
 from lutris.discord import DiscordPresence
 from lutris.util import system
-from lutris.util.display import DISPLAY_MANAGER, USE_DRI_PRIME
+from lutris.util.display import DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, USE_DRI_PRIME
 
 VULKAN_DATA_DIRS = [
     "/usr/local/etc/vulkan",  # standard site-local location
@@ -155,6 +155,17 @@ system_options = [  # pylint: disable=invalid-name
         "advanced": True,
         "help": _("Disable desktop effects while game is running, "
                   "reducing stuttering and increasing performance"),
+    },
+    {
+        "option": "disable_screen_saver",
+        "label": _("Disable screen saver"),
+        "type": "bool",
+        "default": SCREEN_SAVER_INHIBITOR is not None,
+        "advanced": False,
+        "condition": SCREEN_SAVER_INHIBITOR is not None,
+        "help": _("Disable the screen saver while a game is running. "
+                  "Requires the screen saver's functionality "
+                  "to be exposed over DBus."),
     },
     {
         "option": "reset_pulse",


### PR DESCRIPTION
Most screen savers rely on X input events to detect user activity. Gamepad input is not handled by the X server, therefore when playing a game with a gamepad, the screen saver kicks in after a couple of minutes. Thankfully, there's a standard screen saver DBus [interface](https://people.freedesktop.org/~hadess/idle-inhibition-spec/re01.html) that most DEs expose, which allows us to temporarily disable the screen saver. This PR makes use of this API to disable the screen saver while a game is running.

I have checked the following DEs for a DBus screen saver API:
- GNOME
- KDE
- MATE
- XFCE
- DDE (Deepin)

Theoretically, this feature should work an all these DEs, and potentially more. I have so far tested it only on GNOME, works as expected.