### PR TITLE
Remove the runner dir that contains the runner executable

### DIFF
--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -1,6 +1,7 @@
 """Base module for runners"""
 import os
 from gettext import gettext as _
+from pathlib import Path
 
 from gi.repository import Gtk
 
@@ -144,11 +145,13 @@ class Runner:  # pylint: disable=too-many-public-methods
     def get_runner_path(self):
         """Gets the Lutris runner directory that contains this runner, which
         is what we remove for uninstallation."""
-        if self.runner_executable:
-            parts = os.path.split(self.runner_executable)  # ignore runner config
+        name = self.name
+        if self.runner_executable:  # ignore runner config
+            parts = list(Path(self.runner_executable).parts)
             if parts:
-                return os.path.join(settings.RUNNER_DIR, parts[0])
-        return os.path.join(settings.RUNNER_DIR, self.name)
+                name = parts[0]
+
+        return os.path.join(settings.RUNNER_DIR, name or self.name)
 
     def get_env(self, os_env=False):
         """Return environment variables used for a game."""
@@ -435,6 +438,8 @@ class Runner:  # pylint: disable=too-many-public-methods
         runner_path = self.get_runner_path()
         if os.path.isdir(runner_path):
             system.remove_folder(runner_path)
+        elif os.path.isfile(runner_path):
+            os.remove(runner_path)
 
     def find_option(self, options_group, option_name):
         """Retrieve an option dict if it exists in the group"""


### PR DESCRIPTION
Well, the default executable, not custom ones.

If a runner has a default executable, like "fs-uae/fs-uae", we'll now use that to find the directory to remove. If it specifies a file like "easyrpg-player", we'll now delete that file only.

If it has not got a default executable, we'll still delete a directory named with the runner's name as before.

It would be nice to make these names all match nicely, with directories for everyone, but I can't see a way to do that without breaking existing installs. So, this makes the current arrangements work better.

Resolves #3970