### PR TITLE
Restore 'file not found' error for game executable

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -230,7 +230,7 @@ class CommandsMixin:
         for drive in drives:
             required_abspath = os.path.join(drive, requires)
             required_abspath = system.fix_path_case(required_abspath)
-            if required_abspath:
+            if required_abspath and system.path_exists(required_abspath):
                 logger.debug("Found %s on cdrom %s", requires, drive)
                 self.game_disc = drive
                 self._iter_commands()

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -74,10 +74,11 @@ class linux(Runner):
 
     @property
     def game_exe(self):
-        """Return the game's executable's path."""
+        """Return the game's executable's path. The file may not exist, but
+        this returns None if the exe path is not defined."""
         exe = self.game_config.get("exe")
         if not exe:
-            return
+            return None
         if os.path.isabs(exe):
             return exe
         if self.game_path:
@@ -90,7 +91,7 @@ class linux(Runner):
         """
         exe_path = self.game_exe
         working_dir = self.game_config.get("working_dir")
-        if working_dir:
+        if exe_path and working_dir:
             parts = exe_path.split(os.path.expanduser(working_dir))
             if len(parts) == 2:
                 return "." + parts[1]

--- a/lutris/runners/ryujinx.py
+++ b/lutris/runners/ryujinx.py
@@ -46,7 +46,7 @@ class ryujinx(Runner):
         candidates = ("~/.local/share/ryujinx", )
         for candidate in candidates:
             path = system.fix_path_case(os.path.join(os.path.expanduser(candidate), "nand"))
-            if path:
+            if path and system.path_exists(path):
                 return path[:-len("nand")]
 
     def play(self):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -485,18 +485,18 @@ class wine(Runner):
 
     @property
     def game_exe(self):
-        """Return the game's executable's path."""
+        """Return the game's executable's path, which may not exist. None
+        if there is no exe path defined."""
         exe = self.game_config.get("exe")
         if not exe:
             logger.warning("The game doesn't have an executable")
-            return
-        if exe and os.path.isabs(exe):
+            return None
+        if os.path.isabs(exe):
             return system.fix_path_case(exe)
         if not self.game_path:
-            return
-        exe = system.fix_path_case(os.path.join(self.game_path, exe))
-        if system.path_exists(exe):
-            return exe
+            logger.warning("The game has an executable, but not a game path")
+            return None
+        return system.fix_path_case(os.path.join(self.game_path, exe))
 
     @property
     def working_dir(self):
@@ -505,7 +505,9 @@ class wine(Runner):
         if option:
             return option
         if self.game_exe:
-            return os.path.dirname(self.game_exe)
+            game_dir = os.path.dirname(self.game_exe)
+            if os.path.isdir(game_dir):
+                return game_dir
         return super().working_dir
 
     @property
@@ -871,7 +873,7 @@ class wine(Runner):
                 if not display_vulkan_error(True):
                     return {"error": "VULKAN_NOT_FOUND"}
 
-        if not system.path_exists(game_exe):
+        if not game_exe or not system.path_exists(game_exe):
             return {"error": "FILE_NOT_FOUND", "file": game_exe}
 
         if launch_info["env"].get("WINEESYNC") == "1":

--- a/lutris/runners/yuzu.py
+++ b/lutris/runners/yuzu.py
@@ -44,7 +44,7 @@ class yuzu(Runner):
         candidates = ("~/.local/share/yuzu", )
         for candidate in candidates:
             path = system.fix_path_case(os.path.join(os.path.expanduser(candidate), "nand"))
-            if path:
+            if path and system.path_exists(path):
                 return path[:-len("nand")]
 
     def play(self):

--- a/lutris/util/steam/appmanifest.py
+++ b/lutris/util/steam/appmanifest.py
@@ -100,7 +100,7 @@ class AppManifest:
         if not self.installdir:
             return None
         install_path = fix_path_case(os.path.join(self.steamapps_path, "common", self.installdir))
-        if install_path:
+        if install_path and path_exists(install_path):
             return install_path
         return None
 

--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -34,7 +34,7 @@ def search_in_steam_dirs(file):
         path = system.fix_path_case(
             os.path.join(os.path.expanduser(candidate), file)
         )
-        if path:
+        if path and system.path_exists(path):
             return path
 
 

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -282,14 +282,14 @@ def fix_path_case(path):
         current_path = os.path.join(current_path, part)
         if not os.path.exists(current_path) and os.path.isdir(parent_path):
             try:
-                path_contents = os.listdir(current_path)
+                path_contents = os.listdir(parent_path)
             except OSError:
-                logger.error("Can't read contents of %s", current_path)
+                logger.error("Can't read contents of %s", parent_path)
                 path_contents = []
             for filename in path_contents:
                 if filename.lower() == part.lower():
-                    current_path = os.path.join(current_path, filename)
-                    continue
+                    current_path = os.path.join(parent_path, filename)
+                    break
 
     # Only return the path if we got the same number of elements
     if len(parts) == len(current_path.strip("/").split("/")):

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -270,28 +270,26 @@ def is_removeable(path):
 
 
 def fix_path_case(path):
-    """Do a case insensitive check, return the real path with correct case."""
+    """Do a case insensitive check, return the real path with correct case. If the path is
+    not for a real file, this corrects as many components as do exist."""
     if not path or os.path.exists(path):
         # If a path isn't provided or it exists as is, return it.
         return path
     parts = path.strip("/").split("/")
     current_path = "/"
     for part in parts:
-        if not os.path.exists(current_path):
-            return
-        tested_path = os.path.join(current_path, part)
-        if os.path.exists(tested_path):
-            current_path = tested_path
-            continue
-        try:
-            path_contents = os.listdir(current_path)
-        except OSError:
-            logger.error("Can't read contents of %s", current_path)
-            path_contents = []
-        for filename in path_contents:
-            if filename.lower() == part.lower():
-                current_path = os.path.join(current_path, filename)
-                continue
+        parent_path = current_path
+        current_path = os.path.join(current_path, part)
+        if not os.path.exists(current_path) and os.path.isdir(parent_path):
+            try:
+                path_contents = os.listdir(current_path)
+            except OSError:
+                logger.error("Can't read contents of %s", current_path)
+                path_contents = []
+            for filename in path_contents:
+                if filename.lower() == part.lower():
+                    current_path = os.path.join(current_path, filename)
+                    continue
 
     # Only return the path if we got the same number of elements
     if len(parts) == len(current_path.strip("/").split("/")):


### PR DESCRIPTION
This makes the file-not-found error work, by keeping the game's executable path around when it does not refer to a file, rather than replacing it with None in various places.

The big change is that fix_path_case needs to work when the path does not refer to anything. It will now correct each path component that does exist, and leave the rest.

Resolves #3968