### PR TITLE
More careful check of the appid

### DIFF
--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -261,7 +261,7 @@ class GameBar(Gtk.Box):
         """Handler called when the game has changed state"""
         if (
             game.id == self.game.id
-            or game.appid == self.appid
+            or (self.appid and game.appid == self.appid)
         ):
             self.game = game
         else:


### PR DESCRIPTION
When a game state changes, there may be no appid or service_id. This happens for manually added games, not added from any service. So the game-state handlers that match on this id must check for None, or you can get a false match between two games when they both are manual, and the UI state can then be updated when it should not be.

Resolves #4031