### PR TITLE
Don't follow symlinks when merging directories

### DIFF
--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -207,7 +207,7 @@ def merge_folders(source, destination):
             # logger.debug("Copying %s", filename)
             if not os.path.exists(dst_abspath):
                 os.makedirs(dst_abspath)
-            shutil.copy(os.path.join(dirpath, filename), os.path.join(dst_abspath, filename))
+            shutil.copy(os.path.join(dirpath, filename), os.path.join(dst_abspath, filename), follow_symlinks=False)
 
 
 def remove_folder(path):


### PR DESCRIPTION
I found this bug when I tried to install Grim Fandango Remastered from GOG. The archive contains dangling symlinks for some files in *.../usr/share/doc* and the installation fails with `FileNotFoundError`.

Without `follow_symlinks=False` it also fails for symlinks to directories because `shutil.copy` can only handle regular files.
A smaller issue caused by following symlinks are redundant copies of libraries (e.g. `libexample.so.1.0.0`, `libexample.so.1 -> libexample.so.1.0.0`, `libexample.so -> libexample.so.1.0.0`).