### PR TITLE
handle error when no file

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -513,5 +513,6 @@ class GameDialogCommon(Dialog):
             dest_path = resources.get_icon_path(self.game.slug)
         else:
             raise ValueError("Unsupported image type %s" % image_type)
-        os.remove(dest_path)
+        if os.path.isfile(dest_path):
+            os.remove(dest_path)
         self._set_image(image_type)


### PR DESCRIPTION
## Proposed changes

handle FileNotFoundError when click reset image button

```python
Traceback (most recent call last):
  File "/mnt/ac54dceb-73a5-4f94-b52c-cb7a426c0f29/Documents/lutris/lutris/gui/config/common.py", line 516, in on_custom_image_reset_clicked
    os.remove(dest_path)
FileNotFoundError: [Errno 2] No such file or directory: '/home/r3r/.cache/lutris/banners/game.jpg'
```

## Types of changes

What types of changes does your code introduce? _Put an `x` in the boxes that apply_

* [x]  Bugfix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)
* Breaking change (fix or feature that would cause existing functionality to not work as expected)
* Documentation Update (if none of the other choices apply)


## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x]  I have read the [CONTRIBUTING](https://github.com/lutris/lutris/blob/master/CONTRIBUTING.md) doc
* [x]  Formatting my code
*  Writing tests
* [x] Running tests
* [x]  check pr title

