### PR TITLE
The game box can use a dynamic (box based) layout, and ellipsize the game name

### DIFF
--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -10,12 +10,15 @@ from lutris.gui.widgets.utils import get_link_button, get_pixbuf_for_game
 from lutris.util.strings import gtk_safe
 
 
-class GameBar(Gtk.Fixed):
-    play_button_position = (12, 42)
-
+class GameBar(Gtk.Box):
     def __init__(self, db_game, game_actions, application):
         """Create the game bar with a database row"""
-        super().__init__(visible=True)
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, visible=True,
+            margin_top=12,
+            margin_left=12,
+            margin_bottom=12,
+            margin_right=12,
+            spacing=6)
         GObject.add_emission_hook(Game, "game-start", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-started", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-stopped", self.on_game_state_changed)
@@ -63,22 +66,24 @@ class GameBar(Gtk.Fixed):
 
     def update_view(self):
         """Populate the view with widgets"""
-        self.put(self.get_game_name_label(), 16, 8)
-        x_offset = 140
-        y_offset = 40
-        if self.game.is_installed:
-            self.put(self.get_runner_button(), x_offset, y_offset + 2)
-            x_offset += 80
-            self.put(self.get_platform_label(), x_offset, y_offset)
-            x_offset += 120
-        if self.game.lastplayed:
-            self.put(self.get_last_played_label(), x_offset, y_offset)
-            x_offset += 120
-        if self.game.playtime:
-            self.put(self.get_playtime_label(), x_offset, y_offset)
+        game_label = self.get_game_name_label()
+        game_label.set_halign(Gtk.Align.START)
+        self.pack_start(game_label, False, False, 0)
+
+        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, spacing=6)
+        self.pack_start(hbox, False, False, 0)
 
         self.play_button = self.get_play_button()
-        self.put(self.play_button, self.play_button_position[0], self.play_button_position[1])
+        hbox.pack_start(self.play_button, False, False, 0)
+
+        if self.game.is_installed:
+            hbox.pack_start(self.get_runner_button(), False, False, 0)
+            hbox.pack_start(self.get_platform_label(), False, False, 0)
+        if self.game.lastplayed:
+            hbox.pack_start(self.get_last_played_label(), False, False, 0)
+        if self.game.playtime:
+            hbox.pack_start(self.get_playtime_label(), False, False, 0)
+        hbox.show_all()
 
     def get_popover(self, buttons, parent):
         """Return the popover widget containing a list of link buttons"""

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -14,11 +14,11 @@ class GameBar(Gtk.Box):
     def __init__(self, db_game, game_actions, application):
         """Create the game bar with a database row"""
         super().__init__(orientation=Gtk.Orientation.VERTICAL, visible=True,
-            margin_top=12,
-            margin_left=12,
-            margin_bottom=12,
-            margin_right=12,
-            spacing=6)
+                         margin_top=12,
+                         margin_left=12,
+                         margin_bottom=12,
+                         margin_right=12,
+                         spacing=6)
         GObject.add_emission_hook(Game, "game-start", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-started", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-stopped", self.on_game_state_changed)
@@ -109,6 +109,7 @@ class GameBar(Gtk.Box):
     def get_game_name_label(self):
         """Return the label with the game's title"""
         title_label = Gtk.Label(visible=True)
+        title_label.set_ellipsize(Pango.EllipsizeMode.END)
         title_label.set_markup("<span font_desc='16'><b>%s</b></span>" % gtk_safe(self.game.name))
         return title_label
 

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -132,8 +132,8 @@ class GameBar(Gtk.Box):
             style_context = box.get_style_context()
             style_context.add_class("linked")
         else:
-            runner_icon.set_margin_top(8)
-            runner_icon.set_margin_left(48)
+            runner_icon.set_margin_left(49)
+            runner_icon.set_margin_right(6)
             box.add(runner_icon)
         return box
 
@@ -150,12 +150,16 @@ class GameBar(Gtk.Box):
     def get_playtime_label(self):
         """Return the label containing the playtime info"""
         playtime_label = Gtk.Label(visible=True)
+        playtime_label.set_size_request(120, -1)
+        playtime_label.set_alignment(0, 0.5)
         playtime_label.set_markup(_("Time played:\n<b>%s</b>") % self.game.formatted_playtime)
         return playtime_label
 
     def get_last_played_label(self):
         """Return the label containing the last played info"""
         last_played_label = Gtk.Label(visible=True)
+        last_played_label.set_size_request(120, -1)
+        last_played_label.set_alignment(0, 0.5)
         lastplayed = datetime.fromtimestamp(self.game.lastplayed)
         last_played_label.set_markup(_("Last played:\n<b>%s</b>") % lastplayed.strftime("%x"))
         return last_played_label

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -322,7 +322,7 @@ class wine(Runner):
                 "option": "fsr",
                 "label": _("Enable AMD FidelityFX Super Resolution (FSR)"),
                 "type": "bool",
-                "default": False,
+                "default": True,
                 "help": _(
                     "Use FSR to upscale the game window to native resolution.\n"
                     "Requires Lutris Wine FShack >= 6.13 and setting the game to a lower resolution.\n"


### PR DESCRIPTION
This PR replaces the fixed game-box layout with a dynamic one, using Gtk.Box.

This will be more resilient to things like changing fonts, and is fairly close to the old fixed layout. But it is more dynamic- things can move around as you selecting this or that game.

This also changes the game-name label to use automatic ellipsis, which the box layout supports. This prevents long game names from resizing the Lutris window; the name is instead truncated.

Here's what the Lutris window looks like when enlarged to fit a long name:
![Before](https://user-images.githubusercontent.com/6507403/145006060-3a1d604b-489b-4b6e-939d-2a6587f7d8f8.png)

And here's what the ellipsized name looks like:
![After](https://user-images.githubusercontent.com/6507403/145006144-df918e86-bf53-45ad-8aaf-67a521ad1258.png)

Resolves #3517