### PR TITLE
Don't glob the filespec unnecessarily

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -158,7 +158,10 @@ class CommandsMixin:
         src_param = data.get("file") or data.get("src")
         filespec = self._get_file(src_param)
 
-        filenames = glob.glob(filespec)
+        if os.path.exists(filespec):
+            filenames = [filespec]
+        else:
+            filenames = glob.glob(filespec)
 
         if not filenames:
             raise ScriptingError(_("%s does not exist") % filespec)


### PR DESCRIPTION
This allows files to be used by installers that contain '[', '?' or '*' in the file path- which can happen if the user specifies the filename manually.

If the path refers to a file, we just use it. If not, we glob it. It's a heuristic, but it think it'll work pretty well since I think the normal case will be a single file, specified exactly by path.

This will fail if the filespec is meant to be a glob, but just happens to match an existing file exactly. I think this is not likely.

Resolves #3975.