### PR TITLE
Raise RuntimeError when the Ubisoft service returns an error response

### DIFF
--- a/lutris/util/ubisoft/client.py
+++ b/lutris/util/ubisoft/client.py
@@ -4,6 +4,7 @@
 import json
 import time
 from datetime import datetime
+from gettext import gettext as _
 
 import requests
 
@@ -98,7 +99,7 @@ class UbisoftConnectClient():
             logger.error("Unable to refresh authentication calling auth lost: %s", ex)
             if self._auth_lost_callback:
                 self._auth_lost_callback()
-            raise
+            raise RuntimeError(_("Ubisoft authentication has been lost: %s") % ex) from ex
         return result
 
     def _do_options_request(self):


### PR DESCRIPTION
This PR is untested- I don't have an Ubisoft account, so I'm working by guess here. But it *seems* clear that we should report the Ubisoft error, not a downstream KeyError, so I'm trying to do that.

I'll try to get somebody to test this.

Resolves #4143