### PR TITLE
Add deepin-terminal to the terminal list

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -70,6 +70,7 @@ SYSTEM_COMPONENTS = {
         "qterminal",
         "alacritty",
         "kgx",
+        "deepin-terminal",
     ],
     "LIBRARIES": {
         "OPENGL": ["libGL.so.1"],


### PR DESCRIPTION
deepin-terminal is the default terminal for DDE (Deepin Desktop Environment) of the distribution Deepin.

![deepin-terminal](https://user-images.githubusercontent.com/4986069/166479076-b8a22cea-8b5d-4fd7-a9c9-7fd711e5b5d3.png)
