### PR TITLE
Add a duplicate game command

### DIFF
--- a/lutris/config.py
+++ b/lutris/config.py
@@ -2,6 +2,7 @@
 
 import os
 import time
+from shutil import copyfile
 
 import yaml
 
@@ -26,6 +27,16 @@ def write_game_config(game_slug, config):
         logger.debug("Writing game config to %s", config_filename)
         config_file.write(yaml_config)
     return configpath
+
+
+def duplicate_game_config(game_slug, source_config_id):
+    """Copies an existing configuration file, giving it a new id that this
+    function returns."""
+    new_config_id = make_game_config_id(game_slug)
+    src_path = os.path.join(settings.CONFIG_DIR, "games/%s.yml" % source_config_id)
+    dest_path = os.path.join(settings.CONFIG_DIR, "games/%s.yml" % new_config_id)
+    copyfile(src_path, dest_path)
+    return new_config_id
 
 
 class LutrisConfig:

--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -112,7 +112,7 @@ def get_service_games(service):
 
 def get_game_by_field(value, field="slug"):
     """Query a game based on a database field"""
-    if field not in ("slug", "installer_slug", "id", "configpath"):
+    if field not in ("slug", "installer_slug", "id", "configpath", "name"):
         raise ValueError("Can't query by field '%s'" % field)
     game_result = sql.db_select(settings.PGA_DB, "games", condition=(field, value))
     if game_result:
@@ -211,3 +211,21 @@ def get_used_platforms():
         rows = cursor.execute(query)
         results = rows.fetchall()
     return [result[0] for result in results if result[0]]
+
+
+def get_unusued_game_name(game_name):
+    """Returns the given name, but if this name is already used by an installed
+    game, this adds a number to it to make it unique."""
+    def is_name_in_use(name):
+        """Queries the database to see if a given is in use by an installed
+        game."""
+        existing_game = get_game_by_field(assigned_name, "name")
+        return existing_game and existing_game["installed"]
+
+    assigned_name = game_name
+    assigned_index = 1
+    while is_name_in_use(assigned_name):
+        assigned_index += 1
+        assigned_name = f"{game_name} {assigned_index}"
+
+    return assigned_name

--- a/lutris/database/sql.py
+++ b/lutris/database/sql.py
@@ -144,7 +144,7 @@ def filtered_query(
         sql_filters.append("%s LIKE ?" % field)
         params.append("%" + searches[field] + "%")
     for field in filters or {}:
-        if filters[field]:
+        if filters[field] is not None:  # but 0 or False are okay!
             sql_filters.append("%s = ?" % field)
             params.append(filters[field])
     for field in excludes or {}:

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -217,6 +217,10 @@ class GameActions:
         db_game["name"] = assigned_name
         db_game["configpath"] = new_config_id
         db_game.pop("id")
+        # Disconnect duplicate from service- there should be at most
+        # 1 PGA game for a service game.
+        db_game.pop("service", None)
+        db_game.pop("service_id", None)
 
         game_id = add_game(**db_game)
         new_game = Game(game_id)

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -5,18 +5,22 @@
 import os
 from gettext import gettext as _
 
-from gi.repository import Gio
+from gi.repository import Gio, Gtk
 
 from lutris.command import MonitoredCommand
+from lutris.config import duplicate_game_config
+from lutris.database.games import add_game, get_game_by_field, get_unusued_game_name
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.config.add_game import AddGameDialog
 from lutris.gui.config.edit_game import EditGameConfigDialog
+from lutris.gui.dialogs import QuestionDialog
 from lutris.gui.dialogs.log import LogWindow
 from lutris.gui.dialogs.uninstall_game import RemoveGameDialog, UninstallGameDialog
 from lutris.gui.widgets.utils import open_uri
 from lutris.util import xdgshortcuts
 from lutris.util.log import logger
+from lutris.util.strings import gtk_safe
 from lutris.util.system import path_exists
 
 
@@ -60,6 +64,7 @@ class GameActions:
             ("install_dlcs", "Install DLCs", self.on_install_dlc_clicked),
             ("show_logs", _("Show logs"), self.on_show_logs),
             ("add", _("Add installed game"), self.on_add_manually),
+            ("duplicate", _("Duplicate"), self.on_game_duplicate),
             ("configure", _("Configure"), self.on_edit_game_configuration),
             ("favorite", _("Add to favorites"), self.on_add_favorite_game),
             ("deletefavorite", _("Remove from favorites"), self.on_delete_favorite_game),
@@ -96,6 +101,7 @@ class GameActions:
         """Return a dictionary of actions that should be shown for a game"""
         return {
             "add": not self.game.is_installed,
+            "duplicate": True,
             "install": not self.game.is_installed,
             "play": self.game.is_installed and not self.is_game_running,
             "update": self.game.is_updatable,
@@ -185,6 +191,36 @@ class GameActions:
     def on_add_manually(self, _widget, *_args):
         """Callback that presents the Add game dialog"""
         return AddGameDialog(self.window, game=self.game, runner=self.game.runner_name)
+
+    def on_game_duplicate(self, _widget):
+        confirm_dlg = QuestionDialog(
+            {
+                "parent": self.window,
+                "question": _(
+                    "Do you wish to duplicate %s?\nThe configuration will be duplicated, "
+                    "but the games files will <b>not be duplicated</b>."
+                ) % gtk_safe(self.game.name),
+                "title": _("Duplicate game?"),
+            }
+        )
+        if confirm_dlg.result != Gtk.ResponseType.YES:
+            return
+
+        assigned_name = get_unusued_game_name(self.game.name)
+        old_config_id = self.game.game_config_id
+        if old_config_id:
+            new_config_id = duplicate_game_config(self.game.slug, old_config_id)
+        else:
+            new_config_id = None
+
+        db_game = get_game_by_field(self.game.id, "id")
+        db_game["name"] = assigned_name
+        db_game["configpath"] = new_config_id
+        db_game.pop("id")
+
+        game_id = add_game(**db_game)
+        new_game = Game(game_id)
+        new_game.save()
 
     def on_edit_game_configuration(self, _widget):
         """Edit game preferences"""


### PR DESCRIPTION
This PR adds a "Duplicate" command to the game actions. This command duplicates the PGA database row and the config file, but not the game files. There's a question dialog that explains this and confirms the duplication.

This assigns a new name (and ID) to the duplicate.

Resolves #3102