### PR TITLE
Show ErrorDialog if installer can't be retrieved.

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -492,10 +492,18 @@ class Application(Gtk.Application):
         if game.service:
             service = get_enabled_services()[game.service]()
             db_game = ServiceGameCollection.get_game(service.id, game.appid)
-            game_id = service.install(db_game)
+
+            try:
+                game_id = service.install(db_game)
+            except ValueError as e:
+                logger.debug(e)
+                game_id = None
+
             if game_id:
                 game = Game(game_id)
                 game.launch()
+            else:
+                ErrorDialog(message=_("Could not retrieve game installer."), parent=self.window)
             return True
         if not game.slug:
             raise ValueError("Invalid game passed: %s" % game)


### PR DESCRIPTION
Hello,

I implemented partial fix for the issue #3679. Lutris crashes when it can't obtain game from instantiated service. In my particular case, it happens because game slug is not in PGA.db `service_games` table. I'm not sure what the underlying issue is exactly, but in any case I think we should inform the user of the error instead of being vague about it.

Kind regards