### PR TITLE
Move runner menu to arrow button

### DIFF
--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -62,8 +62,9 @@ class GameBar(Gtk.Fixed):
         y_offset = 42
         if self.game.is_installed:
             self.put(self.get_runner_button(), x_offset, y_offset)
-            self.put(self.get_runner_label(), x_offset + 45, y_offset)
-            x_offset += 135
+            x_offset += 80
+            self.put(self.get_runner_label(), x_offset, y_offset)
+            x_offset += 95
         if self.game.lastplayed:
             self.put(self.get_last_played_label(), x_offset, y_offset)
             x_offset += 95
@@ -101,14 +102,25 @@ class GameBar(Gtk.Fixed):
     def get_runner_button(self):
         icon_name = self.game.runner.name + "-symbolic"
         runner_icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-        runner_icon.show()
-        runner_button = Gtk.MenuButton()
+        runner_button = Gtk.Button(visible=True)
+        runner_button.set_sensitive(False)
         runner_button.set_image(runner_icon)
+
+        popover_button = Gtk.MenuButton(visible=True)
+        popover_button.set_size_request(32, 32)
+        popover_button.props.direction = Gtk.ArrowType.UP
         popover = self.get_popover(self.get_runner_buttons())
         if popover:
-            runner_button.set_popover(popover)
-        runner_button.show()
-        return runner_button
+            popover_button.set_popover(popover)
+        else:
+            popover_button.set_sensitive(False)
+
+        box = Gtk.HBox(visible=True)
+        box.add(runner_button)
+        box.add(popover_button)
+        style_context = box.get_style_context()
+        style_context.add_class("linked")
+        return box
 
     def get_runner_label(self):
         runner_label = Gtk.Label(visible=True)


### PR DESCRIPTION
From commit message:

> With the updated location for the runner tasks (wine configuration, run exe in prefix, etc), several people did not realize that the wine icon was actually a button that would open this menu.
> 
> This adds a triangle arrow menu next to the runner icon, which people can't possibly miss (…right?). It is disabled if there are no runner tasks, and the icon button is now always disabled.
> 
> It's not the prettiest solution, but I think it's more usable and that this tradeoff is worth it.

As mentioned in Discord, there are some other things that I think would be nice, but are more time/effort to figure out than I want to spend for now (particularly given my lack of familiarity with python):

- Position the text on the right based on the calculated size of the buttons, rather than hard-coding it
- Don't show the menu button when there are no items, as opposed to just disabling it
- Instead of disabling the button with the icon, make clicking it open the menu (of the button next to it)