### PR TITLE
Install using the WINE runner configuration

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -22,7 +22,11 @@ from lutris.util.wine.wine import WINE_DEFAULT_ARCH, get_wine_version_exe
 
 
 class CommandsMixin:
-    """The directives for the `installer:` part of the install script."""
+    """
+    The directives for the `installer:` part of the install script.
+    This mixin is used by the ScriptInterpreter class and uses its
+    fields and properties.
+    """
 
     def __init__(self):
         if isinstance(self, CommandsMixin):
@@ -364,9 +368,9 @@ class CommandsMixin:
             runner_name = self.installer.runner
         return runner_name, task_name
 
-    def get_wine_path(self):
+    def get_wine_path(self, runner):
         """Return absolute path of wine version used during the install"""
-        wine_version = self._get_runner_version()
+        wine_version = self._get_runner_version() or runner.get_version()
         return get_wine_version_exe(wine_version)
 
     def task(self, data):
@@ -381,7 +385,7 @@ class CommandsMixin:
         runner_name, task_name = self._get_task_runner_and_name(data.pop("name"))
 
         if runner_name.startswith("wine"):
-            wine_path = self.get_wine_path()
+            wine_path = self.get_wine_path(self.runner)
             if wine_path:
                 data["wine_path"] = wine_path
             data["prefix"] = data.get("prefix") \

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -395,7 +395,11 @@ class CommandsMixin:
                 or self.installer.script.get("game", {}).get("arch") \
                 or WINE_DEFAULT_ARCH
             if task_name == "wineexec":
+                # When winexec is used as from a script, it gets
+                # the same prelaunch setup the game would. Otherwise the
+                # caller does this.
                 data["env"] = self.script_env
+                data["preconfigure"] = True
 
         for key in data:
             value = data[key]

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -384,7 +384,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             "RESOLUTION": "x".join(self.current_resolution),
             "RESOLUTION_WIDTH": self.current_resolution[0],
             "RESOLUTION_HEIGHT": self.current_resolution[1],
-            "WINEBIN": self.get_wine_path(),
+            "WINEBIN": self.get_wine_path(self.runner),
         }
         replacements.update(self.installer.variables)
         # Add 'INPUT_<id>' replacements for user inputs with an id

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -84,10 +84,12 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         susbtituted. This value can be used to provide the same environment
         variable as set for the game during the install process.
         """
-        return {
+        env = self.runner.get_env()
+        env.update({
             key: self._substitute(value) for key, value in
             self.installer.script.get('system', {}).get('env', {}).items()
-        }
+        })
+        return env
 
     @staticmethod
     def _get_installed_dependency(dependency):

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -48,6 +48,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         self.current_command = 0  # Current installer command when iterating through them
         self.runners_to_install = []
         self.installer = LutrisInstaller(installer, self, service=self.service, appid=self.appid)
+        self.runner = self.get_runner_class(self.installer.runner)()
         if not self.installer.script:
             raise ScriptingError(_("This installer doesn't have a 'script' section"))
         script_errors = self.installer.get_errors()
@@ -185,9 +186,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         dependencies or runners used for installer tasks.
         """
         runners_to_install = []
-        required_runners = []
-        runner = self.get_runner_class(self.installer.runner)
-        required_runners.append(runner())
+        required_runners = [self.runner]
 
         for command in self.installer.script.get("installer", []):
             command_name, command_params = self._get_command_name_and_params(command)

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -205,12 +205,12 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
                 # Force the wine version to be installed
                 params["fallback"] = False
                 params["min_version"] = wine.MIN_SAFE_VERSION
-                version = self._get_runner_version()
+                version = self._get_runner_version() or runner.get_version(use_default=False)
                 if version:
                     params["version"] = version
                 else:
                     # Looking up default wine version
-                    default_wine = runner.get_runner_version() or {}
+                    default_wine = runner.get_runner_version_info() or {}
                     if "version" in default_wine:
                         logger.debug("Default wine version is %s", default_wine["version"])
                         # Set the version to both the is_installed params and
@@ -245,7 +245,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         logger.debug("Installing %s", runner.name)
         try:
             runner.install(
-                version=self._get_runner_version(),
+                version=self._get_runner_version() or runner.get_version(use_default=False),
                 downloader=simple_downloader,
                 callback=self.install_runners,
             )

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -201,6 +201,7 @@ def wineexec(  # noqa: C901
     disable_runtime=False,
     env=None,
     overrides=None,
+    preconfigure=False,
 ):
     """
     Execute a Wine command.
@@ -216,6 +217,7 @@ def wineexec(  # noqa: C901
         blocking (bool): if true, do not run the process in a thread
         config (LutrisConfig): LutrisConfig object for the process context
         watch (list): list of process names to monitor (even when in a ignore list)
+        preconfigure (bool): True to run preconfigure() before the command
 
     Returns:
         Process results if the process is running in blocking mode or
@@ -291,9 +293,14 @@ def wineexec(  # noqa: C901
     if blocking:
         return system.execute(command_parameters, env=wineenv, cwd=working_dir)
     wine = import_runner("wine")
+    runner = wine()
+
+    if preconfigure:
+        runner.preconfigure()
+
     command = MonitoredCommand(
         command_parameters,
-        runner=wine(),
+        runner=runner,
         env=wineenv,
         cwd=working_dir,
         include_processes=include_processes,

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -301,8 +301,8 @@ class Runner:  # pylint: disable=too-many-public-methods
         """Return whether the runner is installed"""
         return system.path_exists(self.get_executable())
 
-    def get_runner_version(self, version=None):
-        """Get the appropriate version for a runner
+    def get_runner_version_info(self, version=None):
+        """Get the appropriate version info dict for a runner
 
         Params:
             version (str): Optional version to lookup, will return this one if found
@@ -367,7 +367,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         if self.download_url:
             opts["dest"] = os.path.join(settings.RUNNER_DIR, self.name)
             return self.download_and_extract(self.download_url, **opts)
-        runner = self.get_runner_version(version)
+        runner = self.get_runner_version_info(version)
         if not runner:
             raise RunnerInstallationError("Failed to retrieve {} ({}) information".format(self.name, version))
         if not downloader:

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -116,6 +116,12 @@ class Runner:  # pylint: disable=too-many-public-methods
         if self.game_data.get("discord_client_id"):
             return self.game_data.get("discord_client_id")
 
+    def get_version(self, use_default=True):
+        """Returns the version of the runner to use, if applicable, and None
+        for most runners where it isn't. If use_default is False, this ignores
+        system-wide policy and returns only the value from the runner config."""
+        return None
+
     def get_platform(self):
         return self.platforms[0]
 
@@ -277,12 +283,11 @@ class Runner:  # pylint: disable=too-many-public-methods
             }
         )
         if Gtk.ResponseType.YES == dialog.result:
-
             from lutris.gui.dialogs import ErrorDialog
             from lutris.gui.dialogs.download import simple_downloader
             try:
-                if hasattr(self, "get_version"):
-                    version = self.get_version(use_default=False)  # pylint: disable=no-member
+                version = self.get_version(use_default=False)  # pylint: disable=assignment-from-none
+                if version:
                     self.install(downloader=simple_downloader, version=version)
                 else:
                     self.install(downloader=simple_downloader)

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -735,6 +735,12 @@ class wine(Runner):
     def prelaunch(self):
         if not system.path_exists(os.path.join(self.prefix_path, "user.reg")):
             create_prefix(self.prefix_path, arch=self.wine_arch)
+        self.preconfigure()
+
+    def preconfigure(self):
+        """Configures WINE for use. This is the part of prelaunch that we
+        apply even during installations; it does not include running prelaunch
+        scripts, nor will it create the prefix."""
         prefix_manager = WinePrefixManager(self.prefix_path)
         if self.runner_config.get("autoconf_joypad", False):
             prefix_manager.configure_joypads()

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -520,12 +520,14 @@ class wine(Runner):
 
     def get_version(self, use_default=True):
         """Return the Wine version to use. use_default can be set to false to
-        force the installation of a specific wine version"""
+        use only the runner's config, you get None if it is not specified. By
+        default, we'll fall back on the system-wide default."""
         runner_version = self.runner_config.get("version")
         if runner_version:
             return runner_version
         if use_default:
             return get_default_version()
+        return None
 
     def get_path_for_version(self, version):
         """Return the absolute path of a wine executable for a given version"""
@@ -562,7 +564,7 @@ class wine(Runner):
             wine_path = self.get_path_for_version(default_version)
             if wine_path:
                 # Update the version in the config
-                if version == self.runner_config.get("version"):
+                if version == self.get_version(use_default=False):
                     self.runner_config["version"] = default_version
                     # TODO: runner_config is a dict so we have to instanciate a
                     # LutrisConfig object to save it.


### PR DESCRIPTION
There are several parts to this. This PR will pick up the WINE version specified in the WINE runner settings, and get the WINE path for it. It will pick up the environment variables from the runner settings, including dynamic environment variables the WINE runner creates.

It will also run part of the prelaunch when an installer script runs WINE; it does not run the prelaunch script, but it applies various registry keys and copies DLLs into the prefix before running WINE.

To do all this, it needs to generate the wine runner object earlier and pass it around more.

This should allow much more control of the WINE environment during installation by setting running configuration options in the Preferences.

Resolves #3961
Resolves #3882
Resolves #2126
Resolves #1814
