### PR TITLE
Handle private Steam Web API Key (closes #3461)

### DIFF
--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -137,7 +137,11 @@ class ServiceSidebarRow(SidebarRow):
 
     def service_load_cb(self, games, error):
         if not error and not games:
-            error = _("Failed to load games. Check that your profile is set to public during the sync.")
+            error = _(
+                "Failed to load games. "
+                "Check that your profile is set to public during the sync. \n"
+                "You can also provide your private Steam Web API Key in the preferences."
+            )
         if error:
             ErrorDialog(str(error))
         GLib.timeout_add(5000, self.enable_refresh_button)


### PR DESCRIPTION
- Get your own key from https://steamcommunity.com/dev/apikey
- Set the key in lutris preferences
- Get games information even if they are private

Fix #3461