### PR TITLE
Dedicated Proton runner

### DIFF
--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     # Microsoft based
     "wine",
     "winesteam",
+    "proton",
     "dosbox",
     # Multi-system
     "mame",

--- a/lutris/runners/proton.py
+++ b/lutris/runners/proton.py
@@ -1,0 +1,110 @@
+"""Runner for Proton"""
+# Standard Library
+import os
+import stat
+
+# Lutris Modules
+from lutris.runners.runner import Runner
+from lutris.util import system
+
+
+class proton(Runner):
+    description = "Runs Windows games in Valve's Proton"
+    human_name  = "Proton"
+    platforms   = "Windows"
+    multiple_versions = True
+    entry_point_option = "exe"
+
+    game_options = [
+        {
+            "option": "exe",
+            "type": "file",
+            "label": "Executable",
+            "help": "The game's main EXE file",
+        },
+        {
+            "option": "working_dir",
+            "type": "directory_chooser",
+            "label": "Working directory",
+            "help": 
+                "The location where the game is run from.\n"
+                "By default, Lutris uses the directory of the "
+                "executable.",
+        },
+        {
+            "option": "compatdata",
+            "type": "directory_chooser",
+            "label": "Proton compat data",
+            "help": 
+                'The compatdata directory used by Proton.\n'
+                "It's a directory containing a wine prefix "
+                "and extra Proton specific files",
+        },
+    ]
+
+    def __init__(self, config=None):
+        super(proton, self).__init__(config)
+
+    @property
+    def game_exe(self):
+        """Return the game's executable's path."""
+        exe = self.game_config.get("exe")
+        if not exe:
+            return
+        if os.path.isabs(exe):
+            return exe
+        if self.game_path:
+            return os.path.join(self.game_path, exe)
+        return system.find_executable(exe)
+
+    def get_relative_exe(self):
+        """Return a relative path if a working dir is set in the options
+        Some games such as Unreal Gold fail to run if given the absolute path
+        """
+        exe_path = self.game_exe
+        working_dir = self.game_config.get("working_dir")
+        if working_dir:
+            parts = exe_path.split(os.path.expanduser(working_dir))
+            if len(parts) == 2:
+                return "." + parts[1]
+        return exe_path
+
+    @property
+    def working_dir(self):
+        """Return the working directory to use when running the game."""
+        option = self.game_config.get("working_dir")
+        if option:
+            return os.path.expanduser(option)
+        if self.game_exe:
+            return os.path.dirname(self.game_exe)
+        return super(proton, self).working_dir
+
+    def is_installed(self):
+        return True
+
+
+    def play(self):
+        launch_info = {}
+
+
+        if not self.game_exe or not system.path_exists(self.game_exe):
+            return {"error": "FILE_NOT_FOUND", "file": self.game_exe}
+
+        # Quit if the file is not executable
+        mode = os.stat(self.game_exe).st_mode
+        if not mode & stat.S_IXUSR:
+            return {"error": "NOT_EXECUTABLE", "file": self.game_exe}
+
+        if not system.path_exists(self.game_exe):
+            return {"error": "FILE_NOT_FOUND", "file": self.game_exe}
+
+
+
+        command = [(self.runner_config.get("proton_exe"))]
+        command.append("run")
+        command.append(self.game_config.get("exe"))
+
+        launch_info["command"] = command
+        return launch_info
+
+


### PR DESCRIPTION
Hi Team,

I've added a very basic runner to Lutris for Valve's Proton.
It's far from ready for release (I wrote it in about an hour, copying most of the code from the linux runner), but I wanted to send this to you now to make sure you were open to the idea of a runner for Proton, separate from the normal Wine runner. If you're open to it, let me know and I'll keep working on it myself (unless you want to take it over).

Despite the current Wine runner being able to use installed Proton versions, it's not a true Proton implementation.
Proton includes a Python startup script that makes various modifications to the wine prefix before running the Windows exe, you can find it here: https://github.com/ValveSoftware/Proton/blob/proton_5.13/proton

To correctly run a game in Proton, you need to use the command
`STEAM_COMPAT_DATA_PATH=/<path to compatdata>/ /<path to proton>/proton run /<path to exe>/game.exe`
The compat data folder is basically a few Proton specific files, plus a modified wine prefix.

My runner implements the above command.
Since it's still very early days, you have to set the STEAM_COMPAT_DATA_PATH env var in the system options for your game.
Then add your windows executable and Proton startup script file to the game options.
The Proton script will usually be installed at `~/.local/share/Steam/steamapps/common/Proton*/proton` by default.

The main reason I want a true Proton runner is because of the Steam VR related tweaks it implements, which allow a game running in Proton to communicate with native Steam VR for Linux. This would fix #1459.

Please let me know if you'd merge a dedicated Proton runner, and if so, I'll get this up to a releasable state.

Cheers.