### PR TITLE
Check for None when generating the game actions

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -103,7 +103,10 @@ class GameActions:
             "favorite": not self.game.is_favorite,
             "deletefavorite": self.game.is_favorite,
             "install_more": not self.game.service and self.game.is_installed,
-            "execute-script": bool(self.game.is_installed and self.game.runner and self.game.runner.system_config.get("manual_command")),
+            "execute-script": bool(
+                self.game.is_installed and self.game.runner
+                and self.game.runner.system_config.get("manual_command")
+            ),
             "desktop-shortcut": (
                 self.game.is_installed
                 and not xdgshortcuts.desktop_launcher_exists(self.game.slug, self.game.id)

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -103,7 +103,7 @@ class GameActions:
             "favorite": not self.game.is_favorite,
             "deletefavorite": self.game.is_favorite,
             "install_more": not self.game.service and self.game.is_installed,
-            "execute-script": bool(self.game.is_installed and self.game.runner.system_config.get("manual_command")),
+            "execute-script": bool(self.game.is_installed and self.game.runner and self.game.runner.system_config.get("manual_command")),
             "desktop-shortcut": (
                 self.game.is_installed
                 and not xdgshortcuts.desktop_launcher_exists(self.game.slug, self.game.id)


### PR DESCRIPTION
The bug here occurs when an installed game has no runner. This can happen if the runner for a game has been removed from Lutris. We just need to check for None before using the runner to avoid this problem.

Commands using the running still won't be available, but at least you should be able to remove the game.

Resolves #3954