### PR TITLE
Limit the CPU affinity to n cores, where n>=1 and n<∞

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -72,6 +72,12 @@ def get_launch_parameters(runner, gameplay_info):
         launch_arguments.insert(0, "0")
         launch_arguments.insert(0, "-c")
         launch_arguments.insert(0, "taskset")
+    else:
+        limit_cpu_count = system_config.get("limit_cpu_count")
+        if limit_cpu_count and limit_cpu_count.isnumeric():
+            launch_arguments.insert(0, "0-%d" % (int(limit_cpu_count) - 1))
+            launch_arguments.insert(0, "-c")
+            launch_arguments.insert(0, "taskset")
 
     env.update(runner.get_env())
 

--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -68,16 +68,17 @@ def get_launch_parameters(runner, gameplay_info):
 
     single_cpu = system_config.get("single_cpu") or False
     if single_cpu:
-        logger.info("The game will run on a single CPU core")
-        launch_arguments.insert(0, "0")
-        launch_arguments.insert(0, "-c")
-        launch_arguments.insert(0, "taskset")
-    else:
         limit_cpu_count = system_config.get("limit_cpu_count")
         if limit_cpu_count and limit_cpu_count.isnumeric():
-            launch_arguments.insert(0, "0-%d" % (int(limit_cpu_count) - 1))
-            launch_arguments.insert(0, "-c")
-            launch_arguments.insert(0, "taskset")
+            limit_cpu_count = int(limit_cpu_count)
+        else:
+            limit_cpu_count = 1
+
+        limit_cpu_count = max(1, limit_cpu_count)
+        logger.info("The game will run on %d CPU core(s)", limit_cpu_count)
+        launch_arguments.insert(0, "0-%d" % (limit_cpu_count - 1))
+        launch_arguments.insert(0, "-c")
+        launch_arguments.insert(0, "taskset")
 
     env.update(runner.get_env())
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -202,7 +202,7 @@ system_options = [  # pylint: disable=invalid-name
         "label": _("Restrict number of cores used"),
         "advanced": True,
         "default": False,
-        "help": _("Restrict the game to a single CPU core."),
+        "help": _("Restrict the game to a maximum number of CPU cores."),
     },
     {
         "option": "limit_cpu_count",
@@ -210,7 +210,7 @@ system_options = [  # pylint: disable=invalid-name
         "label": _("Restrict number of cores to"),
         "advanced": True,
         "default": "1",
-        "help": _("Number of CPU cores to be used, if 'Restrict number of cores used' is turned on."),
+        "help": _("Maximum number of CPU cores to be used, if 'Restrict number of cores used' is turned on."),
     },
     {
         "option": "restore_gamma",

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -205,6 +205,14 @@ system_options = [  # pylint: disable=invalid-name
         "help": _("Restrict the game to a single CPU core."),
     },
     {
+        "option": "limit_cpu_count",
+        "type": "string",
+        "label": _("Limit number of cores to"),
+        "advanced": True,
+        "default": "",
+        "help": _("Restrict the game to a single CPU core."),
+    },
+    {
         "option": "restore_gamma",
         "type": "bool",
         "default": False,

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -199,7 +199,7 @@ system_options = [  # pylint: disable=invalid-name
     {
         "option": "single_cpu",
         "type": "bool",
-        "label": _("Restrict to single core"),
+        "label": _("Restrict number of cores used"),
         "advanced": True,
         "default": False,
         "help": _("Restrict the game to a single CPU core."),
@@ -207,10 +207,10 @@ system_options = [  # pylint: disable=invalid-name
     {
         "option": "limit_cpu_count",
         "type": "string",
-        "label": _("Limit number of cores to"),
+        "label": _("Restrict number of cores to"),
         "advanced": True,
-        "default": "",
-        "help": _("Restrict the game to a single CPU core."),
+        "default": "1",
+        "help": _("Number of CPU cores to be used, if 'Restrict number of cores used' is turned on."),
     },
     {
         "option": "restore_gamma",


### PR DESCRIPTION
This is a feature, and it's too late for 5.10, obviously, but maybe after that this can go in.

The renames the 'single_cpu' setting to "Restrict number of cores used", and add 'limit_cpu_count', "Restrict number of cores to". When you activate 'single_cpu' it limits to the number of cores given in 'limit_cpu_count'. The default is 1, so it's compatible. Though the option names are not quite ideal.

This is useful for games that fail if there are too many CPUs, but don't really like just one. The game I've dealing with is "XMorph Defense", which is pretty janky on 1 core, but hangs on start with 16.

This still works by using 'taskset' to set processor affinity; this is not always good enough. "Timeshift" crashes if it thinks too many CPUs exist, affinity be damned. You have to turn cores off entirely to make that game work. But that's crazy stuff.