### PR TITLE
Adding gog language installer selection by locale

### DIFF
--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -70,6 +70,7 @@ class GOGService(OnlineService):
     name = _("GOG")
     icon = "gog"
     has_extras = True
+    has_lang_packs = False
     medias = {
         "banner_small": GogSmallBanner,
         "banner": GogMediumBanner,
@@ -322,6 +323,7 @@ class GOGService(OnlineService):
 
         # Filter out Mac installers
         gog_installers = [installer for installer in downloads["installers"] if installer["os"] != "mac"]
+        gog_lang_packs = [language_pack for language_pack in downloads["language_packs"] if language_pack["os"] != "mac"]
         available_platforms = {installer["os"] for installer in gog_installers}
         # If it's a Linux game, also filter out Windows games
         if "linux" in available_platforms:
@@ -330,9 +332,17 @@ class GOGService(OnlineService):
             else:
                 filter_os = "linux"
             gog_installers = [installer for installer in gog_installers if installer["os"] != filter_os]
-
+            gog_lang_packs = [language_pack for language_pack in gog_lang_packs if language_pack["os"] != filter_os]
         language = self.determine_language_installer(gog_installers, language)
         gog_installers = [installer for installer in gog_installers if installer["language"] == language]
+        gog_lang_packs = [language_pack for language_pack in gog_lang_packs if language_pack["language"] == language]
+        if gog_lang_packs:
+            self.has_lang_packs = True
+            for language_pack in gog_lang_packs:
+                for files in language_pack["files"]:
+                    gog_installer_files = gog_installers[0]["files"]
+                    gog_installer_files.append(files)
+                    gog_installers[0]["files"] = gog_installer_files
         return gog_installers
 
     def determine_language_installer(self, gog_installers, default_language):

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -70,7 +70,6 @@ class GOGService(OnlineService):
     name = _("GOG")
     icon = "gog"
     has_extras = True
-    has_lang_packs = False
     medias = {
         "banner_small": GogSmallBanner,
         "banner": GogMediumBanner,
@@ -323,7 +322,6 @@ class GOGService(OnlineService):
 
         # Filter out Mac installers
         gog_installers = [installer for installer in downloads["installers"] if installer["os"] != "mac"]
-        gog_lang_packs = [language_pack for language_pack in downloads["language_packs"] if language_pack["os"] != "mac"]
         available_platforms = {installer["os"] for installer in gog_installers}
         # If it's a Linux game, also filter out Windows games
         if "linux" in available_platforms:
@@ -332,17 +330,9 @@ class GOGService(OnlineService):
             else:
                 filter_os = "linux"
             gog_installers = [installer for installer in gog_installers if installer["os"] != filter_os]
-            gog_lang_packs = [language_pack for language_pack in gog_lang_packs if language_pack["os"] != filter_os]
+
         language = self.determine_language_installer(gog_installers, language)
         gog_installers = [installer for installer in gog_installers if installer["language"] == language]
-        gog_lang_packs = [language_pack for language_pack in gog_lang_packs if language_pack["language"] == language]
-        if gog_lang_packs:
-            self.has_lang_packs = True
-            for language_pack in gog_lang_packs:
-                for files in language_pack["files"]:
-                    gog_installer_files = gog_installers[0]["files"]
-                    gog_installer_files.append(files)
-                    gog_installers[0]["files"] = gog_installer_files
         return gog_installers
 
     def determine_language_installer(self, gog_installers, default_language):

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -2,6 +2,7 @@
 import json
 import os
 import time
+import lutris.util.i18n as i18n
 from collections import defaultdict
 from gettext import gettext as _
 from urllib.parse import parse_qsl, urlencode, urlparse
@@ -330,10 +331,18 @@ class GOGService(OnlineService):
                 filter_os = "linux"
             gog_installers = [installer for installer in gog_installers if installer["os"] != filter_os]
 
-        # Keep only the english installer until we have locale detection
-        # and / or language selection implemented
+        language = self.determine_language_installer(gog_installers, language)
         gog_installers = [installer for installer in gog_installers if installer["language"] == language]
         return gog_installers
+
+    def determine_language_installer(self, gog_installers, default_language):
+        """Return locale language string if available in gog_installers"""
+
+        language = i18n.get_lang()
+        gog_installers = [installer for installer in gog_installers if installer["language"] == language]
+        if not gog_installers:
+            language = default_language
+        return language
 
     def query_download_links(self, download):
         """Convert files from the GOG API to a format compatible with lutris installers"""


### PR DESCRIPTION
Hey there,

I used this cool feature of automatically downloading gog files the first time for Witcher III. It worked great, but as I ran the game, I noticed that spoken language is english. I remembered that they told this in the news back then. 

However, I think this little patch can hopefully do the trick.