### PR TITLE
Use GTK ScreenSaver inhibit API when possible

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -63,6 +63,7 @@ class Application(Gtk.Application):
         super().__init__(
             application_id="net.lutris.Lutris",
             flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
+            register_session=True,
         )
 
         GObject.add_emission_hook(Game, "game-launch", self.on_game_launch)


### PR DESCRIPTION
GTK comes with an implementation of ScreenSaver interface which will
either try to use the org.freedesktop.ScreenSaver or
org.gnome.ScreenSaver DBus interfaces when running on the host, or the
org.freedesktop.portal.ScreenSaver interface when running inside a
sandbox. Note that sandboxes only have access to the .portal variant of
the interface.

To make use of this API, one has to set the
GtkApplication:register-session property to True on construction.

The MATE and XFCE desktop environments will still use their custom
implementations of the ScreenSaver interface as they seem to not support
the Freedesktop implementation in their current releases.

Another benefit is that GTK's api is not blocking.

To make matters worse, the Inhibit and Uninhibit methods used previosly
might not be exposed to PyGObject even if the DBus interface is.

See:
- https://flatpak.github.io/xdg-desktop-portal/#gdbus-org.freedesktop.portal.Inhibit
- https://docs.gtk.org/gtk3/method.Application.inhibit.html