### PR TITLE
lutris: remove proton support from lutris

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -219,17 +219,6 @@ class steam(Runner):
     def get_steamapps_dirs(self):
         """Return a list of the Steam library main + custom folders."""
         dirs = []
-        # Extra colon-separated compatibility tools dirs environment variable
-        if 'STEAM_EXTRA_COMPAT_TOOLS_PATHS' in os.environ:
-            dirs += os.getenv('STEAM_EXTRA_COMPAT_TOOLS_PATHS').split(':')
-        # Main steamapps dir and compatibilitytools.d dir
-        for data_dir in STEAM_DATA_DIRS:
-            for _dir in ["steamapps", "compatibilitytools.d"]:
-                abs_dir = os.path.join(os.path.expanduser(data_dir), _dir)
-                abs_dir = system.fix_path_case(abs_dir)
-                if abs_dir and os.path.isdir(abs_dir):
-                    dirs.append(abs_dir)
-
         # Custom dirs
         steam_config = self.get_steam_config()
         if steam_config:

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -26,7 +26,7 @@ from lutris.util.wine.prefix import WinePrefixManager, find_prefix
 from lutris.util.wine.wine import (
     POL_PATH, WINE_DIR, WINE_PATHS, detect_arch, display_vulkan_error, esync_display_limit_warning,
     esync_display_version_warning, fsync_display_support_warning, fsync_display_version_warning, get_default_version,
-    get_overrides_env, get_proton_paths, get_real_executable, get_system_wine_version, get_wine_versions,
+    get_overrides_env, get_real_executable, get_system_wine_version, get_wine_versions,
     is_esync_limit_set, is_fsync_supported, is_version_esync, is_version_fsync
 )
 from lutris.util.wine.x360ce import X360ce
@@ -551,8 +551,6 @@ class wine(Runner):
     def context_menu_entries(self):
         """Return the contexual menu entries for wine"""
         menu_entries = [("wineexec", _("Run EXE inside wine prefix"), self.run_wineexec)]
-        if "Proton" not in self.get_version():
-            menu_entries.append(("winecfg", _("Wine configuration"), self.run_winecfg))
         menu_entries += [
             ("wineshell", _("Open Bash terminal"), self.run_wine_terminal),
             ("wineconsole", _("Open Wine console"), self.run_wineconsole),
@@ -626,10 +624,6 @@ class wine(Runner):
         # logger.debug("Getting path for Wine %s", version)
         if version in WINE_PATHS.keys():
             return system.find_executable(WINE_PATHS[version])
-        if "Proton" in version:
-            for proton_path in get_proton_paths():
-                if os.path.isfile(os.path.join(proton_path, version, "dist/bin/wine")):
-                    return os.path.join(proton_path, version, "dist/bin/wine")
         if version.startswith("PlayOnLinux"):
             version, arch = version.split()[1].rsplit("-", 1)
             return os.path.join(POL_PATH, "wine", "linux-" + arch, version, "bin/wine")
@@ -913,9 +907,6 @@ class wine(Runner):
         wine_root = None
         if WINE_DIR:
             wine_root = os.path.dirname(os.path.dirname(wine_path))
-        for proton_path in get_proton_paths():
-            if proton_path in wine_path:
-                wine_root = os.path.dirname(os.path.dirname(wine_path))
         if "-4." in wine_path or "/4." in wine_path:
             version = "Ubuntu-18.04"
         else:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -35,28 +35,6 @@ def get_playonlinux():
         return pol_path
     return None
 
-
-def _iter_proton_locations():
-    """Iterate through all existing Proton locations"""
-    for path in [os.path.join(p, "common") for p in steam().get_steamapps_dirs()]:
-        if os.path.isdir(path):
-            yield path
-    for path in [os.path.join(p, "") for p in steam().get_steamapps_dirs()]:
-        if os.path.isdir(path):
-            yield path
-
-
-def get_proton_paths():
-    """Get the Folder that contains all the Proton versions. Can probably be improved"""
-    paths = set()
-    for path in _iter_proton_locations():
-        proton_versions = [p for p in os.listdir(path) if "Proton" in p]
-        for version in proton_versions:
-            if system.path_exists(os.path.join(path, version, "dist/bin/wine")):
-                paths.add(path)
-    return list(paths)
-
-
 POL_PATH = get_playonlinux()
 
 
@@ -168,18 +146,6 @@ def get_lutris_wine_versions():
     return versions
 
 
-def get_proton_versions():
-    """Return the list of Proton versions installed in Steam"""
-    versions = []
-    for proton_path in get_proton_paths():
-        proton_versions = [p for p in os.listdir(proton_path) if "Proton" in p]
-        for version in proton_versions:
-            path = os.path.join(proton_path, version, "dist/bin/wine")
-            if os.path.isfile(path):
-                versions.append(version)
-    return versions
-
-
 def get_pol_wine_versions():
     """Return the list of wine versions installed by Play on Linux"""
     if not POL_PATH:
@@ -201,7 +167,6 @@ def get_wine_versions():
     versions = []
     versions += get_system_wine_versions()
     versions += get_lutris_wine_versions()
-    versions += get_proton_versions()
     versions += get_pol_wine_versions()
     return versions
 
@@ -283,7 +248,7 @@ def is_version_esync(path):
         logger.error("Invalid path '%s'", path)
         return False
     version_number, version_prefix, version_suffix = parse_version(version)
-    esync_compatible_versions = ["esync", "lutris", "tkg", "ge", "proton"]
+    esync_compatible_versions = ["esync", "lutris", "tkg", "ge"]
     for esync_version in esync_compatible_versions:
         if esync_version in version_prefix or esync_version in version_suffix:
             return True
@@ -315,7 +280,7 @@ def is_version_fsync(path):
         logger.error("Invalid path '%s'", path)
         return False
     _, version_prefix, version_suffix = parse_version(version)
-    fsync_compatible_versions = ["fsync", "lutris", "ge", "proton"]
+    fsync_compatible_versions = ["fsync", "lutris", "ge"]
     for fsync_version in fsync_compatible_versions:
         if fsync_version in version_prefix or fsync_version in version_suffix:
             return True


### PR DESCRIPTION
Reasons for doing this:

1. As of Proton 5.13, Proton uses a new runtime which runs in its own container.
Due to this, it is no longer viable or recommended to run proton outside of steam.

2. Additionally, neither the old Proton versions nor the new versions properly
generate the wine prefix in the standard way because they do not ship with wineboot.
So if someone removes their prefix then runs a game with proton, it will not properly
correct a new prefix.

3. Lastly, the proton script uses specific environment variables which are not in place
when running proton directly by the wine executable within it, such as the
steam game ID, gstreamer variables, wine username, and others which are important to the
Proton-specific environment.

4. Since lutris does not run proton games using the lutris script, as mentioned it does not use important environment variables. Not specifying the steam game ID can lead to game-specific fixes not working. Proton also requires a custom patch and WINEUSERNAME defined alongside the patch in order to save to any user other than 'steamuser'. And lastly, it needs the gstreamer library envvar defined so that mfplat games can play. I have submitted other PRs for the gstreamer stuff to work in lutris already.