### PR TITLE
Don't add literal `$LD_LIBRARY_PATH` to env

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -85,12 +85,11 @@ def get_launch_parameters(runner, gameplay_info):
         env["LD_PRELOAD"] = ld_preload
 
     # LD_LIBRARY_PATH
-    game_ld_libary_path = gameplay_info.get("ld_library_path")
-    if game_ld_libary_path:
+    game_ld_library_path = gameplay_info.get("ld_library_path")
+    if game_ld_library_path:
         ld_library_path = env.get("LD_LIBRARY_PATH")
-        if not ld_library_path:
-            ld_library_path = "$LD_LIBRARY_PATH"
-        env["LD_LIBRARY_PATH"] = ":".join([game_ld_libary_path, ld_library_path])
+        env["LD_LIBRARY_PATH"] = os.pathsep.join(filter(None, [
+            game_ld_library_path, ld_library_path]))
 
     # Feral gamemode
     gamemode = system_config.get("gamemode") and LINUX_SYSTEM.gamemode_available()

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -205,14 +205,12 @@ class Runner:  # pylint: disable=too-many-public-methods
 
         if self.use_runtime():
             runtime_env = self.get_runtime_env()
-            if "LD_LIBRARY_PATH" in runtime_env:
-                runtime_ld_library_path = runtime_env["LD_LIBRARY_PATH"]
+            runtime_ld_library_path = runtime_env.get("LD_LIBRARY_PATH")
 
         if runtime_ld_library_path:
             ld_library_path = env.get("LD_LIBRARY_PATH")
-            if not ld_library_path:
-                ld_library_path = "$LD_LIBRARY_PATH"
-            env["LD_LIBRARY_PATH"] = ":".join([runtime_ld_library_path, ld_library_path])
+            env["LD_LIBRARY_PATH"] = os.pathsep.join(filter(None, [
+                runtime_ld_library_path, ld_library_path]))
 
         # Apply user overrides at the end
         env.update(self.system_config.get("env") or {})


### PR DESCRIPTION
The literal string `$LD_LIBRARY_PATH` was only used as a fallback when the path was empty.
For this reason it did not break anything.