### PR TITLE
We need to create the coverart dir inside '~/.cache/lutris', not '~/.local/share/lutris'

### DIFF
--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -35,7 +35,7 @@ def init_dirs():
         os.path.join(settings.DATA_DIR, "covers"),
         settings.ICON_PATH,
         os.path.join(settings.CACHE_DIR, "banners"),
-        os.path.join(settings.DATA_DIR, "coverart"),
+        os.path.join(settings.CACHE_DIR, "coverart"),
         os.path.join(settings.DATA_DIR, "runners"),
         os.path.join(settings.DATA_DIR, "lib"),
         settings.RUNTIME_DIR,


### PR DESCRIPTION
That's where it looks when it uses the dir, so that is what it must create.

Resolves #4049