### PR TITLE
Vulkan loaders: separate amdvlk and amdgpu-pro when possible

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -82,6 +82,7 @@ def get_vk_icd_choices():
     amdradv = []
     nvidia = []
     amdvlk = []
+    amdvlkpro = []
     choices = [(_("Auto: WARNING -- No Vulkan Loader detected!"), "")]
     icd_files = defaultdict(list)
     # Add loaders
@@ -96,13 +97,17 @@ def get_vk_icd_choices():
                 amdradv.append(loader)
             elif "nvidia" in loader:
                 nvidia.append(loader)
-            elif "amd_icd" in loader:
-                amdvlk.append(loader)
+            elif "amd" in loader:
+                if "pro" in loader:
+                    amdvlkpro.append(loader)
+                else:
+                    amdvlk.append(loader)
 
     intel_files = ":".join(intel)
     amdradv_files = ":".join(amdradv)
     nvidia_files = ":".join(nvidia)
     amdvlk_files = ":".join(amdvlk)
+    amdvlkpro_files = ":".join(amdvlkpro)
 
     glxinfocmd = get_gpu_vendor_cmd(0)
     if nvidia_files:
@@ -125,7 +130,12 @@ def get_vk_icd_choices():
     if nvidia_files:
         choices.append(("Nvidia Proprietary", nvidia_files))
     if amdvlk_files:
-        choices.append(("AMDVLK/AMDGPU-PRO Proprietary", amdvlk_files))
+        if not amdvlkpro_files:
+            choices.append(("AMDVLK/AMDGPU-PRO Proprietary", amdvlk_files))
+        else:
+            choices.append(("AMDVLK Open source", amdvlk_files))
+    if amdvlkpro_files:
+        choices.append(("AMDGPU-PRO Proprietary", amdvlkpro_files))
     return choices
 
 


### PR DESCRIPTION
Hello,

As the (fresh) maintainer of the `amdgpu-pro-vulkan` driver on Gentoo, I mirrored something that is also done in the `AUR`'s `PKGBUILD` of the same driver : rename `amd_icd` to `amd_pro_icd` so it can be differentiated from the open source `amdvlk` driver who offers the same name for the icd loader.

This PR is a small tweak in Lutris to recognize when this separation happens then offers both drivers as separate choices.

Note: I relaxed the condition to recognize an icd loaders as `amdvlk` or `amdgpu-pro-vulkan` since other distros can follow suite with a different naming scheme. This should be general enough to capture it properly, and hopefully not too general to confuse it with another driver.

Hopefully this is helpful, otherwise feel free to close this PR.

Adel