### PR TITLE
replace bad Yuzu translation

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -3988,7 +3988,7 @@ msgstr "Winesteam Starter (%s)"
 
 #: lutris/runners/yuzu.py:14
 msgid "Yuzu"
-msgstr "Zuzu"
+msgstr "Yuzu"
 
 #: lutris/runners/yuzu.py:15
 msgid "Nintendo Switch"


### PR DESCRIPTION
reported on the lutris discord in #development
the german translation for Yuzu is incorrectly labeled Zuzu