### PR TITLE
Show runner configure button only if installed

### DIFF
--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -56,10 +56,11 @@ class RunnerBox(Gtk.Box):
         self.configure_button = Gtk.Button.new_from_icon_name("preferences-system-symbolic", Gtk.IconSize.BUTTON)
         self.configure_button.set_margin_right(12)
         self.configure_button.connect("clicked", self.on_configure_clicked)
-        self.configure_button.show()
         self.pack_start(self.configure_button, False, False, 0)
         if not self.runner.is_installed():
             self.runner_label_box.set_sensitive(False)
+        else:
+            self.configure_button.show()
         self.action_alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
         self.action_alignment.show()
         self.action_alignment.add(self.get_action_button())


### PR DESCRIPTION
We hide the runner configuration button when removing it, so let's not show it initially unless it is installed.

Resolves #3926