### PR TITLE
Remove strange 'platform' lookup in print_steam_folders

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -778,8 +778,8 @@ class Application(Gtk.Application):
 
     def print_steam_folders(self, command_line):
         steamapps_paths = get_steamapps_paths()
-        for platform in ("linux", "windows"):
-            for path in steamapps_paths[platform] if steamapps_paths else []:
+        if steamapps_paths:
+            for path in steamapps_paths:
                 self._print(command_line, path)
 
     def print_runners(self):


### PR DESCRIPTION
I don't understand what this code was ever meant to do, but the list of paths is not a dict and does not support look-ups like this.

It seems to me that listing all the steam paths is probably reasonable, so this PR alters the code to do so. This should at least not crash.

Resolves #4202