### PR TITLE
Fix the problem that decode_unicode misses decoding \x after \\

### DIFF
--- a/lutris/util/wine/registry.py
+++ b/lutris/util/wine/registry.py
@@ -297,7 +297,11 @@ class WineRegistryKey:
 
     @staticmethod
     def decode_unicode(string):
-        chunks = re.split(r"[^\\]\\x", string)
+        # There may be a r"\\" in front of r"\x", so replace the r"\\" to r"\x005c"
+        # to avoid missing matches. Example: r"C:\\users\\x1234\\\x0041\x0042CD".
+        # Note the difference between r"\\x1234", r"\\\x0041" and r"\x0042".
+        # It should be r"C:\users\x1234\ABCD" after decoding.
+        chunks = re.split(r"\\x", string.replace(r"\\", r"\x005c"))
         out = chunks.pop(0).encode().decode("unicode_escape")
         for chunk in chunks:
             # We have seen file with unicode characters escaped on 1 byte (\xfa),


### PR DESCRIPTION
Consider the following string (it is `C:\users\x1234\ABCD`):
```python3
r"C:\\users\\x1234\\\x0041\x0042CD"
```

The following code will miss the decoding of `\x0041` because there is a `\` in front of it:
```python3
chunks = re.split(r"[^\\]\\x", string)
```

Then you will get an incorrect decoding result (note the `�`, it is NUL):
```
C:\users\x1234\�4BCD
```

So we changed it like this:
```python3
chunks = re.split(r"\\x", string.replace(r"\\", r"\x005c"))
```
After converting `\\` to `\x005c`, we no longer need to use `[^\\]` to prevent false matches.

------

demo:

```python3
#!/usr/bin/env python3

import os
import re
from collections import OrderedDict
from datetime import datetime

def decode_unicode1(string):
    chunks = re.split(r"[^\\]\\x", string)
    print('chunks1:\t', ', '.join(chunks))
    out = chunks.pop(0).encode().decode("unicode_escape")
    for chunk in chunks:
        for i in [0, 1, 2]:
            try:
                out += ("\\u{}{}".format("0" * i, chunk).encode().decode("unicode_escape"))
                break
            except UnicodeDecodeError:
                pass
    return out

def decode_unicode2(string):
    chunks = re.split(r"\\x", string.replace(r"\\", r"\x005c"))
    print('chunks2:\t', ', '.join(chunks))
    out = chunks.pop(0).encode().decode("unicode_escape")
    for chunk in chunks:
        for i in [0, 1, 2]:
            try:
                out += ("\\u{}{}".format("0" * i, chunk).encode().decode("unicode_escape"))
                break
            except UnicodeDecodeError:
                pass
    return out

def test_string(str):
    print('input:\t\t', str, '\n')
    print('decode1:\t', decode_unicode1(str), '\n')
    print('decode2:\t', decode_unicode2(str))

print('string:\t\t', r"C:\\users\\x1234\\\u0041\u0042CD".encode().decode("unicode_escape"))
test_string(r"C:\\users\\x1234\\\x0041\x0042CD")

print('\n-----------\n')

print('string:\t\t', r"C:\\users\\Public\\\u684c\u9762".encode().decode("unicode_escape"))
test_string(r"C:\\users\\Public\\\x684c\x9762")
```

output:
```
string:		 C:\users\x1234\ABCD
input:		 C:\\users\\x1234\\\x0041\x0042CD 

chunks1:	 C:\\users\\x1234\\\x004, 0042CD
decode1:	 C:\users\x1234\�4BCD 

chunks2:	 C:, 005cusers, 005cx1234, 005c, 0041, 0042CD
decode2:	 C:\users\x1234\ABCD

-----------

string:		 C:\users\Public\桌面
input:		 C:\\users\\Public\\\x684c\x9762 

chunks1:	 C:\\users\\Public\\\x684, 9762
decode1:	 C:\users\Public\h4面 

chunks2:	 C:, 005cusers, 005cPublic, 005c, 684c, 9762
decode2:	 C:\users\Public\桌面
```
