### PR TITLE
Re-initialize the zoom adjustment when the view-type toggles

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -744,6 +744,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         self.set_viewtype_icon(view_type)
         settings.write_setting("view_type", view_type)
         self.redraw_view()
+        self._bind_zoom_adjustment()
 
     def on_icontype_state_change(self, action, value):
         action.set_state(value)


### PR DESCRIPTION
This way, the zoom slider stays in sync with the version of its setting that applies. Simple!

Resolves #4025