### PR TITLE
Stop harder, but WINE gets wineserver -k not SIGTERM

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -542,7 +542,7 @@ class Game(GObject.Object):
             np_file.write(self.name)
 
     def force_stop(self):
-        # If SIGTERM fails, wait a few seconds and try SIGKILL on any survivors
+        # If force_stop_game fails, wait a few seconds and try SIGKILL on any survivors
         self.runner.force_stop_game(self)
         if self.get_stop_pids():
             self.force_kill_delayed()

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -459,5 +459,6 @@ class Runner:  # pylint: disable=too-many-public-methods
         return output
 
     def force_stop_game(self, game):
-        """Stop the running game."""
+        """Stop the running game. If this leaves any game processes running,
+        the caller will SIGKILL them (after a delay)."""
         game.kill_processes(signal.SIGTERM)

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -1,5 +1,6 @@
 """Base module for runners"""
 import os
+import signal
 from gettext import gettext as _
 
 from gi.repository import Gtk
@@ -456,3 +457,7 @@ class Runner:  # pylint: disable=too-many-public-methods
                 output = item
                 break
         return output
+
+    def force_stop_game(self, game):
+        """Stop the running game."""
+        game.kill_processes(signal.SIGTERM)

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -972,6 +972,11 @@ class wine(Runner):
         launch_info["command"] = command
         return launch_info
 
+    def force_stop_game(self, game):
+        """Kill WINE with kindness, or at least with -k. This seems to leave a process
+        alive for some reason, but the caller will detect this and SIGKILL it."""
+        self.run_winekill()
+
     @staticmethod
     def parse_wine_path(path, prefix_path=None):
         """Take a Windows path, return the corresponding Linux path."""

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -484,7 +484,6 @@ class wine(Runner):
             ("wineshell", _("Open Bash terminal"), self.run_wine_terminal),
             ("wineconsole", _("Open Wine console"), self.run_wineconsole),
             ("wine-regedit", _("Wine registry"), self.run_regedit),
-            ("winekill", _("Kill all Wine processes"), self.run_winekill),
             ("winetricks", _("Winetricks"), self.run_winetricks),
             ("winecpl", _("Wine Control Panel"), self.run_winecpl),
         ]

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -390,7 +390,7 @@ def get_disk_size(path):
 
 def get_running_pid_list():
     """Return the list of PIDs from processes currently running"""
-    return [p for p in os.listdir("/proc") if p[0].isdigit()]
+    return [int(p) for p in os.listdir("/proc") if p[0].isdigit()]
 
 
 def get_mounted_discs():


### PR DESCRIPTION
OK, I think this is what was wanted.

The 'Stop' command will send SIGTERM to all non-WINE games, but WINE games get wineserver -k instead.

In either case, if this leaves any processes alive we'll wait up to 5 seconds for the processes to die. If they do not, they get SIGKILL.

This also removes the "Kill all WINE processes" command, as it would just be 'Stop' without the SIGKILL now. The installer 'winekill' task should still work as before, I believe.

Resolves #4046