### PR TITLE
notifications: Use GNotifications

### DIFF
--- a/lutris/gui/widgets/notifications.py
+++ b/lutris/gui/widgets/notifications.py
@@ -1,24 +1,17 @@
-import gi
+from gi.repository import Gio
 
 from lutris.util.log import logger
 
-NOTIFY_SUPPORT = True
-try:
-    gi.require_version('Notify', '0.7')
-    from gi.repository import Notify
-except ImportError:
-    NOTIFY_SUPPORT = False
-
-if NOTIFY_SUPPORT:
-    Notify.init("lutris")
-else:
-    logger.warning("Notifications are disabled, please install GObject bindings for 'Notify' to enable them.")
-
 
 def send_notification(title, text, file_path_to_icon="lutris"):
-    if NOTIFY_SUPPORT:
-        notification = Notify.Notification.new(title, text, file_path_to_icon)
-        notification.show()
-    else:
-        logger.info(title)
-        logger.info(text)
+    icon_file = Gio.File.new_for_path(file_path_to_icon)
+    icon = Gio.FileIcon.new(icon_file)
+    notification = Gio.Notification.new(title)
+    notification.set_body(text)
+    notification.set_icon(icon)
+
+    application = Gio.Application.get_default()
+    application.send_notification(None, notification)
+
+    logger.info(title)
+    logger.info(text)

--- a/share/applications/net.lutris.Lutris.desktop
+++ b/share/applications/net.lutris.Lutris.desktop
@@ -8,3 +8,4 @@ Icon=lutris
 Terminal=false
 Type=Application
 MimeType=x-scheme-handler/lutris;
+X-GNOME-UsesNotifications=true


### PR DESCRIPTION
Instead of libnotify. This is more sandbox friendly and does not
require an additional library.

We also add X-GNOME-UsesNotifications=true to the desktop file, so that
GNOME Software can pick up this info.