### PR TITLE
Raise errors from is_launchable() when possible

### DIFF
--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -56,8 +56,9 @@ def watch_lutris_errors(function):
             return function(*args, **kwargs)
         except Exception as ex:
             game = args[0]
-            game.state = game.STATE_STOPPED
-            game.emit("game-stop")
-            game.emit("game-error", str(ex))
+            if game.state != game.STATE_STOPPED:
+                game.state = game.STATE_STOPPED
+                game.emit("game-stop")
+            game.emit("game-error", ex)
 
     return wrapper

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -49,7 +49,7 @@ class Game(GObject.Object):
     STATE_RUNNING = "running"
 
     __gsignals__ = {
-        "game-error": (GObject.SIGNAL_RUN_FIRST, None, (str, )),
+        "game-error": (GObject.SIGNAL_RUN_FIRST, None, (object, )),
         "game-launch": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -295,15 +295,12 @@ class Game(GObject.Object):
         """Verify that the current game can be launched."""
         if not self.is_installed:
             logger.error("%s (%s) not installed", self, self.id)
-            dialogs.ErrorDialog(_("Tried to launch a game that isn't installed."))
-            return False
+            raise GameConfigError(_("Tried to launch a game that isn't installed."))
         if not self.runner:
-            dialogs.ErrorDialog(_("Invalid game configuration: Missing runner"))
-            return False
+            raise GameConfigError(_("Invalid game configuration: Missing runner"))
         if not self.runner.is_installed():
             installed = self.runner.install_dialog()
             if not installed:
-                dialogs.ErrorDialog(_("Runner not installed."))
                 return False
 
         if self.runner.use_runtime():
@@ -517,6 +514,7 @@ class Game(GObject.Object):
 
         self.start_game()
 
+    @watch_lutris_errors
     def launch(self):
         """Request launching a game. The game may not be installed yet."""
         if not self.is_launchable():

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -675,8 +675,8 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
 
     def on_game_error(self, game, error):
         """Called when a game has sent the 'game-error' signal"""
-        logger.error("%s crashed", game)
-        dialogs.ErrorDialog(error, parent=self)
+        logger.exception("%s has encountered an error: %s", game, error, exc_info=error)
+        dialogs.ErrorDialog(str(error), parent=self)
         return True
 
     @GtkTemplate.Callback


### PR DESCRIPTION
Yeah, this is more than a spot fix. I'm working on removing ErrorDialog and such from the Game class, in favor of raising exceptions. But I reached an actual issue, so have a PR of my work. It's not *that* much more than the spot fix.

The Game.is_launchable() method pops a lot of dialogs, but some are warnings. I won't remove the warnings yet, as that's much less simple than just raising exceptions. Instead, I replace a couple of ErrorDialogs with suitable exceptions.

This PR also makes the launch method signal game-error, without which these exceptions are not reported at all. This will emit game-stop if the game is not already stopped. Also, it improves the game-error handling to handle an entire exception, and to use logger.exception(). This should allow the removal of duplicated error handling code, but I have not done any of that yet.

But... this PR outright removes the runner-not-installed error dialog, rather than raising an exception. This dialog appears after a warning to the same effect. The user just said no to this, he knows about it already.

Resolves #4187