### PR TITLE
Update JSON output function to handle empty values

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -583,11 +583,17 @@ class Application(Gtk.Application):
                 "slug": game["slug"],
                 "name": game["name"],
                 "runner": game["runner"],
-                "platform": game["platform"],
-                "year": game["year"],
-                "playtime": str(timedelta(hours=game["playtime"])),
-                "lastplayed": str(datetime.fromtimestamp(game["lastplayed"])),
-                "directory": game["directory"],
+                "platform": game["platform"] or None,
+                "year": game["year"] or None,
+                "directory": game["directory"] or None,
+                "playtime": (
+                    str(timedelta(hours=game["playtime"]))
+                    if game["playtime"] else None
+                ),
+                "lastplayed": (
+                    str(datetime.fromtimestamp(game["lastplayed"]))
+                    if game["lastplayed"] else None
+                )
             } for game in game_list
         ]
         self._print(command_line, json.dumps(games, indent=2))

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -586,6 +586,7 @@ class Application(Gtk.Application):
                 "platform": game["platform"] or None,
                 "year": game["year"] or None,
                 "directory": game["directory"] or None,
+                "hidden": True if game["hidden"] else False,
                 "playtime": (
                     str(timedelta(hours=game["playtime"]))
                     if game["playtime"] else None


### PR DESCRIPTION
This PR is an bugfix for a [PR](https://github.com/lutris/lutris/pull/3426) I got accepted in January 2021.

I have the following changes to the original PR to solve the following problems:
1. Handle keys that can have a value of `None` or `""` from the database. On one of my installs the database started reporting `None` instead of empty strings `""`. This this made Lutris crash when I tried to get the JSON output using the terminal command flag, since my old code expected only empty strings.
2. Replace empty string values from the database with `null` in the JSON output. This makes the JSON output clearer, since all default, empty values are expressed as `null`.
3. Evaluate a `lastplayed` timestamp of 0 from the database as never played instead of an actual timestamp. This stops games that have never been played from reporting their last played date as `1970-01-01 01:00:00` in the JSON output. Do the same with the key `playtime` for consistency.
3. I have also added `hidden` as a date field to the JSON output to enable filtering of installed, hidden games.

Example of a game entry in the JSON output using the this PR:
```json
{
  "id": 120,
  "slug": "valheim",
  "name": "Valheim",
  "runner": "steam",
  "platform": "Linux",
  "year": null,
  "directory": null,
  "hidden": false,
  "playtime": null,
  "lastplayed": null
}

```
Old PR output of the same entry:
```json
{
  "id": 120,
  "slug": "valheim",
  "name": "Valheim",
  "runner": "steam",
  "platform": "Linux",
  "year": null,
  "directory": "",
  "playtime": 0:00:00,
  "lastplayed": 1970-01-01 01:00:00
}
```
In `application.py` both parenthesis and backslashes are used for line continuation. I have used parenthesised in my PR since I felt it was more readable and it conforms with the style recommendations in PEP8.
