### PR TITLE
Make GameBar more HiDPI friendly

### DIFF
--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -10,12 +10,11 @@ from lutris.gui.widgets.utils import get_link_button, get_pixbuf_for_game
 from lutris.util.strings import gtk_safe
 
 
-class GameBar(Gtk.Fixed):
-    play_button_position = (12, 42)
+class GameBar(Gtk.VBox):
 
     def __init__(self, db_game, game_actions, application):
         """Create the game bar with a database row"""
-        super().__init__(visible=True)
+        super().__init__(visible=True, spacing=12)
         GObject.add_emission_hook(Game, "game-start", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-started", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-stopped", self.on_game_state_changed)
@@ -23,6 +22,9 @@ class GameBar(Gtk.Fixed):
         GObject.add_emission_hook(Game, "game-removed", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-installed", self.on_game_state_changed)
 
+        self.set_margin_top(12)
+        self.set_margin_left(12)
+        self.set_margin_right(12)
         self.set_margin_bottom(12)
         self.game_actions = game_actions
         self.db_game = db_game
@@ -63,22 +65,22 @@ class GameBar(Gtk.Fixed):
 
     def update_view(self):
         """Populate the view with widgets"""
-        self.put(self.get_game_name_label(), 16, 8)
-        x_offset = 140
-        y_offset = 40
-        if self.game.is_installed:
-            self.put(self.get_runner_button(), x_offset, y_offset + 2)
-            x_offset += 80
-            self.put(self.get_platform_label(), x_offset, y_offset)
-            x_offset += 120
-        if self.game.lastplayed:
-            self.put(self.get_last_played_label(), x_offset, y_offset)
-            x_offset += 120
-        if self.game.playtime:
-            self.put(self.get_playtime_label(), x_offset, y_offset)
+        self.pack_start(self.get_game_name_label(), False, False, 0)
+
+        row = Gtk.HBox(spacing=12, visible=True)
 
         self.play_button = self.get_play_button()
-        self.put(self.play_button, self.play_button_position[0], self.play_button_position[1])
+        row.pack_start(self.play_button, False, False, 0)
+
+        if self.game.is_installed:
+            row.pack_start(self.get_runner_button(), False, False, 0)
+            row.pack_start(self.get_platform_label(), False, False, 0)
+        if self.game.lastplayed:
+            row.pack_start(self.get_last_played_label(), False, False, 0)
+        if self.game.playtime:
+            row.pack_start(self.get_playtime_label(), False, False, 0)
+
+        self.pack_start(row, True, True, 0)
 
     def get_popover(self, buttons, parent):
         """Return the popover widget containing a list of link buttons"""
@@ -104,6 +106,7 @@ class GameBar(Gtk.Fixed):
     def get_game_name_label(self):
         """Return the label with the game's title"""
         title_label = Gtk.Label(visible=True)
+        title_label.props.halign = Gtk.Align.START
         title_label.set_markup("<span font_desc='16'><b>%s</b></span>" % gtk_safe(self.game.name))
         return title_label
 


### PR DESCRIPTION
Reworked layout in Boxes to maintain spaces between elements. It is needed for various DPI and also for long texts, which could happen on rare occasions. Since I have very little experience with GTK and python, I do not know how to make spacing pixels indepenend as well. Also, I do not remember how I made larger fonts on my computer. Any suggestions to improve is very welcome.

Previous UI for DPI=160:

![1627851269](https://user-images.githubusercontent.com/38703/127785272-5597ffe2-186e-41dd-852a-abea29ff0b72.png)

After fix:

![1627851284](https://user-images.githubusercontent.com/38703/127785275-0a8da846-d770-46ab-9782-d4c546de82ca.png)
