### PR TITLE
Tab order fix

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -183,6 +183,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
     def on_load(self, widget, data):
         self.game_store = GameStore(self.service_media)
         self.switch_view()
+        self.view.grab_focus()
         self.view.contextual_menu = ContextualMenu(self.game_actions.get_game_actions())
         self.update_runtime()
 

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -389,11 +389,11 @@
         <child>
           <object class="GtkBox" id="main_box">
             <property name="visible">True</property>
-            <property name="can_focus">True</property>
+            <property name="can_focus">False</property>
             <child>
               <object class="GtkRevealer" id="sidebar_revealer">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
+                <property name="can_focus">False</property>
                 <property name="hexpand">False</property>
                 <property name="transition_type">slide-right</property>
                 <child>


### PR DESCRIPTION
Cool feature for keyboard lovers.
Now you can finally use Tab key to change focus (even left or right keys work when focus is on side panels).

Bonus: games list is selecting by default on startup so you can just quickly select your game ~~and hit enter to play.~~