### PR TITLE
Add fsync2 support detection.

### DIFF
--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -11,10 +11,6 @@ import subprocess
 
 __all__ = ('is_fsync_supported',)
 
-###############
-# futex stuff #
-###############
-
 
 # pylint: disable=invalid-name,too-few-public-methods
 class timespec(ctypes.Structure):
@@ -189,11 +185,6 @@ def _get_futex_syscall():
     return _futex_syscall
 
 
-#################################
-# FUTEX_WAIT_MULTIPLE functions #
-#################################
-
-
 def _get_futex_wait_multiple_op(futex_syscall):
     ret = futex_syscall(None, 31, 0, None, None, 0)
     if ret[1] != errno.ENOSYS:
@@ -230,11 +221,6 @@ def is_futex_wait_multiple_supported():
     )[1] != errno.ENOSYS
 
 
-####################
-# futex2 detection #
-####################
-
-
 @functools.lru_cache(1)
 def is_futex2_supported():
     '''Checks whether the Linux futex2 syscall is supported on this
@@ -251,11 +237,6 @@ def is_futex2_supported():
     except OSError:
         return False
     return True
-
-
-##########################
-# Combined support check #
-##########################
 
 
 @functools.lru_cache(1)

--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -250,21 +250,9 @@ def is_futex_wait_multiple_supported():
         Whether this kernel supports the FUTEX_WAIT_MULTIPLE operation.
     """
     try:
-        futex_syscall = _get_futex_syscall()
-        futex_wait_multiple_op = _get_futex_wait_multiple_op(futex_syscall)
+        return _get_futex_wait_multiple_op(_get_futex_syscall()) is not None
     except (AttributeError, RuntimeError):
         return False
-    if futex_wait_multiple_op is None:
-        return False
-
-    return futex_syscall(
-        None,
-        futex_wait_multiple_op,
-        0,
-        None,
-        None,
-        0
-    )[1] != errno.ENOSYS
 
 
 @functools.lru_cache(None)

--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -232,6 +232,12 @@ def _get_futex_syscall():
 
 
 def _get_futex_wait_multiple_op(futex_syscall):
+    """Detects which (if any) futex opcode is used for the
+    FUTEX_WAIT_MULTIPLE operation on this kernel.
+
+    Returns:
+        The opcode number, or None if the operation is not supported.
+    """
     ret = futex_syscall(None, 31, 0, None, None, 0)
     if ret[1] != errno.ENOSYS:
         return 31
@@ -275,4 +281,10 @@ def is_futex2_supported():
 
 @functools.lru_cache(None)
 def is_fsync_supported():
+    """Checks whether the FUTEX_WAIT_MULTIPLE operation or the futex2
+    syscall is supported on this kernel.
+
+    Returns:
+        The result of the check.
+    """
     return is_futex_wait_multiple_supported() or is_futex2_supported()

--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -195,7 +195,7 @@ def _get_futex_wait_multiple_op(futex_syscall):
     return None
 
 
-@functools.lru_cache(1)
+@functools.lru_cache(None)
 def is_futex_wait_multiple_supported():
     '''Checks whether the Linux futex FUTEX_WAIT_MULTIPLE operation is
     supported on this kernel.
@@ -221,7 +221,7 @@ def is_futex_wait_multiple_supported():
     )[1] != errno.ENOSYS
 
 
-@functools.lru_cache(1)
+@functools.lru_cache(None)
 def is_futex2_supported():
     '''Checks whether the Linux futex2 syscall is supported on this
     kernel.
@@ -239,6 +239,6 @@ def is_futex2_supported():
     return True
 
 
-@functools.lru_cache(1)
+@functools.lru_cache(None)
 def is_fsync_supported():
     return is_futex_wait_multiple_supported() or is_futex2_supported()


### PR DESCRIPTION
Patches for futex2/fsync2 are already circulating, and some members of the Discord are already using it.
Add support for detecting an fsync2-compatible kernel.

This PR also fixes the caching of the FUTEX_WAIT_MULTIPLE check.