### PR TITLE
Provide error translation for get_runner_version

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -13,7 +13,7 @@ from lutris.gui import dialogs
 from lutris.runners import RunnerInstallationError
 from lutris.util import system
 from lutris.util.extract import ExtractFailure, extract_archive
-from lutris.util.http import Request, HTTPError
+from lutris.util.http import HTTPError, Request
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 
@@ -313,10 +313,12 @@ class Runner:  # pylint: disable=too-many-public-methods
 
             if not runner_info:
                 logger.error("Failed to get runner information")
-                return
         except HTTPError as ex:
             logger.error("Unable to get runner information: %s", ex)
-            return    
+            runner_info = None
+
+        if not runner_info:
+            return
 
         versions = runner_info.get("versions") or []
         arch = LINUX_SYSTEM.arch


### PR DESCRIPTION
Near as I can make out, the error discipline in Lutris is that errors are detected fairly early and logged, then translated to signal values; and I think get_runner_version() returns None if it fails to obtain the data it wants.

I have added an exception handler to do this for HTTPError; the caller then detects this and re-raises a less informative exception. This does not handle only status 403; it seems to me that a 404 or 401 or 500 deserves handling as much. I can find no other place where this HTTPError would be handled.

I'm not a big fan of all this; translating HTTPError -> None -> RunnerInstallationError seems pointless and is all too easy to forget to do. But this seems to be the Lutris standard. So, here we go.

Resolves #3893 