### PR TITLE
style: fix typo

### DIFF
--- a/lutris/gui/config/services_box.py
+++ b/lutris/gui/config/services_box.py
@@ -4,14 +4,15 @@ from gi.repository import Gtk
 
 from lutris import settings
 from lutris.gui.config.base_config_box import BaseConfigBox
-from lutris.gui.widgets.utils import ICON_SIZE, get_icon
+from lutris.gui.widgets.utils import get_icon
+from lutris.gui.widgets.utils import ICON_SIZE
 from lutris.services import SERVICES
 
 
 class ServicesBox(BaseConfigBox):
     def __init__(self):
         super().__init__()
-        self.add(self.get_section_label(_("Enabled intagrations")))
+        self.add(self.get_section_label(_("Enabled integrations")))
         listbox = Gtk.ListBox(visible=True)
         self.pack_start(listbox, False, False, 12)
 
@@ -29,10 +30,10 @@ class ServicesBox(BaseConfigBox):
             margin_left=12,
             margin_top=12,
             margin_bottom=12,
-            visible=True
+            visible=True,
         )
         service = SERVICES[service_key]
-        pixbuf = get_icon(service.icon, icon_format='pixbuf', size=ICON_SIZE)
+        pixbuf = get_icon(service.icon, icon_format="pixbuf", size=ICON_SIZE)
         if pixbuf:
             icon = Gtk.Image(visible=True)
             icon.set_from_pixbuf(pixbuf)
@@ -45,7 +46,8 @@ class ServicesBox(BaseConfigBox):
         box.pack_start(label, True, True, 0)
 
         checkbox = Gtk.Switch(visible=True)
-        if settings.read_setting(service_key, section="services").lower() == "true":
+        if settings.read_setting(service_key,
+                                 section="services").lower() == "true":
             checkbox.set_active(True)
         checkbox.connect("state-set", self._on_service_change, service_key)
         alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)


### PR DESCRIPTION
Fix a small typo in the Services section of the preferences. Also some light restyling.