### PR TITLE
Additional fixes for log window LOG_BUFFERS access

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -144,7 +144,7 @@ class Game(GObject.Object):
     @property
     def log_buffer(self):
         """Access the log buffer object, creating it if necessary"""
-        _log_buffer = LOG_BUFFERS.get(self.id)
+        _log_buffer = LOG_BUFFERS.get(str(self.id))
         if _log_buffer:
             return _log_buffer
         _log_buffer = Gtk.TextBuffer()
@@ -152,7 +152,7 @@ class Game(GObject.Object):
         if self.game_thread:
             self.game_thread.set_log_buffer(self._log_buffer)
             _log_buffer.set_text(self.game_thread.stdout)
-        LOG_BUFFERS[self.id] = _log_buffer
+        LOG_BUFFERS[str(self.id)] = _log_buffer
         return _log_buffer
 
     @property
@@ -480,8 +480,8 @@ class Game(GObject.Object):
             raise RuntimeError("Tried to launch a game that isn't installed")
         self.load_config()  # Reload the config before launching it.
 
-        if self.id in LOG_BUFFERS:  # Reset game logs on each launch
-            LOG_BUFFERS.pop(self.id)
+        if str(self.id) in LOG_BUFFERS:  # Reset game logs on each launch
+            LOG_BUFFERS.pop(str(self.id))
 
         if not self.runner:
             dialogs.ErrorDialog(_("Invalid game configuration: Missing runner"))


### PR DESCRIPTION
Improves my last commit 'Fix log window not showing logs after game closed' - https://github.com/lutris/lutris/commit/6d56b2ef106564ca31ed3e9501a60df997f315a9

It appears `Game` is inconsistently constructed with game_id as either a `str` or `int` throughout the app and I don't know the best way to fix this, so I'm enforcing LOG_BUFFERS to be keyed by str in every occurrence as a fix for now. Also I didn't want to intruduce new bugs by enforcing str or int in the Game constructor.