### PR TITLE
#4294 - Linux DLC installers not listed under "Install DLC"

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -659,9 +659,8 @@ class Application(Gtk.Application):
         service = get_enabled_services()[game.service]()
         db_game = games_db.get_game_by_field(game.id, "id")
 
-        # installers = service.get_dlc_installers(db_game)
-        # only return owned DLC for now
-        installers = service.get_dlc_installers_owned(db_game)
+        #installers = service.get_dlc_installers(db_game)
+        installers = service.get_dlc_installers_runner(db_game, False)
 
         if installers:
             self.show_installer_window(installers, service, game.appid)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -660,7 +660,7 @@ class Application(Gtk.Application):
         db_game = games_db.get_game_by_field(game.id, "id")
 
         #installers = service.get_dlc_installers(db_game)
-        installers = service.get_dlc_installers_runner(db_game, False)
+        installers = service.get_dlc_installers_runner(db_game, db_game["runner"])
 
         if installers:
             self.show_installer_window(installers, service, game.appid)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -658,7 +658,11 @@ class Application(Gtk.Application):
     def on_game_install_dlc(self, game):
         service = get_enabled_services()[game.service]()
         db_game = games_db.get_game_by_field(game.id, "id")
-        installers = service.get_dlc_installers(db_game)
+
+        # installers = service.get_dlc_installers(db_game)
+        # only return owned DLC for now
+        installers = service.get_dlc_installers_owned(db_game)
+
         if installers:
             self.show_installer_window(installers, service, game.appid)
         else:

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -7,6 +7,7 @@ from gettext import gettext as _
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 from lxml import etree
+from numpy import True_
 
 from lutris import settings
 from lutris.exceptions import AuthenticationError, UnavailableGame
@@ -603,6 +604,17 @@ class GOGService(OnlineService):
 
         return installers
 
+    def get_dlc_installers_runner(self, db_game, only_owned=True):
+        """Return DLC installers for games current runner"""
+        """only_owned=True only return installers for owned DLC (default)"""
+        if (only_owned):
+            installers = self.get_dlc_installers_owned(db_game)
+        else:
+            installers = self.get_dlc_installers(db_game)
+
+        installers = [installer for installer in installers if installer["runner"] == db_game["runner"]]
+        
+        return installers
 
     def get_update_installers(self, db_game):
         appid = db_game["service_id"]

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -1,7 +1,6 @@
 """Module for handling the GOG service"""
 import json
 import os
-from pickle import TRUE
 import time
 from collections import defaultdict
 from gettext import gettext as _
@@ -604,7 +603,7 @@ class GOGService(OnlineService):
 
         return installers
 
-    def get_dlc_installers_runner(self, db_game, only_owned=TRUE):
+    def get_dlc_installers_runner(self, db_game, runner, only_owned=True):
         """Return DLC installers for games current runner"""
         """only_owned=True only return installers for owned DLC (default)"""
         if (only_owned):
@@ -612,7 +611,7 @@ class GOGService(OnlineService):
         else:
             installers = self.get_dlc_installers(db_game)
 
-        installers = [installer for installer in installers if installer["runner"] == db_game["runner"]]
+        installers = [installer for installer in installers if installer["runner"] == runner]
         
         return installers
 

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -604,12 +604,16 @@ class GOGService(OnlineService):
         return installers
 
     def get_dlc_installers_runner(self, db_game, runner, only_owned=True):
-        """Return DLC installers for games current runner"""
+        """Return DLC installers for requested runner"""
         """only_owned=True only return installers for owned DLC (default)"""
         if (only_owned):
             installers = self.get_dlc_installers_owned(db_game)
         else:
             installers = self.get_dlc_installers(db_game)
+
+        # only handle linux & wine for now
+        if runner != "linux":
+            runner = "wine"
 
         installers = [installer for installer in installers if installer["runner"] == runner]
         

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -1,13 +1,13 @@
 """Module for handling the GOG service"""
 import json
 import os
+from pickle import TRUE
 import time
 from collections import defaultdict
 from gettext import gettext as _
 from urllib.parse import parse_qsl, urlencode, urlparse
 
 from lxml import etree
-from numpy import True_
 
 from lutris import settings
 from lutris.exceptions import AuthenticationError, UnavailableGame
@@ -604,7 +604,7 @@ class GOGService(OnlineService):
 
         return installers
 
-    def get_dlc_installers_runner(self, db_game, only_owned=True):
+    def get_dlc_installers_runner(self, db_game, only_owned=TRUE):
         """Return DLC installers for games current runner"""
         """only_owned=True only return installers for owned DLC (default)"""
         if (only_owned):


### PR DESCRIPTION
Hello,

This is my attempt at resolving #4294.

Modifies get_dlc_installers() to return all installers available for db_game (except mac)
Adds function get_dlc_installers_owned() to return all installers for DLC owned by user
Adds function get_dlc_installers_runner() to return all installers for requested runner (only linux & wine for now)
Adds function get_games_owned() as get_library() did not seem to return owned DLC

This did allow me to successfully install Kingmaker Pathfinder Linux DLC, but it does need more testing.