### PR TITLE
Actually make removing game files be optional

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -491,7 +491,7 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
     def cancel_installation(self, _widget=None):
         """Ask a confirmation before cancelling the install"""
         remove_checkbox = Gtk.CheckButton.new_with_label(_("Remove game files"))
-        if self.interpreter:
+        if self.interpreter and self.interpreter.target_path:
             remove_checkbox.set_active(self.interpreter.game_dir_created)
             remove_checkbox.show()
         confirm_cancel_dialog = QuestionDialog(
@@ -507,8 +507,8 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         if self._cancel_files_func:
             self._cancel_files_func()
         if self.interpreter:
-            self.interpreter.revert()
-            self.interpreter.cleanup()
+            self.interpreter.revert(remove_game_dir=remove_checkbox.get_active())
+            self.interpreter.cleanup()  # still remove temporary downloads in any case
         self.destroy()
 
     def on_source_clicked(self, _button):

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -354,7 +354,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         os.chdir(os.path.expanduser("~"))
         system.remove_folder(self.cache_path)
 
-    def revert(self):
+    def revert(self, remove_game_dir=True):
         """Revert installation in case of an error"""
         logger.info("Cancelling installation of %s", self.installer.game_name)
         if self.installer.runner.startswith("wine"):
@@ -365,7 +365,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         if self.abort_current_task:
             self.abort_current_task()
 
-        if self.game_dir_created:
+        if self.target_path and remove_game_dir:
             system.remove_folder(self.target_path)
 
     def _substitute(self, template_string):


### PR DESCRIPTION
We've got the checkbox, but it does nothing.

I've hooked it up, so revert() will delete the game directory if you check it- but not if you don't.

Also, the checkbox is shown if there is a target game directory for this installer, regardless of who created it. It's checked by default only if it did create it, but you can delete what you did not create.

Resolves #3910