### PR TITLE
Trim game name & release year if length exceeded (Exception/Hang prevention)

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -113,6 +113,7 @@ class GameDialogCommon(Dialog):
         label = Label(_("Name"))
         box.pack_start(label, False, False, 0)
         self.name_entry = Gtk.Entry()
+        self.name_entry.set_max_length(150)
         if self.game:
             self.name_entry.set_text(self.game.name)
         box.pack_start(self.name_entry, True, True, 0)
@@ -196,8 +197,8 @@ class GameDialogCommon(Dialog):
 
         label = Label(_("Release year"))
         box.pack_start(label, False, False, 0)
-
         self.year_entry = NumberEntry()
+        self.year_entry.set_max_length(10)
         if self.game:
             self.year_entry.set_text(str(self.game.year or ""))
         box.pack_start(self.year_entry, True, True, 0)

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -298,7 +298,7 @@
               <object class="GtkLabel" id="zoom_label">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
-                <property name="label" translatable="yes">Zoom:</property>
+                <property name="label" translatable="yes">Zoom </property>
               </object>
               <packing>
                 <property name="expand">False</property>


### PR DESCRIPTION
- <b>Removed ':' (colon) from 'Zoom: ' (Sorting Dropdown Box) on line 301 in lutris_window.ui</b>
    The colon is not stylistically fitting and takes up an unnecessary space.
    <img width="140" alt="image" src="https://user-images.githubusercontent.com/45468984/179312916-384baf6c-9d8c-444a-9b60-4295bcb534ab.png">
<br>

The following changes in common.py are regarding the input boxes "Name" and "Release year" in the "Add locally installed game" menu.

- <b>Added set_max_text(150) on line 116 for _get_name_box() function.</b>
    If the typed game name is longer than 150 characters, it'll be trimmed to 150. The longest game name online was 77 characters.
    - Why is this necessary? Without a max_length, unsual behaviours could occur such as OSErrors/FileNotFound-Exceptions or visual anomalies in the grid layout.
![reasonable_length](https://user-images.githubusercontent.com/45468984/179311174-c41af82b-3518-4c10-9c04-c78b0d76f9d1.png)
    As seen in the image above, 150 max characters seems to be the a reasonable number, as it allows for very obscure names as well as maintain a somewhat consistent grid-layout. 
    Anything greater (such as 200, 250, ...) will result in a very oddly spaced grid.<br><br>
- <b>Added set_max_text(10) on line 201  for _get_year_box() function</b>
    If the entered digit-sequence exceeds the max. specified length of 10 then, just like before, it will be trimmed.
    - Why is this necessary? If the entered release-year is too long, it results in an OverflowError. ![overflow_exception_release_year](https://user-images.githubusercontent.com/45468984/179311656-08471f6d-78cd-45af-bfdf-0315b998c028.png)
    The number 10 (as well as 150 for the game name) was abitrarily chosen (with some consideration of additional factors). 10 digits is simply a last-resort safety net.

----

- Additional Notes:
1. (Without these changes) In both instances, if the entered input is too long, the "Add Game" window will simply hang, without showing any error message (except console/non-gui). So the user has no idea why nothing is happening.
1. Yes this is not an every day occurrence for the vast majority of people, but preventing issues, regardless how likely they're is never a bad idea.