### PR TITLE
Provide error handling when counting the Steam shortcuts

### DIFF
--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -41,20 +41,27 @@ def shortcut_exists(game, shortcut_path):
 
 
 def all_shortcuts_set(game):
-    paths_shortcut = get_shortcuts_vdf_paths()
-    shortcuts_found = 0
-    for shortcut_path in paths_shortcut:
-        with open(shortcut_path, "rb") as shortcut_file:
-            shortcuts = vdf.binary_loads(shortcut_file.read())['shortcuts'].values()
-        shortcut_found = [
-            s for s in shortcuts
-            if matches_appname(s, game)
-        ]
-        shortcuts_found += len(shortcut_found)
+    """True if every shortcuts.vdf file found contains the game given (exactly once). But
+    False if there are no shortcuts.vdf files at all. False if any shortcuts.vdf file
+    cannot be read or decoded."""
+    try:
+        paths_shortcut = get_shortcuts_vdf_paths()
+        shortcuts_found = 0
+        for shortcut_path in paths_shortcut:
+            with open(shortcut_path, "rb") as shortcut_file:
+                shortcuts = vdf.binary_loads(shortcut_file.read())['shortcuts'].values()
+            shortcut_found = [
+                s for s in shortcuts
+                if matches_appname(s, game)
+            ]
+            shortcuts_found += len(shortcut_found)
 
-    if len(paths_shortcut) == shortcuts_found:
-        return True
-    return False
+        if len(paths_shortcut) == shortcuts_found:
+            return True
+        return False
+    except Exception as ex:
+        logger.exception("Unable to read Steam shortcuts: %s", ex)
+        return False
 
 
 def has_steamtype_runner(game):


### PR DESCRIPTION
A second attempt at improved robustness, but not as robust as the last one. But cleaner!

This catches ('excepts'?) errors in all_shortcuts_set() only; this is treated as meaning 'not all shortcuts set', which may leave some Steam-shortcut commands visible but won't bring down the UI.

There are other functions being called, but they seem low risk, so I left them alone.

I also added a comment to all_shortcuts_set() explaining what I think it is meant to do. If I'm right, it's still slightly buggy. It will think all shortcuts are set if some shortcut files do not have the game, and others have multiples. The 'contains' match used for the app name means that false matches could occur, so this seems possible. But I may have misinterpreted what this function is supposed to do.