### PR TITLE
Fix download timeout measurement

### DIFF
--- a/lutris/util/update_cache.py
+++ b/lutris/util/update_cache.py
@@ -42,4 +42,4 @@ def get_last_call(key):
     if not date:
         return 0
     delta = datetime.now() - date
-    return delta.seconds
+    return delta.total_seconds()


### PR DESCRIPTION
Using .seconds can't return more than a days worth of seconds, so downloads can stop working if you don't get them after a day of inactivity. It'll trigger if you start Lutris in the right time window, but you can miss it and if you're missing components it can lead to crashes.

So, total_seconds() for the win!

Resolves the missing versions.json issue referred to in #4216. Just restart Lutris and it'll notice that it need to download updates, and that should fix things.