### PR TITLE
Widen the preferences window slightly

### DIFF
--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -17,7 +17,7 @@ class PreferencesDialog(GameDialogCommon):
     def __init__(self, parent=None):
         super().__init__(_("Lutris settings"), parent=parent)
         self.set_border_width(0)
-        self.set_default_size(960, 600)
+        self.set_default_size(1010, 600)
         self.lutris_config = LutrisConfig()
 
         hbox = Gtk.HBox(visible=True)


### PR DESCRIPTION
The content of the preferences window now fit- except for the global options.

But they *almost* fit, and making that complex UI narrower seems risky- so this PR widens the default size of the preferences window to 1010px (from 960px).

My testing indicates that this does not break it if the screen is not this wide- it just comes out smaller, which is no worse that what it is now. So I think there's no downside here.

Resolves #3928 (what little is left of that bug!)