### PR TITLE
Use correct parent window for ErrorDialog

### DIFF
--- a/lutris/gui/dialogs/runners.py
+++ b/lutris/gui/dialogs/runners.py
@@ -144,7 +144,7 @@ class RunnersDialog(GtkBuilderDialog):
             runners.RunnerInstallationError,
             runners.NonInstallableRunnerError,
         ) as ex:
-            ErrorDialog(ex.message, parent=self)
+            ErrorDialog(ex.message, parent=self.dialog)
         if runner.is_installed():
             self.emit("runner-installed")
             self.refresh_button.emit("clicked")


### PR DESCRIPTION
Pass embedded self.dialog instead of self: RunnersDialog uses
composition instead of inheritance. Fixes:

TypeError: could not convert value for property `transient_for' from RunnersDialog to GtkWindow