### PR TITLE
WINE should use 'baseenv' not 'wineenv' when blocking

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -299,7 +299,7 @@ def wineexec(  # noqa: C901
     wine.prelaunch()
 
     if blocking:
-        return system.execute(command_parameters, env=wineenv, cwd=working_dir)
+        return system.execute(command_parameters, env=baseenv, cwd=working_dir)
 
     command = MonitoredCommand(
         command_parameters,


### PR DESCRIPTION
It needs to be consistent, I think.

This change allows 'Osu!' to install, probably other things too.

Resolves #4200
Resolves #4184