### PR TITLE
Allow value "unset" for SDL_VIDEO_FULLSCREEN_DISPLAY

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -157,8 +157,9 @@ class Runner:  # pylint: disable=too-many-public-methods
             env["SDL_GAMECONTROLLERCONFIG"] = sdl_gamecontrollerconfig
 
         # Set monitor to use for SDL 1 games
-        if self.system_config.get("sdl_video_fullscreen"):
-            env["SDL_VIDEO_FULLSCREEN_DISPLAY"] = self.system_config["sdl_video_fullscreen"]
+        sdl_video_fullscreen = self.system_config.get("sdl_video_fullscreen")
+        if sdl_video_fullscreen and sdl_video_fullscreen != "unset":
+            env["SDL_VIDEO_FULLSCREEN_DISPLAY"] = sdl_video_fullscreen
 
         # DRI Prime
         if self.system_config.get("dri_prime"):

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -42,7 +42,7 @@ def get_output_list():
     """Return a list of output with their index.
     This is used to indicate to SDL 1.2 which monitor to use.
     """
-    choices = [(_("Off"), "off")]
+    choices = [(_("Off"), "off"), (_("Unset"), "unset")]
     displays = DISPLAY_MANAGER.get_display_names()
     for index, output in enumerate(displays):
         # Display name can't be used because they might not be in the right order


### PR DESCRIPTION
For a game I have been setting up ("Die Siedler II" aka "Settlers II"),
in-game fullscreen switching with Alt-Enter only works if
SDL_VIDEO_FULLSCREEN_DISPLAY is not present at all in dosbox's environment.
Even if set to the empty string, resolution switchin won't work and the
1024x768 graphics will look tiny on a modern display.

Add the option "unset" which avoids setting SDL_VIDEO_FULLSCREEN_DISPLAY
altogether.