### PR TITLE
if RADV_DEBUG already exists and is not empty just append "zerovram"

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -893,8 +893,13 @@ class wine(Runner):
         # On AMD, mimic the video memory management behavior of Windows DX12
         # drivers more closely, otherwise d3d12 games will crash and have other
         # funky issues.
+        # RADV_DEBUG is a comma separated list. If it is already set, we want to
+        # append to it.
         if self.runner_config.get("dxvk") and drivers.is_amd():
-            env["RADV_DEBUG"] = "zerovram"
+            if "RADV_DEBUG" not in env or not env["RADV_DEBUG"]:
+                env["RADV_DEBUG"] = "zerovram"
+            elif "zerovram" not in env["RADV_DEBUG"]:
+                env["RADV_DEBUG"] += ",zerovram"
 
         overrides = self.get_dll_overrides()
         if overrides:


### PR DESCRIPTION
if user sets a value for RADV_DEBUG, "zerovram" is appended to it (if its not already in the list).
This prevents user RADV_DEBUG value from being overwritten