### PR TITLE
Add locale option into the game settings

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -37,6 +37,10 @@ def get_launch_parameters(runner, gameplay_info):
         logger.info("Game launched from steam (AppId: %s)", os.environ["SteamAppId"])
         env["LC_ALL"] = ""
 
+    # Set correct LC_ALL depending on user settings
+    if system_config["locale"] != "":
+        env["LC_ALL"] = system_config["locale"]
+
     # Optimus
     optimus = system_config.get("optimus")
     if optimus == "primusrun" and system.find_executable("primusrun"):

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -29,6 +29,24 @@ def get_resolution_choices():
     return resolution_choices
 
 
+def get_locale_choices():
+    """Return list of available locales as label, value tuples
+    suitable for inclusion in drop-downs.
+    """
+    locales = system.get_locale_list()
+
+    # adds "(recommended)" string to utf8 locales
+    locales_humanized = locales.copy()
+    for index, locale in enumerate(locales_humanized):
+        if "utf8" in locale:
+            locales_humanized[index] += " " + _("(recommended)")
+
+    locale_choices = list(zip(locales_humanized, locales))
+    locale_choices.insert(0, (_("System"), ""))
+
+    return locale_choices
+
+
 def get_output_choices():
     """Return list of outputs for drop-downs"""
     displays = DISPLAY_MANAGER.get_display_names()
@@ -347,6 +365,17 @@ system_options = [  # pylint: disable=invalid-name
         "help": _("The terminal emulator used with the CLI mode. "
                   "Choose from the list of detected terminal apps or enter "
                   "the terminal's command or path."),
+    },
+    {
+        "option": "locale",
+        "type": "choice",
+        "label": _("Locale"),
+        "choices": (
+            get_locale_choices()
+        ),
+        "default": "",
+        "advanced": False,
+        "help": _("Can be used to force certain locale for an app. Fixes encoding issues in legacy software."),
     },
     {
         "option": "env",

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -379,6 +379,14 @@ def get_disk_size(path):
     return total_size
 
 
+def get_locale_list():
+    """Return list of available locales"""
+    locale_getter = subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE)
+    output = locale_getter.communicate()
+    locales = output[0].decode('ASCII').split() # locale names use only ascii characters
+    return locales
+
+
 def get_running_pid_list():
     """Return the list of PIDs from processes currently running"""
     return [p for p in os.listdir("/proc") if p[0].isdigit()]


### PR DESCRIPTION
This allows users to choose a locale for their games from a simple drop down menu. 

If a user has changed locale before using the environment variable setting in game configuration, then this environment variable is more important so this won't break games people already set up before this change.

All locales with `utf8` string are marked as recommended so users who do not have an experience dealing with locales won't choose the wrong one.

![image](https://user-images.githubusercontent.com/25853767/127845352-738765ff-afb5-478c-a504-a3597fa82192.png)
