### PR TITLE
Set name property on LutrisWindow

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -66,6 +66,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
             default_width=width,
             default_height=height,
             window_position=Gtk.WindowPosition.NONE,
+            name="lutris",
             icon_name="lutris",
             application=application,
             **kwargs


### PR DESCRIPTION
this creates a top-level id which can be used as a CSS selector for application-specific overrides in the user's `gtk.css`:

![20201115_12h25m45s_grim](https://user-images.githubusercontent.com/454825/99193366-1cd35680-273e-11eb-82b4-5248bb949a00.png)

afterwards, app-specific overrides can be easily specified:

```css
#lutris .sidebar row {
  border-radius: 0;
}
```