### PR TITLE
Changed "Services" to "Sources"

### DIFF
--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -25,7 +25,7 @@ class PreferencesDialog(GameDialogCommon):
         sidebar.connect("row-selected", self.on_sidebar_activated)
         sidebar.add(self.get_sidebar_button("prefs-stack", _("Interface"), "view-grid-symbolic"))
         sidebar.add(self.get_sidebar_button("runners-stack", _("Runners"), "applications-utilities-symbolic"))
-        sidebar.add(self.get_sidebar_button("services-stack", _("Services"), "application-x-addon-symbolic"))
+        sidebar.add(self.get_sidebar_button("services-stack", _("Sources"), "application-x-addon-symbolic"))
         sidebar.add(self.get_sidebar_button("sysinfo-stack", _("Hardware information"), "computer-symbolic"))
         sidebar.add(self.get_sidebar_button("system-stack", _("Global options"), "emblem-system-symbolic"))
         hbox.pack_start(sidebar, False, False, 0)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45468984/151622280-9ff6c4fd-5e4b-45fb-9d9c-aff80ec133c2.png)
Throughout the entire application, the term "sources" is used everywhere. 
For some reason, the sidebar is the only place where the term "Services" is used, in which the term "Sources" is also unanimously used.
- Propersal: Replacing the lonely term "Services" to the more appropriate one "Sources". 
- Replaced line 28 String from "Services" to "Sources".
