### PR TITLE
Disable DXVK logging by default

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -838,6 +838,8 @@ class wine(Runner):
         show_debug = self.runner_config.get("show_debug", "-all")
         if show_debug != "inherit":
             env["WINEDEBUG"] = show_debug
+        if show_debug == "-all":
+            env["DXVK_LOG_LEVEL"] = "none"
         env["WINEARCH"] = self.wine_arch
         env["WINE"] = self.get_executable()
         if is_gstreamer_build(self.get_executable()):


### PR DESCRIPTION
This makes it so that if the option "Output debugging info" is set to disabled (default), DXVK log level is set to none.
Closes https://github.com/lutris/lutris/issues/3887