### PR TITLE
Remove sidebar row hover styling

### DIFF
--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,12 +212,13 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkButton">
+              <object class="GtkMenuButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
+                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -212,13 +212,12 @@
             <property name="can-focus">False</property>
             <property name="spacing">6</property>
             <child>
-              <object class="GtkMenuButton">
+              <object class="GtkButton">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">False</property>
                 <property name="tooltip-text" translatable="yes">Add Game</property>
                 <property name="action-name">win.add-game</property>
-                <property name="use-popover">False</property>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -31,7 +31,3 @@
 .panel-button label {
     font-weight: normal;
 }
-
-.sidebar row:hover {
-  background: rgba(0, 0, 0, 0.1);
-}


### PR DESCRIPTION
An alternative way to restore the contrast in sidebar rows when hovered- just let the current theme do its thing unmolested.

This ought to work and look 'right' with any style. I think maybe the hover appearance of the action buttons is not ideal, but it's legible.

Resolves #3916