### PR TITLE
Set env correctly when scummvm runs alone

### DIFF
--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -117,7 +117,10 @@ class scummvm(Runner):
         return data_dir
 
     def get_run_data(self):
-        env = {"LD_LIBRARY_PATH": "%s;$LD_LIBRARY_PATH" % self.libs_dir}
+        env = self.get_env()
+        env["LD_LIBRARY_PATH"] = os.pathsep.join(filter(None, [
+            self.libs_dir,
+            env.get("LD_LIBRARY_PATH")]))
         return {"env": env, "command": self.get_command()}
 
     def play(self):


### PR DESCRIPTION
`env` not inherited from `get_env()`.
`;` instead of `:` used as path separator.
Adding the literal string `$LD_LIBRARY_PATH` to environment variable doesn't make sense.