### PR TITLE
Optionally launch prelaunch-script before anything else

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -439,6 +439,14 @@ system_options = [  # pylint: disable=invalid-name
         "help": _("Run the game only once the pre-launch script has exited"),
     },
     {
+        "option": "prelaunch_early_exec",
+        "type": "bool",
+        "label": _("Launch pre-launch script before all other checks"),
+        "advanced": True,
+        "default": False,
+        "help": _("Useful, if the command copies the executable onto tmpfs"),
+    },
+    {
         "option": "postexit_command",
         "type": "file",
         "label": _("Post-exit script"),


### PR DESCRIPTION
Suppose you have a lot of ram, e.g. 128GB, then you might be tempted to move wineprefixes or games to a tmpfs (or imdisk in Windows) with a prelaunch command. The problem is, that lutris checks, whether the wineprefix and the game executable are present for some reason and it does that before the prelaunch_command is executed.

So I introduced the system_option prelaunch_early_exec, which will execute the prelaunch_command before any checks in a blocking manner, which will prevent prelaunch() from creating a new wine prefix and configure_game() from finding no executable. A working prelaunch-script example follows. Synchronizing it back just swaps the ${src} and ${tmpfsDir} parameters.

This is my first python code, so please bear with me. :)

As a side note, it might be worthwhile to implement the tmpfs usage as a lutris feature, but I wouldn’t recommend reinventing the wheel, since rsync already does a good job at this. It’s obviously not essentially required for copying to ram, but very much for copying from ram, since stand-alone game launchers might update the game. (Path of Exile, and Enderal Skyrim mod would be examples). I leave it for discussion in the lutris developer community, whether a rsync dependency makes sense for this kind of niche feature.

```
#!/bin/bash
##invocation
# copyToRam "${WINEPREFIX}" "${game_name}"
#
# tmpfs mount point, e.g. /mnt/fast
declare tmpfsDir=/mnt/schnell
# lutris games folder, e.g. /mnt/space/lutris/games
declare lutrisGamesDir=/mnt/platz/lutris/games
# maximum tmpfs size in Gibibytes (base 1024)
# tmpfs could also be mounted with a size option of this size
declare maxTmpfsSize=70
declare -p tmpfsDir lutrisGamesDir maxTmpfsSize
if ! echo "${1}" | grep -q "${tmpfsDir}"; then
    exit 0
fi
declare src="$(find \"${lutrisGamesDir}\" -type d -name \"${1##*/}\")"
declare dest="${1}"
declare gameName="${2}"
declare -p src
declare -i srcSize=$(du -s --block-size=1G "${src}" | grep -oe '^[[:digit:]]\+')
declare -i fsSize=$(du -s --block-size=1G /mnt/schnell | grep -oe '^[[:digit:]]\+')
declare -p srcSize fsSize
if (( ${srcSize} + ${fsSize} > ${maxTmpfsSize} )) && [[ ! -d "${dest}" ]]; then
    [[ -n "${tmpfsDir}" ]] && rm -rf "${tmpfsDir}"/*
fi
if [[ -z "${gameName}" ]]; then
    gameName="${1##*/}"
fi
declare -p dest gameName
# Note: multiple rsync processes are spawned for an unknown reason in
# this pipe construct, so the destination must not be the actual
# wineprefix, since subsequent rsync processes will write into its
# subdirectories
rsync -au --no-i-r --info=progress2 "${src}" "${tmpfsDir}" | stdbuf -i0 -o0 -e0 tr '\r' '\n' | stdbuf -i0 -o0 -e0 awk -f ~/scripts/rsync.awk | zenity --progress --text="Copying ${gameName} to ram" --auto-kill --title="Copy to ram" --auto-close
# auto-kill is not reliable
killall rsync
```
and ~/scripts/rsync.awk being
```
/^ / { print int(+$2) ; fflush() ;  next } $0 { print "# " $0  }
```
Note: zenity pipe is from
https://stackoverflow.com/questions/59032910/formatting-piped-rsync-output-for-zenity-progress

PS: If those comment edits got you a mail each time… sorry for those.