### PR TITLE
Use mono and gecko from runtime

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -119,16 +119,20 @@ def create_prefix(  # noqa: C901
         )
         return
 
-    if install_gecko == "False":
-        overrides["mshtml"] = "disabled"
-    if install_mono == "False":
-        overrides["mscoree"] = "disabled"
-
     wineenv = {
         "WINEARCH": arch,
         "WINEPREFIX": prefix,
         "WINEDLLOVERRIDES": get_overrides_env(overrides),
+        "WINE_MONO_CACHE_DIR": os.path.join(settings.RUNTIME_DIR, "wine-mono"),
+        "WINE_GECKO_CACHE_DIR": os.path.join(settings.RUNTIME_DIR, "wine-gecko"),
     }
+
+    if install_gecko == "False":
+        wineenv["WINE_SKIP_GECKO_INSTALLATION"] = "1"
+        overrides["mshtml"] = "disabled"
+    if install_mono == "False":
+        wineenv["WINE_SKIP_MONO_INSTALLATION"] = "1"
+        overrides["mscoree"] = "disabled"
 
     system.execute([wineboot_path], env=wineenv)
     for loop_index in range(60):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -842,6 +842,8 @@ class wine(Runner):
             env["DXVK_LOG_LEVEL"] = "none"
         env["WINEARCH"] = self.wine_arch
         env["WINE"] = self.get_executable()
+        env["WINE_MONO_CACHE_DIR"] = os.path.join(settings.RUNTIME_DIR, "wine-mono")
+        env["WINE_GECKO_CACHE_DIR"] = os.path.join(settings.RUNTIME_DIR, "wine-gecko")
         if is_gstreamer_build(self.get_executable()):
             path_64 = os.path.join(WINE_DIR, self.get_version(), "lib64/gstreamer-1.0/")
             path_32 = os.path.join(WINE_DIR, self.get_version(), "lib/gstreamer-1.0/")


### PR DESCRIPTION
To avoid asking user to click a button to download mono and gecko, we can provide them in our runtime and point Wine to the location so that it automatically picks those up as if from cache.
This also adds support for disabling mono/gecko installation through envars instead of overrides, which to me seems cleaner.
Both features require upcoming lutris wine 7.1