### PR TITLE
fix explicit_dpi not integer exception on python 3.7.3.

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -759,7 +759,7 @@ class wine(Runner):
                 explicit_dpi = None
             try:
                 explicit_dpi = int(explicit_dpi)
-            except ValueError:
+            except:
                 explicit_dpi = None
             return explicit_dpi or get_default_dpi()
 


### PR DESCRIPTION
```py
            if explicit_dpi == "auto":
                explicit_dpi = None
            try:
                explicit_dpi = int(explicit_dpi)
            except ValueError:
                explicit_dpi = None
```

When `explicit_dpi` is `auto` (so it will be `None`), `int(explicit_dpi)` causes `TypeError` instead of `ValueError` on Python 3.7.3, so removing the type is a good idea.

```
2022-05-02 16:20:46,922: Error while completing task <bound method wine.prelaunch of <lutris.runners.wine.wine object at 0x7f7a4c104f98>>: <class 'TypeError'> int() argument must be a string, a bytes-like object or a number, not 'NoneType'
  File "/usr/lib/python3/dist-packages/lutris/util/jobs.py", line 34, in target
    result = self.function(*args, **kwargs)
  File "/usr/lib/python3/dist-packages/lutris/runners/wine.py", line 799, in prelaunch
    self.set_regedit_keys()
  File "/usr/lib/python3/dist-packages/lutris/runners/wine.py", line 751, in set_regedit_keys
    prefix_manager.set_dpi(self.get_dpi())
  File "/usr/lib/python3/dist-packages/lutris/runners/wine.py", line 761, in get_dpi
    explicit_dpi = int(explicit_dpi)
```

![image](https://user-images.githubusercontent.com/4986069/166207400-a5ab589f-38af-46da-8527-522113ee324d.png)
