### PR TITLE
Ubuntu 18.04 x86_64 install from GitHub

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ secretstorage==3.1.2 ; sys_platform == 'linux'
 six==1.15.0
 urllib3==1.25.10
 wrapt==1.12.1
+lxml


### PR DESCRIPTION
This PR is a placeholder for improving the repo, documenting the steps I had to go through using ubuntu 18.04 on x86_64 (amd64)

## Cairo & Python
- if you're interested let me know
## GCC-5
- if you're interested let me know
## Libgirepository
- if you're interested let me know
## LXML

I don't know the lower-bound of lxml, so I've not even attempted to pin the dependency.

I am aware this might need more effort, such as finding that minimum bar.

Let me know if there is interest in documenting this dependency.

Related #3553