### PR TITLE
Fix vk icd filenames

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -177,7 +177,7 @@ class Runner:  # pylint: disable=too-many-public-methods
 
         # Vulkan ICD files
         vk_icd = self.system_config.get("vk_icd")
-        if vk_icd and vk_icd != "off" and system.path_exists(vk_icd):
+        if vk_icd:
             env["VK_ICD_FILENAMES"] = vk_icd
 
         runtime_ld_library_path = None

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -237,7 +237,7 @@ system_options = [  # pylint: disable=invalid-name
     {
         "option": "vk_icd",
         "type": "choice",
-        "default": "",
+        "default": get_vk_icd_choices()[0][1],
         "choices": get_vk_icd_choices,
         "label": _("Vulkan ICD loader"),
         "advanced": True,

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -65,7 +65,7 @@ def get_optirun_choices():
 
 def get_vk_icd_choices():
     """Return available Vulkan ICD loaders"""
-    choices = [(_("Auto"), "")]
+    loaders = []
     icd_files = defaultdict(list)
     # Add loaders
     for data_dir in VULKAN_DATA_DIRS:
@@ -73,10 +73,15 @@ def get_vk_icd_choices():
         for loader in glob.glob(path):
             icd_key = os.path.basename(loader).split(".")[0]
             icd_files[icd_key].append(os.path.join(path, loader))
+            loaders.append(loader)
+
+    loader_files = ":".join(loaders)
+    choices = [(_("Auto"), loader_files)]
 
     for icd_key in icd_files:
         files = ":".join(icd_files[icd_key])
         choices.append((icd_key.capitalize().replace("_icd", " ICD"), files))
+
     return choices
 
 


### PR DESCRIPTION
Currently, Lutris's default value does not set any VK_ICD_FILENAMES value, which defaults to loading 64 bit only ICD loaders on some distros (Fedora). These changes append all possible ICDs into the 'Auto' option and set Auto as the default.

Additionally, currently when an ICD file is selected, it's not actually applied because a file path check is in place, which fails because we are now passing a concatenated list of paths instead of a single file. This PR fixes that. 

> Correctly fixes https://github.com/lutris/lutris/issues/3612
> May fix some games for various users that are reported as not working which are 32 bit (League of Legends)