### PR TITLE
Fix install from local yaml file

### DIFF
--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -257,7 +257,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         """Install from a YAML file"""
         script_dlg = FileDialog(_("Select a Lutris installer"))
         if script_dlg.filename:
-            installers = get_installers(script_dlg.filename)
+            installers = get_installers(installer_file=script_dlg.filename)
             application = Gio.Application.get_default()
             application.show_installer_window(installers)
         self.destroy()

--- a/lutris/installer/__init__.py
+++ b/lutris/installer/__init__.py
@@ -21,7 +21,7 @@ def read_script(filename):
         return [script]
 
 
-def get_installers(game_slug, installer_file=None, revision=None):
+def get_installers(game_slug=None, installer_file=None, revision=None):
     # check if installer is local or online
     if system.path_exists(installer_file):
         return read_script(installer_file)


### PR DESCRIPTION
When installing a game from a YAML file, the selected installer file was passed as the game slug. This should have been passed as the `installer_file`.