### PR TITLE
Make System Winetricks System-ier.

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -6,7 +6,6 @@ import time
 
 from lutris import runtime, settings
 from lutris.command import MonitoredCommand
-from lutris.config import LutrisConfig
 from lutris.runners import import_runner
 from lutris.util import linux, system
 from lutris.util.log import logger
@@ -334,21 +333,21 @@ def winetricks(
     config=None,
     env=None,
     disable_runtime=False,
+    system_winetricks=False,
     runner=None
 ):
     """Execute winetricks."""
-    wine_config = config or LutrisConfig(runner_slug="wine")
     winetricks_path = os.path.join(settings.RUNTIME_DIR, "winetricks/winetricks")
-    if (wine_config.runner_config.get("system_winetricks") or not system.path_exists(winetricks_path)):
+    if system_winetricks or not system.path_exists(winetricks_path):
         winetricks_path = system.find_executable("winetricks")
-        disable_runtime=True
         if not winetricks_path:
             raise RuntimeError("No installation of winetricks found")
     if wine_path:
         winetricks_wine = wine_path
     else:
-        wine = import_runner("wine")
-        winetricks_wine = wine().get_executable()
+        if not runner:
+            runner = import_runner("wine")()
+        winetricks_wine = runner.get_executable()
     if arch not in ("win32", "win64"):
         arch = detect_arch(prefix, winetricks_wine)
     args = app

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -208,6 +208,7 @@ def wineexec(  # noqa: C901
     disable_runtime=False,
     env=None,
     overrides=None,
+    wine=None
 ):
     """
     Execute a Wine command.
@@ -240,7 +241,8 @@ def wineexec(  # noqa: C901
     if isinstance(exclude_processes, str):
         exclude_processes = shlex.split(exclude_processes)
 
-    wine = import_runner("wine")()
+    if not wine:
+        wine = import_runner("wine")()
 
     if not wine_path:
         wine_path = wine.get_executable()
@@ -328,6 +330,7 @@ def winetricks(
     config=None,
     env=None,
     disable_runtime=False,
+    wine=None
 ):
     """Execute winetricks."""
     wine_config = config or LutrisConfig(runner_slug="wine")
@@ -356,6 +359,7 @@ def winetricks(
         config=config,
         env=env,
         disable_runtime=disable_runtime,
+        wine=wine
     )
 
 

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -296,7 +296,7 @@ def wineexec(  # noqa: C901
     if overrides:
         wineenv["WINEDLLOVERRIDES"] = get_overrides_env(overrides)
 
-    baseenv = runner.get_env()
+    baseenv = runner.get_env(disable_runtime=disable_runtime)
     baseenv.update(wineenv)
     baseenv.update(env)
 
@@ -341,6 +341,7 @@ def winetricks(
     winetricks_path = os.path.join(settings.RUNTIME_DIR, "winetricks/winetricks")
     if (wine_config.runner_config.get("system_winetricks") or not system.path_exists(winetricks_path)):
         winetricks_path = system.find_executable("winetricks")
+        disable_runtime=True
         if not winetricks_path:
             raise RuntimeError("No installation of winetricks found")
     if wine_path:

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -226,7 +226,7 @@ def wineexec(  # noqa: C901
         blocking (bool): if true, do not run the process in a thread
         config (LutrisConfig): LutrisConfig object for the process context
         watch (list): list of process names to monitor (even when in a ignore list)
-        runner (runner): the wine runner that carries teh configuration to use
+        runner (runner): the wine runner that carries the configuration to use
 
     Returns:
         Process results if the process is running in blocking mode or

--- a/lutris/runners/easyrpg.py
+++ b/lutris/runners/easyrpg.py
@@ -273,8 +273,8 @@ class easyrpg(Runner):
 
         return ""
 
-    def get_env(self, os_env=False):
-        env = super().get_env(os_env)
+    def get_env(self, os_env=False, disable_runtime=False):
+        env = super().get_env(os_env, disable_runtime=disable_runtime)
 
         rpg2k_rtp_path = self.runner_config.get("rpg2k_rtp_path")
         if rpg2k_rtp_path:

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -160,7 +160,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             raise ValueError("runner_executable not set for {}".format(self.name))
         return os.path.join(settings.RUNNER_DIR, self.runner_executable)
 
-    def get_env(self, os_env=False):
+    def get_env(self, os_env=False, disable_runtime=False):
         """Return environment variables used for a game."""
         env = {}
         if os_env:
@@ -207,7 +207,7 @@ class Runner:  # pylint: disable=too-many-public-methods
 
         runtime_ld_library_path = None
 
-        if self.use_runtime():
+        if not disable_runtime and self.use_runtime():
             runtime_env = self.get_runtime_env()
             runtime_ld_library_path = runtime_env.get("LD_LIBRARY_PATH")
 

--- a/lutris/runners/web.py
+++ b/lutris/runners/web.py
@@ -175,8 +175,8 @@ class web(Runner):
     system_options_override = [{"option": "disable_runtime", "default": True}]
     runner_executable = "web/electron/electron"
 
-    def get_env(self, os_env=True):
-        env = super().get_env(os_env)
+    def get_env(self, os_env=True, disable_runtime=False):
+        env = super().get_env(os_env, disable_runtime=disable_runtime)
 
         enable_flash_player = self.runner_config.get("enable_flash")
         env["ENABLE_FLASH_PLAYER"] = "1" if enable_flash_player else "0"

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -700,13 +700,19 @@ class wine(Runner):
     def run_winetricks(self, *args):
         """Run winetricks in the current context"""
         self.prelaunch()
-        disable_runtime = not self.use_runtime() or self.runner_config.get("system_winetricks")
+        disable_runtime = not self.use_runtime()
+        system_winetricks = self.runner_config.get("system_winetricks")
+        if system_winetricks:
+            # Don't run the system winetricks with the runtime; let the
+            # system be the system
+            disable_runtime = True
         winetricks(
             "",
             prefix=self.prefix_path,
             wine_path=self.get_executable(),
             config=self,
             disable_runtime=disable_runtime,
+            system_winetricks=system_winetricks,
             env=self.get_env(os_env=True, disable_runtime=disable_runtime),
             runner=self
         )

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -654,6 +654,7 @@ class wine(Runner):
             working_dir=self.prefix_path,
             config=self,
             env=self.get_env(os_env=True),
+            runner=self
         )
 
     def run_wineexec(self, *args):
@@ -679,6 +680,7 @@ class wine(Runner):
             arch=self.wine_arch,
             config=self,
             env=self.get_env(os_env=True),
+            runner=self
         )
 
     def run_regedit(self, *args):
@@ -704,7 +706,7 @@ class wine(Runner):
             wine_path=self.get_executable(),
             config=self,
             env=self.get_env(os_env=True),
-            wine=self
+            runner=self
         )
 
     def run_winecpl(self, *args):
@@ -795,7 +797,7 @@ class wine(Runner):
     def prelaunch(self):
         if not system.path_exists(os.path.join(self.prefix_path, "user.reg")):
             logger.warning("No valid prefix detected in %s, creating one...", self.prefix_path)
-            create_prefix(self.prefix_path, wine_path=self.get_executable(), arch=self.wine_arch)
+            create_prefix(self.prefix_path, wine_path=self.get_executable(), arch=self.wine_arch, runner=self)
 
         prefix_manager = WinePrefixManager(self.prefix_path)
         if self.runner_config.get("autoconf_joypad", False):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -699,7 +699,12 @@ class wine(Runner):
         """Run winetricks in the current context"""
         self.prelaunch()
         winetricks(
-            "", prefix=self.prefix_path, wine_path=self.get_executable(), config=self, env=self.get_env(os_env=True)
+            "",
+            prefix=self.prefix_path,
+            wine_path=self.get_executable(),
+            config=self,
+            env=self.get_env(os_env=True),
+            wine=self
         )
 
     def run_winecpl(self, *args):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -700,12 +700,14 @@ class wine(Runner):
     def run_winetricks(self, *args):
         """Run winetricks in the current context"""
         self.prelaunch()
+        disable_runtime = not self.use_runtime() or self.runner_config.get("system_winetricks")
         winetricks(
             "",
             prefix=self.prefix_path,
             wine_path=self.get_executable(),
             config=self,
-            env=self.get_env(os_env=True),
+            disable_runtime=disable_runtime,
+            env=self.get_env(os_env=True, disable_runtime=disable_runtime),
             runner=self
         )
 
@@ -843,12 +845,12 @@ class wine(Runner):
             overrides = {}
         return overrides
 
-    def get_env(self, os_env=False):
+    def get_env(self, os_env=False, disable_runtime=False):
         """Return environment variables used by the game"""
         # Always false to runner.get_env, the default value
         # of os_env is inverted in the wine class,
         # the OS env is read later.
-        env = super().get_env(False)
+        env = super().get_env(False, disable_runtime=disable_runtime)
         if os_env:
             env.update(os.environ.copy())
         show_debug = self.runner_config.get("show_debug", "-all")


### PR DESCRIPTION
The Lutris runtime is interfering with winetricks on Pop!_OS 22.04, but switching to the system winetricks or turning the Lutris runtime off does not help. That's because it doesn't apply fully; the environment is still generated *with* the runtime's stuff in it.

This PR fixes two things. It makes turning off the runtime more effective in WINE by passing the runner around to wineexec(), so the configuration setting there will affect the environment generated better.

It also passes the disabled_runtime flag around in more places to get it to get_env(); this is used when system-winetricks is turned on. It disables the runtime for system-winetricks even if it is not disabled for everything, so that in this case the winetricks can be more system-y.

This is not a complete fix- it allows the existing configuration flags to work better and so help out. But plain default Lutris winetricks should work and still does not.

Still, this helps with #4231.