### PR TITLE
Make the DisplayManagers more consistent in monitor handling

### DIFF
--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -94,6 +94,9 @@ class DisplayManager:
     def get_resolutions(self):
         """Return available resolutions"""
         resolutions = ["%sx%s" % (mode.get_width(), mode.get_height()) for mode in self.rr_screen.list_modes()]
+        if not resolutions:
+            logger.error("Failed to generate resolution list from default GdkScreen")
+            resolutions = ['1280x720']
         return sorted(set(resolutions), key=lambda x: int(x.split("x")[0]), reverse=True)
 
     def _get_primary_output(self):

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -96,7 +96,7 @@ class DisplayManager:
         resolutions = ["%sx%s" % (mode.get_width(), mode.get_height()) for mode in self.rr_screen.list_modes()]
         if not resolutions:
             logger.error("Failed to generate resolution list from default GdkScreen")
-            resolutions = ['1280x720']
+            resolutions = ['%dx%d' % (DEFAULT_RESOLUTION_WIDTH, DEFAULT_RESOLUTION_HEIGHT)]
         return sorted(set(resolutions), key=lambda x: int(x.split("x")[0]), reverse=True)
 
     def _get_primary_output(self):

--- a/lutris/util/graphics/displayconfig.py
+++ b/lutris/util/graphics/displayconfig.py
@@ -635,7 +635,7 @@ class MutterDisplayManager:
         resolutions = ["%sx%s" % (mode.width, mode.height) for mode in self.display_config.modes]
         if not resolutions:
             logger.error("Could not generate resolution list")
-            resolutions = ['1280x720']
+            resolutions = ['%dx%d' % (DEFAULT_RESOLUTION_WIDTH, DEFAULT_RESOLUTION_HEIGHT)]
         return sorted(set(resolutions), key=lambda x: int(x.split("x")[0]), reverse=True)
 
     def get_current_resolution(self):

--- a/lutris/util/graphics/displayconfig.py
+++ b/lutris/util/graphics/displayconfig.py
@@ -403,9 +403,23 @@ class DisplayState:
         """Display configuration properties"""
         return self._state[3]
 
+    def get_primary_logical_monitor(self):
+        """Return the primary logical monitor"""
+        for lm in self.logical_monitors:
+            if lm.primary:
+                return lm
+        return None
+
+    def get_primary_monitor(self):
+        """Returns the first physical monitor on the primary logical monitor."""
+        lm = self.get_primary_logical_monitor()
+        if lm:
+            return lm.monitors[0]
+        return self.monitors[0]
+
     def get_current_mode(self):
         """Return the current mode"""
-        return self.monitors[0].get_current_mode()
+        return self.get_primary_monitor().get_current_mode()
 
 
 class MutterDisplayConfig():
@@ -571,12 +585,13 @@ class MutterDisplayConfig():
                 return mode
         return
 
-    def get_primary_output(self):
-        """Return the primary output"""
-        for output in self.current_state.logical_monitors:
-            if output.primary:
-                return output
-        return
+    def get_primary_logical_monitor(self):
+        """Return the primary logical monitor"""
+        return self.current_state.get_primary_logical_monitor()
+
+    def get_primary_monitor(self):
+        """Returns the first physical monitor on the primary logical monitor."""
+        return self.current_state.get_primary_monitor()
 
     def apply_monitors_config(self, display_configs):
         """Set the selected display to the desired resolution"""
@@ -632,13 +647,13 @@ class MutterDisplayManager:
     def set_resolution(self, resolution):
         """Change the current resolution"""
         if isinstance(resolution, str):
-            output = self.display_config.get_primary_output()
-            mode = output.monitors[0].get_mode_for_resolution(resolution)
+            monitor = self.display_config.get_primary_monitor()
+            mode = monitor.get_mode_for_resolution(resolution)
             if not mode:
                 logger.error("Could not find  valid mode for %s", resolution)
                 return
             config = [
-                DisplayConfig([(output.monitors[0].name, mode.id)], output.monitors[0].name, (0, 0), 0, True, 1.0)
+                DisplayConfig([(monitor.name, mode.id)], monitor.name, (0, 0), 0, True, 1.0)
             ]
             self.display_config.apply_monitors_config(config)
         elif resolution:

--- a/lutris/util/graphics/displayconfig.py
+++ b/lutris/util/graphics/displayconfig.py
@@ -633,6 +633,9 @@ class MutterDisplayManager:
     def get_resolutions(self):
         """Return available resolutions"""
         resolutions = ["%sx%s" % (mode.width, mode.height) for mode in self.display_config.modes]
+        if not resolutions:
+            logger.error("Could not generate resolution list")
+            resolutions = ['1280x720']
         return sorted(set(resolutions), key=lambda x: int(x.split("x")[0]), reverse=True)
 
     def get_current_resolution(self):

--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -3,6 +3,7 @@ import re
 import subprocess
 from collections import namedtuple
 
+from lutris.settings import DEFAULT_RESOLUTION_HEIGHT, DEFAULT_RESOLUTION_WIDTH
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger, logging
 from lutris.util.system import read_process_output
@@ -97,7 +98,7 @@ def get_resolutions():
             if resolution_match:
                 resolution_list.append(resolution_match.groups()[0])
     if not resolution_list:
-        resolution_list = ['1280x720']
+        resolution_list = ['%dx%d' % (DEFAULT_RESOLUTION_WIDTH, DEFAULT_RESOLUTION_HEIGHT)]
         _log_vidmodes("Unable to generate resolution list from xrandr output")
     return sorted(set(resolution_list), key=lambda x: int(x.split("x")[0]), reverse=True)
 
@@ -178,7 +179,7 @@ class LegacyDisplayManager:  # pylint: disable=too-few-public-methods
                 if resolution_match:
                     return resolution_match.groups()[0].split("x")
         _log_vidmodes("Unable to find the current resolution from xrandr output")
-        return ("1280", "720")
+        return str(DEFAULT_RESOLUTION_WIDTH), str(DEFAULT_RESOLUTION_HEIGHT)
 
     @staticmethod
     def set_resolution(resolution):


### PR DESCRIPTION
Chiefly, this makes the MutterDisplayManager pick the same 'one true screen' always; it is the 0th monitor attached to the primary logical monitor, or the 0th monitor overall if no primary logical monitor is found.

Previously, it sometimes did this and sometimes picked the 0th overall monitor. This didn't work too well on multi-monitor setups.

Also, update the DisplayManager and MutterDisplayManager to fail over to a resolution of "1280x720" if a proper resolution cannot be found, instead of "" x "". The LegacyDisplayManager was already doing this, and the last changelog suggests this is a general change- so let's make it so.

This should help with the problems chronicled in #4218. This issue is closed, because we fixed one cause of the issue. This PR fixes another cause for not having a current resolution.