### PR TITLE
When DRI_PRIME is detected, pick the 'best' hardware for the Vulkan ICD

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -106,6 +106,8 @@ def get_vk_icd_choices():
     amdvlk_files = ":".join(amdvlk)
     amdvlkpro_files = ":".join(amdvlkpro)
 
+    is_nvidia = bool(nvidia_files)
+
     glxinfocmd = get_gpu_vendor_cmd(bool(nvidia_files))
     with subprocess.Popen(glxinfocmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as glxvendorget:
         glxvendor = glxvendorget.communicate()[0].decode("utf-8")
@@ -115,7 +117,7 @@ def get_vk_icd_choices():
         choices = [(_("Auto: Intel Open Source (MESA: ANV)"), intel_files)]
     elif "AMD" in default_gpu:
         choices = [(_("Auto: AMD RADV Open Source (MESA: RADV)"), amdradv_files)]
-    elif "NVIDIA" in default_gpu:
+    elif "NVIDIA" in default_gpu or (USE_DRI_PRIME and is_nvidia):
         choices = [(_("Auto: Nvidia Proprietary"), nvidia_files)]
 
     if intel_files:

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -108,7 +108,7 @@ def get_vk_icd_choices():
 
     is_nvidia = bool(nvidia_files)
 
-    glxinfocmd = get_gpu_vendor_cmd(bool(nvidia_files))
+    glxinfocmd = get_gpu_vendor_cmd(is_nvidia)
     with subprocess.Popen(glxinfocmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT) as glxvendorget:
         glxvendor = glxvendorget.communicate()[0].decode("utf-8")
     default_gpu = glxvendor

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -55,6 +55,14 @@ def restore_gamma():
         logger.warning("you do not have permission to call xgamma")
 
 
+def has_graphic_adapter_description(match_text):
+    """Returns True if a graphics adapter is found with 'match_text' in its description."""
+    for adapter in _get_graphics_adapters():
+        if match_text in adapter[1]:
+            return True
+    return False
+
+
 def _get_graphics_adapters():
     """Return the list of graphics cards available on a system
 


### PR DESCRIPTION
When 'Hybrid Mode' is in use in Pop!_OS, Lutris fails to detect the video hardware properly and can produce no default Vulkan ICD choice.

If this happens, but the USE_DRI_PRIME option is on (which happens if there's more than one video system detected), this PR will look at the GPU descriptions to see what you have installed; it goes with the NVIDIA ICD if you have NVIDIA hardware, then AMD, then Intel. You must also have the ICD files, mind. This should make the auto-detect work for NVIDIA/Intel or AMD/Intel setups.

We only do any of this if the normal GPU detection does not find an answer, so this should be no worse than the previous behavior. If it worked before, it'll work the same now.

I'm popping this as a PR partly because I do not understand Vulkan ICDs very clearly, and partly because we've got the beta for  5.11 out right now, and maybe this should be delayed until the next release.

Resolves #4400