### PR TITLE
The game-update signal may add a game to the Lutris window

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -776,7 +776,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
             return True
         updated = self.game_store.update(db_game)
         if not updated:
-            logger.debug("Game %s not updated in view", game)
+            self.update_store()
         return True
 
     def on_game_stopped(self, game):

--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -121,7 +121,8 @@ class GameStore(GObject.Object):
 
     def update(self, db_game):
         """Update game informations
-        Return whether a row was updated
+        Return whether a row was updated; False if the game was not already
+        present.
         """
         store_item = StoreItem(db_game, self.service_media)
         row = self.get_row_by_id(store_item.id)


### PR DESCRIPTION
There seem to be several code paths that expect this, so let's do it.

The PR still tries to update or remove the game as appropriate, but if this fails it will go ahead and update the entire view from the top.

This approach should ensure that any filters that were applied, still are.

Resolves #4048