### PR TITLE
Revamped wine runner screen and added subscreen to view apps of given runner

### DIFF
--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -2,7 +2,6 @@
 # pylint: disable=no-member
 import gettext
 import os
-import random
 from collections import defaultdict
 from gettext import gettext as _
 
@@ -18,8 +17,39 @@ from lutris.util.extract import extract_archive
 from lutris.util.log import logger
 
 
-class RunnerInstallDialog(Dialog):
+class ShowAppsDialog(Dialog):
+    def __init__(self, title, parent, runner_version, apps):
+        super().__init__(title, parent, Gtk.DialogFlags.MODAL)
+        self.add_buttons(
+            Gtk.STOCK_OK, Gtk.ResponseType.OK
+        )
 
+        self.set_default_size(400, 500)
+
+        label = Gtk.Label.new(_("Showing games of %s") % runner_version)
+        self.vbox.add(label)
+        scrolled_listbox = Gtk.ScrolledWindow()
+        listbox = Gtk.ListBox()
+        listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        scrolled_listbox.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled_listbox.set_shadow_type(Gtk.ShadowType.ETCHED_OUT)
+        scrolled_listbox.add(listbox)
+        self.vbox.pack_start(scrolled_listbox, True, True, 14)
+
+        for app in apps:
+            row = Gtk.ListBoxRow()
+            hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+
+            lbl_game = Gtk.Label(app.name)
+            lbl_game.set_halign(Gtk.Align.START)
+            hbox.pack_start(lbl_game, True, True, 5)
+            row.add(hbox)
+            listbox.add(row)
+
+        self.show_all()
+
+
+class RunnerInstallDialog(Dialog):
     """Dialog displaying available runner version and downloads them"""
     COL_VER = 0
     COL_ARCH = 1
@@ -35,10 +65,10 @@ class RunnerInstallDialog(Dialog):
         self.runner_info = {}
         self.installing = {}
         self.set_default_size(640, 480)
+        self.runners = []
+        self.listbox = None
 
-        self.renderer_progress = Gtk.CellRendererProgress()
-
-        label = Gtk.Label.new(_("Waiting for response from %s") % (settings.SITE_URL))
+        label = Gtk.Label.new(_("Waiting for response from %s") % settings.SITE_URL)
         self.vbox.pack_start(label, False, False, 18)
 
         spinner = Gtk.Spinner(visible=True)
@@ -47,7 +77,7 @@ class RunnerInstallDialog(Dialog):
 
         self.show_all()
 
-        self.runner_store = Gtk.ListStore(str, str, str, bool, int, str)
+        self.runner_store = Gtk.ListStore(str, str, str, bool, int, int)
         jobs.AsyncCall(api.get_runners, self.runner_fetch_cb, self.runner)
 
     def runner_fetch_cb(self, runner_info, error):
@@ -75,59 +105,115 @@ class RunnerInstallDialog(Dialog):
             if child_widget.get_name() not in "GtkBox":
                 child_widget.destroy()
 
-        self.populate_store()
-
         label = Gtk.Label.new(_("%s version management") % self.runner_info["name"])
         self.vbox.add(label)
-        scrolled_window = Gtk.ScrolledWindow()
-        treeview = self.get_treeview(self.runner_store)
         self.installing = {}
         self.connect("response", self.on_destroy)
 
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        scrolled_window.set_shadow_type(Gtk.ShadowType.ETCHED_OUT)
-        scrolled_window.add(treeview)
+        scrolled_listbox = Gtk.ScrolledWindow()
+        self.listbox = Gtk.ListBox()
+        self.listbox.set_selection_mode(Gtk.SelectionMode.NONE)
+        scrolled_listbox.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        scrolled_listbox.set_shadow_type(Gtk.ShadowType.ETCHED_OUT)
+        scrolled_listbox.add(self.listbox)
+        self.vbox.pack_start(scrolled_listbox, True, True, 14)
 
-        self.vbox.pack_start(scrolled_window, True, True, 14)
+        self.populate_store()
         self.show_all()
+        self.populate_listboxrows(self.runner_store)
 
-    def get_treeview(self, model):
-        """Return TreeeView widget"""
-        treeview = Gtk.TreeView(model=model)
-        treeview.set_headers_visible(False)
+    def populate_listboxrows(self, store):
+        for runner in store:
+            row = Gtk.ListBoxRow()
+            row.runner = runner
+            hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
+            row.hbox = hbox
+            chk_installed = Gtk.CheckButton()
+            chk_installed.set_sensitive(False)
+            chk_installed.set_active(runner[self.COL_INSTALLED])
+            hbox.pack_start(chk_installed, False, True, 0)
+            row.chk_installed = chk_installed
 
-        renderer_toggle = Gtk.CellRendererToggle()
-        renderer_text = Gtk.CellRendererText()
+            lbl_version = Gtk.Label(runner[self.COL_VER])
+            lbl_version.set_max_width_chars(20)
+            lbl_version.set_property("width-chars", 20)
+            lbl_version.set_halign(Gtk.Align.START)
+            hbox.pack_start(lbl_version, False, False, 5)
 
-        installed_column = Gtk.TreeViewColumn(None, renderer_toggle, active=3)
-        renderer_toggle.connect("toggled", self.on_installed_toggled)
-        treeview.append_column(installed_column)
+            arch_label = Gtk.Label(runner[self.COL_ARCH])
+            arch_label.set_max_width_chars(8)
+            arch_label.set_halign(Gtk.Align.START)
+            hbox.pack_start(arch_label, False, True, 5)
 
-        version_column = Gtk.TreeViewColumn(None, renderer_text)
-        version_column.add_attribute(renderer_text, "text", self.COL_VER)
-        version_column.set_property("min-width", 80)
-        treeview.append_column(version_column)
+            install_progress = Gtk.ProgressBar()
+            install_progress.set_show_text(True)
+            hbox.pack_end(install_progress, True, True, 5)
+            row.install_progress = install_progress
 
-        arch_column = Gtk.TreeViewColumn(None, renderer_text, text=self.COL_ARCH)
-        arch_column.set_property("min-width", 50)
-        treeview.append_column(arch_column)
+            if runner[self.COL_INSTALLED]:
+                # Check if there are apps installed, if so, show the view apps button
+                app_count = runner[self.COL_USAGE]
+                if app_count > 0:
+                    usage_button_text = gettext.ngettext(
+                        "_View app",
+                        "_View %d apps",
+                        app_count) % app_count
 
-        progress_column = Gtk.TreeViewColumn(
-            None,
-            self.renderer_progress,
-            value=self.COL_PROGRESS,
-            visible=self.COL_PROGRESS,
-        )
-        progress_column.set_property("fixed-width", 120)
-        progress_column.set_property("min-width", 120)
-        progress_column.set_property("resizable", True)
-        treeview.append_column(progress_column)
+                    usage_button = Gtk.Button.new_with_mnemonic(usage_button_text)
+                    usage_button.connect("button_press_event", self.on_show_apps_usage, row)
+                    hbox.pack_end(usage_button, False, True, 2)
 
-        usage_column = Gtk.TreeViewColumn(None, renderer_text, text=self.COL_USAGE)
-        usage_column.set_property("min-width", 150)
-        treeview.append_column(usage_column)
+            button = Gtk.Button()
+            hbox.pack_end(button, False, True, 0)
+            hbox.reorder_child(button, 0)
+            row.install_uninstall_cancel_button = button
+            row.handler_id = None
 
-        return treeview
+            row.add(hbox)
+            self.listbox.add(row)
+            row.show_all()
+            self.update_listboxrow(row)
+
+    def update_listboxrow(self, row):
+        row.install_progress.set_visible(False)
+        row.chk_installed.set_active(row.runner[self.COL_INSTALLED])
+        button = row.install_uninstall_cancel_button
+        if row.handler_id is not None:
+            button.disconnect(row.handler_id)
+            row.handler_id = None
+        if row.runner[self.COL_VER] in self.installing:
+            button.set_label(_("Cancel"))
+            handler_id = button.connect("button_press_event", self.on_cancel_install, row)
+        else:
+            if row.runner[self.COL_INSTALLED]:
+                button.set_label(_("Uninstall"))
+                handler_id = button.connect("button_press_event", self.on_uninstall_runner, row)
+            else:
+                button.set_label(_("Install"))
+                handler_id = button.connect("button_press_event", self.on_install_runner, row)
+
+        row.install_uninstall_cancel_button = button
+        row.handler_id = handler_id
+
+    def on_show_apps_usage(self, _widget, _button, row):
+        """Return grid with games that uses this wine version"""
+        runner = row.runner
+        runner_version = "%s-%s" % (runner[self.COL_VER], runner[self.COL_ARCH])
+        runner_games = get_games_by_runner(self.runner)
+        apps = []
+        for db_game in runner_games:
+            if not db_game["installed"]:
+                continue
+            game = Game(db_game["id"])
+            version = game.config.runner_config["version"]
+            if version != runner_version:
+                continue
+            apps.append(game)
+
+        dialog = ShowAppsDialog("Show apps", self.get_toplevel(), runner_version, apps)
+        dialog.run()
+
+        dialog.destroy()
 
     def populate_store(self):
         """Return a ListStore populated with the runner versions"""
@@ -135,14 +221,10 @@ class RunnerInstallDialog(Dialog):
         for version_info in reversed(self.runner_info["versions"]):
             is_installed = os.path.exists(self.get_runner_path(version_info["version"], version_info["architecture"]))
             games_using = version_usage.get("%(version)s-%(architecture)s" % version_info)
-            usage_summary = gettext.ngettext(
-                "In use by %d game",
-                "In use by %d games",
-                len(games_using)) % len(games_using) if games_using else _("Not in use")
             self.runner_store.append(
                 [
                     version_info["version"], version_info["architecture"], version_info["url"], is_installed, 0,
-                    usage_summary if is_installed else ""
+                    len(games_using) if games_using else 0
                 ]
             )
 
@@ -181,60 +263,83 @@ class RunnerInstallDialog(Dialog):
         else:
             self.install_runner(row)
 
+    def on_cancel_install(self, widget, button, row):
+        self.cancel_install(row)
+
     def cancel_install(self, row):
         """Cancel the installation of a runner version"""
-        self.installing[row[self.COL_VER]].cancel()
+        runner = row.runner
+        self.installing[runner[self.COL_VER]].cancel()
         self.uninstall_runner(row)
-        row[self.COL_PROGRESS] = 0
-        self.installing.pop(row[self.COL_VER])
+        runner[self.COL_PROGRESS] = 0
+        self.installing.pop(runner[self.COL_VER])
+        self.update_listboxrow(row)
+        row.install_progress.set_visible(False)
+
+    def on_uninstall_runner(self, widget, button, row):
+        self.uninstall_runner(row)
 
     def uninstall_runner(self, row):
         """Uninstall a runner version"""
-        version = row[self.COL_VER]
-        arch = row[self.COL_ARCH]
+        runner = row.runner
+        version = runner[self.COL_VER]
+        arch = runner[self.COL_ARCH]
         system.remove_folder(self.get_runner_path(version, arch))
-        row[self.COL_INSTALLED] = False
+        runner[self.COL_INSTALLED] = False
         if self.runner == "wine":
             logger.debug("Clearing wine version cache")
             from lutris.util.wine.wine import get_wine_versions
 
             get_wine_versions.cache_clear()
+        self.update_listboxrow(row)
+
+    def on_install_runner(self, _widget, _button, row):
+        self.install_runner(row)
 
     def install_runner(self, row):
         """Download and install a runner version"""
-        dest_path = self.get_dest_path(row)
-        url = row[self.COL_URL]
+        runner = row.runner
+        row.install_progress.set_fraction(0.0)
+        dest_path = self.get_dest_path(runner)
+        url = runner[self.COL_URL]
         if not url:
-            ErrorDialog("Version %s is not longer available" % row[self.COL_VER])
+            ErrorDialog("Version %s is not longer available" % runner[self.COL_VER])
             return
-        downloader = Downloader(row[self.COL_URL], dest_path, overwrite=True)
+        downloader = Downloader(runner[self.COL_URL], dest_path, overwrite=True)
         GLib.timeout_add(100, self.get_progress, downloader, row)
-        self.installing[row[self.COL_VER]] = downloader
+        self.installing[runner[self.COL_VER]] = downloader
         downloader.start()
+        self.update_listboxrow(row)
 
     def get_progress(self, downloader, row):
         """Update progress bar with download progress"""
+        runner = row.runner
         if downloader.state == downloader.CANCELLED:
             return False
         if downloader.state == downloader.ERROR:
             self.cancel_install(row)
             return False
+        row.install_progress.show()
         downloader.check_progress()
         percent_downloaded = downloader.progress_percentage
         if percent_downloaded >= 1:
-            row[self.COL_PROGRESS] = percent_downloaded
-            self.renderer_progress.props.pulse = -1
-            self.renderer_progress.props.text = "%d %%" % int(percent_downloaded)
+            runner[self.COL_PROGRESS] = percent_downloaded
+            row.install_progress.set_fraction(percent_downloaded / 100)
         else:
-            row[self.COL_PROGRESS] = 1
-            self.renderer_progress.props.pulse = random.randint(1, 100)
-            self.renderer_progress.props.text = _("Downloading…")
+            runner[self.COL_PROGRESS] <= 1
+            row.install_progress.pulse()
+            row.install_progress.set_text = _("Downloading…")
         if downloader.state == downloader.COMPLETED:
-            row[self.COL_PROGRESS] = 99
-            self.renderer_progress.props.text = _("Extracting…")
+            runner[self.COL_PROGRESS] = 99
+            row.install_progress.set_text = _("Extracting…")
             self.on_runner_downloaded(row)
             return False
         return True
+
+    def progress_pulse(self, row):
+        runner = row.runner
+        row.install_progress.pulse()
+        return not runner[self.COL_INSTALLED]
 
     def get_usage_stats(self):
         """Return the usage for each version"""
@@ -250,11 +355,13 @@ class RunnerInstallDialog(Dialog):
 
     def on_runner_downloaded(self, row):
         """Handler called when a runner version is downloaded"""
-        version = row[self.COL_VER]
-        architecture = row[self.COL_ARCH]
+        runner = row.runner
+        version = runner[self.COL_VER]
+        architecture = runner[self.COL_ARCH]
         logger.debug("Runner %s for %s has finished downloading", version, architecture)
-        src = self.get_dest_path(row)
+        src = self.get_dest_path(runner)
         dst = self.get_runner_path(version, architecture)
+        GLib.timeout_add(100, self.progress_pulse, row)
         jobs.AsyncCall(self.extract, self.on_extracted, src, dst, row)
 
     @staticmethod
@@ -269,11 +376,15 @@ class RunnerInstallDialog(Dialog):
             ErrorDialog(_("Failed to retrieve the runner archive"), parent=self)
             return
         src, row = row_info
+        runner = row.runner
         os.remove(src)
-        row[self.COL_PROGRESS] = 0
-        row[self.COL_INSTALLED] = True
-        self.renderer_progress.props.text = ""
-        self.installing.pop(row[self.COL_VER])
+        runner[self.COL_PROGRESS] = 0
+        runner[self.COL_INSTALLED] = True
+        self.installing.pop(runner[self.COL_VER])
+        row.install_progress.set_text = ""
+        row.install_progress.set_fraction(0.0)
+        row.install_progress.hide()
+        self.update_listboxrow(row)
         if self.runner == "wine":
             logger.debug("Clearing wine version cache")
             from lutris.util.wine.wine import get_wine_versions


### PR DESCRIPTION
Changed config runner view to add new button to show active apps for the given installed runners.
I also changed the install action to a dedicated button that is more explicit for the end-users.

Screen now appears as following:
![image](https://user-images.githubusercontent.com/1876754/155861559-d5d02fef-6df6-4065-a75b-40b0659ed46c.png)

Then, when clicking on "View %d apps", the subscreen shows the apps using the runner. This is looking like:
![image](https://user-images.githubusercontent.com/1876754/155881542-06e6ac4f-55ba-48e3-b3ed-242a1d96368e.png)
