### PR TITLE
Preserve log TextBuffers forever and ever

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -484,7 +484,8 @@ class Game(GObject.Object):
         self.load_config()  # Reload the config before launching it.
 
         if str(self.id) in LOG_BUFFERS:  # Reset game logs on each launch
-            LOG_BUFFERS.pop(str(self.id))
+            log_buffer = LOG_BUFFERS[str(self.id)]
+            log_buffer.delete(log_buffer.get_start_iter(), log_buffer.get_end_iter())
 
         if not self.runner:
             dialogs.ErrorDialog(_("Invalid game configuration: Missing runner"))

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -16,7 +16,7 @@ from lutris.gui.dialogs.log import LogWindow
 from lutris.gui.dialogs.uninstall_game import RemoveGameDialog, UninstallGameDialog
 from lutris.gui.widgets.utils import open_uri
 from lutris.util import xdgshortcuts
-from lutris.util.log import LOG_BUFFERS, logger
+from lutris.util.log import logger
 from lutris.util.system import path_exists
 
 

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -145,7 +145,7 @@ class GameActions:
 
     def on_show_logs(self, _widget):
         """Display game log"""
-        _buffer = LOG_BUFFERS.get(str(self.game.id))
+        _buffer = self.game.log_buffer
         if not _buffer:
             logger.info("No log for game %s", self.game)
         return LogWindow(


### PR DESCRIPTION
This change causes Lutris to allocate the per-game log textbuffers as soon as it needs them, and never ever discard them.

On game launch, it clears the content of the text buffer. If a log window is open, it will be cleared by this.

Opening the log window will also create the buffer. The window needs it, and the game can pick up this buffer when it later starts.

This is of course a memory leak- the buffers are never reclaimed. But since you can always summon the log window and see the buffer, it's hard to see how this can really be much better. It is at least in a sense bounded- you won't have more buffers than games.

Resolves #3840 
Resolves #3841 