### PR TITLE
Add a check to make sure the current resolution is usable

### DIFF
--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -394,13 +394,19 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             "USER": os.getenv("USER"),
             "INPUT": self.user_inputs[-1]["value"] if self.user_inputs else "",
             "VERSION": self.installer.version,
-            "RESOLUTION": "x".join(self.current_resolution),
-            "RESOLUTION_WIDTH": self.current_resolution[0],
-            "RESOLUTION_HEIGHT": self.current_resolution[1],
-            "RESOLUTION_WIDTH_HEX": hex(int(self.current_resolution[0])),
-            "RESOLUTION_HEIGHT_HEX": hex(int(self.current_resolution[1])),
             "WINEBIN": self.get_wine_path(),
         }
+
+        current_resolution = self.current_resolution
+        if current_resolution and len(current_resolution) == 2 and current_resolution[0] and current_resolution[1]:
+            replacements.update({
+                "RESOLUTION": "x".join(self.current_resolution),
+                "RESOLUTION_WIDTH": self.current_resolution[0],
+                "RESOLUTION_HEIGHT": self.current_resolution[1],
+                "RESOLUTION_WIDTH_HEX": hex(int(self.current_resolution[0])),
+                "RESOLUTION_HEIGHT_HEX": hex(int(self.current_resolution[1]))
+            })
+
         replacements.update(self.installer.variables)
         # Add 'INPUT_<id>' replacements for user inputs with an id
         for input_data in self.user_inputs:

--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -85,16 +85,10 @@ def get_resolutions():
     """Return the list of supported screen resolutions."""
     resolution_list = []
     for line in _get_vidmodes():
-        if line.startswith("  "):
-            resolution_match = re.match(r".*?(\d+x\d+).*", line)
-            if resolution_match:
-                resolution_list.append(resolution_match.groups()[0])
-    return resolution_list
-
-
-def get_unique_resolutions():
-    """Return available resolutions, without duplicates and ordered with highest resolution first"""
-    return sorted(set(get_resolutions()), key=lambda x: int(x.split("x")[0]), reverse=True)
+        resolution_match = re.match(r"^\s*(\d+x\d+).*", line)
+        if resolution_match:
+            resolution_list.append(resolution_match.groups()[0])
+    return sorted(set(resolution_list), key=lambda x: int(x.split("x")[0]), reverse=True)
 
 
 def change_resolution(resolution):


### PR DESCRIPTION
On the LegacyDisplayManager, the resolution is ("" x "") if xrandr provides nothing it can use, which produces various amusing failure modes.

But a crash when building the replacements dict is ugly and hard for users to deal with, so add some validity checks for that. Those replacements are then removed.

This means that installers that use the RESOLUTION replacements will fail, as the replacement won't be done and the variable will be left in.

An alternative I see is to generate blank replacements as Lutris does in other places, but that also won't actually work and may be less obvious. Alternatively again, we could just crash with a nice error at some point- but I suspect most installers don't use these replacements and would therefore actually work if we let them try.

I've also tried to improve the handling of xrandr output. I've adjusted get_resolutions() to no longer require each resolution line to start with two spaces; instead it starts with whitespace, followed by digits, an x, and more digits, then anything else. This should be more resilient to formatting, though if a resolution line does not start with the resolution it won't work. Also, it de-duplicates the resolution list and sorts it. get_unique_resolutions() was not called, so I removed that.

Resolves #4218