### PR TITLE
debian: suggest gamescope

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -41,6 +41,7 @@ Recommends: python3-evdev,
             libwine-development,
             winetricks,
 Suggests: gamemode,
+          gamescope,
 Description: video game preservation platform
  Lutris helps you install and play video games from all eras and from most
  gaming systems. By leveraging and combining existing emulators, engine


### PR DESCRIPTION
gamescope is not available in Debian (https://tracker.debian.org/pkg/gamescope) and will migrate to Ubuntu in their next release, so let's suggest to users to install it.