### PR TITLE
Fix Steam Sync issues in 5.8 beta

### DIFF
--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -60,7 +60,7 @@ def get_user_steam_id(steam_data_dir):
     if not user_config or "users" not in user_config:
         return
     for steam_id in user_config["users"]:
-        if user_config["users"][steam_id].get("mostrecent") == "1":
+        if user_config["users"][steam_id].get("MostRecent") == "1":
             return steam_id
 
 


### PR DESCRIPTION
Fixes an issue where the `read_steam_config()` function tries to check for a Steam `mostrecent` using an all lowercase configuration key when the configuration key itself is camel cased (`MostRecent`) in the `localusers.vdf` file.

Fixes #3219
