### PR TITLE
incompatible runners won't get downloaded anymore

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -348,13 +348,13 @@ class Runner:  # pylint: disable=too-many-public-methods
         if len(runner_info_for_provided_version) != 0:
             logger.info("Using provided version compatible for architecture")
             return runner_info_for_provided_version[0]
-        elif len(compatible_runner_versions) > 0:
+        if len(compatible_runner_versions) > 0:
             logger.info("Using latest version compatible for architecture")
             return compatible_runner_versions[len(compatible_runner_versions) - 1]
-        else:
-            logger.error(
-                "The architecture of the system does not match any runner architecture currently provided by Lutris.net")
-            return {}
+
+        logger.error(
+            "The architecture of the system does not match any runner architecture currently provided by Lutris.net")
+        return {}
 
     def install(self, version=None, downloader=None, callback=None):
         """Install runner using package management systems."""

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -351,9 +351,10 @@ class Runner:  # pylint: disable=too-many-public-methods
         elif len(compatible_runner_versions) > 0:
             logger.info("Using latest version compatible for architecture")
             return compatible_runner_versions[len(compatible_runner_versions) - 1]
-
-        logger.error("The system architecture does not match any architecture currently provided by Lutris.net")
-        return {}
+        else:
+            logger.error(
+                "The architecture of the system does not match any runner architecture currently provided by Lutris.net")
+            return {}
 
     def install(self, version=None, downloader=None, callback=None):
         """Install runner using package management systems."""

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -337,7 +337,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         runner_versions = runner_info.get("versions") or []
 
         compatible_runner_versions = list(
-            filter(lambda runner_version: True if runner_version.get("architecture") == system_architecture else False,
+            filter(lambda runner_version: bool(runner_version.get("architecture") == system_architecture),
                    runner_versions))
 
         logger.debug(compatible_runner_versions)

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -443,9 +443,3 @@ class Runner:  # pylint: disable=too-many-public-methods
                 output = item
                 break
         return output
-
-    def has_system_architecture(runner_info):
-        if runner_info["architecture"] == system.LINUX_SYSTEM.arch:
-            return True
-        else:
-            return False


### PR DESCRIPTION
This should fix the issue https://github.com/lutris/lutris/issues/3367.

I'm not sure if I actually made thinks better but I think it is more readable however it is also very strict and I'm not sure if maybe just thought too simple.

However the basic logic is, 

- filter first for compatible architectures,

- afterwards check if the provided version is in this list of compatible architecture take it if yes and if not take the latest version (assumption array last entry always most recent version)

- otherwise return empty object indicating there is no compatible version on Lutris.net for the users system architecture.

I've checked this by hardcoding the architecture in linux.py. 
