### PR TITLE
Lutris.desktop: update comment

### DIFF
--- a/share/applications/net.lutris.Lutris.desktop
+++ b/share/applications/net.lutris.Lutris.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Lutris
-Comment=video game preservation platform
+Comment=Open Gaming Platform
 Categories=Game;
 Keywords=gaming;wine;emulator;
 Exec=lutris %U


### PR DESCRIPTION
The lowercase first letter ruins the harmony of every other application, which either have the first letter capitalized or use letter case.
Also, Lutris does more than preserving games (since it allows you to play newly released games too), so I took the first sentence from the wiki home page.