### PR TITLE
Moved Add Game into hamburger menu

### DIFF
--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -474,7 +474,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.add-game</property>
-            <property name="text" translatable="yes">Add Game</property>
+            <property name="text" translatable="yes">Add a game manually</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -474,7 +474,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.add-game</property>
-            <property name="text" translatable="yes">Add a game manually</property>
+            <property name="text" translatable="yes">Add a Game Manually</property>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -207,35 +207,6 @@
           </object>
         </child>
         <child>
-          <object class="GtkBox" id="left_header_box">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkMenuButton">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="tooltip-text" translatable="yes">Add Game</property>
-                <property name="action-name">win.add-game</property>
-                <property name="use-popover">False</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">list-add-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
-        </child>
-        <child>
           <object class="GtkBox" id="right_header_box">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -324,7 +295,6 @@
   <object class="GtkSizeGroup" id="size1">
     <property name="mode">both</property>
     <widgets>
-      <widget name="left_header_box"/>
       <widget name="right_header_box"/>
     </widgets>
   </object>
@@ -501,6 +471,31 @@
         <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="action-name">win.add-game</property>
+            <property name="text" translatable="yes">Add Game</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.show-installed-only</property>
@@ -510,7 +505,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">3</property>
           </packing>
         </child>
         <child>
@@ -524,7 +519,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">2</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -539,7 +534,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -553,7 +548,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>


### PR DESCRIPTION
Closes #3896 
This removes the "Add Game" button (the "+" on the top left), and moved it into the hamburger menu.
Here's how it look like:
![image](https://user-images.githubusercontent.com/47753585/145461947-22361cd8-9366-4239-8a8b-24f64cf4ed8d.png)
