### PR TITLE
Improve read_process_output()

### DIFF
--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -78,14 +78,16 @@ def execute(command, env=None, cwd=None, log_errors=False, quiet=False, shell=Fa
     return stdout.decode(errors="replace").strip()
 
 
-def read_process_output(command, timeout=2):
+def read_process_output(command, timeout=5):
     """Return the output of a command as a string"""
     try:
         return subprocess.check_output(
             command,
-            timeout=timeout
-        ).decode("utf-8", errors="ignore").strip()
-    except (OSError, subprocess.CalledProcessError) as ex:
+            timeout=timeout,
+            encoding="utf-8",
+            errors="ignore"
+        ).strip()
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as ex:
         logger.error("%s command failed: %s", command, ex)
         return ""
 


### PR DESCRIPTION
- Increased timeout from 2 to 5
- Added encoding and errors arguments to check_output(), removed call to decode()
- Added subprocess.TimeoutExpired to except tuple

The changes were made to potentially cover the following scenario (replaced username and hostname for privacy reasons):
[subprocess_check_output_timeout.txt](https://github.com/lutris/lutris/files/7404527/subprocess_check_output_timeout.txt)
