### PR TITLE
use spdx license id

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -5,6 +5,6 @@ Upstream-Source: https://github.com/lutris
 
 Files: *
 Copyright: 2009-2020 Mathieu Comandon <strider@strycore.com>
-License: GPL-3
+License: GPL-3.0-or-later
  On Debian systems, the complete text of the General Public License version 3
  can be found in "/usr/share/common-licenses/GPL-3".

--- a/share/metainfo/net.lutris.Lutris.metainfo.xml
+++ b/share/metainfo/net.lutris.Lutris.metainfo.xml
@@ -2,8 +2,8 @@
 <!-- Copyright 2020 Lutris -->
 <component type="desktop">
   <id>net.lutris.Lutris</id>
-  <project_license>GPL-3.0</project_license>
-  <metadata_license>GPL-3.0</metadata_license>
+  <project_license>GPL-3.0-or-later</project_license>
+  <metadata_license>GPL-3.0-or-later</metadata_license>
   <translation type="gettext">lutris</translation>
   <developer_name translatable="no">Lutris Team</developer_name>
   <update_contact>strider@lutris.net</update_contact>


### PR DESCRIPTION
Fixes this lintian warning:
```
W: lutris source: inconsistent-appstream-metadata-license share/metainfo/net.lutris.Lutris.metainfo.xml (gpl-3.0 != gpl-3)
```
For more on SPDX IDs see here: https://spdx.dev/ids/