### PR TITLE
runners: add gstreamer library path to wine runner

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -886,6 +886,7 @@ class wine(Runner):
             env["WINEDEBUG"] = show_debug
         env["WINEARCH"] = self.wine_arch
         env["WINE"] = self.get_executable()
+        env["GST_PLUGIN_SYSTEM_PATH_1_0"] = os.path.join(WINE_DIR, self.get_version(), "lib64/gstreamer-1.0/") + ":" + os.path.join(WINE_DIR, self.get_version(), "lib/gstreamer-1.0/")
         if self.prefix_path:
             env["WINEPREFIX"] = self.prefix_path
 


### PR DESCRIPTION
this allows builds which utilize mfplat + gstreamer to play mfplat videos correctly, if they are known working (this does not fix mfplat games that are already known to be broken even with current gstreamer work)