### PR TITLE
Add appstream dependency to control file

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,6 +3,7 @@ Section: games
 Priority: optional
 Maintainer: Mathieu Comandon <strider@strycore.com>
 Build-Depends: debhelper-compat (= 12),
+               appstream,
                dh-sequence-python3,
                meson,
 Rules-Requires-Root: no


### PR DESCRIPTION
@stephanlachnit 
Is that Ok?
It fails to [build](https://launchpadlibrarian.net/506261860/buildlog_ubuntu-focal-amd64.lutris_0.5.8+git4449-1a44b28c~ubuntu20.04.1_BUILDING.txt.gz) without appstream dependency.