### PR TITLE
Make config-based environment variables override system ones in WINE

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -854,9 +854,7 @@ class wine(Runner):
         # Always false to runner.get_env, the default value
         # of os_env is inverted in the wine class,
         # the OS env is read later.
-        env = super().get_env(False, disable_runtime=disable_runtime)
-        if os_env:
-            env.update(os.environ.copy())
+        env = super().get_env(os_env, disable_runtime=disable_runtime)
         show_debug = self.runner_config.get("show_debug", "-all")
         if show_debug != "inherit":
             env["WINEDEBUG"] = show_debug


### PR DESCRIPTION
This really just reverts commit 182fd5a3628c1b4ddcf3d5fbee425bc978593aeb.

That commit makes WINE (and only WINE) apply os-level env vars *after* many others, include those from the game config.

This breaks any attempt to override such an env-var use Lutris configuration, but only for WINE. I don't think this was intended.

The reason for the commit is not clear to me; the commit message is unhelpful. The comment seems to be wrong- "the default value of os_env is inverted in that class" it says. But I see no inversion compared to the WINE overrides behavior. The override changes the priority order of env-vars.

I am perhaps just overlooking what that commit actually fixed. @strycore, if you can explain that to me I can try to fix it again in a way that doesn't break config-based env-vars.

Resolves #4260

I've looked at #875, and that one does not repro for me now. There's some stuff in #903 suggesting the commit maybe did something for the "Lutris + Steam" runtime- not sure what that is.