### PR TITLE
Tolerate ints as accepted_return_code

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -447,7 +447,7 @@ class CommandsMixin:
     def _monitor_task(self, command):
         if not command.is_running:
             logger.debug("Return code: %s", command.return_code)
-            if command.return_code not in (command.accepted_return_code, "0"):
+            if command.return_code not in (str(command.accepted_return_code), "0"):
                 raise ScriptingError(_("Command exited with code %s") % command.return_code)
             self._iter_commands()
             return False


### PR DESCRIPTION
There's an installer (Final Fantasy XIV/Launcher) failing because it specifies return_code in its JSON but has an int, not a string there. That is a very easy mistake to make!

This PR just converts this return_code, whatever it is, to a string with str(); this should allow ints to match.

Resolves #4177