### PR TITLE
Enable gamescope usage on nvidia >= 515

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -8,7 +8,6 @@ from gettext import gettext as _
 from lutris import runners
 from lutris.util import linux, system
 from lutris.util.display import DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, USE_DRI_PRIME
-from lutris.util.graphics import drivers
 
 VULKAN_DATA_DIRS = [
     "/usr/local/etc/vulkan",  # standard site-local location
@@ -184,7 +183,7 @@ system_options = [  # pylint: disable=invalid-name
         "label": _("Enable gamescope"),
         "default": False,
         "advanced": True,
-        "condition": bool(system.find_executable("gamescope")) and not drivers.is_nvidia(),
+        "condition": bool(system.find_executable("gamescope")) and linux.LINUX_SYSTEM.nvidia_gamescope_support(),
         "help": _("Use gamescope to draw the game window isolated from your desktop.\n"
                   "Use Ctrl+Super+F to toggle fullscreen"),
     },

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -215,6 +215,23 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
             return True
         return False
 
+    def nvidia_gamescope_support(self):
+        """ Return whether gamescope is supported if we're on nvidia"""
+        if not drivers.is_nvidia():
+            return True
+
+        # 515.43.04 was the first driver to support
+        # VK_EXT_image_drm_format_modifier, required by gamescope.
+        minimum_nvidia_version_supported = 515
+        driver_info = drivers.get_nvidia_driver_info()
+        driver_version = driver_info["nvrm"]["version"]
+        major_version = int(driver_version.split(".")[0])
+
+        if not major_version >= minimum_nvidia_version_supported:
+            return False
+        else:
+            return True
+
     @property
     def has_steam(self):
         """Return whether Steam is installed locally"""


### PR DESCRIPTION
With 515.43.04 and gamescope git, gamescope is working (albeit not greatly) as the nvidia driver now supports `VK_EXT_image_drm_format_modifier`. Therefore, allow usage of gamescope on nvidia if the major driver version is 515 or higher.

AFAIK 515.43.04 is the first release in the 515 series so it should be safe to check for major version only.