### PR TITLE
Use arg `filters` on `get_games` to find installed

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -409,9 +409,9 @@ class Application(Gtk.Application):
 
         # List game
         if options.contains("list-games"):
-            game_list = games_db.get_games()
-            if options.contains("installed"):
-                game_list = [game for game in game_list if game["installed"]]
+            game_list = games_db.get_games(filters=(
+                {"installed": 1} if options.contains("installed") else None)
+            )
             if options.contains("json"):
                 self.print_game_json(command_line, game_list)
             else:


### PR DESCRIPTION
Previously, all games were retrieved, then tested for installation status. Instead, the `{"installed": 1}` `filters` should be applied to the query when the command line option is provided, otherwise `filters` should remain None.