### PR TITLE
Add datafields to JSON output

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -21,6 +21,8 @@ import os
 import signal
 import sys
 import tempfile
+
+from datetime import datetime, timedelta
 from gettext import gettext as _
 
 import gi
@@ -556,6 +558,9 @@ class Application(Gtk.Application):
                 "name": game["name"],
                 "runner": game["runner"],
                 "platform": game["platform"],
+                "year": game["year"],
+                "playtime": str(timedelta(hours=game["playtime"])),
+                "lastplayed": str(datetime.fromtimestamp(game["lastplayed"])),
                 "directory": game["directory"],
             } for game in game_list
         ]


### PR DESCRIPTION
This PR add the following datafields to the JSON output: `year`, `playtime` and `lastplayed`. I have tried to make the date and time fields human readable, while still making them easy to parse for programs using the output.

Sample output:
```sh
[
  {
    "id": 1,
    "slug": "supertux",
    "name": "SuperTux",
    "runner": "linux",
    "platform": "Linux",
    "year": 2003,
    "playtime": "0:19:14",
    "lastplayed": "2021-02-12 16:24:04",
    "directory": "/home/lutris/Games/supertux"
  }
]
```
