### PR TITLE
Stop button will resort to SIGKILL if SIGTERM fails

### DIFF
--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -390,7 +390,7 @@ def get_disk_size(path):
 
 def get_running_pid_list():
     """Return the list of PIDs from processes currently running"""
-    return [p for p in os.listdir("/proc") if p[0].isdigit()]
+    return [int(p) for p in os.listdir("/proc") if p[0].isdigit()]
 
 
 def get_mounted_discs():


### PR DESCRIPTION
This PR tries to SIGTERM all of a games processes, but if this does not kill them all, it waits up to 5 seconds and tries again with SIGKILL.

This seems to be an effective way to kill all wine processes, even when they don't want to die- but will still allow processes that will respond to SIGTERM to do so, as long as they do it promptly.

If it must wait for the game to die, it does this on a thread to avoid freezing the UI.

Resolves #4046