### PR TITLE
Tolerate missing system information in the Preferences dialog

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -446,10 +446,10 @@ def gather_system_info_str():
     system_info_readable["System"] = system_dict
     # Add CPU information
     cpu_dict = {}
-    cpu_dict["Vendor"] = system_info["cpus"][0]["vendor_id"]
-    cpu_dict["Model"] = system_info["cpus"][0]["model name"]
-    cpu_dict["Physical cores"] = system_info["cpus"][0]["cpu cores"]
-    cpu_dict["Logical cores"] = system_info["cpus"][0]["siblings"]
+    cpu_dict["Vendor"] = system_info["cpus"][0].get("vendor_id", "Vendor unavailable")
+    cpu_dict["Model"] = system_info["cpus"][0].get("model name", "Model unavailable")
+    cpu_dict["Physical cores"] = system_info["cpus"][0].get("cpu cores", "Physical cores unavailable")
+    cpu_dict["Logical cores"] = system_info["cpus"][0].get("siblings", "Logical cores unavailable")
     system_info_readable["CPU"] = cpu_dict
     # Add memory information
     ram_dict = {}
@@ -459,9 +459,9 @@ def gather_system_info_str():
     # Add graphics information
     graphics_dict = {}
     if LINUX_SYSTEM.glxinfo:
-        graphics_dict["Vendor"] = system_info["glxinfo"]["opengl_vendor"]
-        graphics_dict["OpenGL Renderer"] = system_info["glxinfo"]["opengl_renderer"]
-        graphics_dict["OpenGL Version"] = system_info["glxinfo"]["opengl_version"]
+        graphics_dict["Vendor"] = system_info["glxinfo"].get("opengl_vendor", "Vendor unavailable")
+        graphics_dict["OpenGL Renderer"] = system_info["glxinfo"].get("opengl_renderer", "OpenGL Renderer unavailable")
+        graphics_dict["OpenGL Version"] = system_info["glxinfo"].get("opengl_version", "OpenGL Version unavailable")
         graphics_dict["OpenGL Core"] = system_info["glxinfo"].get(
             "opengl_core_profile_version", "OpenGL core unavailable"
         )

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,12 +212,13 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkButton">
+              <object class="GtkMenuButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
+                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,13 +212,12 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkMenuButton">
+              <object class="GtkButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
-                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>


### PR DESCRIPTION
Lutris assumes that Linux will supply certain fields and crashes if not. Things like the CPU vendor.

This PR provides defaults in the form of "Vendor unavailable" or whatnot if one of these fields winds up being missing. In this way, you can at least see what Linux did supply.

Resolves #3988