### PR TITLE
Set __GL_SHADER_DISK_CACHE etc per game

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -147,6 +147,11 @@ class Runner:  # pylint: disable=too-many-public-methods
         if os_env:
             env.update(os.environ.copy())
 
+        # By default we'll set NVidia's shader disk cache to be
+        # per-game, so it overflows less readily.
+        env["__GL_SHADER_DISK_CACHE"] = "1"
+        env["__GL_SHADER_DISK_CACHE_PATH"] = self.game_path
+
         # Override SDL2 controller configuration
         sdl_gamecontrollerconfig = self.system_config.get("sdl_gamecontrollerconfig")
         if sdl_gamecontrollerconfig:


### PR DESCRIPTION
This sets __GL_SHADER_DISK_CACHE and __GL_SHADER_DISK_CACHE_PATH to each game's
directory, by default. Game settings can override this setting.

This causes NVidia to keep a separate shader cache on disk for each game, so the caches can get
bigger in total.

Resolves #3838