### PR TITLE
Periodically update dxvk_versions.json

### DIFF
--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -1,4 +1,5 @@
 """DXVK helper module"""
+import datetime
 import json
 import os
 import shutil
@@ -19,7 +20,7 @@ def fetch_dxvk_versions():
         os.mkdir(dxvk_path)
     versions_path = os.path.join(dxvk_path, "dxvk_versions.json")
     logger.info("Downloading DXVK releases to %s", versions_path)
-    return download_file(DXVK_RELEASES_URL, versions_path)
+    return download_file(DXVK_RELEASES_URL, versions_path, overwrite=True, max_age=datetime.timedelta(days=1))
 
 
 class UnavailableDXVKVersion(RuntimeError):


### PR DESCRIPTION
Currently the `dxvk_versions.json` file isn't automatically updated as new DXVK versions are released.
This PR adds a new optional parameter to the `download_file()` function that allows us to check for a new version if the local one is old enough. We use it to download the newest version of `dxvk_versions.json` every day.