### PR TITLE
Fix service id key in generated GOG installers

### DIFF
--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -469,7 +469,7 @@ class GOGService(OnlineService):
             "slug": details["slug"],
             "game_slug": slugify(db_game["name"]),
             "runner": runner,
-            "humbleid": db_game["appid"],
+            "gogid": db_game["appid"],
             "script": {
                 "game": game_config,
                 "system": system_config,


### PR DESCRIPTION
GOG generated installers currently use `humbleid` but it should be `gogid`.