### PR TITLE
Set the executable bit for runner executables

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -411,6 +411,11 @@ class Runner:  # pylint: disable=too-many-public-methods
             from lutris.util.wine.wine import get_wine_versions
             get_wine_versions.cache_clear()
 
+        if self.runner_executable:
+            runner_executable = os.path.join(settings.RUNNER_DIR, self.runner_executable)
+            if os.path.isfile(runner_executable):
+                system.make_executable(runner_executable)
+
         if callback:
             callback()
 


### PR DESCRIPTION
If a runner has a runner_executable, we'll make it executable after extracting it.

Makes MicroM8 runner work; I'm surprised many runners work without this.

Resolves #3735