### PR TITLE
DRM-be-gone!

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -162,7 +162,7 @@ class GameActions:
         self.game.emit("game-install")
 
     def on_locate_installed_game(self, _button, game):
-        """Show the user a dialog to import an existing install to a DRM free service
+        """Show the user a dialog to import an existing install of a game
 
         Params:
             game (Game): Game instance without a database ID, populated with a fields the service can provides

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -203,14 +203,13 @@ class GameBar(Gtk.Box):
                 if self.service.local:
                     # Local services don't show an install dialog, they can be launched directly
                     button.set_label(_("Play"))
-                if self.service.drm_free:
-                    button.set_size_request(84, 32)
-                    box.add(button)
-                    popover = self.get_popover(self.get_locate_installed_game_button(), popover_button)
-                    popover_button.set_popover(popover)
-                    box.add(popover_button)
-                    return box
-                return button
+
+                button.set_size_request(84, 32)
+                box.add(button)
+                popover = self.get_popover(self.get_locate_installed_game_button(), popover_button)
+                popover_button.set_popover(popover)
+                box.add(popover_button)
+                return box
         button.set_size_request(84, 32)
         box.add(button)
         popover = self.get_popover(self.get_game_buttons(), popover_button)

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -57,7 +57,6 @@ class BaseService(GObject.Object):
     icon = NotImplemented
     online = False
     local = False
-    drm_free = False  # DRM free games can be added to Lutris from an existing install
     client_installer = None  # ID of a script needed to install the client used by the service
     medias = {}
     extra_medias = {}

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -68,7 +68,6 @@ class GOGService(OnlineService):
     name = _("GOG")
     icon = "gog"
     has_extras = True
-    drm_free = True
     medias = {
         "banner_small": GogSmallBanner,
         "banner": GogMediumBanner,

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -57,7 +57,6 @@ class HumbleBundleService(OnlineService):
     name = _("Humble Bundle")
     icon = "humblebundle"
     online = True
-    drm_free = True
     medias = {
         "small_icon": HumbleSmallIcon,
         "icon": HumbleBundleIcon,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+
+import gi
+
+gi.require_version('Gtk', '3.0')
+
+
+from lutris.gui.application import Application
+
+
+class TestPrint(TestCase):
+
+    def setUp(self):
+        self.lutris_application = Application()
+
+    def test_print_steam_list(self):
+        self.lutris_application.print_steam_list('cmd')
+
+    def test_print_steam_folders(self):
+        self.lutris_application.print_steam_folders('cmd')


### PR DESCRIPTION
This removes the DRM-free flag. This merely enables the "Locate installed game" command for every source- it does not enable you to install anything you couldn't before.

I don't think giving only GOG and Humble-Bundle sources the "Locate installed game" command makes a lot of sense; this command does not let you install a DRMed game at all. You would install it via another method, perhaps the Steam client say, and this command would make it easier to connect that game to Lutris.

And anyway, even Steam has a few DRM free games, hasn't it?

Resolves #3950