### PR TITLE
Fix python-magic

### DIFF
--- a/lutris/util/game_finder.py
+++ b/lutris/util/game_finder.py
@@ -12,13 +12,15 @@ except ImportError:
     magic = None
 
 
-if not hasattr(magic, "from_file"):
-    if hasattr(magic, "detect_from_filename"):
-        magic.from_file = magic.detect_from_filename  # pylint: disable=no-member
-        MAGIC_AVAILABLE = True
-    else:
-        logger.error("Your version of python-magic is too old.")
-        MAGIC_AVAILABLE = False
+if not MAGIC_AVAILABLE:
+    logger.error("Magic not available. Unable to automatically find game executables. Please install python-magic")
+else:
+    if not hasattr(magic, "from_file"):
+        if hasattr(magic, "detect_from_filename"):
+            magic.from_file = lambda f: magic.detect_from_filename(f).name  # pylint: disable=no-member
+        else:
+            logger.error("Your version of python-magic is too old.")
+            MAGIC_AVAILABLE = False
 
 
 def is_excluded_elf(filename):


### PR DESCRIPTION
There are two providers for the magic module: the [official file bindings](https://github.com/file/file/tree/master/python) and [ahupp/python-magic](https://github.com/ahupp/python-magic).

Lutris tries to support both by first checking for `magic.from_file` (ahupp) then `magic.detect_from_filename` (official):
- If `magic.detect_from_filename` is found `magic.from_file` is aliased to it, but the APIs are not compatible. The official bindings return a namedtuple while ahupp returns a string. This PR fixes this, tested with official v5.39 and ahupp v4.20.
- If neither is found a message is displayed about python-magic being too old, even when python-magic is not installed. This PR changes this to first check if python-magic is installed and properly inform the user if not.