### PR TITLE
Copy the DLL overrides before allowing modification

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -105,7 +105,7 @@ class wine(Runner):
 
     def __init__(self, config=None):  # noqa: C901
         super().__init__(config)
-        self.dll_overrides = DEFAULT_DLL_OVERRIDES
+        self.dll_overrides = DEFAULT_DLL_OVERRIDES.copy()  # we'll modify this, so we better copy it
 
         def get_wine_version_choices():
             version_choices = [(_("Custom (select executable below)"), "custom")]


### PR DESCRIPTION
This fixes an aliasing bug; the default DLL overrides are placed in the WINE runner, but not copied- then modified. The original, global dict is being modified here, which corrupts it until you restart Lutris.

So, just copy it on runner init. Nothing to it.

Resolves #3823