### PR TITLE
[Fix CI] linting: unused import

### DIFF
--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -13,7 +13,6 @@ from lutris.gui.dialogs.runner_install import RunnerInstallDialog
 from lutris.gui.dialogs.runners import RunnersDialog
 from lutris.services.base import BaseService
 from lutris.util.jobs import AsyncCall
-from lutris.util.log import logger
 
 TYPE = 0
 SLUG = 1


### PR DESCRIPTION
CI jobs are failing because of: `flake8`: `lutris/gui/widgets/sidebar.py:16:1: F401 'lutris.util.log.logger' imported but unused`