### PR TITLE
Raising Errors from beat()

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -628,13 +628,13 @@ class Game(GObject.Object):
             self.timer.end()
             self.playtime += self.timer.duration / 3600
 
+    @watch_lutris_errors(game_stop_result=False)
     def beat(self):
         """Watch the game's process(es)."""
         if self.game_thread.error:
-            dialogs.ErrorDialog(_("<b>Error lauching the game:</b>\n") + self.game_thread.error)
             self.on_game_quit()
-            return False
-
+            raise RuntimeError(_("<b>Error lauching the game:</b>\n") + self.game_thread.error)
+            
         # The killswitch file should be set to a device (ie. /dev/input/js0)
         # When that device is unplugged, the game is forced to quit.
         killswitch_engage = self.killswitch and not system.path_exists(self.killswitch)
@@ -727,13 +727,13 @@ class Game(GObject.Object):
             error = "error while loading shared lib"
             error_line = strings.lookup_string_in_text(error, self.game_thread.stdout)
             if error_line:
-                dialogs.ErrorDialog(_("<b>Error: Missing shared library.</b>\n\n%s") % error_line)
+                raise RuntimeError(_("<b>Error: Missing shared library.</b>\n\n%s") % error_line)
 
         if self.game_thread.return_code == 1:
             # Error Wine version conflict
             error = "maybe the wrong wineserver"
             if strings.lookup_string_in_text(error, self.game_thread.stdout):
-                dialogs.ErrorDialog(_("<b>Error: A different Wine version is already using the same Wine prefix.</b>"))
+                raise RuntimeError(_("<b>Error: A different Wine version is already using the same Wine prefix.</b>"))
 
     def write_script(self, script_path):
         """Output the launch argument in a bash script"""


### PR DESCRIPTION
It's the PR you've all been waiting for, *Project: Get ErrorDialog out of Game, Part 4 - Revengeance*

This time its the ErrorDialogs triggered from beat(), the method that runs periodically to see if the game is still running. This method can be put on the @watch_lutris_error plan, and any exceptions it raises will be reported via the game-error signal. This allows those error dialogs to have their parent set.

beat() returns false to stop the heartbeat timer, and this happens when the game is found to have stopped. Any error will be treated this way too, and will trigger the game-stop signal (if the game has not yet stopped officially) and also stop the heartbeat. It works out very neatly.

Most of the replaced ErrorDialogs were in process_return_codes(), but that method is called only from beat().