### PR TITLE
file_pattern and dest_path None type error when switching to local tab

### DIFF
--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -31,11 +31,17 @@ class ServiceMedia:
             os.makedirs(self.dest_path)
 
     def get_filename(self, slug):
-        return self.file_pattern % slug
+        if isinstance(self.file_pattern, str):
+            return self.file_pattern % slug
+        else:
+            return str('')
 
     def get_absolute_path(self, slug):
         """Return the abolute path of a local media"""
-        return os.path.join(self.dest_path, self.get_filename(slug))
+        if (isinstance(self.dest_path, str)):
+            return os.path.join(self.dest_path, self.get_filename(slug))
+        else:
+            return str('')
 
     def exists(self, slug):
         """Whether the icon for the specified slug exists locally"""


### PR DESCRIPTION
The file_pattern and dest_path have None, which can not be used in string operations. This doesn't seem to cause any adverse effects, but it probably should be fixed.

`Traceback (most recent call last):
  File "/home/brian/gits/lutris/lutris/gui/lutriswindow.py", line 472, in update_store
    self.game_store.add_game(game)
  File "/home/brian/gits/lutris/lutris/gui/views/store.py", line 161, in add_game
    game.get_pixbuf() if settings.SHOW_MEDIA else None,
  File "/home/brian/gits/lutris/lutris/gui/views/store_item.py", line 108, in get_pixbuf
    return self.service_media.get_pixbuf_for_game(
  File "/home/brian/gits/lutris/lutris/services/service_media.py", line 45, in get_pixbuf_for_game
    image_abspath = self.get_absolute_path(slug)
  File "/home/brian/gits/lutris/lutris/services/service_media.py", line 38, in get_absolute_path
    return os.path.join(self.dest_path, self.get_filename(slug))
  File "/home/brian/gits/lutris/lutris/services/service_media.py", line 34, in get_filename
    return self.file_pattern % slug
TypeError: unsupported operand type(s) for %: 'NotImplementedType' and 'str'
`

And after the file_pattern None is handled:

`Traceback (most recent call last):
  File "/home/brian/gits/lutris-beastwick/lutris/gui/lutriswindow.py", line 472, in update_store
    self.game_store.add_game(game)
  File "/home/brian/gits/lutris-beastwick/lutris/gui/views/store.py", line 161, in add_game
    game.get_pixbuf() if settings.SHOW_MEDIA else None,
  File "/home/brian/gits/lutris-beastwick/lutris/gui/views/store_item.py", line 108, in get_pixbuf
    return self.service_media.get_pixbuf_for_game(
  File "/home/brian/gits/lutris-beastwick/lutris/services/service_media.py", line 51, in get_pixbuf_for_game
    image_abspath = self.get_absolute_path(slug)
  File "/home/brian/gits/lutris-beastwick/lutris/services/service_media.py", line 42, in get_absolute_path
    return os.path.join(self.dest_path, self.get_filename(slug))
  File "/usr/lib64/python3.10/posixpath.py", line 76, in join
    a = os.fspath(a)
TypeError: expected str, bytes or os.PathLike object, not NoneType`