### PR TITLE
Rework simple dialogs to return results (and check for them)

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -208,11 +208,11 @@ class GameActions:
         """Callback to open a game folder in the file browser"""
         path = self.game.get_browse_dir()
         if not path:
-            dialogs.NoticeDialog(_("This game has no installation directory"))
+            dialogs.NoticeDialog.display(_("This game has no installation directory"))
         elif path_exists(path):
             open_uri("file://%s" % path)
         else:
-            dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path)
+            dialogs.NoticeDialog.display(_("Can't open %s \nThe folder doesn't exist.") % path)
 
     def on_create_menu_shortcut(self, *_args):
         """Add the selected game to the system's Games menu."""

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -78,7 +78,7 @@ class Application(Gtk.Application):
         self.run_in_background = False
 
         if os.geteuid() == 0:
-            ErrorDialog(_("Running Lutris as root is not recommended and may cause unexpected issues"))
+            ErrorDialog.display(_("Running Lutris as root is not recommended and may cause unexpected issues"))
 
         try:
             self.css_provider.load_from_path(os.path.join(datapath.get(), "ui", "lutris.css"))
@@ -88,7 +88,7 @@ class Application(Gtk.Application):
         if hasattr(self, "add_main_option"):
             self.add_arguments()
         else:
-            ErrorDialog(_("Your Linux distribution is too old. Lutris won't function properly."))
+            ErrorDialog.display(_("Your Linux distribution is too old. Lutris won't function properly."))
 
     def add_arguments(self):
         if hasattr(self, "set_option_context_summary"):

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -345,7 +345,7 @@ class GameDialogCommon(Dialog):
         """Action called when runner drop down is changed."""
         new_runner_index = widget.get_active()
         if self.runner_index and new_runner_index != self.runner_index:
-            dlg = QuestionDialog(
+            answer = QuestionDialog.display(
                 {
                     "question":
                     _("Are you sure you want to change the runner for this game ? "
@@ -356,7 +356,7 @@ class GameDialogCommon(Dialog):
                 }
             )
 
-            if dlg.result == Gtk.ResponseType.YES:
+            if answer:
                 self.runner_index = new_runner_index
                 self._switch_runner(widget)
             else:

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -244,10 +244,10 @@ class GameDialogCommon(Dialog):
         self.slug_change_button.set_label(_("Change"))
 
     def on_move_clicked(self, _button):
-        new_location = DirectoryDialog("Select new location for the game", default_path=self.game.directory)
-        if not new_location.folder or new_location.folder == self.game.directory:
+        new_location = DirectoryDialog.display("Select new location for the game", default_path=self.game.directory)
+        if not new_location or new_location == self.game.directory:
             return
-        move_dialog = dialogs.MoveDialog(self.game, new_location.folder)
+        move_dialog = dialogs.MoveDialog(self.game, new_location)
         move_dialog.connect("game-moved", self.on_game_moved)
         move_dialog.move()
 

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -400,13 +400,13 @@ class GameDialogCommon(Dialog):
 
     def is_valid(self):
         if not self.runner_name:
-            ErrorDialog(_("Runner not provided"))
+            ErrorDialog.display(_("Runner not provided"))
             return False
         if not self.name_entry.get_text():
-            ErrorDialog(_("Please fill in the name"))
+            ErrorDialog.display(_("Please fill in the name"))
             return False
         if self.runner_name == "steam" and not self.lutris_config.game_config.get("appid"):
-            ErrorDialog(_("Steam AppID not provided"))
+            ErrorDialog.display(_("Steam AppID not provided"))
             return False
         invalid_fields = []
         runner_class = import_runner(self.runner_name)
@@ -424,7 +424,7 @@ class GameDialogCommon(Dialog):
                     except Exception:
                         invalid_fields.append(option.get("label"))
         if invalid_fields:
-            ErrorDialog(_("The following fields have invalid values: ") + ", ".join(invalid_fields))
+            ErrorDialog.display(_("The following fields have invalid values: ") + ", ".join(invalid_fields))
             return False
         return True
 

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -101,7 +101,7 @@ class RunnerBox(Gtk.Box):
             runners.NonInstallableRunnerError,
         ) as ex:
             logger.error(ex)
-            ErrorDialog(ex.message)
+            ErrorDialog.display(ex.message)
             return
         if self.runner.is_installed():
             self.emit("runner-installed")

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -112,14 +112,13 @@ class RunnerBox(Gtk.Box):
         RunnerConfigDialog(self.runner)
 
     def on_remove_clicked(self, widget):
-        dialog = QuestionDialog(
+        answer = QuestionDialog.display(
             {
                 "title": _("Do you want to uninstall %s?") % self.runner.human_name,
                 "question": _("This will remove <b>%s</b> and all associated data." % self.runner.human_name)
-
             }
         )
-        if Gtk.ResponseType.YES == dialog.result:
+        if answer:
             self.runner.uninstall()
             self.emit("runner-removed")
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -82,8 +82,14 @@ class NoticeDialog(Gtk.MessageDialog):
     def __init__(self, message, parent=None):
         super().__init__(buttons=Gtk.ButtonsType.OK, parent=parent)
         self.set_markup(message)
-        self.run()
-        self.destroy()
+
+    @staticmethod
+    def display(message, parent=None):
+        dialog = NoticeDialog(message, parent=parent)
+        try:
+            dialog.run()
+        finally:
+            dialog.destroy()
 
 
 class ErrorDialog(Gtk.MessageDialog):
@@ -299,7 +305,7 @@ class ClientLoginDialog(GtkBuilderDialog):
         username, password = self.get_credentials()
         token = api.connect(username, password)
         if not token:
-            NoticeDialog(_("Login failed"), parent=self.parent)
+            NoticeDialog.display(_("Login failed"), parent=self.parent)
         else:
             self.emit("connected", username)
             self.dialog.destroy()

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -102,8 +102,14 @@ class ErrorDialog(Gtk.MessageDialog):
         self.set_markup(message[:256])
         if secondary:
             self.format_secondary_text(secondary[:256])
-        self.run()
-        self.destroy()
+
+    @staticmethod
+    def display(message, secondary=None, parent=None):
+        dialog = ErrorDialog(message, secondary=secondary, parent=parent)
+        try:
+            dialog.run()
+        finally:
+            dialog.destroy()
 
 
 class QuestionDialog(Gtk.MessageDialog):
@@ -221,7 +227,7 @@ class LutrisInitDialog(Gtk.Dialog):
 
     def init_cb(self, _result, error):
         if error:
-            ErrorDialog(str(error))
+            ErrorDialog.display(str(error))
         self.destroy()
 
 
@@ -438,6 +444,6 @@ class MoveDialog(Gtk.Dialog):
 
     def on_game_moved(self, _result, error):
         if error:
-            ErrorDialog(str(error))
+            ErrorDialog.display(str(error))
         self.emit("game-moved")
         self.destroy()

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -114,8 +114,15 @@ class QuestionDialog(Gtk.MessageDialog):
         if "widgets" in dialog_settings:
             for widget in dialog_settings["widgets"]:
                 self.get_message_area().add(widget)
-        self.result = self.run()
-        self.destroy()
+
+    @staticmethod
+    def display(dialog_settings):
+        """Static method to ask a question; returns True or False, True for Yes, Accept or OK."""
+        dialog = QuestionDialog(dialog_settings)
+        try:
+            return dialog.run() in (Gtk.ResponseType.YES, Gtk.ResponseType.ACCEPT, Gtk.ResponseType.OK)
+        finally:
+            dialog.destroy()
 
 
 class DirectoryDialog(Gtk.FileChooserDialog):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -142,8 +142,8 @@ class DirectoryDialog(Gtk.FileChooserDialog):
         try:
             if dialog.result == Gtk.ResponseType.OK:
                 return dialog.folder
-            else:
-                return None
+
+            return None
         finally:
             dialog.destroy()
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -135,6 +135,18 @@ class DirectoryDialog(Gtk.FileChooserDialog):
         self.folder = self.get_current_folder()
         self.destroy()
 
+    @staticmethod
+    def display(message, default_path=None, parent=None):
+        """Simple method to ask for a directory; returns None if cancelled."""
+        dialog = DirectoryDialog(message, default_path=default_path, parent=parent)
+        try:
+            if dialog.result == Gtk.ResponseType.OK:
+                return dialog.folder
+            else:
+                return None
+        finally:
+            dialog.destroy()
+
 
 class FileDialog(Gtk.FileChooserDialog):
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -131,17 +131,14 @@ class DirectoryDialog(Gtk.FileChooserDialog):
         )
         if default_path:
             self.set_current_folder(default_path)
-        self.result = self.run()
-        self.folder = self.get_current_folder()
-        self.destroy()
 
     @staticmethod
     def display(message, default_path=None, parent=None):
         """Simple method to ask for a directory; returns None if cancelled."""
         dialog = DirectoryDialog(message, default_path=default_path, parent=parent)
         try:
-            if dialog.result == Gtk.ResponseType.OK:
-                return dialog.folder
+            if dialog.run() == Gtk.ResponseType.OK:
+                return dialog.get_current_folder()
 
             return None
         finally:
@@ -152,7 +149,7 @@ class FileDialog(Gtk.FileChooserDialog):
 
     """Ask the user to select a file."""
 
-    def __init__(self, message=None, default_path=None, mode="open"):
+    def __init__(self, message=None, default_path=None, mode="open", parent=None):
         self.filename = None
         if not message:
             message = _("Please choose a file")
@@ -165,15 +162,23 @@ class FileDialog(Gtk.FileChooserDialog):
             None,
             action,
             (_("_Cancel"), Gtk.ResponseType.CANCEL, _("_OK"), Gtk.ResponseType.OK),
+            parent=parent
         )
         if default_path and os.path.exists(default_path):
             self.set_current_folder(default_path)
         self.set_local_only(False)
-        response = self.run()
-        if response == Gtk.ResponseType.OK:
-            self.filename = self.get_filename()
 
-        self.destroy()
+    @staticmethod
+    def display(message=None, default_path=None, mode="open", parent=None):
+        """Simple method to ask for a file; returns None if cancelled."""
+        dialog = FileDialog(message=message, default_path=default_path, mode=mode, parent=parent)
+        try:
+            if dialog.run() == Gtk.ResponseType.OK:
+                return dialog.get_filename()
+
+            return None
+        finally:
+            dialog.destroy()
 
 
 class LutrisInitDialog(Gtk.Dialog):

--- a/lutris/gui/dialogs/issue.py
+++ b/lutris/gui/dialogs/issue.py
@@ -87,5 +87,5 @@ class IssueReportWindow(BaseApplicationWindow):
         with open(issue_path, "w", encoding='utf-8') as issue_file:
             json.dump(issue_info, issue_file, indent=2)
         dialog.destroy()
-        NoticeDialog(_("Issue saved in %s") % issue_path)
+        NoticeDialog.display(_("Issue saved in %s") % issue_path)
         self.destroy()

--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -17,8 +17,8 @@ class LogWindow(GObject.Object):
         builder = Gtk.Builder()
         builder.add_from_file(ui_filename)
         builder.connect_signals(self)
-        window = builder.get_object("log_window")
-        window.set_title(title)
+        self.window = builder.get_object("log_window")
+        self.window.set_title(title)
         self.title = title
 
         self.buffer = buffer
@@ -35,8 +35,8 @@ class LogWindow(GObject.Object):
         save_button = builder.get_object("save_button")
         save_button.connect("clicked", self.on_save_clicked)
 
-        window.connect("key-press-event", self.on_key_press_event)
-        window.show_all()
+        self.window.connect("key-press-event", self.on_key_press_event)
+        self.window.show_all()
 
     def on_key_press_event(self, widget, event):
         shift = (event.state & Gdk.ModifierType.SHIFT_MASK)
@@ -50,12 +50,13 @@ class LogWindow(GObject.Object):
         """Handler to save log to a file"""
         now = datetime.now()
         log_filename = "%s (%s).log" % (self.title, now.strftime("%Y-%m-%d-%H-%M"))
-        file_dialog = FileDialog(
+        log_path = FileDialog.display(
             message="Save the logs to...",
             default_path=os.path.expanduser("~/%s" % log_filename),
-            mode="save"
+            mode="save",
+            parent=self.window
         )
-        log_path = file_dialog.filename
+
         if not log_path:
             return
 

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -168,13 +168,13 @@ class RunnerInstallDialog(Dialog):
     def on_installed_toggled(self, _widget, path):
         row = self.runner_store[path]
         if row[self.COL_VER] in self.installing:
-            confirm_dlg = QuestionDialog(
+            confirm_answer = QuestionDialog.display(
                 {
                     "question": _("Do you want to cancel the download?"),
                     "title": _("Download starting"),
                 }
             )
-            if confirm_dlg.result == confirm_dlg.YES:
+            if confirm_answer:
                 self.cancel_install(row)
         elif row[self.COL_INSTALLED]:
             self.uninstall_runner(row)

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -54,7 +54,7 @@ class RunnerInstallDialog(Dialog):
         """Clear the box and display versions from runner_info"""
         if error:
             logger.error(error)
-            ErrorDialog(_("Unable to get runner versions: %s") % error)
+            ErrorDialog.display(_("Unable to get runner versions: %s") % error)
             return
 
         self.runner_info = runner_info
@@ -68,7 +68,7 @@ class RunnerInstallDialog(Dialog):
             })
 
         if not self.runner_info:
-            ErrorDialog(_("Unable to get runner versions from lutris.net"))
+            ErrorDialog.display(_("Unable to get runner versions from lutris.net"))
             return
 
         for child_widget in self.vbox.get_children():
@@ -205,7 +205,7 @@ class RunnerInstallDialog(Dialog):
         dest_path = self.get_dest_path(row)
         url = row[self.COL_URL]
         if not url:
-            ErrorDialog("Version %s is not longer available" % row[self.COL_VER])
+            ErrorDialog.display("Version %s is not longer available" % row[self.COL_VER])
             return
         downloader = Downloader(row[self.COL_URL], dest_path, overwrite=True)
         GLib.timeout_add(100, self.get_progress, downloader, row)
@@ -266,7 +266,7 @@ class RunnerInstallDialog(Dialog):
     def on_extracted(self, row_info, error):
         """Called when a runner archive is extracted"""
         if error or not row_info:
-            ErrorDialog(_("Failed to retrieve the runner archive"), parent=self)
+            ErrorDialog.display(_("Failed to retrieve the runner archive"), parent=self)
             return
         src, row = row_info
         os.remove(src)

--- a/lutris/gui/dialogs/uninstall_game.py
+++ b/lutris/gui/dialogs/uninstall_game.py
@@ -87,7 +87,7 @@ class UninstallGameDialog(Dialog):
         if not self.confirm_delete_button.get_active():
             self.delete_files = False
         if self.delete_files and not hasattr(self.game.runner, "no_game_remove_warning"):
-            dlg = QuestionDialog(
+            answer = QuestionDialog.display(
                 {
                     "question": _(
                         "Please confirm.\nEverything under <b>%s</b>\n"
@@ -96,7 +96,7 @@ class UninstallGameDialog(Dialog):
                     "title": _("Permanently delete files?"),
                 }
             )
-            if dlg.result != Gtk.ResponseType.YES:
+            if not answer:
                 button.set_sensitive(True)
                 return
         if self.delete_files:

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -244,8 +244,7 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         buttons_box.pack_start(browse_button, True, True, 40)
 
     def on_browse_clicked(self, widget, callback_data):
-        dialog = DirectoryDialog(_("Select the folder where the disc is mounted"), parent=self)
-        folder = dialog.folder
+        folder = DirectoryDialog.display(_("Select the folder where the disc is mounted"), parent=self)
         callback = callback_data["callback"]
         requires = callback_data["requires"]
         callback(widget, requires, folder)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -245,6 +245,8 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
 
     def on_browse_clicked(self, widget, callback_data):
         folder = DirectoryDialog.display(_("Select the folder where the disc is mounted"), parent=self)
+        if not folder:
+            return
         callback = callback_data["callback"]
         requires = callback_data["requires"]
         callback(widget, requires, folder)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -158,13 +158,13 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
             )
 
         except MissingGameDependency as ex:
-            dlg = QuestionDialog(
+            answer = QuestionDialog.display(
                 {
                     "question": _("This game requires %s. Do you want to install it?") % ex.slug,
                     "title": _("Missing dependency"),
                 }
             )
-            if dlg.result == Gtk.ResponseType.YES:
+            if answer:
                 InstallerWindow(
                     installers=self.installers,
                     service=self.service,
@@ -493,14 +493,14 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         if self.interpreter:
             remove_checkbox.set_active(self.interpreter.game_dir_created)
             remove_checkbox.show()
-        confirm_cancel_dialog = QuestionDialog(
+        confirm_cancel_answer = QuestionDialog.display(
             {
                 "question": _("Are you sure you want to cancel the installation?"),
                 "title": _("Cancel installation?"),
                 "widgets": [remove_checkbox]
             }
         )
-        if confirm_cancel_dialog.result != Gtk.ResponseType.YES:
+        if not confirm_cancel_answer:
             logger.debug("User aborted installation cancellation")
             return True
         if self._cancel_files_func:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -711,7 +711,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
     def on_game_error(self, game, error):
         """Called when a game has sent the 'game-error' signal"""
         logger.error("%s crashed", game)
-        dialogs.ErrorDialog(error, parent=self)
+        dialogs.ErrorDialog.display(error, parent=self)
 
     @GtkTemplate.Callback
     def on_add_game_button_clicked(self, *_args):

--- a/lutris/gui/widgets/download_progress_box.py
+++ b/lutris/gui/widgets/download_progress_box.py
@@ -72,7 +72,7 @@ class DownloadProgressBox(Gtk.Box):
             except RuntimeError as ex:
                 from lutris.gui.dialogs import ErrorDialog
 
-                ErrorDialog(ex.args[0])
+                ErrorDialog.display(ex.args[0])
                 self.emit("cancel")
                 return None
 

--- a/lutris/gui/widgets/gi_composites.py
+++ b/lutris/gui/widgets/gi_composites.py
@@ -83,7 +83,7 @@ def _register_template(cls, template_bytes):
     # we can't do that anyways due to PyGObject limitations so it's ok
 
     if not hasattr(cls, "set_template"):
-        ErrorDialog("Your Linux distribution is too old. Lutris won't function properly.")
+        ErrorDialog.display("Your Linux distribution is too old. Lutris won't function properly.")
         raise TypeError("Requires PyGObject 3.13.2 or greater")
 
     cls.set_template(template_bytes)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -141,7 +141,7 @@ class ServiceSidebarRow(SidebarRow):
                 self.service.logout()
                 self.service.login()
             else:
-                ErrorDialog(str(error))
+                ErrorDialog.display(str(error))
         GLib.timeout_add(2000, self.enable_refresh_button)
 
     def enable_refresh_button(self):

--- a/lutris/installer/errors.py
+++ b/lutris/installer/errors.py
@@ -48,7 +48,7 @@ def error_handler(error_type, value, traceback):
         message = value.message
         if value.faulty_data:
             message += "\n<b>%s</b>" % gtk_safe(value.faulty_data)
-        ErrorDialog(message)
+        ErrorDialog.display(message)
     else:
         _excepthook(error_type, value, traceback)
 

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -101,7 +101,7 @@ class atari800(Runner):
             dlg = DownloadDialog(self.bios_url, bios_archive)
             dlg.run()
             if not system.path_exists(bios_archive):
-                ErrorDialog(_("Could not download Atari 800 BIOS archive"))
+                ErrorDialog.display(_("Could not download Atari 800 BIOS archive"))
                 return
             extract.extract_archive(bios_archive, config_path)
             os.remove(bios_archive)

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -139,10 +139,11 @@ class hatari(Runner):
                 }
             )
             if dlg.result == dlg.YES:
-                bios_dlg = FileDialog(_("Select a BIOS file"))
-                bios_filename = bios_dlg.filename
+                bios_filename = FileDialog.display(_("Select a BIOS file"))
+
                 if not bios_filename:
                     return
+
                 shutil.copy(bios_filename, bios_path)
                 bios_path = os.path.join(bios_path, os.path.basename(bios_filename))
                 config = LutrisConfig(runner_slug="hatari")

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -132,13 +132,13 @@ class hatari(Runner):
 
         def on_runner_installed(*args):
             bios_path = system.create_folder("~/.hatari/bios")
-            dlg = QuestionDialog(
+            answer = QuestionDialog.display(
                 {
                     "question": _("Do you want to select an Atari ST BIOS file?"),
                     "title": _("Use BIOS file?"),
                 }
             )
-            if dlg.result == dlg.YES:
+            if answer:
                 bios_filename = FileDialog.display(_("Select a BIOS file"))
 
                 if not bios_filename:

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -98,13 +98,13 @@ class redream(Runner):
 
     def install(self, version=None, downloader=None, callback=None):
         def on_runner_installed(*args):
-            dlg = QuestionDialog(
+            answer = QuestionDialog.display(
                 {
                     "question": _("Do you want to select a premium license file?"),
                     "title": _("Use premium version?"),
                 }
             )
-            if dlg.result == dlg.YES:
+            if answer:
                 license_filename = FileDialog.display(_("Select a license file"))
 
                 if not license_filename:

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -105,10 +105,11 @@ class redream(Runner):
                 }
             )
             if dlg.result == dlg.YES:
-                license_dlg = FileDialog(_("Select a license file"))
-                license_filename = license_dlg.filename
+                license_filename = FileDialog.display(_("Select a license file"))
+
                 if not license_filename:
                     return
+
                 shutil.copy(
                     license_filename, os.path.join(settings.RUNNER_DIR, "redream")
                 )

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -81,7 +81,7 @@ class reicast(Runner):
                 shutil.copy(os.path.join(mapping_source, mapping_file), mapping_path)
 
             system.create_folder("~/.reicast/data")
-            NoticeDialog(_("You have to copy valid BIOS files to ~/.reicast/data before playing"))
+            NoticeDialog.display(_("You have to copy valid BIOS files to ~/.reicast/data before playing"))
 
         super().install(version, downloader, on_runner_installed)
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -285,7 +285,7 @@ class Runner:  # pylint: disable=too-many-public-methods
                 else:
                     self.install(downloader=simple_downloader)
             except RunnerInstallationError as ex:
-                ErrorDialog(ex.message)
+                ErrorDialog.display(ex.message)
 
             return self.is_installed()
         return False

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -2,8 +2,6 @@
 import os
 from gettext import gettext as _
 
-from gi.repository import Gtk
-
 from lutris import runtime, settings
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
@@ -269,14 +267,14 @@ class Runner:  # pylint: disable=too-many-public-methods
 
         Return success of runner installation.
         """
-        dialog = dialogs.QuestionDialog(
+        answer = dialogs.QuestionDialog.display(
             {
                 "question": _("The required runner is not installed.\n"
                               "Do you wish to install it now?"),
                 "title": _("Required runner unavailable"),
             }
         )
-        if Gtk.ResponseType.YES == dialog.result:
+        if answer:
 
             from lutris.gui.dialogs import ErrorDialog
             from lutris.gui.dialogs.download import simple_downloader

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -623,10 +623,10 @@ class wine(Runner):
 
     def run_wineexec(self, *args):
         """Ask the user for an arbitrary exe file to run in the game's prefix"""
-        dlg = FileDialog(_("Select an EXE or MSI file"), default_path=self.game_path)
-        filename = dlg.filename
+        filename = FileDialog.display(_("Select an EXE or MSI file"), default_path=self.game_path)
         if not filename:
             return
+
         self.prelaunch()
         self._run_executable(filename)
 

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -365,7 +365,7 @@ def display_vulkan_error(on_launch):
 
 
 def esync_display_limit_warning():
-    ErrorDialog(_(
+    ErrorDialog.display(_(
         "Your limits are not set correctly."
         " Please increase them as described here:"
         " <a href='https://github.com/lutris/lutris/wiki/How-to:-Esync'>"
@@ -374,7 +374,7 @@ def esync_display_limit_warning():
 
 
 def fsync_display_support_warning():
-    ErrorDialog(_(
+    ErrorDialog.display(_(
         "Your kernel is not patched for fsync."
         " Please get a patched kernel to use fsync."
     ))


### PR DESCRIPTION
My, this came out bigger than I expected. But I think this is right.

Lutris has directory dialogs, which are invoked by constructed a DirectoryDialog and then the __init__ method actually shows the dialog, and the caller must check d.result and d.folder for the results. But they don't; they just use the folder. This is present even if the user cancelled, which means the users cancellation is not honored. Dangerous!

This code is *weird*, and so unconventional that we have to expect it to be misused. This PR redoes it to use a static method. It's old school, but the method returns the folder or None; even if not checked for, the None will cause a crash instead of being easily ignored.

However, there are several dialogs that work like this: FileDialog, QuestionDialog, NoticeDialog and ErrorDialog. This PR updates *all* off them to use a static method (each) for consistency. The last two don't exactly need this- they don't return anything anyway- but I figure doing most but not all the dialog would just breed confusion.

The bad news is, this PR touches a lot of code. Particularly for ErrorDialog. There's no way I tested every code-path.

I am in doubt that @strycore will tolerate this. But I figure it is better to try.

Resolves #3912, and then some.

I've also provided a targeted PR that just fixes the darn issue: #3932. This will also be a lot more compatible with my other PRs!