### PR TITLE
Suppress flash when update_store completes quickly

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -517,23 +517,28 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
             self.save_icon_type(icon_type)
 
     def show_label(self, message):
-        """Display a label in the middle of the UI"""
+        """Display a label in the middle of the UI, instead of the game view"""
+        label = Gtk.Label(message, visible=True)
         for child in self.blank_overlay.get_children():
             child.destroy()
-        label = Gtk.Label(message, visible=True)
         self.blank_overlay.add(label)
-        self.blank_overlay.props.visible = True
+        self.blank_overlay.show()
+        self.games_scrollwindow.hide()
 
     def show_spinner(self):
+        """Display a spinner in the middle of the UI, instead of the game view"""
         spinner = Gtk.Spinner(visible=True)
         spinner.start()
         for child in self.blank_overlay.get_children():
             child.destroy()
         self.blank_overlay.add(spinner)
-        self.blank_overlay.props.visible = True
+        self.blank_overlay.show()
+        self.games_scrollwindow.hide()
 
     def hide_overlay(self):
-        self.blank_overlay.props.visible = False
+        """Restore the game view, and remove the spinner or label."""
+        self.games_scrollwindow.show()
+        self.blank_overlay.hide()
         for child in self.blank_overlay.get_children():
             child.destroy()
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -467,9 +467,9 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     def update_store_cb(self, games, error):
         self.hide_overlay()
-        
+
         if error:
-            ErrorDialog(str(error))
+            dialogs.ErrorDialog(str(error))
         else:
             self.game_store.store.clear()
             logger.debug("Showing %d games", len(games))

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -463,7 +463,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     def update_store(self, *_args, **_kwargs):
         thread = AsyncCall(self.get_games_from_filters, self.update_store_cb)
-        if thread.await_completion(.25):
+        if not thread.await_completion(.25):
             self.show_spinner()
 
     def update_store_cb(self, games, error):
@@ -480,7 +480,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
                 self.game_store.add_game(game)
             if not games:
                 self.show_empty_label()
-            self.search_timer_id = None
+        self.search_timer_id = None
         return False
 
     def set_dark_theme(self):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -117,7 +117,6 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
         self.sidebar_revealer.set_reveal_child(self.side_panel_visible)
         self.sidebar_revealer.set_transition_duration(300)
-        self.tabs_box.hide()
 
         self.game_bar = None
         self.revealer_box = Gtk.HBox(visible=True)

--- a/lutris/util/jobs.py
+++ b/lutris/util/jobs.py
@@ -32,6 +32,7 @@ class AsyncCall(threading.Thread):
         and returns True. Returns False if it times out."""
         self.join(timeout)
         if not self.is_alive():
+            GLib.source_remove(self.source_id)
             self.complete()
             return True
         return False
@@ -54,11 +55,7 @@ class AsyncCall(threading.Thread):
 
     def complete(self):
         callback_args = self.completion_callback_args
-        if callback_args is not None:
-            # Make sure we don't call the callback twice, even if
-            # await_completion succeeds.
-            self.completion_callback_args = None
-            self.callback(*callback_args)
+        self.callback(*callback_args)
 
 
 def synchronized_call(func, event, result):

--- a/lutris/util/jobs.py
+++ b/lutris/util/jobs.py
@@ -27,6 +27,9 @@ class AsyncCall(threading.Thread):
         self.start()
 
     def await_completion(self, timeout):
+        """Block waiting for the call to complete for a time.
+        If it completes in time,  invokes the callback synchronously
+        and returns True. Returns False if it times out."""
         self.join(timeout)
         if not self.is_alive():
             self.complete()
@@ -52,6 +55,8 @@ class AsyncCall(threading.Thread):
     def complete(self):
         callback_args = self.completion_callback_args
         if callback_args is not None:
+            # Make sure we don't call the callback twice, even if
+            # await_completion succeeds.
             self.completion_callback_args = None
             self.callback(*callback_args)
 

--- a/lutris/util/jobs.py
+++ b/lutris/util/jobs.py
@@ -60,6 +60,7 @@ class AsyncCall(threading.Thread):
             self.completion_callback_args = None
             self.callback(*callback_args)
 
+
 def synchronized_call(func, event, result):
     """Calls func, stores the result by reference, set an event when finished"""
     result.append(func())

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,12 +212,13 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkButton">
+              <object class="GtkMenuButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
+                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,13 +212,12 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkMenuButton">
+              <object class="GtkButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
-                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -69,7 +69,6 @@
                     <property name="can-focus">False</property>
                     <child>
                       <object class="GtkBox" id="tabs_box">
-                        <property name="visible">True</property>
                         <property name="can-focus">False</property>
                         <property name="homogeneous">True</property>
                         <child>
@@ -77,8 +76,8 @@
                             <property name="label" translatable="yes">Your Library</property>
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="active">True</property>
                             <property name="receives-default">False</property>
+                            <property name="active">True</property>
                             <property name="draw-indicator">False</property>
                             <signal name="toggled" handler="on_game_collection_changed" swapped="no"/>
                           </object>


### PR DESCRIPTION
This improves the visual appearance when switching between views. It runs the get_games_from_filter() asynchronously (this only works because of the global interpreter lock), and adds a new method to AsyncCall so that if this async call completes quickly (in a quarter second) then it dispatches the callback and completes the beast synchronously.

*That* means there's no chance for GTK to redraw the view in an 'intermediate' state.

If the update takes more than a quarter second, it will also show the spinner, which replaces the normal view. If you are searching Lutris, this gives a progress indicator while the search occurs.

Resolves #3995