### PR TITLE
Capitalize menu items consistently

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -166,7 +166,7 @@ msgid "Show Side _Panel"
 msgstr "Zeige seitliches _Bedienfeld"
 
 #: share/lutris/ui/lutris-window.ui:500
-msgid "Add games"
+msgid "Add Games"
 msgstr "Spiele hinzufügen"
 
 #: share/lutris/ui/lutris-window.ui:514
@@ -178,11 +178,11 @@ msgid "Discord"
 msgstr "Discord (EN)"
 
 #: share/lutris/ui/lutris-window.ui:553
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Lutris-Foren (EN)"
 
 #: share/lutris/ui/lutris-window.ui:567
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "Spenden"
 
 #: lutris/exceptions.py:27

--- a/po/es.po
+++ b/po/es.po
@@ -169,7 +169,7 @@ msgid "Show Side _Panel"
 msgstr "Mostrar panel _lateral"
 
 #: share/lutris/ui/lutris-window.ui:500
-msgid "Add games"
+msgid "Add Games"
 msgstr "Añadir juegos"
 
 #: share/lutris/ui/lutris-window.ui:514
@@ -181,11 +181,11 @@ msgid "Discord"
 msgstr "Discord"
 
 #: share/lutris/ui/lutris-window.ui:553
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Foros de Lutris"
 
 #: share/lutris/ui/lutris-window.ui:567
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "Hacer una donación"
 
 #: lutris/exceptions.py:26

--- a/po/hr.po
+++ b/po/hr.po
@@ -184,11 +184,11 @@ msgid "Discord"
 msgstr "Discord"
 
 #: share/lutris/ui/lutris-window.ui:590
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Lutris forum"
 
 #: share/lutris/ui/lutris-window.ui:604
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "Donirajte"
 
 #: lutris/exceptions.py:27

--- a/po/nl.po
+++ b/po/nl.po
@@ -164,7 +164,7 @@ msgid "Show Side _Panel"
 msgstr "Zij_paneel tonen"
 
 #: share/lutris/ui/lutris-window.ui:500
-msgid "Add games"
+msgid "Add Games"
 msgstr "Games toevoegen"
 
 #: share/lutris/ui/lutris-window.ui:514
@@ -176,11 +176,11 @@ msgid "Discord"
 msgstr "Discord"
 
 #: share/lutris/ui/lutris-window.ui:553
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Lutris-forum"
 
 #: share/lutris/ui/lutris-window.ui:567
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "Doneren"
 
 #: lutris/exceptions.py:26

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -159,7 +159,7 @@ msgid "Show Side _Panel"
 msgstr "Mostrar Painel _Lateral"
 
 #: share/lutris/ui/lutris-window.ui:500
-msgid "Add games"
+msgid "Add Games"
 msgstr "Adicionar jogos"
 
 #: share/lutris/ui/lutris-window.ui:514
@@ -171,11 +171,11 @@ msgid "Discord"
 msgstr "Discord"
 
 #: share/lutris/ui/lutris-window.ui:553
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Forums do Lutris"
 
 #: share/lutris/ui/lutris-window.ui:567
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "Faça uma doação"
 
 #: lutris/exceptions.py:27

--- a/po/ru.po
+++ b/po/ru.po
@@ -173,11 +173,11 @@ msgid "Discord"
 msgstr "Discord"
 
 #: share/lutris/ui/lutris-window.ui:155
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Форум Lutris"
 
 #: share/lutris/ui/lutris-window.ui:169
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "Сделать пожертвование"
 
 #: share/lutris/ui/lutris-window.ui:218

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -168,7 +168,7 @@ msgid "Show Side _Panel"
 msgstr "显示边栏 (_P)"
 
 #: share/lutris/ui/lutris-window.ui:500
-msgid "Add games"
+msgid "Add Games"
 msgstr "添加游戏"
 
 #: share/lutris/ui/lutris-window.ui:514
@@ -180,11 +180,11 @@ msgid "Discord"
 msgstr "Discord 讨论组"
 
 #: share/lutris/ui/lutris-window.ui:553
-msgid "Lutris forums"
+msgid "Lutris Forums"
 msgstr "Lutris 论坛"
 
 #: share/lutris/ui/lutris-window.ui:567
-msgid "Make a donation"
+msgid "Make a Donation"
 msgstr "捐助"
 
 #: lutris/exceptions.py:26

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -497,7 +497,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.add-game</property>
-            <property name="text" translatable="yes">Add games</property>
+            <property name="text" translatable="yes">Add Games</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -550,7 +550,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.open-forums</property>
-            <property name="text" translatable="yes">Lutris forums</property>
+            <property name="text" translatable="yes">Lutris Forums</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -564,7 +564,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.donate</property>
-            <property name="text" translatable="yes">Make a donation</property>
+            <property name="text" translatable="yes">Make a Donation</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
Some of Lutris's menu items aren't capitalized consistently. "Show Side Panel" versus "Make a donation" for instance.

This PR makes them all 'title cased'. That seems like the norm for menus in GNOME. So, "Add Games", "Lutris Forums" and "Make a Donation"

I updated the msgids in the .po files, but not any translations. I don't know how to capitalize crazy moon-speak!