### PR TITLE
Fix "Add 'variables' section to scripts"

### DIFF
--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -32,7 +32,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         self.game_slug = installer["game_slug"]
         self.service = self.get_service(initial=service)
         self.service_appid = self.get_appid(installer, initial=appid)
-        self.variables = installer.get("variables", {})
+        self.variables = self.script.get("variables", {})
         self.files = [
             InstallerFile(self.game_slug, file_id, file_meta)
             for file_desc in self.script.get("files", [])


### PR DESCRIPTION
The previous version would only find variables when defined in a collection _outside_ of the `script:`.
https://github.com/lutris/lutris/commit/9cc189429c673e7fa06767226f8f1fc3d4348d5b