### PR TITLE
Add command line option --force-media-update

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -44,7 +44,7 @@ from lutris.gui.installerwindow import InstallerWindow
 from lutris.gui.widgets.status_icon import LutrisStatusIcon
 from lutris.migrations import migrate
 from lutris.startup import init_lutris, run_all_checks, update_runtime
-from lutris.util import datapath, log
+from lutris.util import datapath, log, update_cache
 from lutris.util.http import HTTPError, Request
 from lutris.util.log import logger
 from lutris.util.steam.appmanifest import AppManifest, get_appmanifests
@@ -192,6 +192,14 @@ class Application(Gtk.Application):
             None,
         )
         self.add_main_option("submit-issue", 0, GLib.OptionFlags.NONE, GLib.OptionArg.NONE, _("Submit an issue"), None)
+        self.add_main_option(
+            "force-media-update",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.NONE,
+            _("Force download of missing media"),
+            None,
+        )
         self.add_main_option(
             GLib.OPTION_REMAINING,
             0,
@@ -341,6 +349,10 @@ class Application(Gtk.Application):
             print(executable_name + "-" + settings.VERSION)
             logger.setLevel(logging.NOTSET)
             return 0
+
+        if options.contains("force-media-update"):
+            # force media update next time later, when the GUI is ready to do it
+            update_cache.remove_date_from_cache("media")
 
         init_lutris()
         migrate()

--- a/lutris/util/update_cache.py
+++ b/lutris/util/update_cache.py
@@ -17,6 +17,14 @@ def write_date_to_cache(key):
         json.dump(cache, json_file, indent=2)
 
 
+def remove_date_from_cache(key):
+    """Deletes a datetime object for 'key'"""
+    cache = _read_cache_content()
+    del cache[key]
+    with open(UPDATE_CACHE_PATH, "w", encoding='utf-8') as json_file:
+        json.dump(cache, json_file, indent=2)
+
+
 def _read_cache_content():
     """Return the content of the cache"""
     if not os.path.exists(UPDATE_CACHE_PATH):

--- a/lutris/util/update_cache.py
+++ b/lutris/util/update_cache.py
@@ -20,7 +20,7 @@ def write_date_to_cache(key):
 def remove_date_from_cache(key):
     """Deletes a datetime object for 'key'"""
     cache = _read_cache_content()
-    del cache[key]
+    cache.pop(key, None)
     with open(UPDATE_CACHE_PATH, "w", encoding='utf-8') as json_file:
         json.dump(cache, json_file, indent=2)
 


### PR DESCRIPTION
Presently the only way to trigger the media update to repair your library's missing media is to edit the source code.

Perhaps we don't want to make this super easy to trigger, but this is going a bit far.

This PR adds a command line option to trigger the update. There's no environment variable; we don't want to encourage people to set this to happen on every Lutris startup, I think.