### PR TITLE
Unhook the hooks keeping the GameBar alive

### DIFF
--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -95,7 +95,6 @@ class GameBar(Gtk.Box):
         if self.game.playtime:
             hbox.pack_start(self.get_playtime_label(), False, False, 0)
         hbox.show_all()
-        logger.info("Show: %s", self.game.name)
 
     def get_popover(self, buttons, parent):
         """Return the popover widget containing a list of link buttons"""

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -7,7 +7,6 @@ from lutris import runners, services
 from lutris.database.games import get_game_by_field, get_game_for_service
 from lutris.game import Game
 from lutris.gui.widgets.utils import get_link_button
-from lutris.util.log import logger
 from lutris.util.strings import gtk_safe
 
 


### PR DESCRIPTION
While we were failing to repro issue #4031, I discovered that that game update signals were being processed for the non-selected game. That was a dead end; they were being processed by a leaked GameBar object that did not impact the UI.

When you switch between games, the current GameBar is destroyed and a new one takes its place. But the old one doesn't die! It continues, animated by a perverse unlife!

OK, not so much unlife, By perverse emission hooks; this old GameBar is still hooked up to various game related signals and still handles them- forever. It doesn't even crash. But it can never be collected by the GC either; it's a memory leak. It's also wasting time processing these events.

As far as I can tell, it's no worse than that. There are no real symptoms or anything.

Still, we can't old widgets lurching around groping after *braaaaains*. This PR adds code to unhook all the emission hooks for the GameBar when it is destroyed. I've verified that it is now collected promptly.

There are other emission hooks in Lutris, but I think all of those other objects survive for the life of Lutris anyway. They won't survive process termination in any case.