### PR TITLE
fix missing lutris.util.amazon error reported:

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(
         'lutris.scanners',
         'lutris.services',
         'lutris.util',
+        'lutris.util.amazon',
         'lutris.util.dolphin',
         'lutris.util.egs',
         'lutris.util.graphics',


### PR DESCRIPTION
  File "/usr/lib/python3.10/site-packages/lutris/services/amazon.py", line 20, in <module>
    from lutris.util.amazon.sds_proto2 import CompressionAlgorithm, HashAlgorithm, Manifest, ManifestHeader
ModuleNotFoundError: No module named 'lutris.util.amazon'