### PR TITLE
Add check for 'contentstatsid' key before attempting to remove it. Fi…

### DIFF
--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -170,7 +170,8 @@ def read_library_folders(steam_data_dir):
     with open(library_filename, "r", encoding='utf-8') as steam_library_file:
         library = vdf_parse(steam_library_file, {})
         # The contentstatsid key is unused and causes problems when looking for library paths.
-        library["libraryfolders"].pop("contentstatsid", None)
+        if "contentstatsid" in library["libraryfolders"]:
+            library["libraryfolders"].pop("contentstatsid", None)
     try:
         return get_entry_case_insensitive(library, ["libraryfolders"])
     except KeyError as ex:


### PR DESCRIPTION
Fixes the issue of no wine games starting due to error KeyError: 'contentstatsid'. Might fix #4141 as well. Solution discovered on https://www.reddit.com/r/Lutris/comments/t6fbxl/comment/hzavg33/

My library vdf does not contain that key, so it crashes when I want to start any game. Might have something to do with the fact I'm using the Steam Beta on Linux. After the code change everything starts as desired.