### PR TITLE
Prevent the creation of a blank game on GOG update install

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -465,9 +465,11 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         if self.config.get("create_menu_shortcut"):
             self.create_shortcut()
 
-        # Save game to trigger a game-updated signal
-        game = Game(game_id)
-        game.save()
+        # Save game to trigger a game-updated signal,
+        # but take care not to create a blank game
+        if game_id:
+            game = Game(game_id)
+            game.save()
 
         self.install_in_progress = False
 
@@ -477,7 +479,7 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
         self.cancel_button.hide()
         self.continue_button.hide()
         self.install_button.hide()
-        if game.id:
+        if game and game.id:
             self.play_button.show()
 
         self.close_button.grab_focus()

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -79,7 +79,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         # If the game is in the library and uninstalled, the first installation
         # updates it
         existing_game = get_game_by_field(self.game_slug, "slug")
-        if existing_game and not existing_game["installed"]:
+        if existing_game and (self.extends or not existing_game["installed"]):
             return existing_game["id"]
 
     @property
@@ -241,7 +241,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
                 "This is an extension to %s, not creating a new game entry",
                 self.extends,
             )
-            return
+            return self.game_id
 
         if self.is_gog:
             gog_config = get_gog_config_from_path(self.interpreter.target_path)


### PR DESCRIPTION
This PR ensures that the installer save() method returns a game_id, which the __init__ method now finds. It may not be the same game as you used to trigger the update, since the slug it has is not a unique ID, but it's better to fail that way than to create a blank game.

I think the consequence of this would be that the "Launch" button at the end of the install could launch the wrong game entry (if more than one game shares a slug)

Also, I've added code to suppress the effort to resave the game after installing should there be no game ID. Just in case the game_id somehow is not found.

Resolves #4135