### PR TITLE
A more limited attempt to manage problems with xrandr

### DIFF
--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -16,6 +16,12 @@ def _get_vidmodes():
     return read_process_output([LINUX_SYSTEM.get("xrandr")]).split("\n")
 
 
+def _log_vidmodes(message):
+    """Write the xrandr output to the log for debugging purposes"""
+    xrandr_output = read_process_output([LINUX_SYSTEM.get("xrandr")])
+    logger.debug("%s\n%s", message, xrandr_output)
+
+
 def get_outputs():  # pylint: disable=too-many-locals
     """Return list of namedtuples containing output 'name', 'geometry',
     'rotation' and whether it is the 'primary' display."""
@@ -89,6 +95,9 @@ def get_resolutions():
             resolution_match = re.match(r".*?(\d+x\d+).*", line)
             if resolution_match:
                 resolution_list.append(resolution_match.groups()[0])
+    if not resolution_list:
+        resolution_list = ['1280x720']
+        _log_vidmodes("Unable to generate resolution list from xrandr output")
     return sorted(set(resolution_list), key=lambda x: int(x.split("x")[0]), reverse=True)
 
 
@@ -167,7 +176,8 @@ class LegacyDisplayManager:  # pylint: disable=too-few-public-methods
                 resolution_match = re.match(r".*?(\d+x\d+).*", line)
                 if resolution_match:
                     return resolution_match.groups()[0].split("x")
-        return ("", "")
+        _log_vidmodes("Unable to find the current resolution from xrandr output")
+        return ("1280", "720")
 
     @staticmethod
     def set_resolution(resolution):

--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -89,12 +89,7 @@ def get_resolutions():
             resolution_match = re.match(r".*?(\d+x\d+).*", line)
             if resolution_match:
                 resolution_list.append(resolution_match.groups()[0])
-    return resolution_list
-
-
-def get_unique_resolutions():
-    """Return available resolutions, without duplicates and ordered with highest resolution first"""
-    return sorted(set(get_resolutions()), key=lambda x: int(x.split("x")[0]), reverse=True)
+    return sorted(set(resolution_list), key=lambda x: int(x.split("x")[0]), reverse=True)
 
 
 def change_resolution(resolution):

--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -4,7 +4,7 @@ import subprocess
 from collections import namedtuple
 
 from lutris.util.linux import LINUX_SYSTEM
-from lutris.util.log import logger
+from lutris.util.log import logger, logging
 from lutris.util.system import read_process_output
 
 Output = namedtuple("Output", ("name", "mode", "position", "rotation", "primary", "rate"))
@@ -18,8 +18,9 @@ def _get_vidmodes():
 
 def _log_vidmodes(message):
     """Write the xrandr output to the log for debugging purposes"""
-    xrandr_output = read_process_output([LINUX_SYSTEM.get("xrandr")])
-    logger.debug("%s\n%s", message, xrandr_output)
+    if logger.isEnabledFor(logging.DEBUG):
+        xrandr_output = read_process_output([LINUX_SYSTEM.get("xrandr")])
+        logger.debug("%s\n%s", message, xrandr_output)
 
 
 def get_outputs():  # pylint: disable=too-many-locals


### PR DESCRIPTION
This PR does not change how xrandr output is handled, but does check to see if it found any resolutions (or a current resolution).

If not, it writes the xrandr output to the log (in debug mode only) and substitutes an arbitrary fake resolution of 1280x720.

This should fail less hard than returning nothing or empty strings, and should enable better troubleshooting in future.

One again, this adds sorting and de-duplication to get_resolutions() for the xrandr code-path, since all the other implementations do that.

Resolves #4218
Replaces #4220
