### PR TITLE
lutris/util/test_config.py: Fix gtk ImportError

### DIFF
--- a/lutris/util/test_config.py
+++ b/lutris/util/test_config.py
@@ -1,5 +1,8 @@
 import os
 
+import gi
+gi.require_version('Gtk', '3.0')
+
 from lutris import startup
 from lutris.database import schema
 


### PR DESCRIPTION
Otherwise I get:
```
importError (Requiring namespace 'Gtk' version '3.0', but '4.0' is already loaded)
```
When running pytest

Signed-off-by: Andrew Ammerlaan <andrewammerlaan@gentoo.org>