### PR TITLE
Prevent ugly flashing when switching sidebar rows

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -564,7 +564,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         self.games_scrollwindow.add(self.view)
 
         self.view.show_all()
-        GLib.idle_add(self.update_store)
+        self.update_store()
 
     def set_viewtype_icon(self, view_type):
         self.viewtype_icon.set_from_icon_name("view-%s-symbolic" % view_type, Gtk.IconSize.BUTTON)


### PR DESCRIPTION
This re-fixes a previous bug, but something must have gone wrong with the old fix since you've reverted it.

But much of the complexity of that fix was to deal with the slow search-Lutris-website feature. That's gone now, so the fix can be much simpler- a one-liner.

Just don't defer the update of the game store to idle time; do it right away. I don't think the idle time thing serves any purpose anymore since it can only access the PGA anyway, and in my testing the direct approach works fine and is flashless.

If the update is slow due to your giant PGA it will still be slow, but I don't think this problem is meaningfully worse this way- just less flashy.

Resolves #3995 again