### PR TITLE
Optimizations in regards to usages of makedir()/makedirs(), empty file creation and copying/merging folders

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -6,6 +6,7 @@ import os
 import shlex
 import shutil
 from gettext import gettext as _
+from pathlib import Path
 
 from gi.repository import GLib
 
@@ -253,8 +254,7 @@ class CommandsMixin:
                 logger.info("Optional path %s not present", src)
                 return
             raise ScriptingError("Source does not exist: %s" % src, params)
-        if not os.path.exists(dst):
-            os.makedirs(dst)
+        os.makedirs(dst, exist_ok=True)
         if os.path.isfile(src):
             # If single file, copy it and change reference in game file so it
             # can be used as executable. Skip copying if the source is the same
@@ -431,8 +431,7 @@ class CommandsMixin:
 
         # Create dir if necessary
         basedir = os.path.dirname(dest_file_path)
-        if not os.path.exists(basedir):
-            os.makedirs(basedir)
+        os.makedirs(basedir, exist_ok=True)
 
         mode = params.get("mode", "w")
         if not mode.startswith(("a", "w")):
@@ -450,15 +449,12 @@ class CommandsMixin:
 
         # Create dir if necessary
         basedir = os.path.dirname(filename)
-        if not os.path.exists(basedir):
-            os.makedirs(basedir)
+        os.makedirs(basedir, exist_ok=True)
 
         merge = params.get("merge", True)
 
-        if not os.path.exists(filename):
-            # create an empty file
-            with open(filename, "a+", encoding='utf-8'):
-                pass
+        # create an empty file if it doesn't exist
+        Path(filename).touch(exist_ok=True)
 
         with open(filename, "r+" if merge else "w", encoding='utf-8') as json_file:
             json_data = {}
@@ -483,8 +479,7 @@ class CommandsMixin:
 
         # Create dir if necessary
         basedir = os.path.dirname(config_file_path)
-        if not os.path.exists(basedir):
-            os.makedirs(basedir)
+        os.makedirs(basedir, exist_ok=True)
 
         merge = params.get("merge", True)
 

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -266,8 +266,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         """Run the pre-installation steps and launch install."""
         if self.target_path and os.path.exists(self.target_path):
             os.chdir(self.target_path)
-        if not os.path.exists(self.cache_path):
-            os.mkdir(self.cache_path)
+        os.makedirs(self.cache_path, exist_ok=True)
 
         # Copy extras to game folder
         for extra in self.extras:

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -240,8 +240,7 @@ class mame(Runner):  # pylint: disable=invalid-name
 
     def write_xml_list(self):
         """Write the full game list in XML to disk"""
-        if not os.path.exists(self.cache_dir):
-            os.makedirs(self.cache_dir)
+        os.makedirs(self.cache_dir, exist_ok=True)
         output = system.execute(
             [self.get_executable(), "-listxml"],
             env=runtime.get_env()

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -135,8 +135,7 @@ class HumbleBundleService(OnlineService):
             with open(cache_filename, encoding='utf-8') as cache_file:
                 return json.load(cache_file)
         response = self.make_api_request(self.api_url + "api/v1/order/%s?all_tpkds=true" % gamekey)
-        if not os.path.exists(self.cache_path):
-            os.makedirs(self.cache_path)
+        os.makedirs(self.cache_path, exist_ok=True)
         with open(cache_filename, "w", encoding='utf-8') as cache_file:
             json.dump(response, cache_file)
         return response

--- a/lutris/util/extract.py
+++ b/lutris/util/extract.py
@@ -277,8 +277,7 @@ def decompress_gz(file_path, dest_path):
         dest_filename = os.path.join(dest_path, os.path.basename(file_path[:-3]))
     else:
         dest_filename = file_path[:-3]
-    if not os.path.exists(os.path.dirname(dest_filename)):
-        os.makedirs(os.path.dirname(dest_filename))
+    os.makedirs(os.path.dirname(dest_filename), exist_ok=True)
 
     with open(dest_filename, "wb") as dest_file:
         gzipped_file = gzip.open(file_path, "rb")

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -1,5 +1,6 @@
 """System utilities"""
 import hashlib
+import inspect
 import os
 import re
 import shutil
@@ -189,7 +190,7 @@ def substitute(string_template, variables):
     identifiers = variables.keys()
 
     # We support dashes in identifiers but they are not valid in python
-    # identifers, which is a requirement for the templating engine we use
+    # identifiers, which is a requirement for the templating engine we use
     # Replace the dashes with underscores in the mapping and template
     variables = dict((k.replace("-", "_"), v) for k, v in variables.items())
     for identifier in identifiers:
@@ -204,22 +205,12 @@ def substitute(string_template, variables):
 def merge_folders(source, destination):
     """Merges the content of source to destination"""
     logger.debug("Merging %s into %s", source, destination)
-    source = os.path.abspath(source)
-    for (dirpath, dirnames, filenames) in os.walk(source):
-        source_relpath = dirpath[len(source):].strip("/")
-        dst_abspath = os.path.join(destination, source_relpath)
-        for dirname in dirnames:
-            new_dir = os.path.join(dst_abspath, dirname)
-            logger.debug("creating dir: %s", new_dir)
-            try:
-                os.mkdir(new_dir)
-            except OSError:
-                pass
-        for filename in filenames:
-            # logger.debug("Copying %s", filename)
-            if not os.path.exists(dst_abspath):
-                os.makedirs(dst_abspath)
-            shutil.copy(os.path.join(dirpath, filename), os.path.join(dst_abspath, filename), follow_symlinks=False)
+    # Check if dirs_exist_ok is defined ( Python >= 3.8)
+    sig = inspect.signature(shutil.copytree)
+    if "dirs_exist_ok" in sig.parameters:
+        shutil.copytree(source, destination, symlinks=False, ignore_dangling_symlinks=True, dirs_exist_ok=True)
+    else:
+        shutil.copytree(source, destination, symlinks=False, ignore_dangling_symlinks=True)
 
 
 def remove_folder(path):
@@ -245,8 +236,7 @@ def create_folder(path):
     if not path:
         return
     path = os.path.expanduser(path)
-    if not os.path.exists(path):
-        os.makedirs(path)
+    os.makedirs(path, exist_ok=True)
     return path
 
 

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -75,15 +75,13 @@ def create_launcher(game_slug, game_id, game_name, desktop=False, menu=False):
     )
 
     if desktop:
-        if not os.path.exists(desktop_dir):
-            os.mkdir(desktop_dir)
+        os.makedirs(desktop_dir, exist_ok=True)
         launcher_path = os.path.join(desktop_dir, launcher_filename)
         logger.debug("Creating Desktop icon in %s", launcher_path)
         shutil.copy(tmp_launcher_path, launcher_path)
     if menu:
         menu_path = os.path.join(GLib.get_user_data_dir(), "applications")
-        if not os.path.exists(menu_path):
-            os.mkdir(menu_path)
+        os.makedirs(menu_path, exist_ok=True)
         launcher_path = os.path.join(menu_path, launcher_filename)
         logger.debug("Creating menu launcher in %s", launcher_path)
         shutil.copy(tmp_launcher_path, launcher_path)


### PR DESCRIPTION
- Replaced instances of:
`if not os.path.exists(dst):
   os.makedir(dst)` (or makedirs)
with:
 `os.makedirs(dst,exist_ok=True)` (Python >= 3.2)
- Replaced empty file creation with Path(file).touch()
- Refactored merge_folders() from lutris/util/system.py to use shutil.copytree()