### PR TITLE
Enable context menu for all games in library

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -313,7 +313,7 @@ class GameActions:
 
     def on_view_game(self, _widget):
         """Callback to open a game on lutris.net"""
-        open_uri("https://lutris.net/games/%s" % self.game.slug)
+        open_uri("https://lutris.net/games/%s" % self.game.slug.replace("_", "-"))
 
     def on_remove_game(self, *_args):
         """Callback that present the uninstall dialog to the user"""

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -111,7 +111,7 @@ class GameActions:
         """Return a dictionary of actions that should be shown for a game"""
         return {
             "add": not self.game.is_installed,
-            "duplicate": True,
+            "duplicate": self.game.is_installed,
             "install": not self.game.is_installed,
             "play": self.game.is_installed and not self.is_game_running,
             "update": self.game.is_updatable,
@@ -120,7 +120,7 @@ class GameActions:
             "configure": bool(self.game.is_installed),
             "browse": self.game.is_installed and self.game.runner_name != "browser",
             "show_logs": self.game.is_installed,
-            "favorite": not self.game.is_favorite,
+            "favorite": not self.game.is_favorite and self.game.is_installed,
             "deletefavorite": self.game.is_favorite,
             "install_more": not self.game.service and self.game.is_installed,
             "execute-script": bool(
@@ -153,7 +153,7 @@ class GameActions:
                 and steam_shortcut.shortcut_exists(self.game)
                 and not steam_shortcut.is_steam_game(self.game)
             ),
-            "remove": True,
+            "remove": self.game.is_installed,
             "view": True,
             "hide": self.game.is_installed and not self.game.is_hidden,
             "unhide": self.game.is_hidden,

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -1,6 +1,7 @@
 from gi.repository import Gdk, GObject, Gtk
 
 from lutris.database.games import get_game_for_service
+from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
 from lutris.game_actions import GameActions
 from lutris.gui.views import COL_ID
@@ -38,7 +39,7 @@ class GameView:
             game_row = self.game_store.get_row_by_id(selected_id)
             game_id = None
             if self.service:
-                game = get_game_for_service(self.service, game_row[COL_ID])
+                game = ServiceGameCollection.get_game(self.service, game_row[COL_ID])
                 if game:
                     game_id = game["id"]
             else:

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -1,7 +1,6 @@
 from gi.repository import Gdk, GObject, Gtk
 
 from lutris.database.games import get_game_for_service
-from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
 from lutris.game_actions import GameActions
 from lutris.gui.views import COL_ID
@@ -37,11 +36,9 @@ class GameView:
                 return
             selected_id = self.get_selected_id(_iter)
             game_row = self.game_store.get_row_by_id(selected_id)
-            game_id = None
             if self.service:
-                game = ServiceGameCollection.get_game(self.service, game_row[COL_ID])
-                if game:
-                    game_id = game["id"]
+                game = get_game_for_service(self.service, game_row[COL_ID])
+                game_id = game["id"] if game else -1
             else:
                 game_id = game_row[COL_ID]
             if not game_id:

--- a/lutris/gui/widgets/contextual_menu.py
+++ b/lutris/gui/widgets/contextual_menu.py
@@ -54,6 +54,6 @@ class ContextualMenu(Gtk.Menu):
         for menuitem in self.get_children():
             if not isinstance(menuitem, Gtk.ImageMenuItem):
                 continue
-            menuitem.set_visible(displayed.get(menuitem.action_id, True))
+            menuitem.set_visible(displayed.get(menuitem.action_id, False))
 
         super().popup_at_pointer(event)


### PR DESCRIPTION
This PR enables the (minimal) context menu for games that aren't installed.

![image](https://user-images.githubusercontent.com/6317548/187095631-d0ff6780-51cb-48da-9022-82fe7000593e.png)

For this to work, the following changes were necessary:

- Use a fallback game id of `-1` in lutris/gui/views/base.py#L41 if the game isn't installed. This causes the game_actions to be initialized with an empty "dummy" `Game` object
- Adjust `get_displayed_entries` in `game_actions.py` to only enable the "install", "add installed game" and "view on lutris" entries for non-installed games
- Fix slugs containing underscores (see lutris/game_actions.py#L316). I found that some GOG games had slugs containing underscores instead of dashes. Not sure, if this is the best place to fix this, though - probably should be fixed wherever these slugs are generated.

## Going forward

This is a very simple patch to show the context menu (especially to be able to view games on Lutris before installing them). However, if the Game class was refactored to use the dependency injection and composition patterns, this would make it easy to enable more features for non-installed games (e.g. favoriting) and it would be less likely that things break.
I'm thinking of something like this:

```py
from database.services import ServiceGameCollection
import database.games as games_db

class Game(GObject.Object)
  def __init__(self, service_game=None, local_game=None):
    super().__init__()
    self.service_game = service_game  # contains metadata and all functionality for interacting with installers, lutris.net 
    self.local = local_game  # contains all functionality and configuration for installed games
    ....

game = Game(
  ServiceGameCollection.get_game("lutris", appid),
  games_db.get_game_for_service("lutris", appid))
```
