### PR TITLE
Migrate banners to .cache/lutris

### DIFF
--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -3,7 +3,7 @@ import importlib
 from lutris import settings
 from lutris.util.log import logger
 
-MIGRATION_VERSION = 10  # Never decrease this number
+MIGRATION_VERSION = 11  # Never decrease this number
 
 # Replace deprecated migrations with empty lists
 MIGRATIONS = [
@@ -11,6 +11,7 @@ MIGRATIONS = [
     ["mess_to_mame"],
     ["migrate_hidden_ids"],
     ["migrate_steam_appids"],
+    ["migrate_banners"]
 ]
 
 

--- a/lutris/migrations/migrate_banners.py
+++ b/lutris/migrations/migrate_banners.py
@@ -2,20 +2,27 @@
 import os
 
 from lutris import settings
+from lutris.util.log import logger
 
 
 def migrate():
     dest_dir = settings.BANNER_PATH
     src_dir = os.path.join(settings.DATA_DIR, "banners")
 
-    # init_lutris() creates the new banners directrory
-    if os.path.isdir(src_dir) and os.path.isdir(dest_dir):
-        for filename in os.listdir(src_dir):
-            try:
-                src_file = os.path.join(src_dir, filename)
-                dest_file = os.path.join(dest_dir, filename)
+    try:
+        # init_lutris() creates the new banners directrory
+        if os.path.isdir(src_dir) and os.path.isdir(dest_dir):
+            for filename in os.listdir(src_dir):
+                try:
+                    src_file = os.path.join(src_dir, filename)
+                    dest_file = os.path.join(dest_dir, filename)
 
-                if not os.path.exists(dest_file):
-                    os.rename(src_file, dest_file)
-            except OSError:
-                pass  # Skip what we can't migrate
+                    if not os.path.exists(dest_file):
+                        os.rename(src_file, dest_file)
+                except OSError as ex:  # Skip what we can't migrate
+                    logger.exception("Failed to migrate banner %s: %s", filename, ex)
+
+            if not os.listdir(src_dir):
+                os.rmdir(src_dir)
+    except OSError as ex:
+        logger.exception("Failed to migrate banners: %s", ex)

--- a/lutris/migrations/migrate_banners.py
+++ b/lutris/migrations/migrate_banners.py
@@ -1,0 +1,21 @@
+"""Migrate banners from .local/share/lutris to .cache/lutris"""
+import os
+
+from lutris import settings
+
+
+def migrate():
+    dest_dir = settings.BANNER_PATH
+    src_dir = os.path.join(settings.DATA_DIR, "banners")
+
+    # init_lutris() creates the new banners directrory
+    if os.path.isdir(src_dir) and os.path.isdir(dest_dir):
+        for filename in os.listdir(src_dir):
+            try:
+                src_file = os.path.join(src_dir, filename)
+                dest_file = os.path.join(dest_dir, filename)
+
+                if not os.path.exists(dest_file):
+                    os.rename(src_file, dest_file)
+            except OSError:
+                pass  # Skip what we can't migrate

--- a/lutris/migrations/migrate_banners.py
+++ b/lutris/migrations/migrate_banners.py
@@ -13,14 +13,11 @@ def migrate():
         # init_lutris() creates the new banners directrory
         if os.path.isdir(src_dir) and os.path.isdir(dest_dir):
             for filename in os.listdir(src_dir):
-                try:
-                    src_file = os.path.join(src_dir, filename)
-                    dest_file = os.path.join(dest_dir, filename)
+                src_file = os.path.join(src_dir, filename)
+                dest_file = os.path.join(dest_dir, filename)
 
-                    if not os.path.exists(dest_file):
-                        os.rename(src_file, dest_file)
-                except OSError as ex:  # Skip what we can't migrate
-                    logger.exception("Failed to migrate banner %s: %s", filename, ex)
+                if not os.path.exists(dest_file):
+                    os.rename(src_file, dest_file)
 
             if not os.listdir(src_dir):
                 os.rmdir(src_dir)

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -32,7 +32,7 @@ def init_dirs():
         settings.DATA_DIR,
         os.path.join(settings.DATA_DIR, "covers"),
         settings.ICON_PATH,
-        os.path.join(settings.DATA_DIR, "banners"),
+        os.path.join(settings.CACHE_DIR, "banners"),
         os.path.join(settings.DATA_DIR, "coverart"),
         os.path.join(settings.DATA_DIR, "runners"),
         os.path.join(settings.DATA_DIR, "lib"),


### PR DESCRIPTION
This adds a migration that moves each banner from ~/.local/share/lutris/banners to ~/.cache/lutris/banners.

This also adjusts init_lutris() to create the new directory, so we can move stuff in there.

This will try withstand odd conditions like errors moving the files, or if some banners are already there in the cache for some reason.

Resolves #3906