### PR TITLE
Fix the sidebar so that the headers are reset for every row every time

### DIFF
--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -379,7 +379,6 @@ class LutrisSidebar(Gtk.ListBox):
         else:
             row.set_header(None)
 
-
     def update(self, *_args):
         self.installed_runners = [runner.name for runner in runners.get_installed()]
         self.active_platforms = games_db.get_used_platforms()

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -368,8 +368,6 @@ class LutrisSidebar(Gtk.ListBox):
         return row.id in self.active_platforms
 
     def _header_func(self, row, before):
-        if row.get_header():
-            return
         if not before:
             row.set_header(self.row_headers["library"])
         elif before.type in ("category", "dynamic_category") and row.type == "service":
@@ -378,6 +376,9 @@ class LutrisSidebar(Gtk.ListBox):
             row.set_header(self.row_headers["runners"])
         elif before.type == "runner" and row.type == "platform":
             row.set_header(self.row_headers["platforms"])
+        else:
+            row.set_header(None)
+
 
     def update(self, *_args):
         self.installed_runners = [runner.name for runner in runners.get_installed()]


### PR DESCRIPTION
This change makes sure that if a row should no longer bear a header, it is removed. This way, the same header is not attached to two rows at once, which does not work.

Resolves #3924