### PR TITLE
just check entire version string in is_version_fsync() and is_version_esync()

### DIFF
--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -311,7 +311,7 @@ def is_version_fsync(path):
     except IndexError:
         logger.error("Invalid path '%s'", path)
         return False
-    _, version_prefix, version_suffix = parse_version(version)
+    _version_number, version_prefix, version_suffix = parse_version(version)
     fsync_compatible_versions = ["fsync", "lutris", "ge", "proton"]
     for fsync_version in fsync_compatible_versions:
         if fsync_version in version_prefix or fsync_version in version_suffix:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -288,7 +288,7 @@ def is_version_esync(path):
     _version_number, version_prefix, version_suffix = parse_version(version)
     esync_compatible_versions = ["esync", "lutris", "tkg", "ge", "proton", "staging"]
     for esync_version in esync_compatible_versions:
-        if esync_version in version_prefix or esync_version in version_suffix:
+        if esync_version in version:
             return True
     wine_version = get_wine_version(path)
     if wine_version:
@@ -314,7 +314,7 @@ def is_version_fsync(path):
     _version_number, version_prefix, version_suffix = parse_version(version)
     fsync_compatible_versions = ["fsync", "lutris", "ge", "proton"]
     for fsync_version in fsync_compatible_versions:
-        if fsync_version in version_prefix or fsync_version in version_suffix:
+        if fsync_version in version:
             return True
     wine_version = get_wine_version(path)
     if wine_version:


### PR DESCRIPTION
We can just check the entire version string for fsync compatible versions rather than trying to check individual parts from parse_version.

This fixes newer lutris-ge-proton7-* builds from incorrectly being detected as not having fsync enabled.

The cause is due to parse_version failing to parse the version string correctly since lutrig-ge-proton7-* naming scheme has changed in recent versions (notably not having a version number)

Fixes:

https://github.com/GloriousEggroll/wine-ge-custom/commit/b8d36a49a518e22ce0c941e9ee0cd785e54df3c6#commitcomment-68599599