### PR TITLE
lxml is now in setup.py - fixes an issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
         'PyGObject',
         'evdev',
         'requests',
-        'python-magic'
+        'python-magic',
+        'lxml'
     ],
     url='https://lutris.net',
     description='Video game preservation platform',


### PR DESCRIPTION
This fixes the issue on Gentoo GNU/linux and it is a good idea to have in setup.py. I have written an issue about this but it seems developers are to busy to adress every single issue. https://github.com/lutris/lutris/issues/4008