### PR TITLE
Just use default styling for the sidebar

### DIFF
--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -22,10 +22,6 @@
     font-weight: normal;
 }
 
-.sidebar row:hover {
-  background: alpha(currentColor, .07);
-}
-
 .info-pill {
   background-color:rgb(100, 100, 100);
   color:rgb(155, 155, 155);


### PR DESCRIPTION
This should work with any theme. It does make the sidebar buttons look a bit too prominent in Adwaita in a selected sidebar row during hover over the button, but it remains legible.

Maybe we could style these buttons instead of the sidebar row; that would be less consequential when it goes wrong, at least.

Resolves #4086