### PR TITLE
Stop the timeout that is animating init progress

### DIFF
--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -178,8 +178,9 @@ class LutrisInitDialog(Gtk.Dialog):
         self.progress.set_pulse_step(0.1)
         vbox.add(self.progress)
         self.get_content_area().add(vbox)
-        GLib.timeout_add(125, self.show_progress)
+        self.progress_timeout = GLib.timeout_add(125, self.show_progress)
         self.show_all()
+        self.connect("destroy", self.on_destroy)
         AsyncCall(self.initialize, self.init_cb, init_lutris)
 
     def show_progress(self):
@@ -193,6 +194,10 @@ class LutrisInitDialog(Gtk.Dialog):
         if error:
             ErrorDialog(str(error))
         self.destroy()
+
+    def on_destroy(self, window):
+        GLib.source_remove(self.progress_timeout)
+        return True
 
 
 class InstallOrPlayDialog(Gtk.Dialog):


### PR DESCRIPTION
I don't really have any symptoms from this, but I think it's not ideal to keep pulsing that progress bar forever, even after the init window is destroyed.

This doesn't even use enough CPU to measure on my machine, but it irritates me during interactive debugging, and I'll sometimes wind up stepping into the show_progress method for no good reason.

This PR adds a destroy handler that removes the timeout to stop it.