### PR TITLE
Fix process monitoring

### DIFF
--- a/share/lutris/bin/lutris-wrapper
+++ b/share/lutris/bin/lutris-wrapper
@@ -164,7 +164,7 @@ def main():
             time.sleep(0.1)
         reap_children()
         #  The game is no longer running. We kill other processes
-        for child in watcher.iterate_monitored_processes():
+        for child in watcher.iterate_processes():
             kill_pid(child.pid)
         reap_children()
     except NoMoreChildren:


### PR DESCRIPTION
Current master fails when running a game:

```
Traceback (most recent call last):
  File "/usr/share/lutris/bin/lutris-wrapper", line 190, in <module>
    main()
  File "/usr/share/lutris/bin/lutris-wrapper", line 167, in main
    for child in watcher.iterate_monitored_processes():
AttributeError: 'ProcessWatcher' object has no attribute 'iterate_monitored_processes'
```