### PR TITLE
Auto update Collections when modified (Fixes #3620)

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -788,6 +788,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         updated = self.game_store.update(db_game)
         if not updated:
             self.game_store.add_game(db_game)
+        self.on_game_collection_changed(db_game)
         return True
 
     def on_game_collection_changed(self, _sender):


### PR DESCRIPTION
A quick one liner for #3620 to dip my toes in. Also fixes the same issues for un-favouriting a game.

Are the Contributing Guidelines still followed? ```make sc``` fails with two issues seemingly unrelated to my change:
```
pipenv run flake8 lutris
lutris/runners/steam.py:217:5: C901 'steam.get_steamapps_dirs' is too complex (16)
lutris/runners/wine.py:16:1: F401 'lutris.util.graphics.drivers' imported but unused
make: *** [Makefile:90: flake8] Error 1
```

And ```make test``` has a smattering of one reoccurring fail:
```
ImportError: Requiring namespace 'Gtk' version '3.0', but '4.0' is already loaded
```

Cheers,
Tom