### PR TITLE
Use case-folding for alphabetical sorting

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -252,8 +252,8 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     @property
     def sort_params(self):
-        _sort_params = [("installed", "DESC")]
-        _sort_params.append((self.view_sorting, "ASC" if self.view_sorting_ascending else "DESC"))
+        _sort_params = [("installed", "COLLATE NOCASE DESC")]
+        _sort_params.append((self.view_sorting, "COLLATE NOCASE ASC" if self.view_sorting_ascending else "COLLATE NOCASE DESC"))
         return _sort_params
 
     def get_running_games(self):


### PR DESCRIPTION
### About
This PR fixes case-folding for alphabetical sorting in the Lutris GUI. Game titles starting with capital and lower case letters are sorted together. This sorting is applied to the grid and list views, and when using the search function.

<img src="https://user-images.githubusercontent.com/7732292/105871392-89e65080-5ff9-11eb-9c39-e6ad364b6e52.png" width="400">

<img src="https://user-images.githubusercontent.com/7732292/105871310-76d38080-5ff9-11eb-9a8c-14b791cbabf5.png" width="400">

### Tests
This PR passes both the style-checks and the test suite.

### Limitations
Unicode characters are not sorted sorted correctly. This is a limitation of `COLLATE NOCASE` which only can collate ASCII characters. To enable Unicode collation the [ICU](https://www.sqlite.org/src/artifact?ci=trunk&filename=ext/icu/README.txt) extension or similar must be enabled.

Also, not installed games are sorted after installed games in the Lutris GUI since they are fetched by a different function and appended to the view.