### PR TITLE
Added small_image to Discord rich presence

### DIFF
--- a/lutris/discord.py
+++ b/lutris/discord.py
@@ -96,7 +96,8 @@ class DiscordPresence(object):
                 state_text = "via %s" % self.runner_name if self.show_runner else "  "
                 logger.info("Attempting to update Discord status: %s, %s", self.game_name, state_text)
                 self.rpc_client.update(details="Playing %s" % self.game_name, state=state_text,
-                                       large_image="large_image", large_text="Using Lutris")
+                                       large_image="large_image", large_text="Using Lutris",
+                                       small_image="small_image")
             except PyPresenceException as ex:
                 logger.error("Unable to update Discord: %s", ex)
 


### PR DESCRIPTION
Added a `small_image` to the Discord rich presence you can add by adding a `small_image` asset to your Rich Presence Assets of a custom rich presence.

For example following settings
![Screenshot_20201218_013313](https://user-images.githubusercontent.com/32276754/102559796-015ac300-40d1-11eb-9524-a3d3cef3ad46.png)
would result in
![Screenshot_20201218_013247](https://user-images.githubusercontent.com/32276754/102559760-f142e380-40d0-11eb-896d-1caf1262f256.png)
