### PR TITLE
Set the text color for hovered sidebar rows

### DIFF
--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -36,3 +36,7 @@
   background: rgba(0, 0, 0, 0.1);
   color: black;
 }
+
+.sidebar row:hover button {
+  color: black;
+}

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -33,7 +33,7 @@
 }
 
 .sidebar row:hover {
-  background: rgba(0, 0, 0, 0.1);
+  background: rgb(229, 229, 229);
   color: black;
 }
 

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -34,4 +34,5 @@
 
 .sidebar row:hover {
   background: rgba(0, 0, 0, 0.1);
+  color: black;
 }


### PR DESCRIPTION
We set the background color (for whatever reason), but if we leave the foreground as default, it may have poor contrast. So this sets both, and sets the background to a non-transparent color.

It looks like this:

![Screenshot from 2021-12-20 04-19-24](https://user-images.githubusercontent.com/6507403/146744897-18e443ff-89b9-4a5b-8225-e825ec8321cc.png)

It looks rather less nice in dark themes, however, but I believe the action buttons look right.

Resolves #3916