### PR TITLE
[Doc update] installer extractable format

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -459,7 +459,7 @@ should be extracted in some other location than the ``$GAMEDIR``, you can specif
 
 You can optionally specify the archive's type with the ``format`` option.
 This is useful if the archive's file extension does not match what it should
-be. Accepted values for ``format`` are: zip, tgz, gzip, bz2, and gog (innoextract).
+be. Accepted values for ``format`` are: tgz, tar, zip, 7z, rar, txz, bz2, gzip, deb, exe and gog(innoextract), as well as all other formats supported by 7zip.
 
 Example::
 


### PR DESCRIPTION
The `extract` directive in the installer has a `format` argument, which specifies the extraction format.

Updated docs to specify all supported values for `format`.
most formats listed can be found [here](https://github.com/lutris/lutris/blob/66675a4d5537f6b2a2ba2b6df0b3cdf8924c823a/lutris/util/extract.py#L93), and the rest are [passed down to 7zip](https://github.com/lutris/lutris/blob/66675a4d5537f6b2a2ba2b6df0b3cdf8924c823a/lutris/util/extract.py#L289).

Resolves #3923.