### PR TITLE
Use CACHE_DIR for banners

### DIFF
--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -23,7 +23,7 @@ CACHE_DIR = os.path.join(GLib.get_user_cache_dir(), "lutris")
 GAME_CONFIG_DIR = os.path.join(CONFIG_DIR, "games")
 
 TMP_PATH = os.path.join(CACHE_DIR, "tmp")
-BANNER_PATH = os.path.join(DATA_DIR, "banners")
+BANNER_PATH = os.path.join(CACHE_DIR, "banners")
 COVERART_PATH = os.path.join(DATA_DIR, "coverart")
 ICON_PATH = os.path.join(GLib.get_user_data_dir(), "icons", "hicolor", "128x128", "apps")
 


### PR DESCRIPTION
This resolves #3625
There's no change to gracefully migrate old banners in this commit, but these can be re-downloaded by going to the "local" tab and pressing the refresh button.