### PR TITLE
add Patreon badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Lutris
 ******
 
-|LiberaPayBadge|_
+|LiberaPayBadge|  |PatreonBadge|
 
 Lutris helps you install and play video games from all eras and from most
 gaming systems. By leveraging and combining existing emulators, engine
@@ -146,3 +146,5 @@ You can always reach us on:
 
 .. |LiberaPayBadge| image:: http://img.shields.io/liberapay/receives/Lutris.svg?logo=liberapay
 .. _LiberaPayBadge: https://liberapay.com/Lutris/
+.. |PatreonBadge| image:: https://img.shields.io/badge/dynamic/json?color=%23ff424d&label=Patreon&query=data.attributes.patron_count&suffix=%20Patreons&url=https%3A%2F%2Fwww.patreon.com%2Fapi%2Fcampaigns%2F556103&style=flat&logo=patreon
+.. _PatreonBadge: https://www.patreon.com/lutris

--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,7 @@
 Lutris
 ******
 
-|LiberaPayBadge|  |PatreonBadge|
+|LiberaPayBadge|_ |PatreonBadge|_
 
 Lutris helps you install and play video games from all eras and from most
 gaming systems. By leveraging and combining existing emulators, engine


### PR DESCRIPTION
I tried to add a Patreon badge to show the current amount of Patreons supporting the Lutris Project.
It's using the [generic shield api of shields.io](https://shields.io/#dynamic-badge) bolted onto the patreon-api: https://www.patreon.com/api/campaigns/556103