### PR TITLE
More logging in the lutriswrapper

### DIFF
--- a/share/lutris/bin/lutris-wrapper
+++ b/share/lutris/bin/lutris-wrapper
@@ -126,9 +126,10 @@ def main():
 
     returncode = None
     try:
+        log(f"Executing process: {' '.join(args)}")
         process_pid = subprocess.Popen(args).pid
     except FileNotFoundError:
-        log("Failed to execute process. Check that the file exists")
+        log(f"Failed to execute process. Check that the file exists: {args[0]}")
         return
     log("Started initial process %d from %s" % (process_pid, " ".join(args)))
 


### PR DESCRIPTION
This adds more explicit logging when launching executables with the Lutris wrapper. It logs the args before launch, and if a file-not-found occurs, it names the file being executed.

This doesn't really resolve #3960, but it helped diagnose it.