### PR TITLE
None safety in print_game_json

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -586,7 +586,9 @@ class Application(Gtk.Application):
                 "platform": game["platform"],
                 "year": game["year"],
                 "playtime": str(timedelta(hours=game["playtime"] or 0)),
-                "lastplayed": str(datetime.fromtimestamp(game["lastplayed"])) if game["lastplayed"] is not None else None,
+                "lastplayed": str(datetime.fromtimestamp(game["lastplayed"]))
+                if game["lastplayed"] is not None
+                else None,
                 "directory": game["directory"],
             } for game in game_list
         ]

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -585,8 +585,8 @@ class Application(Gtk.Application):
                 "runner": game["runner"],
                 "platform": game["platform"],
                 "year": game["year"],
-                "playtime": str(timedelta(hours=game["playtime"])),
-                "lastplayed": str(datetime.fromtimestamp(game["lastplayed"])),
+                "playtime": str(timedelta(hours=game["playtime"] or 0)),
+                "lastplayed": str(datetime.fromtimestamp(game["lastplayed"])) if game["lastplayed"] is not None else None,
                 "directory": game["directory"],
             } for game in game_list
         ]


### PR DESCRIPTION
Currently, `lutris -ojl` fails if any `playtime` or `lastplayed` is `None`. This prevents that.