### PR TITLE
Fix invalid syntax error on LMDE 4

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -240,7 +240,8 @@ class steam(Runner):
                 i += 1
 
         # New Custom dirs
-        if library_config := self.get_library_config():
+        library_config = self.get_library_config()
+        if library_config:
             paths = []
             for entry in library_config.values():
                 if "mounted" in entry:


### PR DESCRIPTION
Walrus operator **:=** supported only on python 3.8 an greater, but LMDE which is based on Debian 10 only has python 3.7

- https://docs.python.org/3/whatsnew/3.8.html
- https://linuxmint.com/download_lmde.php