### PR TITLE
Correct handling for missing GOG id

### DIFF
--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -153,7 +153,10 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
                 self.files.append(installer_file)
             if not installer_files:
                 # Failed to get the service game, put back a user provided file
-                self.files.insert(0, "N/A: Provider installer file")
+                self.files.insert(0, InstallerFile(self.game_slug, installer_file_id, {
+                    "url": "N/A: Provider installer file",
+                    "filename": ""
+                }))
 
     def _substitute_config(self, script_config):
         """Substitute values such as $GAMEDIR in a config dict."""

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -302,10 +302,13 @@ class GOGService(OnlineService):
 
     def get_downloads(self, gogid):
         """Return all available downloads for a GOG ID"""
+        if not gogid:
+            logger.warning("Unable to get GOG data because no GOG ID is available")
+            return {}
         gog_data = self.get_game_details(gogid)
         if not gog_data:
             logger.warning("Unable to get GOG data for game %s", gogid)
-            return []
+            return {}
         return gog_data["downloads"]
 
     def get_extras(self, gogid):
@@ -323,7 +326,7 @@ class GOGService(OnlineService):
     def get_installers(self, downloads, runner, language="en"):
         """Return available installers for a GOG game"""
         # Filter out Mac installers
-        gog_installers = [installer for installer in downloads["installers"] if installer["os"] != "mac"]
+        gog_installers = [installer for installer in downloads.get("installers", []) if installer["os"] != "mac"]
         available_platforms = {installer["os"] for installer in gog_installers}
         # If it's a Linux game, also filter out Windows games
         if "linux" in available_platforms:


### PR DESCRIPTION
This PR fixes multiple error handling bugs, which are mostly about returning the correct type of data so downstream code does not crash.

* get_downloads() should return a dict, never a list.
* When there is no GOG ID, get_downloads() should return an empty dict and not raise ValueError.
* When there are no downloads, the substitute file must be an InstallerFile, not a string.
* When there are no downloads, get_installers() should return an empty list and not crash.

Resolves #4043

This may help with #4016 too, but it won't fix the networking errors- it should prevent the downstream failure of the installer window.