### PR TITLE
Tolerate obsolete view_sorting values

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -348,7 +348,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
             if value:
                 return value
             # Users may have obsolete view_sorting settings, so
-            # we must tolerate them. We treat them all all blank.
+            # we must tolerate them. We treat them all as blank.
             return sort_defaults.get(view_sorting, "")
 
         return [

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -340,13 +340,16 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
                 "installed_at": 0.0,
                 "playtime": 0.0,
             }
+            view_sorting = self.view_sorting
             lutris_game = lutris_games.get(game["appid"])
             if not lutris_game:
-                return sort_defaults[self.view_sorting]
-            value = lutris_game[self.view_sorting]
+                return sort_defaults.get(view_sorting, "")
+            value = lutris_game.get(view_sorting)
             if value:
                 return value
-            return sort_defaults[self.view_sorting]
+            # Users may have obsolete view_sorting settings, so
+            # we must tolerate them. We treat them all all blank.
+            return sort_defaults.get(view_sorting, "")
 
         return [
             self.combine_games(game, lutris_games.get(game["appid"])) for game in sorted(


### PR DESCRIPTION
With this fix, Lutris won't crash if an obsolete value is found in the view_sorting setting.

This just uses .get(x, "") instead of [x] to retrieve the sort key. Simple.

In this case the list won't be sorted and no sorting option will be ticked in the menu. But the user can go ahead and select one.

Resolves #3859

