### PR TITLE
Add explicit checks that a version is available

### DIFF
--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -48,8 +48,12 @@ class DLLManager:
 
     @property
     def path(self):
-        """Path to local folder containing DDLs"""
-        return os.path.join(self.base_dir, self.version)
+        """Path to local folder containing DLLs"""
+        version = self.version
+        if not version:
+            raise RuntimeError(
+                "No path can be generated for %s because no version information is available." % self.component)
+        return os.path.join(self.base_dir, version)
 
     @property
     def version_choices(self):
@@ -82,7 +86,7 @@ class DLLManager:
 
     def is_available(self):
         """Return whether component is cached locally"""
-        return system.path_exists(self.path)
+        return self.version and system.path_exists(self.path)
 
     def dll_exists(self, dll_name):
         """Check if the dll is provided by the component
@@ -189,5 +193,8 @@ class DLLManager:
     def upgrade(self):
         self.fetch_versions()
         if not self.is_available():
-            logger.info("Downloading %s %s...", self.component, self.version)
-            self.download()
+            if self.version:
+                logger.info("Downloading %s %s...", self.component, self.version)
+                self.download()
+            else:
+                logger.warning("Unable to download %s because version information was not available.", self.component)


### PR DESCRIPTION
While we were failing to repro issue #4031 @tannisroot had a crash while creating a clean new profile. He'd failed to download version data for a DXVK component and Lutris could not cope.

In this weird scenario, a DllManager can be left with *no* version number: the version property is None.

This PR adds some checks and adds a logger warning in this scenario. The component will be unavailable, but Lutris won't try to download it.

This lets Lutris at least start.

I have not included any fancy retry logic for the version numbers. That stuff is treacherous; I'm just trying not to crash here.

I don't really have a solid reproduction for this; I had to test this by munging download_file() to always return None. That's more sabotage than bug.

Still, better to have these checks for robustness, I think.