### PR TITLE
Don't crash if get_pixbuf() can't read the file

### DIFF
--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -54,7 +54,7 @@ def get_pixbuf(image, size, fallback=None, is_installed=True):
             fallback = get_default_icon(size)
         if system.path_exists(fallback):
             pixbuf = GdkPixbuf.Pixbuf.new_from_file_at_size(fallback, width, height)
-    if is_installed:
+    if is_installed and pixbuf:
         pixbuf = pixbuf.scale_simple(width, height, GdkPixbuf.InterpType.NEAREST)
         return pixbuf
     overlay = os.path.join(datapath.get(), "media/unavailable.png")


### PR DESCRIPTION
When we can't read the pixbuf, this will now return the pixbuf for unavailable.png- which is transparent.

This is what it was doing for 'non-installed' images that could not be read. It's now doing it for all images that can't be read.

Resolves #3768
Resolves #3802
