### PR TITLE
Update es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -4621,7 +4621,7 @@ msgstr ""
 
 #: lutris/runners/wine.py:346
 msgid "Enable Easy Anti-Cheat"
-msgstr "Activar anti-trampas Easy"
+msgstr "Activar anti-trampas (Easy Anti-Cheat)"
 
 #: lutris/runners/wine.py:350
 msgid ""


### PR DESCRIPTION
the change occurs, since it is not well translated, since "easy anti cheat" is a proper name, and should not be translated, and since it is written in Spanish, people do not identify only with the word "easy" which is fair that anticheat, then it must be the full name together