### PR TITLE
Stop download processes on cancel installation

### DIFF
--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -49,6 +49,16 @@ class InstallerFilesBox(Gtk.ListBox):
             else:
                 self.installer_files_boxes[file_id].start()
 
+    def stop_all(self):
+        """Stops all ongoing files gathering.
+        Iterates through installer files, and call the "stop" command
+        if they've been started and not available yet.
+        """
+        self._file_queue.clear()
+        for file_id, file_box in self.installer_files_boxes.items():
+            if file_box.started and file_id not in self.available_files and file_box.stop_func is not None:
+                file_box.stop_func()
+
     @property
     def is_ready(self):
         """Return True if all files are ready to be fetched"""


### PR DESCRIPTION
If the user cancels the installation while downloads are still in progress, they continue in the background even if the installation is now aborted and the window closed. If the user wants to download something else instead, his bandwidth might be a bit short.

This patch takes advantage of the `stop_func` already exposed by individual `InstallerFileBox`instances, alongside with their state, so that the container `InstallerFileBoxes` is able to stop all currently processing downloads.
`InstallerWindow` keeps a ref on this new method and calls it when the user confirms he wants to cancel installation.