### PR TITLE
Add Platform to --list-games command line flag

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -510,6 +510,7 @@ class Application(Gtk.Application):
                 "slug": game["slug"],
                 "name": game["name"],
                 "runner": game["runner"],
+                "platform": game["platform"],
                 "directory": game["directory"],
             } for game in game_list
         ]


### PR DESCRIPTION
I've added the platform to the json output of the `--list-games` command line flag as I need this info for scripted import of non steam games into steam collections.