### PR TITLE
Adjust the button code for 'View Games' to work more often

### DIFF
--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -155,7 +155,7 @@ class RunnerInstallDialog(Dialog):
                 app_count = runner[self.COL_USAGE] or 0
                 if app_count > 0:
                     usage_button_text = gettext.ngettext(
-                        "_View game",
+                        "_View %d game",
                         "_View %d games",
                         app_count
                     ) % app_count

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -152,7 +152,7 @@ class RunnerInstallDialog(Dialog):
 
             if runner[self.COL_INSTALLED]:
                 # Check if there are apps installed, if so, show the view apps button
-                app_count = runner[self.COL_USAGE]
+                app_count = runner[self.COL_USAGE] or 0
                 if app_count > 0:
                     usage_button_text = gettext.ngettext(
                         "_View game",


### PR DESCRIPTION
This PR tweaks the new "View Games" button to work better. It chiefly inserts the '1' in the 'View Game' button even when there is only one game, so that the '%' operator does not choke on it. It also adds some defense against the usage count being missing.

Resolves #4139