### PR TITLE
Configuration of the WINE DPI setting

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -12,7 +12,7 @@ from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-
 )
 from lutris.runners.runner import Runner
 from lutris.util import system
-from lutris.util.display import DISPLAY_MANAGER
+from lutris.util.display import DISPLAY_MANAGER, get_default_dpi
 from lutris.util.graphics.vkquery import is_vulkan_supported
 from lutris.util.jobs import thread_safe_call
 from lutris.util.log import logger
@@ -632,6 +632,7 @@ class wine(Runner):
 
     def run_wineconsole(self, *args):
         """Runs wineconsole inside wine prefix."""
+        self.prelaunch()
         self._run_executable("wineconsole")
 
     def run_winecfg(self, *args):
@@ -709,6 +710,10 @@ class wine(Runner):
                     value = int(value)
 
                 prefix_manager.set_registry_key(path, key, value)
+
+        dpi = get_default_dpi()
+        prefix_manager.set_registry_key("HKEY_CURRENT_USER/Software/Wine/Fonts", "LogPixels", dpi)
+        prefix_manager.set_registry_key("HKEY_CURRENT_USER/Control Panel/Desktop", "LogPixels", dpi)
 
     def setup_dlls(self, manager_class, enable, version):
         """Enable or disable DLLs"""

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -733,9 +733,7 @@ class wine(Runner):
 
         # We always configure the DPI, because if the user turns off DPI scaling, but it
         # had been on the only way to implement that is to save 96 DPI into the registry.
-        dpi = self.get_dpi()
-        prefix_manager.set_registry_key("HKEY_CURRENT_USER/Software/Wine/Fonts", "LogPixels", dpi)
-        prefix_manager.set_registry_key("HKEY_CURRENT_USER/Control Panel/Desktop", "LogPixels", dpi)
+        prefix_manager.set_dpi(self.get_dpi())
 
     def get_dpi(self):
         """Return the DPI to be used by Wine; returns 96 to disable scaling,

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -358,6 +358,26 @@ class wine(Runner):
                 "help": _("The size of the virtual desktop in pixels."),
             },
             {
+                "option": "Dpi",
+                "label": _("Enable DPI Scaling"),
+                "type": "bool",
+                "default": False,
+                "help": _(
+                    "Enables the Windows application's DPI scaling.\n"
+                    "Otherwise, disables DPI scaling by using 96 DPI.\n"
+                    "This corresponds to Wine's Screen Resolution option."
+                ),
+            },
+            {
+                "option": "ExplicitDpi",
+                "label": _("DPI"),
+                "type": "string",
+                "help": _(
+                    "The DPI to be used if 'Enable DPI Scaling' is turned on.\n"
+                    "If blank or 'auto', Lutris will auto-detect this."
+                ),
+            },
+            {
                 "option": "MouseWarpOverride",
                 "label": _("Mouse Warp Override"),
                 "type": "choice",
@@ -711,9 +731,26 @@ class wine(Runner):
 
                 prefix_manager.set_registry_key(path, key, value)
 
-        dpi = get_default_dpi()
+        # We always configure the DPI, because if the user turns off DPI scaling, but it
+        # had been on the only way to implement that is to save 96 DPI into the registry.
+        dpi = self.get_dpi()
         prefix_manager.set_registry_key("HKEY_CURRENT_USER/Software/Wine/Fonts", "LogPixels", dpi)
         prefix_manager.set_registry_key("HKEY_CURRENT_USER/Control Panel/Desktop", "LogPixels", dpi)
+
+    def get_dpi(self):
+        """Return the DPI to be used by Wine; returns 96 to disable scaling,
+        as this is Window's unscaled default DPI."""
+        if bool(self.runner_config.get("Dpi")):
+            explicit_dpi = self.runner_config.get("ExplicitDpi")
+            if explicit_dpi == "auto":
+                explicit_dpi = None
+            try:
+                explicit_dpi = int(explicit_dpi)
+            except ValueError:
+                explicit_dpi = None
+            return explicit_dpi or get_default_dpi()
+
+        return 96
 
     def setup_dlls(self, manager_class, enable, version):
         """Enable or disable DLLs"""

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -26,6 +26,16 @@ class NoScreenDetected(Exception):
     """Raise this when unable to detect screens"""
 
 
+def get_default_dpi():
+    """Computes the DPI to use for the primary monitor
+    which we pass to WINE."""
+    display = Gdk.Display.get_default()
+    monitor = display.get_primary_monitor()
+    scale = monitor.get_scale_factor()
+    dpi = 96 * scale
+    return int(dpi)
+
+
 def restore_gamma():
     """Restores gamma to a normal level."""
     xgamma_path = system.find_executable("xgamma")

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -207,6 +207,11 @@ class WinePrefixManager:
         if desktop_size:
             self.set_registry_key(path, "WineDesktop", desktop_size)
 
+    def set_dpi(self, dpi):
+        """Sets the DPI for WINE to use. 96 DPI is effectively unscaled."""
+        self.set_registry_key(self.hkcu_prefix + "/Software/Wine/Fonts", "LogPixels", dpi)
+        self.set_registry_key(self.hkcu_prefix + "/Control Panel/Desktop", "LogPixels", dpi)
+
     def configure_joypads(self):
         """Disables some joypad devices"""
         key = self.hkcu_prefix + "/Software/Wine/DirectInput/Joysticks"


### PR DESCRIPTION
This provides configuration options to control WINE's DPI setting.

This works by setting a couple of registry values. If turned off (the default) it sets the DPI to 96 dpi, which produces no scaling. If on, it will auto-detect the scaling used by the primary monitor. You can override this with a second config option.

But it always sets the DPI, so that you can recover to a 'normal' state by turning it off. The bad news- WINE provides access to this setting in 'Wine Configuration', and this code just overwrites that setting.

This seems to work fairly well for integer scaling in GNOME, but gets more dicey with fractional scaling. The Windows GUI stuff works- we provide an integer scaling (x2 = 192 dpi, etc) but GNOME scales the result down so it all balances. But actual game-play seems to bug out quite easily.

I don't think I can fix that; WINE or GNOME will have to.

Resolves #3617