### PR TITLE
Normal is 1x in ScummVM

### DIFF
--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -73,7 +73,7 @@ class scummvm(Runner):
             "default":
             "3x",
             "choices": [
-                (_("normal"), "normal"),
+                (_("1x"), "1x"),
                 ("2x", "2x"),
                 ("3x", "3x"),
                 ("hq2x", "hq2x"),


### PR DESCRIPTION
If you start a game with the normal Graphics scaler option selected then you get a warning:

```
Unrecognized graphics mode 'normal'. Switching to default mode!
```

There is no normal Graphics scaler option in ScummVM. This can be verified by running `scummvm --help` or reading the `HELP_STRING` in `commandLine.cpp` in the ScummVM source code [[1]].

I noticed that the `1x` option is missing so I suspect the intent was to use that.

[1]: https://github.com/scummvm/scummvm/blob/14c92e617925e8c26160826d2c1f841186053471/base/commandLine.cpp