### PR TITLE
Fix the pixbuf loading for the Configure dialog

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -14,8 +14,9 @@ from lutris.gui.config.boxes import GameBox, RunnerBox, SystemBox
 from lutris.gui.dialogs import Dialog, DirectoryDialog, ErrorDialog, QuestionDialog
 from lutris.gui.widgets.common import Label, NumberEntry, SlugEntry, VBox
 from lutris.gui.widgets.notifications import send_notification
-from lutris.gui.widgets.utils import BANNER_SIZE, ICON_SIZE, get_pixbuf, get_pixbuf_for_game
+from lutris.gui.widgets.utils import BANNER_SIZE, ICON_SIZE, get_pixbuf
 from lutris.runners import import_runner
+from lutris.services.lutris import LutrisBanner, LutrisIcon
 from lutris.util import resources, system
 from lutris.util.log import logger
 from lutris.util.strings import slugify
@@ -190,9 +191,9 @@ class GameDialogCommon(Dialog):
 
     def _set_image(self, image_format):
         image = Gtk.Image()
-        size = BANNER_SIZE if image_format == "banner" else ICON_SIZE
+        service_media = LutrisBanner() if image_format == "banner" else LutrisIcon()
         game_slug = self.game.slug if self.game else ""
-        image.set_from_pixbuf(get_pixbuf_for_game(game_slug, size))
+        image.set_from_pixbuf(service_media.get_pixbuf_for_game(game_slug))
         if image_format == "banner":
             self.banner_button.set_image(image)
         else:

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -4,7 +4,7 @@ import time
 from lutris.database.games import get_service_games
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
-from lutris.gui.widgets.utils import get_pixbuf, get_pixbuf_for_game
+from lutris.gui.widgets.utils import get_pixbuf
 from lutris.runners import RUNNER_NAMES
 from lutris.util import system
 from lutris.util.log import logger
@@ -105,9 +105,8 @@ class StoreItem:
                     image_path = self.service_media.get_absolute_path(service_game["slug"])
         if system.path_exists(image_path):
             return get_pixbuf(image_path, self.service_media.size, is_installed=self.installed)
-        return get_pixbuf_for_game(
+        return self.service_media.get_pixbuf_for_game(
             self._game_data["slug"],
-            self.service_media.size,
             self.installed
         )
 

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -6,7 +6,7 @@ from gi.repository import GObject, Gtk, Pango
 from lutris import runners, services
 from lutris.database.games import get_game_by_field, get_game_for_service
 from lutris.game import Game
-from lutris.gui.widgets.utils import get_link_button, get_pixbuf_for_game
+from lutris.gui.widgets.utils import get_link_button
 from lutris.util.strings import gtk_safe
 
 
@@ -94,12 +94,6 @@ class GameBar(Gtk.Fixed):
         popover.set_constrain_to(Gtk.PopoverConstraint.NONE)
         popover.set_relative_to(parent)
         return popover
-
-    def get_icon(self):
-        """Return the game icon"""
-        icon = Gtk.Image.new_from_pixbuf(get_pixbuf_for_game(self.game.slug, (32, 32)))
-        icon.show()
-        return icon
 
     def get_game_name_label(self):
         """Return the label with the game's title"""

--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -123,10 +123,6 @@ def get_default_icon(size):
     return os.path.join(datapath.get(), "media/default_banner.png")
 
 
-def get_pixbuf_for_game(image_abspath, size, is_installed=True):
-    return get_pixbuf(image_abspath, size, fallback=get_default_icon(size), is_installed=is_installed)
-
-
 def convert_to_background(background_path, target_size=(320, 1080)):
     """Converts a image to a pane background"""
     coverart = Image.open(background_path)

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from lutris import settings
 from lutris.database.services import ServiceGameCollection
+from lutris.gui.widgets.utils import get_pixbuf, get_default_icon
 from lutris.util import system
 from lutris.util.http import HTTPError, download_file
 from lutris.util.log import logger
@@ -43,6 +44,10 @@ class ServiceMedia:
 
     def get_url(self, service_game):
         return self.url_pattern % service_game[self.api_field]
+
+    def get_pixbuf_for_game(self, slug, is_installed=True):
+        image_abspath = self.get_absolute_path(slug)
+        return get_pixbuf(image_abspath, self.size, fallback=get_default_icon(self.size), is_installed=is_installed)
 
     def get_media_url(self, details):
         if self.api_field not in details:

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -6,7 +6,7 @@ from typing import Optional
 
 from lutris import settings
 from lutris.database.services import ServiceGameCollection
-from lutris.gui.widgets.utils import get_pixbuf, get_default_icon
+from lutris.gui.widgets.utils import get_default_icon, get_pixbuf
 from lutris.util import system
 from lutris.util.http import HTTPError, download_file
 from lutris.util.log import logger


### PR DESCRIPTION
The get_pixbuf_for_game method gets a slug every time- but it needs a path. It has no way to convert to a path here.

But by moving it to the ServiceMedia class, it can do it. Three points of call needs to be updated. One has a service media handy. One is dead code anyway.

The last is the configure dialog, and here I had to arbitrarily make a LutrisBanner or LutrisIcon. I think this is correct- it always displays Lutris banners in this dialog, not those of the game services.

Resolves #3829