### PR TITLE
Do not crash if installing from Steam, when Steam is not available

### DIFF
--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -44,12 +44,12 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
     def get_service(self, initial=None):
         if initial:
             return initial
-        if "steam" in self.runner:
+        if "steam" in self.runner and "steam" in SERVICES:
             return SERVICES["steam"]()
         version = self.version.lower()
-        if "humble" in version:
+        if "humble" in version and "humblebundle" in SERVICES:
             return SERVICES["humblebundle"]()
-        if "gog" in version:
+        if "gog" in version and "gog" in SERVICES:
             return SERVICES["gog"]()
 
     def get_appid(self, installer, initial=None):

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,12 +212,13 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkButton">
+              <object class="GtkMenuButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
+                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,13 +212,12 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkMenuButton">
+              <object class="GtkButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
-                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>


### PR DESCRIPTION
I find that there's a nice error for this case, but Lutris crashes first. This PR adds checks so that if Steam is not available, we do not crash but continue with no service. The result is a nice error telling the user to install Steam.

Resolves #3985

Got some messiness with by local repo, which hopefully will not cause trouble for this PR. I'll delete and refork it once my outstanding PRs are disposed of.