### PR TITLE
Remove games from the running page when they stop

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -123,6 +123,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
         GObject.add_emission_hook(BaseService, "service-games-loaded", self.on_service_games_updated)
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
+        GObject.add_emission_hook(Game, "game-stop", self.on_game_stop)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_collection_changed)
 
     def _init_actions(self):
@@ -799,6 +800,11 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         updated = self.game_store.update(db_game)
         if not updated:
             self.game_store.add_game(db_game)
+        return True
+
+    def on_game_stop(self, game):
+        """Updates the game list when a game stops; this keeps the 'running' page updated."""
+        self.update_store()
         return True
 
     def on_game_collection_changed(self, _sender):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -804,7 +804,11 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     def on_game_stop(self, game):
         """Updates the game list when a game stops; this keeps the 'running' page updated."""
-        self.update_store()
+        selected_row = self.sidebar.get_selected_row()
+        # Only update the running page- we lose the selected when we do this,
+        # but on the running page this is okay.
+        if selected_row is not None and selected_row.id == "running":
+            self.update_store()
         return True
 
     def on_game_collection_changed(self, _sender):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -388,6 +388,10 @@ class LutrisSidebar(Gtk.ListBox):
         """Hide the "running" section when no games are running"""
         if not self.application.running_games.get_n_items():
             self.running_row.hide()
+
+            if self.get_selected_row() == self.running_row:
+                self.select_row(self.get_children()[0])
+
         return True
 
     def on_service_auth_changed(self, service):


### PR DESCRIPTION
This hooks up the 'game-stop' emission and updates the page whenever it occurs, but only if the page is the 'Running' page.

It also detects if running page is removed while selected, and selects the first page ('Games') so you don't wind up looking at a misleading message.

I think there's a flaw here; I expect if you have enough running games that you can scroll, your scroll position will be lost. But re-updating the game store seems safer to me than just removing the stopped game, and I think 'so many running games that you scroll' is not likely.

Resolves #3863