### PR TITLE
Replace the cheeky no-installers log message with an error dialog

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -514,8 +514,7 @@ class Application(Gtk.Application):
         if installers:
             self.show_installer_window(installers)
         else:
-            logger.debug("Should generate automagical installer here but....")
-            logger.debug("Wait? how did you get here?")
+            ErrorDialog(_("There is no installer available for %s.") % game.name, parent=self.window)
         return True
 
     def get_running_game_ids(self):


### PR DESCRIPTION
That is, if we can find no installers, tell the user instead of the log. Simple!

Resolves #3939

This adds an error message that should be localized. I put it in _( ), hope that helps.