### PR TITLE
Silence bogus "Could not retrieve game installer" dialog

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -502,8 +502,6 @@ class Application(Gtk.Application):
             if game_id:
                 game = Game(game_id)
                 game.launch()
-            else:
-                ErrorDialog(message=_("Could not retrieve game installer."), parent=self.window)
             return True
         if not game.slug:
             raise ValueError("Invalid game passed: %s" % game)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -808,7 +808,6 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     def on_game_activated(self, view, game_id):
         """Handles view activations (double click, enter press)"""
-        initial_game_id = game_id
         if self.service:
             logger.debug("Looking up %s game %s", self.service.id, game_id)
             db_game = games_db.get_game_for_service(self.service.id, game_id)
@@ -837,5 +836,3 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
                 game.emit("game-launch")
             else:
                 game.emit("game-install")
-        else:
-            logger.warning("No game found for %s", initial_game_id)

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -187,7 +187,7 @@ class BaseService(GObject.Object):
         """Install a service game, or starts the installer of the game.
 
         Args:
-            db_name (dict or str): Database fields of the game to add, or (for Lutris service only
+            db_game (dict or str): Database fields of the game to add, or (for Lutris service only
                 the slug of the game.)
 
         Returns:

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -184,7 +184,17 @@ class BaseService(GObject.Object):
         return service_installers
 
     def install(self, db_game):
-        """Install a service game"""
+        """Install a service game, or starts the installer of the game.
+
+        Args:
+            db_name (dict or str): Database fields of the game to add, or (for Lutris service only
+                the slug of the game.)
+
+        Returns:
+            str: The slug of the game that was installed, to be run. None if the game should not be
+                run now. Many installers start from here, but continue running after this returns;
+                they return None.
+        """
         appid = db_game["appid"]
         logger.debug("Installing %s from service %s", appid, self.id)
         if self.local:


### PR DESCRIPTION
This removes two bogus error reports - one is a dialog, the other a log message.

The offending code treats 'None' coming back from the install() method of a game service as an 'installer not found' error, but this is not correct. This method returns 'None' when it has starting an installation, but it is still ongoing.

This PR also adds a comment on the base-class install() method to explain this behavior.

Resolves #3853