### PR TITLE
Search for Lutris games asynchronously

### DIFF
--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -54,6 +54,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         super().__init__(application=application)
         self.set_default_size(640, 450)
         self.search_timer_id = None
+        self.search_spinner = None
         self.text_query = None
         self.result_label = None
         self.title_label = Gtk.Label(visible=True)
@@ -124,8 +125,12 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         """Search installers with the Lutris API"""
         self.title_label.set_markup("<b>Search Lutris.net</b>")
         self.listbox.destroy()
-        entry = Gtk.Entry(visible=True)
-        self.vbox.add(entry)
+        hbox = Gtk.Box(Gtk.Orientation.HORIZONTAL, visible=True)
+        entry = Gtk.SearchEntry(visible=True)
+        hbox.pack_start(entry, True, True, 0)
+        self.search_spinner = Gtk.Spinner(visible=False)
+        hbox.pack_end(self.search_spinner, False, False, 6)
+        self.vbox.add(hbox)
         self.result_label = self._get_label("")
         self.vbox.add(self.result_label)
         entry.connect("changed", self._on_search_updated)
@@ -192,9 +197,25 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.destroy()
 
     def update_search_results(self):
-        if not self.text_query:
+        # Don't start a search while another is going; defer it instead.
+        if self.search_spinner.get_visible():
+            self.search_timer_id = GLib.timeout_add(750, self.update_search_results)
             return
-        api_games = api.search_games(self.text_query)
+
+        self.search_timer_id = None
+
+        if self.text_query:
+            self.search_spinner.show()
+            self.search_spinner.start()
+            AsyncCall(api.search_games, self.update_search_results_cb, self.text_query)
+
+    def update_search_results_cb(self, api_games, error):
+        if error:
+            ErrorDialog(error)
+            return
+
+        self.search_spinner.stop()
+        self.search_spinner.hide()
         total_count = api_games.get("count", 0)
         count = len(api_games.get('results', []))
 


### PR DESCRIPTION
It's not very classy to freeze the UI while searching the Lutris website.

This PR uses AsyncCall to do this in the background, and tweaks the UI slightly to include a spinner to show when searching is happening. This also clears a timer-id field so that we don't remove this timer once it no longer exists (this is not safe to do in GTK- the IDs can be reused). 

These changes mean you can alter the search while it is running. If you do, the search is not restarted until it completes- the timer is just restarted. It's polling and is inelegant, but it's simple and safe.

Plus, this uses SearchEntry instead of an Entry just to be a pain.

It's actually a fairly narrow change set, though. Very local. Honest!