### PR TITLE
Fix authentication with GOG

### DIFF
--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -139,6 +139,9 @@ class GOGService(OnlineService):
         self.emit("service-games-loaded")
         return games
 
+    def login_callback(self, url):
+        return self.request_token(url)
+
     def request_token(self, url="", refresh_token=""):
         """Get authentication token from GOG"""
         if refresh_token:


### PR DESCRIPTION
In commit 12d3c550fe321ab71c763e48912ea6cf8dd490e0,
the WebConnectDialog login callback was renamed from request_token
to login_callback, but the change was not implemented for GOGService
and thus broke authentication with GOG.
