### PR TITLE
Ensure that the sidebar's icons are MENU sized

### DIFF
--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -276,7 +276,15 @@ class LutrisSidebar(Gtk.ListBox):
         self.show_all()
 
     def get_sidebar_icon(self, icon_name):
-        return Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+        icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+        
+        # We can wind up with an icon of the wrong size, if that's what is
+        # available. So we'll fix that.
+        icon_size = Gtk.IconSize.lookup(Gtk.IconSize.MENU)
+        if icon_size[0]:
+            icon.set_pixel_size(icon_size[2])
+        
+        return icon
 
     def initialize_rows(self):
         """

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -277,13 +277,13 @@ class LutrisSidebar(Gtk.ListBox):
 
     def get_sidebar_icon(self, icon_name):
         icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
-        
+
         # We can wind up with an icon of the wrong size, if that's what is
         # available. So we'll fix that.
         icon_size = Gtk.IconSize.lookup(Gtk.IconSize.MENU)
         if icon_size[0]:
             icon.set_pixel_size(icon_size[2])
-        
+
         return icon
 
     def initialize_rows(self):


### PR DESCRIPTION
When the proper symbolic icon is missing we'll get some other version, but it may not be the right size.

This PR sets it to be MENU sized anyway, so it is scaled. We might prefer a proper symbolic icon but this way it won't disrupt the layout.

Resolves #3911
Well, not entirely- but it helps. We could still use a symbolic Redream icon.