### PR TITLE
contextual_menu: Use popup_at_pointer

### DIFF
--- a/lutris/gui/widgets/contextual_menu.py
+++ b/lutris/gui/widgets/contextual_menu.py
@@ -56,4 +56,4 @@ class ContextualMenu(Gtk.Menu):
                 continue
             menuitem.set_visible(displayed.get(menuitem.action_id, True))
 
-        super().popup(None, None, None, None, event.button, event.time)
+        super().popup_at_pointer(event)


### PR DESCRIPTION
gtk_menu_popup is deprecated since GTK 3.22 and causes the following error on wayland:

    Gdk-Message: 22:29:12.612: Window 0x220c760 is a temporary window without parent, application will not be able to position it on screen.
    (lutris:883897): Gdk-CRITICAL **: 22:29:12.624: gdk_wayland_window_handle_configure_popup: assertion 'impl->transient_for' failed

see https://docs.gtk.org/gtk3/method.Menu.popup.html