### PR TITLE
Remove stopped games from the running page

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -123,6 +123,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
         GObject.add_emission_hook(BaseService, "service-games-loaded", self.on_service_games_updated)
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
+        GObject.add_emission_hook(Game, "game-stop", self.on_game_stop)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_collection_changed)
 
     def _init_actions(self):
@@ -799,6 +800,11 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         updated = self.game_store.update(db_game)
         if not updated:
             self.game_store.add_game(db_game)
+        return True
+
+    def on_game_stop(self, game):
+        """Updates the game list when a game stops; this keeps the 'running' page updated."""
+        self.update_store()
         return True
 
     def on_game_collection_changed(self, _sender):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -804,7 +804,11 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     def on_game_stop(self, game):
         """Updates the game list when a game stops; this keeps the 'running' page updated."""
-        self.update_store()
+        selected_row = self.sidebar.get_selected_row()
+        # Only update the running page- we lose the selected when we do this,
+        # but on the running page this is okay.
+        if selected_row is not None and selected_row.id == "running":
+            self.update_store()
         return True
 
     def on_game_collection_changed(self, _sender):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -123,7 +123,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
         GObject.add_emission_hook(BaseService, "service-games-loaded", self.on_service_games_updated)
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
-        GObject.add_emission_hook(Game, "game-stop", self.on_game_stop)
+        GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_collection_changed)
 
     def _init_actions(self):
@@ -786,6 +786,13 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         """Return whether a game should be displayed on the view"""
         if game.is_hidden and not self.show_hidden_games:
             return False
+
+        # Stopped games do not get displayed on the running page
+        if game.state == game.STATE_STOPPED:
+            selected_row = self.sidebar.get_selected_row()
+            if selected_row is not None and selected_row.id == "running":
+                return False
+
         return True
 
     def on_game_updated(self, game):
@@ -802,13 +809,13 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
             self.game_store.add_game(db_game)
         return True
 
-    def on_game_stop(self, game):
+    def on_game_stopped(self, game):
         """Updates the game list when a game stops; this keeps the 'running' page updated."""
         selected_row = self.sidebar.get_selected_row()
         # Only update the running page- we lose the selected when we do this,
         # but on the running page this is okay.
         if selected_row is not None and selected_row.id == "running":
-            self.update_store()
+            self.game_store.remove_game(game.id)
         return True
 
     def on_game_collection_changed(self, _sender):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -388,6 +388,10 @@ class LutrisSidebar(Gtk.ListBox):
         """Hide the "running" section when no games are running"""
         if not self.application.running_games.get_n_items():
             self.running_row.hide()
+
+            if self.get_selected_row() == self.running_row:
+                self.select_row(self.get_children()[0])
+
         return True
 
     def on_service_auth_changed(self, service):


### PR DESCRIPTION
Let's try this again.

The new version of this removes the individual game when it stops. But as the game stops, it gets updated (for the play time, I guess) and so I've adjusted is_game_displayed() to reject stopped games when on the running tab. This prevents on_game_updated from re-adding the game.

I think this PR is less broken!

Thanks to @tannisroot  for the tip about game.state.

Resolves #3863