### PR TITLE
Fix wrong wine version being used to create prefix during prelaunch phase

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -778,7 +778,7 @@ class wine(Runner):
     def prelaunch(self):
         if not system.path_exists(os.path.join(self.prefix_path, "user.reg")):
             logger.warning("No valid prefix detected in %s, creating one...", self.prefix_path)
-            create_prefix(self.prefix_path, arch=self.wine_arch)
+            create_prefix(self.prefix_path, wine_path=self.get_executable(), arch=self.wine_arch)
 
         prefix_manager = WinePrefixManager(self.prefix_path)
         if self.runner_config.get("autoconf_joypad", False):


### PR DESCRIPTION
The `wine_path` parameter should be passed to the `create_prefix` function, otherwise the highest installed wine version will be used instead of the version selected by the user.

In some cases, this can lead to unexpected results (if the chosen wine version is very different from the highest wine version).

![截图_code_20220223171416](https://user-images.githubusercontent.com/26923506/155293081-b31361d7-957b-4a78-b368-e5dbf75717bd.png)

