### PR TITLE
Add hex resolution vars to installer substitutions (Resolves #3900).

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -385,6 +385,8 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             "RESOLUTION": "x".join(self.current_resolution),
             "RESOLUTION_WIDTH": self.current_resolution[0],
             "RESOLUTION_HEIGHT": self.current_resolution[1],
+            "RESOLUTION_WIDTH_HEX": hex(int(self.current_resolution[0])),
+            "RESOLUTION_HEIGHT_HEX": hex(int(self.current_resolution[1])),
             "WINEBIN": self.get_wine_path(),
         }
         replacements.update(self.installer.variables)


### PR DESCRIPTION
Adds hexadecimal versions of the RESOLUTION_WIDTH and RESOLUTION_HEIGHT variables for installer substitution as requested by issue #3900.