### PR TITLE
Make DirectoryDialog work consistently with FileDialog

### DIFF
--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -123,6 +123,7 @@ class DirectoryDialog(Gtk.FileChooserDialog):
     """Ask the user to select a directory."""
 
     def __init__(self, message, default_path=None, parent=None):
+        self.folder = None
         super().__init__(
             title=message,
             action=Gtk.FileChooserAction.SELECT_FOLDER,
@@ -132,7 +133,8 @@ class DirectoryDialog(Gtk.FileChooserDialog):
         if default_path:
             self.set_current_folder(default_path)
         self.result = self.run()
-        self.folder = self.get_current_folder()
+        if self.result == Gtk.ResponseType.OK:
+            self.folder = self.get_current_folder()
         self.destroy()
 
 


### PR DESCRIPTION
Here's a much less ambitious fix. DirectoryDialog will not extract the path if cancelled, so callers can detect that the folder is still None.

It's still very strange, but this is how FileDialog works and this is a much smaller PR than my last try.

Resolves #3912