### PR TITLE
Make steam shortcut support more tolerant of shortcut.vdf variants

### DIFF
--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -32,7 +32,7 @@ def shortcut_exists(game, shortcut_path):
         shortcuts = vdf.binary_loads(shortcut_file.read())['shortcuts'].values()
     shortcut_found = [
         s for s in shortcuts
-        if game.name in s['AppName']
+        if matches_appname(s, game)
     ]
     if not shortcut_found:
         return False
@@ -47,7 +47,7 @@ def all_shortcuts_set(game):
             shortcuts = vdf.binary_loads(shortcut_file.read())['shortcuts'].values()
         shortcut_found = [
             s for s in shortcuts
-            if game.name in s['AppName']
+            if matches_appname(s, game)
         ]
         shortcuts_found += len(shortcut_found)
 
@@ -97,7 +97,7 @@ def remove_shortcut(game, shortcut_path):
         shortcuts = vdf.binary_loads(shortcut_file.read())['shortcuts'].values()
     shortcut_found = [
         s for s in shortcuts
-        if game.name in s['AppName']
+        if matches_appname(s, game)
     ]
 
     if not shortcut_found:
@@ -105,7 +105,7 @@ def remove_shortcut(game, shortcut_path):
 
     other_shortcuts = [
         s for s in shortcuts
-        if game.name not in s['AppName']
+        if not matches_appname(s, game)
     ]
     updated_shortcuts = {
         'shortcuts': {
@@ -143,6 +143,12 @@ def generate_shortcut(game):
             '0': "Lutris"   # to identify generated shortcuts
         }
     }
+
+
+def matches_appname(shortcut, game):
+    """Test if the game seems to be the a shortcut refers to."""
+    appname = shortcut.get('AppName') or shortcut.get('appname')
+    return appname and game.name in appname
 
 
 def get_steam_shortcut_id(game):

--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -146,7 +146,7 @@ def generate_shortcut(game):
 
 
 def matches_appname(shortcut, game):
-    """Test if the game seems to be the a shortcut refers to."""
+    """Test if the game seems to be the one a shortcut refers to."""
     appname = shortcut.get('AppName') or shortcut.get('appname')
     return appname and game.name in appname
 


### PR DESCRIPTION
This isn't a complete fix, since tolerating errors occurring inside GameActions.get_displayed_entries() is going to be more complicated than this, or so I fear. But this seems to deal with the immediate problem.

This makes Lutris accept 'shortcuts.vdf' files that have the AppName key listed as 'appname', in lower case, or at least to not crash if this is missing entirely.

Resolves #4195
Resolves #4196