### PR TITLE
Remove redundant checks and casts to float for playtime

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -73,11 +73,7 @@ class Game(GObject.Object):
         self.has_custom_banner = bool(game_data.get("has_custom_banner"))
         self.has_custom_icon = bool(game_data.get("has_custom_icon"))
         self.discord_presence = DiscordPresence()
-        try:
-            self.playtime = float(game_data.get("playtime") or 0.0)
-        except ValueError:
-            logger.error("Invalid playtime value %s", game_data.get("playtime"))
-            self.playtime = 0.0
+        self.playtime = game_data.get("playtime") or 0.0
 
         if self.game_config_id:
             self.load_config()

--- a/lutris/util/strings.py
+++ b/lutris/util/strings.py
@@ -119,10 +119,6 @@ def get_formatted_playtime(playtime):
     if not playtime:
         return "No play time recorded"
 
-    try:
-        playtime = float(playtime)
-    except TypeError:
-        return "Invalid playtime %s" % playtime
     hours = math.floor(playtime)
 
     if hours:


### PR DESCRIPTION
After my PR #2704 I forget to check for code which casts the playtime (which was changed to float) to float.
The 2 changes delete code which does so.

Too make sure I didn't remember incorrectly and this will produce an exception, I added `assert game_data.get("playtime") is None or isinstance(game_data.get("playtime"), float), "playtime is not a float"` before the changed lines and monitored the terminal. I did not find any issues.
