### PR TITLE
feat(bug): fix keyerror on contentstatsid missing from steam config

### DIFF
--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -169,8 +169,12 @@ def read_library_folders(steam_data_dir):
         return None
     with open(library_filename, "r", encoding='utf-8') as steam_library_file:
         library = vdf_parse(steam_library_file, {})
-        # The contentstatsid key is unused and causes problems when looking for library paths.
-        library["libraryfolders"].pop("contentstatsid", None)
+        try:
+            # The contentstatsid key is unused and causes problems when looking for library paths.
+            library["libraryfolders"].pop("contentstatsid", None)
+        except KeyError:
+            # We don't care if we don't find it
+            pass
     try:
         return get_entry_case_insensitive(library, ["libraryfolders"])
     except KeyError as ex:


### PR DESCRIPTION
Found this attempting to run NeverwinterNights Complete. Mind you, I don't think it's specific to the game per se. Anyways, decided to patch it myself since it seems rather straight forward.

No idea why this value isn't in my steam config(s). But if we're popping it because it can cause issues then surely we don't want to raise in the event that we cannot find it in order to remove it ..

```
DEBUG    2022-05-29 15:20:20,542 [dll_manager.enable_dll:131]:Replacing /home/$USER/games/gog/neverwinter-nights-2-complete/drive_c/windows/system32/d3dx9_43.dll with D3D Extras version
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/lutris/exceptions.py", line 57, in wrapper
    return function(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/lutris/game.py", line 420, in configure_game
    gameplay_info = self.get_gameplay_info()
  File "/usr/lib/python3.9/site-packages/lutris/game.py", line 398, in get_gameplay_info
    gameplay_info = self.runner.play()
  File "/usr/lib/python3.9/site-packages/lutris/runners/wine.py", line 825, in play
    launch_info = {"env": self.get_env(os_env=False)}
  File "/usr/lib/python3.9/site-packages/lutris/runners/wine.py", line 749, in get_env
    env = super(wine, self).get_env(False)
  File "/usr/lib/python3.9/site-packages/lutris/runners/runner.py", line 186, in get_env
    runtime_env = self.get_runtime_env()
  File "/usr/lib/python3.9/site-packages/lutris/runners/wine.py", line 789, in get_runtime_env
    for proton_path in get_proton_paths():
  File "/usr/lib/python3.9/site-packages/lutris/util/wine/wine.py", line 49, in get_proton_paths
    for path in _iter_proton_locations():
  File "/usr/lib/python3.9/site-packages/lutris/util/wine/wine.py", line 38, in _iter_proton_locations
    for path in [os.path.join(p, "common") for p in steam().get_steamapps_dirs()]:
  File "/usr/lib/python3.9/site-packages/lutris/runners/steam.py", line 243, in get_steamapps_dirs
    library_config = self.get_library_config()
  File "/usr/lib/python3.9/site-packages/lutris/runners/steam.py", line 149, in get_library_config
    return read_library_folders(self.steam_data_dir)
  File "/usr/lib/python3.9/site-packages/lutris/util/steam/config.py", line 161, in read_library_folders
    library["libraryfolders"].pop("contentstatsid")
KeyError: 'contentstatsid'
```

