### PR TITLE
Default fsync to on only if supported

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -309,7 +309,7 @@ class wine(Runner):
                 "option": "fsync",
                 "label": _("Enable Fsync"),
                 "type": "extended_bool",
-                "default": True,
+                "default": is_fsync_supported(),
                 "callback": fsync_support_callback,
                 "callback_on": True,
                 "active": True,


### PR DESCRIPTION
We have checks to see if fsync is supported when you turn it on, but if it *defaults* to on, as it now does, this is skipped.

So, this PR makes  the default be on if and only if fsync is supported, so if not you'll have to turn it on and be warned. It does not consider the WINE version (which may not support fsync) since this is a separate configuration and there's not an easy way to make one config option's default depend on another. It might be confusing if it did that anyway.

Resolves #4208