### PR TITLE
Let pipewire users toggle "Reduce PulseAudio latency"

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -171,7 +171,7 @@ system_options = [  # pylint: disable=invalid-name
         "label": _("Reduce PulseAudio latency"),
         "default": False,
         "advanced": True,
-        "condition": system.find_executable("pulseaudio"),
+        "condition": system.find_executable("pulseaudio") or system.find_executable("pipewire-pulse"),
         "help": _("Set the environment variable PULSE_LATENCY_MSEC=60 "
                   "to improve audio quality on some games"),
     },


### PR DESCRIPTION
PULSE_LATENCY_MSEC affects pipewire's latency as indicated in the [FAQ](https://gitlab.freedesktop.org/pipewire/pipewire/-/wikis/FAQ#pipewire-buffering-explained)
Certain scripts such as [osu-windows](https://lutris.net/games/install/3548/view) set pulse_latency to true. The problem is that pipewire users can't toggle the setting off unless you create an empty binary that's called pulseaudio inside /usr/bin/.