### PR TITLE
Make various dialogs properly modal

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -167,15 +167,15 @@ class GameActions:
         Params:
             game (Game): Game instance without a database ID, populated with a fields the service can provides
         """
-        AddGameDialog(self.window, game=game)
+        AddGameDialog(self.window, game=game).run()
 
     def on_add_manually(self, _widget, *_args):
         """Callback that presents the Add game dialog"""
-        return AddGameDialog(self.window, game=self.game, runner=self.game.runner_name)
+        AddGameDialog(self.window, game=self.game, runner=self.game.runner_name).run()
 
     def on_edit_game_configuration(self, _widget):
         """Edit game preferences"""
-        EditGameConfigDialog(self.window, self.game)
+        EditGameConfigDialog(self.window, self.game).run()
 
     def on_add_favorite_game(self, _widget):
         """Add to favorite Games list"""

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -237,6 +237,6 @@ class GameActions:
     def on_remove_game(self, *_args):
         """Callback that present the uninstall dialog to the user"""
         if self.game.is_installed:
-            UninstallGameDialog(game_id=self.game.id, parent=self.window)
+            UninstallGameDialog(game_id=self.game.id, parent=self.window).run()
         else:
-            RemoveGameDialog(game_id=self.game.id, parent=self.window)
+            RemoveGameDialog(game_id=self.game.id, parent=self.window).run()

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -208,11 +208,11 @@ class GameActions:
         """Callback to open a game folder in the file browser"""
         path = self.game.get_browse_dir()
         if not path:
-            dialogs.NoticeDialog(_("This game has no installation directory"))
+            dialogs.NoticeDialog(_("This game has no installation directory"), parent=self.window)
         elif path_exists(path):
             open_uri("file://%s" % path)
         else:
-            dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path)
+            dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path, parent=self.window)
 
     def on_create_menu_shortcut(self, *_args):
         """Add the selected game to the system's Games menu."""

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -452,7 +452,7 @@ class Application(Gtk.Application):
         if not action:
             if db_game and db_game["installed"]:
                 # Game found but no action provided, ask what to do
-                dlg = InstallOrPlayDialog(db_game["name"])
+                dlg = InstallOrPlayDialog(db_game["name"], parent=self.window)
                 if not dlg.action_confirmed:
                     action = None
                 elif dlg.action == "play":

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -254,6 +254,7 @@ class Application(Gtk.Application):
             self.app_windows[window_key].present()
             return self.app_windows[window_key]
         if issubclass(window_class, Gtk.Dialog):
+            logger.debug("%s is being used as a modeless window, but it is a dialog.", window_class)
             window_inst = window_class(parent=self.window, **kwargs)
         else:
             window_inst = window_class(application=self, **kwargs)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -347,6 +347,7 @@ class GameDialogCommon(Dialog):
         if self.runner_index and new_runner_index != self.runner_index:
             dlg = QuestionDialog(
                 {
+                    "parent": self,
                     "question":
                     _("Are you sure you want to change the runner for this game ? "
                       "This will reset the full configuration for this game and "

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -109,7 +109,7 @@ class RunnerBox(Gtk.Box):
             logger.error("Runner failed to install")
 
     def on_configure_clicked(self, widget):
-        RunnerConfigDialog(self.runner)
+        RunnerConfigDialog(self.runner).run()
 
     def on_remove_clicked(self, widget):
         dialog = QuestionDialog(

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -114,9 +114,9 @@ class RunnerBox(Gtk.Box):
     def on_remove_clicked(self, widget):
         dialog = QuestionDialog(
             {
+                "parent": self.get_toplevel(),
                 "title": _("Do you want to uninstall %s?") % self.runner.human_name,
                 "question": _("This will remove <b>%s</b> and all associated data." % self.runner.human_name)
-
             }
         )
         if Gtk.ResponseType.YES == dialog.result:

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -86,9 +86,9 @@ class RunnerBox(Gtk.Box):
     def on_versions_clicked(self, widget):
         RunnerInstallDialog(
             _("Manage %s versions") % self.runner.name,
-            None,
-            self.runner.name
-        )
+            self.get_toplevel(),
+            self.runner.name,
+        ).run()
         # connect a runner-installed signal from the above dialog?
 
     def on_install_clicked(self, widget):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -108,7 +108,8 @@ class QuestionDialog(Gtk.MessageDialog):
     NO = Gtk.ResponseType.NO
 
     def __init__(self, dialog_settings):
-        super().__init__(message_type=Gtk.MessageType.QUESTION, buttons=Gtk.ButtonsType.YES_NO)
+        super().__init__(message_type=Gtk.MessageType.QUESTION, buttons=Gtk.ButtonsType.YES_NO,
+                         parent=dialog_settings.get("parent"))
         self.set_markup(dialog_settings["question"])
         self.set_title(dialog_settings["title"])
         if "widgets" in dialog_settings:

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -199,8 +199,8 @@ class LutrisInitDialog(Gtk.Dialog):
 
 class InstallOrPlayDialog(Gtk.Dialog):
 
-    def __init__(self, game_name):
-        Gtk.Dialog.__init__(self, _("%s is already installed") % game_name)
+    def __init__(self, game_name, parent):
+        Gtk.Dialog.__init__(self, _("%s is already installed") % game_name, parent=parent)
         self.connect("delete-event", lambda *x: self.destroy())
 
         self.action = "play"

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -141,7 +141,7 @@ class FileDialog(Gtk.FileChooserDialog):
 
     """Ask the user to select a file."""
 
-    def __init__(self, message=None, default_path=None, mode="open"):
+    def __init__(self, message=None, default_path=None, mode="open", parent=None):
         self.filename = None
         if not message:
             message = _("Please choose a file")
@@ -154,6 +154,7 @@ class FileDialog(Gtk.FileChooserDialog):
             None,
             action,
             (_("_Cancel"), Gtk.ResponseType.CANCEL, _("_OK"), Gtk.ResponseType.OK),
+            parent=parent
         )
         if default_path and os.path.exists(default_path):
             self.set_current_folder(default_path)

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -276,7 +276,7 @@ class ClientLoginDialog(GtkBuilderDialog):
         username, password = self.get_credentials()
         token = api.connect(username, password)
         if not token:
-            NoticeDialog(_("Login failed"), parent=self.parent)
+            NoticeDialog(_("Login failed"), parent=self.dialog)
         else:
             self.emit("connected", username)
             self.dialog.destroy()

--- a/lutris/gui/dialogs/issue.py
+++ b/lutris/gui/dialogs/issue.py
@@ -87,5 +87,5 @@ class IssueReportWindow(BaseApplicationWindow):
         with open(issue_path, "w", encoding='utf-8') as issue_file:
             json.dump(issue_info, issue_file, indent=2)
         dialog.destroy()
-        NoticeDialog(_("Issue saved in %s") % issue_path)
+        NoticeDialog(_("Issue saved in %s") % issue_path, parent=self)
         self.destroy()

--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -17,8 +17,8 @@ class LogWindow(GObject.Object):
         builder = Gtk.Builder()
         builder.add_from_file(ui_filename)
         builder.connect_signals(self)
-        window = builder.get_object("log_window")
-        window.set_title(title)
+        self.window = builder.get_object("log_window")
+        self.window.set_title(title)
         self.title = title
 
         self.buffer = buffer
@@ -35,8 +35,8 @@ class LogWindow(GObject.Object):
         save_button = builder.get_object("save_button")
         save_button.connect("clicked", self.on_save_clicked)
 
-        window.connect("key-press-event", self.on_key_press_event)
-        window.show_all()
+        self.window.connect("key-press-event", self.on_key_press_event)
+        self.window.show_all()
 
     def on_key_press_event(self, widget, event):
         shift = (event.state & Gdk.ModifierType.SHIFT_MASK)
@@ -53,7 +53,8 @@ class LogWindow(GObject.Object):
         file_dialog = FileDialog(
             message="Save the logs to...",
             default_path=os.path.expanduser("~/%s" % log_filename),
-            mode="save"
+            mode="save",
+            parent=self.window
         )
         log_path = file_dialog.filename
         if not log_path:

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -170,6 +170,7 @@ class RunnerInstallDialog(Dialog):
         if row[self.COL_VER] in self.installing:
             confirm_dlg = QuestionDialog(
                 {
+                    "parent": self,
                     "question": _("Do you want to cancel the download?"),
                     "title": _("Download starting"),
                 }

--- a/lutris/gui/dialogs/uninstall_game.py
+++ b/lutris/gui/dialogs/uninstall_game.py
@@ -89,6 +89,7 @@ class UninstallGameDialog(Dialog):
         if self.delete_files and not hasattr(self.game.runner, "no_game_remove_warning"):
             dlg = QuestionDialog(
                 {
+                    "parent": self,
                     "question": _(
                         "Please confirm.\nEverything under <b>%s</b>\n"
                         "will be deleted."

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -496,6 +496,7 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
             remove_checkbox.show()
         confirm_cancel_dialog = QuestionDialog(
             {
+                "parent": self,
                 "question": _("Are you sure you want to cancel the installation?"),
                 "title": _("Cancel installation?"),
                 "widgets": [remove_checkbox]

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -670,7 +670,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
     @GtkTemplate.Callback
     def on_preferences_activate(self, *_args):
         """Callback when preferences is activated."""
-        self.application.show_window(PreferencesDialog)
+        PreferencesDialog(parent=self).run()
 
     def on_show_installed_state_change(self, action, value):
         """Callback to handle uninstalled game filter switch"""
@@ -720,7 +720,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
             runner = self.filters["runner"]
         else:
             runner = None
-        AddGameDialog(self, runner=runner)
+        AddGameDialog(self, runner=runner).run()
         return True
 
     def on_toggle_viewtype(self, *args):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -196,12 +196,12 @@ class RunnerSidebarRow(SidebarRow):
 
     def on_configure_runner(self, *_args):
         """Show runner configuration"""
-        self.application.show_window(RunnerConfigDialog, runner=self.runner)
+        RunnerConfigDialog(self.runner, parent=self.get_toplevel()).run()
 
     def on_manage_versions(self, *_args):
         """Manage runner versions"""
         dlg_title = _("Manage %s versions") % self.runner.name
-        RunnerInstallDialog(dlg_title, self.get_toplevel(), self.runner.name)
+        RunnerInstallDialog(dlg_title, self.get_toplevel(), self.runner.name).run()
 
 
 class SidebarHeader(Gtk.Box):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -139,7 +139,7 @@ class ServiceSidebarRow(SidebarRow):
         if error:
             if isinstance(error, AuthTokenExpired):
                 self.service.logout()
-                self.service.login()
+                self.service.login(parent=self.get_toplevel())
             else:
                 ErrorDialog(str(error))
         GLib.timeout_add(2000, self.enable_refresh_button)
@@ -168,7 +168,7 @@ class OnlineServiceSidebarRow(ServiceSidebarRow):
         if self.service.is_authenticated():
             self.service.logout()
         else:
-            self.service.login()
+            self.service.login(parent=self.get_toplevel())
         self.create_button_box()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+import gi
+
+gi.require_version('Gtk', '3.0')
+
+
+from lutris.gui.application import Application
+
+
+class TestPrint(TestCase):
+
+    def setUp(self):
+        self.lutris_application = Application()
+
+    def test_print_steam_list(self):
+        self.lutris_application.print_steam_list('cmd')
+
+    def test_print_steam_folders(self):
+        self.lutris_application.print_steam_folders('cmd')


### PR DESCRIPTION
The trick to a 'proper' modal dialog is to show it with the run() method (and to set its parent of course).

This changes Lutris to do this for configuration dialogs and for preferences. Not the installer window, which was not modal at all.

There may be more dialog to be done, but this is what I've found so far.

Resolves #3936
Resolves #3466

Of course, it may be that this PR goes the wrong way- #3466 seemed to think so. This PR is the easy thing to do, but maybe we'd rather make all these dialogs fully independent of the Lutris window.