### PR TITLE
Fix: [Issue 3913] remove winesteam.py from i18n scripts

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -125,7 +125,6 @@ lutris/runners/steam.py
 lutris/runners/vice.py
 lutris/runners/web.py
 lutris/runners/wine.py
-lutris/runners/winesteam.py
 lutris/runners/yuzu.py
 lutris/runners/zdoom.py
 lutris/runtime.py


### PR DESCRIPTION
File was removed in commit: e12641b0c89aa2a0a704cd8f598c06254cf16577