### PR TITLE
Enable "Install another version"

### DIFF
--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -112,7 +112,7 @@ def get_service_games(service):
 
 def get_game_by_field(value, field="slug"):
     """Query a game based on a database field"""
-    if field not in ("slug", "installer_slug", "id", "configpath"):
+    if field not in ("slug", "installer_slug", "id", "configpath", "name"):
         raise ValueError("Can't query by field '%s'" % field)
     game_result = sql.db_select(settings.PGA_DB, "games", condition=(field, value))
     if game_result:

--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -211,3 +211,21 @@ def get_used_platforms():
         rows = cursor.execute(query)
         results = rows.fetchall()
     return [result[0] for result in results if result[0]]
+
+
+def get_unusued_game_name(game_name):
+    """Returns the given name, but if this name is already used by an installed
+    game, this adds a number to it to make it unique."""
+    def is_name_in_use(name):
+        """Queries the database to see if a given is in use by an installed
+        game."""
+        existing_game = get_game_by_field(assigned_name, "name")
+        return existing_game and existing_game["installed"]
+
+    assigned_name = game_name
+    assigned_index = 1
+    while is_name_in_use(assigned_name):
+        assigned_index += 1
+        assigned_name = f"{game_name} {assigned_index}"
+
+    return assigned_name

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -102,7 +102,7 @@ class GameActions:
             "show_logs": self.game.is_installed,
             "favorite": not self.game.is_favorite,
             "deletefavorite": self.game.is_favorite,
-            "install_more": not self.game.service and self.game.is_installed,
+            "install_more": self.game.is_installed,
             "execute-script": bool(
                 self.game.is_installed and self.game.runner
                 and self.game.runner.system_config.get("manual_command")

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -39,8 +39,10 @@ class GameActions:
         return self._game
 
     def refresh_game(self):
-        """Discard the cached game and fetch it again so it is up to date."""
-        self._game = None
+        """Discard the cached game and fetch it again so it is up to date,
+        provide that refetch is possible."""
+        if self.game_id is not None:
+            self._game = None
         return self.game
 
     @property

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -38,6 +38,11 @@ class GameActions:
             self._game.connect("game-error", self.window.on_game_error)
         return self._game
 
+    def refresh_game(self):
+        """Discard the cached game and fetch it again so it is up to date."""
+        self._game = None
+        return self.game
+
     @property
     def is_game_running(self):
         return bool(self.application.get_game_by_id(self.game_id))
@@ -162,7 +167,8 @@ class GameActions:
         # Install the currently selected game in the UI
         if not self.game.slug:
             raise RuntimeError("No game to install: %s" % self.game.id)
-        self.game.emit("game-install")
+        # Make sure we install with non-cached game data
+        self.refresh_game().emit("game-install")
 
     def on_locate_installed_game(self, _button, game):
         """Show the user a dialog to import an existing install to a DRM free service

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -508,7 +508,7 @@ class Application(Gtk.Application):
 
     def on_game_install(self, game):
         """Request installation of a game"""
-        if game.service and game.service != "lutris":
+        if not game.is_installed and game.service and game.service != "lutris":
             service = get_enabled_services()[game.service]()
             db_game = ServiceGameCollection.get_game(service.id, game.appid)
 

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -4,7 +4,7 @@ import os
 from gettext import gettext as _
 
 from lutris.config import LutrisConfig, write_game_config
-from lutris.database.games import add_or_update, get_game_by_field
+from lutris.database.games import add_or_update, get_game_by_field, get_unusued_game_name
 from lutris.installer import AUTO_ELF_EXE, AUTO_WIN32_EXE
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer_file import InstallerFile
@@ -241,7 +241,10 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         else:
             service_id = None
 
-        assigned_name = self.get_unusued_game_name()
+        if assign_unique_name:
+            assigned_name = get_unusued_game_name(self.game_name)
+        else:
+            assigned_name = self.game_name
 
         self.game_id = add_or_update(
             name=assigned_name,
@@ -260,23 +263,6 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
             id=self.game_id,
         )
         return self.game_id
-
-    def get_unusued_game_name(self):
-        """Returns the game's name, but if this name is already used by an installed
-        name, this adds a number to it to make it unique."""
-        def is_name_in_use(name):
-            """Queries the database to see if a given is in use by an installed
-            game."""
-            existing_game = get_game_by_field(assigned_name, "name")
-            return existing_game and existing_game["installed"]
-
-        assigned_name = self.game_name
-        assigned_index = 1
-        while is_name_in_use(assigned_name):
-            assigned_index += 1
-            assigned_name = f"{self.game_name} {assigned_index}"
-
-        return assigned_name
 
     def get_game_launcher_config(self, game_files):
         """Game options such as exe or main_file can be added at the root of the

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -218,7 +218,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
                 config["game"]["exe"] = find_windows_game_executable(self.interpreter.target_path)
         return config
 
-    def save(self):
+    def save(self, assign_unique_name=False):
         """Write the game configuration in the DB and config file"""
         if self.extends:
             logger.info(
@@ -240,8 +240,11 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
             service_id = self.service.id
         else:
             service_id = None
+
+        assigned_name = self.get_unusued_game_name()
+
         self.game_id = add_or_update(
-            name=self.game_name,
+            name=assigned_name,
             runner=self.runner,
             slug=self.game_slug,
             platform=runner_inst.get_platform(),
@@ -257,6 +260,23 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
             id=self.game_id,
         )
         return self.game_id
+
+    def get_unusued_game_name(self):
+        """Returns the game's name, but if this name is already used by an installed
+        name, this adds a number to it to make it unique."""
+        def is_name_in_use(name):
+            """Queries the database to see if a given is in use by an installed
+            game."""
+            existing_game = get_game_by_field(assigned_name, "name")
+            return existing_game and existing_game["installed"]
+
+        assigned_name = self.game_name
+        assigned_index = 1
+        while is_name_in_use(assigned_name):
+            assigned_index += 1
+            assigned_name = f"{self.game_name} {assigned_index}"
+
+        return assigned_name
 
     def get_game_launcher_config(self, game_files):
         """Game options such as exe or main_file can be added at the root of the

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -343,6 +343,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             path = self._substitute(launcher_value)
             if not os.path.isabs(path) and self.target_path:
                 path = os.path.join(self.target_path, path)
+        self.installer.save(assign_unique_name=True)
         if path and not os.path.isfile(path) and self.installer.runner not in ("web", "browser"):
             self.parent.set_status(
                 _(

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -17,6 +17,7 @@ from lutris.runners import InvalidRunner, NonInstallableRunnerError, RunnerInsta
 from lutris.services.lutris import download_lutris_media
 from lutris.util import system
 from lutris.util.display import DISPLAY_MANAGER
+from lutris.util.fileio import get_unused_directory_path
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 from lutris.util.strings import unpack_dependencies
@@ -70,7 +71,9 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             service_dir = self.service.id
         else:
             service_dir = ""
-        return os.path.expanduser(os.path.join(games_dir, service_dir, self.installer.game_slug))
+
+        target_path = os.path.expanduser(os.path.join(games_dir, service_dir, self.installer.game_slug))
+        return get_unused_directory_path(target_path)
 
     @property
     def cache_path(self):

--- a/lutris/util/fileio.py
+++ b/lutris/util/fileio.py
@@ -1,7 +1,30 @@
 # Standard Library
+import os
 import re
 from collections import OrderedDict
 from configparser import RawConfigParser
+
+
+def get_unused_directory_path(path):
+    """Generates a path to a directory that does not exist, or if it does
+    is empty. This is used to make sure multiple installations of the same game
+    do not overwrite each other.
+
+    If 'path' is an empty directory or missing entirely, this will return
+    'path'. It otherwise appends a number to make it unique."""
+    def is_usable_path(path):
+        if not os.path.exists(path):
+            return True
+        return os.path.isdir(path) and not os.listdir(path)
+
+    index = 1
+    unused_path = path
+
+    while not is_usable_path(unused_path):
+        index += 1  # suffixes start at 2
+        unused_path = f"{path}-{index}"
+
+    return unused_path
 
 
 class EvilConfigParser(RawConfigParser):  # pylint: disable=too-many-ancestors


### PR DESCRIPTION
This enables the "Install another version" command for already installed games.

This also addresses some collateral issues: Installing an already installed game will default to a different directory and name. Also, the install command will re-fetch the game data from the PGA, since it can be stale.

When installing another version of an installed game, Lutris will now detect if the game's name is in use for an installed game and add a numerical suffix (starting with 2) to make it unique.

It also detects if it is defaulting to a target directory path that is in use; if there is a file or a non-empty directory already there, Lutris will add a suffix (starting with '-2') to make that unique also.

Resolves #3874

Consider merging PR #3966 instead of this- it incorporates this PR to reuse its code, but also adds a "Duplicate" command.