### PR TITLE
Add NoneType check for variable folder in util/wine/prefix.py

### DIFF
--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -62,8 +62,8 @@ class WinePrefixManager:
             self.hkcu_prefix + "/Software/Microsoft/Windows/CurrentVersion/Explorer/Shell Folders",
             "AppData",
         )
-        if(folder is None):
-            logger.error("Get Registry Key function returned NoneType to variable folder.")
+        if folder is None:
+            logger.warning("Get Registry Key function returned NoneType to variable folder.")
         else:
             # Don't try to resolve the Windows path we get- there's
             # just two options, the Vista-and later option and the


### PR DESCRIPTION

![Screenshot_20220322_202824](https://user-images.githubusercontent.com/45468984/159565010-a03f9964-a1ca-4caa-8d19-eb19579f88c4.png)


Upon opening winetricks for a faulty origin installation, a stack-trace / NoneType exception is thrown out for the variable folder, which calls function get_registry_key.

- Propersal: Adding an if-else statement, on line 65, to check whether the result of function get_registry_key equals NoneType and make use of logger.