### PR TITLE
Fix Python 3.9 compatibility

### DIFF
--- a/lutris/util/wine/cabinstall.py
+++ b/lutris/util/wine/cabinstall.py
@@ -124,7 +124,7 @@ class CabInstaller:
         arch = self.get_arch_from_manifest(root)
         registry_keys = root.findall("{urn:schemas-microsoft-com:asm.v3}registryKeys")
         if registry_keys:
-            for registry_key in registry_keys[0].getchildren():
+            for registry_key in list(registry_keys[0]):
                 key = self.process_key(registry_key.attrib["keyName"])
                 out += "[%s]\n" % key
                 for reg_value in registry_key.findall("{urn:schemas-microsoft-com:asm.v3}registryValue"):


### PR DESCRIPTION
The following line can cause issues, because xml.etree.ElementTree.Element.getchildren is deprecated and was removed in python 3.9, [see](https://docs.python.org/3.8/library/xml.etree.elementtree.html#xml.etree.ElementTree.Element.getchildren).

The basis of this cabinstall class [here](https://github.com/tonix64/python-installcab/blob/7f7ac03e4359115568eeaf3ed7571bd7522d9083/installcab.py#L174) already fixed it.