### PR TITLE
Escape special characters when globbing in installers

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -180,7 +180,7 @@ class CommandsMixin:
         if os.path.exists(filespec):
             filenames = [filespec]
         else:
-            filenames = glob.glob(filespec)
+            filenames = glob.glob(glob.escape(filespec))
 
         if not filenames:
             raise ScriptingError(_("%s does not exist") % filespec)


### PR DESCRIPTION
This fixes an issue where paths don't get correctly globbed in the installer if they contain special characters like `[`