### PR TITLE
css: Use a color that behaves better with themes

### DIFF
--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -23,8 +23,7 @@
 }
 
 .info-pill {
-  background-color:rgb(100, 100, 100);
-  color:rgb(155, 155, 155);
+  background-color: alpha(currentColor, .07);
   border-radius: 5px;
   padding: 3px 6px;
 }


### PR DESCRIPTION
Using currentColor on backgrounds allows for a style that works both in Adwaita:light
and Adwaita:dark, and as higher chances of working on an arbitrary theme.

For comparison

current style:

![image](https://user-images.githubusercontent.com/11528996/156254162-a25efecf-254f-4692-bbfc-c65c0ec60aa8.png)
![image](https://user-images.githubusercontent.com/11528996/156254200-efeb6811-59b5-4bf5-af9a-219f84dbcad4.png)

now:

![image](https://user-images.githubusercontent.com/11528996/156254285-e00adad8-ef20-4184-b18f-e82407e6dfca.png)
![image](https://user-images.githubusercontent.com/11528996/156254329-a4dd2e87-cb87-457f-ac53-5cea7c8efef5.png)
