### PR TITLE
Handle case where no versions of a WINE DLL-manager thingy are installed

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -772,8 +772,10 @@ class wine(Runner):
             arch=self.wine_arch,
             version=version,
         )
+
         # manual version only sets the dlls to native
-        if dll_manager.version.lower() != "manual":
+        manager_version = dll_manager.version
+        if not manager_version or manager_version.lower() != "manual":
             if enable:
                 dll_manager.enable()
             else:


### PR DESCRIPTION
If you have no versions of a WINE DLL-set then there's no default version to use, and the check to see if the version is manual fails because of it.

This PR makes it assume the DLL-manager is not set to manual. This allows it to reach the actual handling, which may download the missing version list, or it it fails it may give an error.

Resolves #4216