### PR TITLE
Add ability to add more than one account per service

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -52,7 +52,7 @@ from lutris.util.http import HTTPError, Request
 from lutris.util.log import logger
 from lutris.util.steam.appmanifest import AppManifest, get_appmanifests
 from lutris.util.steam.config import get_steamapps_paths
-from lutris.services import get_enabled_services
+from lutris.services import get_service
 from lutris.database.services import ServiceGameCollection
 
 from .lutriswindow import LutrisWindow
@@ -614,7 +614,7 @@ class Application(Gtk.Application):
         if service:
             service_game = ServiceGameCollection.get_game(service, appid)
             if service_game:
-                service = get_enabled_services()[service]()
+                service = get_service(service)
                 service.install(service_game)
                 return 0
 
@@ -698,8 +698,8 @@ class Application(Gtk.Application):
     @watch_errors(error_result=True)
     def on_game_install(self, game):
         """Request installation of a game"""
-        if game.service and game.service != "lutris":
-            service = get_enabled_services()[game.service]()
+        service = get_service(game.service) if game.service else None
+        if service and service.type != "lutris":
             db_game = ServiceGameCollection.get_game(service.id, game.appid)
             if not db_game:
                 logger.error("Can't find %s for %s", game.name, service.name)
@@ -731,7 +731,7 @@ class Application(Gtk.Application):
 
     @watch_errors(error_result=True)
     def on_game_install_update(self, game):
-        service = get_enabled_services()[game.service]()
+        service = get_service(game.service)
         db_game = games_db.get_game_by_field(game.id, "id")
         installers = service.get_update_installers(db_game)
         if installers:
@@ -742,7 +742,7 @@ class Application(Gtk.Application):
 
     @watch_errors(error_result=True)
     def on_game_install_dlc(self, game):
-        service = get_enabled_services()[game.service]()
+        service = get_service(game.service)
         db_game = games_db.get_game_by_field(game.id, "id")
         installers = service.get_dlc_installers_runner(db_game, db_game["runner"])
         if installers:

--- a/lutris/gui/config/services_box.py
+++ b/lutris/gui/config/services_box.py
@@ -45,7 +45,7 @@ class ServicesBox(BaseConfigBox):
         )
         service = SERVICES[service_key]
 
-        icon = ScaledImage.get_runtime_icon_image(service.icon, service.id,
+        icon = ScaledImage.get_runtime_icon_image(service.icon, service.type,
                                                   scale_factor=self.get_scale_factor(),
                                                   visible=True)
         box.pack_start(icon, False, False, 0)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -507,11 +507,11 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
     def get_service_media(self, icon_type):
         """Return the ServiceMedia class used for this view"""
-        service = self.service if self.service else LutrisService
+        service = self.service if self.service else LutrisService("lutris")
         medias = service.medias
         if icon_type in medias:
-            return medias[icon_type]()
-        return medias[service.default_format]()
+            return service.create_media_instance(icon_type)
+        return service.create_media_instance(service.default_format)
 
     def update_revealer(self, game=None):
         if game:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -427,16 +427,16 @@ class LutrisWindow(Gtk.ApplicationWindow,
             return True
         return self.filters["text"] in game["name"].lower()
 
-    def set_service(self, service_name):
-        if self.service and self.service.id == service_name:
+    def set_service(self, service_id):
+        if self.service and self.service.id == service_id:
             return self.service
-        if not service_name:
+        if not service_id:
             self.service = None
             return
         try:
-            self.service = services.SERVICES[service_name]()
+            self.service = services.get_service(service_id)
         except KeyError:
-            logger.error("Non existent service '%s'", service_name)
+            logger.error("Non existent service '%s'", service_id)
             self.service = None
         return self.service
 
@@ -448,10 +448,10 @@ class LutrisWindow(Gtk.ApplicationWindow,
                 service_game[field] = lutris_game[field]
         return service_game
 
-    def get_service_games(self, service_name):
-        """Switch the current service to service_name and return games if available"""
-        service_games = ServiceGameCollection.get_for_service(service_name)
-        if service_name == "lutris":
+    def get_service_games(self, service_id):
+        """Switch the current service to service_id and return games if available"""
+        service_games = ServiceGameCollection.get_for_service(service_id)
+        if service_id == "lutris":
             lutris_games = {g["slug"]: g for g in games_db.get_games()}
         else:
             lutris_games = {g["service_id"]: g for g in games_db.get_games(filters={"service": self.service.id})}
@@ -464,12 +464,12 @@ class LutrisWindow(Gtk.ApplicationWindow,
         ]
 
     def get_games_from_filters(self):
-        service_name = self.filters.get("service")
-        if service_name in services.SERVICES:
+        service_id = self.filters.get("service")
+        if service_id and services.service_type_for_id(service_id) in services.SERVICES:
             if self.service.online and not self.service.is_authenticated():
                 self.show_label(_("Connect your %s account to access your games") % self.service.name)
                 return []
-            return self.get_service_games(service_name)
+            return self.get_service_games(service_id)
         if self.filters.get("dynamic_category") in self.dynamic_categories_game_factories:
             return self.dynamic_categories_game_factories[self.filters["dynamic_category"]]()
         if self.filters.get("category") and self.filters["category"] != "all":
@@ -685,7 +685,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
     def load_icon_type(self):
         """Return the icon style depending on the type of view."""
         setting_key = "icon_type_%sview" % self.current_view_type
-        if self.service and self.service.id != "lutris":
+        if self.service and self.service.type != "lutris":
             setting_key += "_%s" % self.service.id
         self.icon_type = settings.read_setting(setting_key)
         return self.icon_type
@@ -694,7 +694,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """Save icon type to settings"""
         self.icon_type = icon_type
         setting_key = "icon_type_%sview" % self.current_view_type
-        if self.service and self.service.id != "lutris":
+        if self.service and self.service.type != "lutris":
             setting_key += "_%s" % self.service.id
         settings.write_setting(setting_key, self.icon_type)
         self.redraw_view()
@@ -932,8 +932,8 @@ class LutrisWindow(Gtk.ApplicationWindow,
             row_type = "category"
         self.filters[row_type] = row_id
 
-        service_name = self.filters.get("service")
-        self.set_service(service_name)
+        service_id = self.filters.get("service")
+        self.set_service(service_id)
         self._bind_zoom_adjustment()
         self.redraw_view()
 
@@ -1039,7 +1039,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         if self.service:
             logger.debug("Looking up %s game %s", self.service.id, game_id)
             db_game = games_db.get_game_for_service(self.service.id, game_id)
-            if self.service.id == "lutris":
+            if self.service.type == "lutris":
                 if not db_game or not db_game["installed"]:
                     self.service.install(game_id)
                     return

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -4,7 +4,7 @@ import time
 from lutris.database import games
 from lutris.database.games import get_service_games
 from lutris.runners import get_runner_human_name
-from lutris.services import SERVICES
+from lutris.services import get_service
 from lutris.util.log import logger
 from lutris.util.strings import get_formatted_playtime, gtk_safe
 
@@ -99,11 +99,15 @@ class StoreItem:
         """Platform"""
         _platform = self._get_game_attribute("platform")
 
-        if not _platform and self.service in SERVICES:
-            service = SERVICES[self.service]()
-            _platforms = service.get_game_platforms(self._game_data)
-            if _platforms:
-                _platform = ", ".join(_platforms)
+        if not _platform:
+            try:
+                service = get_service(self.service)
+            except KeyError:
+                pass
+            else:
+                _platforms = service.get_game_platforms(self._game_data)
+                if _platforms:
+                    _platform = ", ".join(_platforms)
 
         return gtk_safe(_platform)
 

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -37,7 +37,7 @@ class GameBar(Gtk.Box):
         self.service = None
         if db_game.get("service"):
             try:
-                self.service = services.SERVICES[db_game["service"]]()
+                self.service = services.get_service(db_game["service"])
             except KeyError:
                 pass
 

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -138,7 +138,7 @@ class ServiceSidebarRow(SidebarRow):
 
     @property
     def sort_key(self):
-        return SERVICE_INDICES[self.id]
+        return SERVICE_INDICES[services.service_type_for_id(self.id)]
 
     def get_actions(self):
         """Return the definition of buttons to be added to the row"""
@@ -527,12 +527,11 @@ class LutrisSidebar(Gtk.ListBox):
         self.installed_runners = [runner.name for runner in runners.get_installed()]
         self.active_platforms = games_db.get_used_platforms()
 
-        for service_name, service_class in self.active_services.items():
-            if service_name not in self.service_rows:
-                service = service_class()
+        for service_id, service in self.active_services.items():
+            if service_id not in self.service_rows:
                 row_class = OnlineServiceSidebarRow if service.online else ServiceSidebarRow
                 service_row = row_class(service)
-                self.service_rows[service_name] = service_row
+                self.service_rows[service_id] = service_row
                 insert_row(service_row)
 
         for runner_name in self.installed_runners:

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -11,7 +11,7 @@ from lutris.installer.errors import ScriptingError
 from lutris.installer.installer_file import InstallerFile
 from lutris.installer.legacy import get_game_launcher
 from lutris.runners import import_runner
-from lutris.services import SERVICES
+from lutris.services import SERVICES, get_service
 from lutris.util.game_finder import find_linux_game_executable, find_windows_game_executable
 from lutris.util.gog import convert_gog_config_to_lutris, get_gog_config_from_path, get_gog_game_path
 from lutris.util.log import logger
@@ -52,12 +52,12 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         if initial:
             return initial
         if "steam" in self.runner and "steam" in SERVICES:
-            return SERVICES["steam"]()
+            return get_service("steam")
         version = self.version.lower()
         if "humble" in version and "humblebundle" in SERVICES:
-            return SERVICES["humblebundle"]()
+            return get_service("humblebundle")
         if "gog" in version and "gog" in SERVICES:
-            return SERVICES["gog"]()
+            return get_service("gog")
         if "itch.io" in version and "itchio" in SERVICES:
             return SERVICES["itchio"]()
 
@@ -69,12 +69,12 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         if not self.service:
             return
         service_id = None
-        if self.service.id == "steam":
+        if self.service.type == "steam":
             service_id = installer.get("steamid") or installer.get("service_id")
         game_config = self.script.get("game", {})
-        if self.service.id == "gog":
+        if self.service.type == "gog":
             service_id = game_config.get("gogid") or installer.get("gogid") or installer.get("service_id")
-        if self.service.id == "humblebundle":
+        if self.service.type == "humblebundle":
             service_id = game_config.get("humbleid") or installer.get("humblestoreid") or installer.get("service_id")
         if self.service.id == "itchio":
             service_id = game_config.get("itchid") or installer.get("itchid") or installer.get("service_id")

--- a/lutris/services/__init__.py
+++ b/lutris/services/__init__.py
@@ -26,7 +26,8 @@ DEFAULT_SERVICES = ["lutris", "gog", "egs", "origin", "ubisoft", "steam"]
 
 
 def get_services():
-    """Return a mapping of available services"""
+    """Return a mapping of available service classes by their respective
+       service type names"""
     _services = {
         "lutris": LutrisService,
         "gog": GOGService,
@@ -63,8 +64,21 @@ if os.environ.get("LUTRIS_ENABLE_ALL_SERVICES"):
     SERVICES.update(WIP_SERVICES)
 
 
+def service_type_for_id(service_id):
+    """Derive the service type name from a service ID by dropping everything
+       following the first tilde character"""
+    return service_id.split("~", 1)[0]
+
+
+def get_service(service_id):
+    """Return a new service instance object for the given service ID
+
+    Raises `KeyError` if no matching service """
+    return SERVICES[service_type_for_id(service_id)](id=service_id)
+
+
 def get_enabled_services():
     return {
-        key: _class for key, _class in SERVICES.items()
-        if settings.read_setting(key, section="services").lower() == "true"
+        _type: _class(id=_type) for _type, _class in SERVICES.items()
+        if settings.read_setting(_type, section="services").lower() == "true"
     }

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -58,7 +58,7 @@ class AmazonGame(ServiceGame):
 class AmazonService(OnlineService):
     """Service class for Amazon"""
 
-    id = "amazon"
+    type = "amazon"
     name = _("Amazon Prime Gaming")
     icon = "amazon"
     has_extras = False

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -82,11 +82,15 @@ class AmazonService(OnlineService):
 
     redirect_uri = "https://www.amazon.com/?"
 
-    cookies_path = os.path.join(settings.CACHE_DIR, ".amazon.auth")
-    user_path = os.path.join(settings.CACHE_DIR, ".amazon.user")
-    cache_path = os.path.join(settings.CACHE_DIR, "amazon-library.json")
+    cache_path_tmpl = "{id}-library.json"
+    cookies_path_tmpl = ".{id}.auth"
+    user_path_tmpl = ".{id}.user"
 
     locale = "en-US"
+
+    @property
+    def user_path(self):
+        return os.path.join(settings.CACHE_DIR, self._format_props(user_path_tmpl))
 
     @property
     def credential_files(self):

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -28,7 +28,6 @@ from lutris.util.strings import slugify
 
 class AmazonBanner(ServiceMedia):
     """Game logo"""
-    service = "amazon"
     size = (200, 112)
     dest_path = os.path.join(settings.CACHE_DIR, "amazon/banners")
     file_pattern = "%s.jpg"
@@ -42,12 +41,11 @@ class AmazonBanner(ServiceMedia):
 
 class AmazonGame(ServiceGame):
     """Representation of a Amazon game"""
-    service = "amazon"
 
     @classmethod
-    def new_from_amazon_game(cls, amazon_game):
+    def new_from_amazon_game(cls, service_id, amazon_game):
         """Return a Amazon game instance from the API info"""
-        service_game = AmazonGame()
+        service_game = cls(service_id)
         service_game.appid = str(amazon_game["id"])
         service_game.slug = slugify(amazon_game["product"]["title"])
         service_game.name = amazon_game["product"]["title"]
@@ -153,7 +151,7 @@ class AmazonService(OnlineService):
         if not self.is_connected():
             logger.error("User not connected to Amazon")
             return
-        games = [AmazonGame.new_from_amazon_game(game) for game in self.get_library()]
+        games = [AmazonGame.new_from_amazon_game(self.id, game) for game in self.get_library()]
         for game in games:
             game.save()
         return games

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -73,7 +73,8 @@ class LutrisCoverartMedium(LutrisCoverart):
 
 class BaseService(GObject.Object):
     """Base class for local services"""
-    id = NotImplemented
+    type = NotImplemented  # String identifier for this kind of service
+    id: str  # Identifier of a single account created at this service
     _matcher = None
     has_extras = False
     name = NotImplemented
@@ -94,6 +95,10 @@ class BaseService(GObject.Object):
         "service-login": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "service-logout": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
+
+    def __init__(self, id):
+        super().__init__()
+        self.id = id
 
     @property
     def matcher(self):

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -32,6 +32,9 @@ class BaseService(GObject.Object):
     """Base class for local services"""
     type = NotImplemented  # String identifier for this kind of service
     id: str  # Identifier of a single account created at this service
+    # The values of `id` and `type` may always be assumed to be identical unless the service has
+    # opted into the multiple account feature by setting `multi_account` to True below.
+
     _matcher = None
     has_extras = False
     name = NotImplemented
@@ -39,6 +42,7 @@ class BaseService(GObject.Object):
     online = False
     local = False
     drm_free = False  # DRM free games can be added to Lutris from an existing install
+    multi_account = False  # Whether this service supports logging into more than one account at once
     client_installer = None  # ID of a script needed to install the client used by the service
     scripts = {}  # Mapping of Javascript snippets to handle redirections during auth
     medias = {}

--- a/lutris/services/battlenet.py
+++ b/lutris/services/battlenet.py
@@ -87,7 +87,7 @@ class BattleNetGame(ServiceGame):
 class BattleNetService(BaseService):
     """Service class for Battle.net"""
 
-    id = "battlenet"
+    type = "battlenet"
     name = _("Battle.net")
     icon = "battlenet"
     runner = "wine"

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -24,7 +24,7 @@ class DolphinBanner(ServiceMedia):
 
 
 class DolphinService(BaseService):
-    id = "dolphin"
+    type = "dolphin"
     icon = "dolphin"
     name = _("Dolphin")
     local = True

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -15,7 +15,6 @@ from lutris.util.strings import slugify
 
 
 class DolphinBanner(ServiceMedia):
-    service = "dolphin"
     source = "local"
     size = (96, 32)
     file_pattern = "%s.png"
@@ -36,7 +35,7 @@ class DolphinService(BaseService):
         if not system.path_exists(DOLPHIN_GAME_CACHE_FILE):
             return
         cache_reader = DolphinCacheReader()
-        dolphin_games = [DolphinGame.new_from_cache(game) for game in cache_reader.get_games()]
+        dolphin_games = [DolphinGame.new_from_cache(self.id, game) for game in cache_reader.get_games()]
         for game in dolphin_games:
             game.save()
         return dolphin_games
@@ -79,15 +78,14 @@ class DolphinService(BaseService):
 class DolphinGame(ServiceGame):
     """Game for the Dolphin emulator"""
 
-    service = "dolphin"
     runner = "dolphin"
     installer_slug = "dolphin"
 
     @classmethod
-    def new_from_cache(cls, cache_entry):
+    def new_from_cache(cls, service_id, cache_entry):
         """Create a service game from an entry from the Dolphin cache"""
         name = cache_entry["internal_name"] or os.path.splitext(cache_entry["file_name"])[0]
-        service_game = cls()
+        service_game = cls(service_id)
         service_game.name = name
         service_game.appid = str(cache_entry["game_id"])
         service_game.slug = slugify(name)

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -31,7 +31,6 @@ BOX_ART_SIZE = (200, 267)
 
 
 class DieselGameMedia(ServiceMedia):
-    service = "egs"
     remote_size = (200, 267)
     file_pattern = "%s.jpg"
     file_format = "jpeg"
@@ -116,12 +115,11 @@ class DieselGameBoxLogo(DieselGameMedia):
 
 class EGSGame(ServiceGame):
     """Service game for Epic Games Store"""
-    service = "egs"
 
     @classmethod
-    def new_from_api(cls, egs_game):
+    def new_from_api(cls, service_id, egs_game):
         """Convert an EGS game to a service game"""
-        service_game = cls()
+        service_game = cls(service_id)
         service_game.appid = egs_game["appName"]
         service_game.slug = slugify(egs_game["title"])
         service_game.name = egs_game["title"]
@@ -312,7 +310,7 @@ class EpicGamesStoreService(OnlineService):
             raise AuthTokenExpired from ex
         egs_games = []
         for game in library:
-            egs_game = EGSGame.new_from_api(game)
+            egs_game = EGSGame.new_from_api(self.id, game)
             egs_game.save()
             egs_games.append(egs_game)
         return egs_games

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -132,7 +132,7 @@ class EGSGame(ServiceGame):
 class EpicGamesStoreService(OnlineService):
     """Service class for Epic Games Store"""
 
-    id = "egs"
+    type = "egs"
     name = _("Epic Games Store")
     login_window_width = 500
     login_window_height = 850
@@ -170,8 +170,8 @@ class EpicGamesStoreService(OnlineService):
         'Chrome/84.0.4147.38 Safari/537.36'
     )
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, id):
+        super().__init__(id)
         self.session = requests.session()
         self.session.headers['User-Agent'] = self.user_agent
         if os.path.exists(self.token_path):

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -149,9 +149,9 @@ class EpicGamesStoreService(OnlineService):
     }
     default_format = "game_banner_small"
     requires_login_page = True
-    cookies_path = os.path.join(settings.CACHE_DIR, ".egs.auth")
-    token_path = os.path.join(settings.CACHE_DIR, ".egs.token")
-    cache_path = os.path.join(settings.CACHE_DIR, "egs-library.json")
+    cache_path_tmpl = "{id}-library.json"
+    cookies_path_tmpl = ".{id}.auth"
+    token_path_tmpl = ".{id}.token"
     login_url = ("https://www.epicgames.com/id/login?redirectUrl="
                  "https%3A//www.epicgames.com/id/api/redirect%3F"
                  "clientId%3D34a02cf8f4414e29b15921876da36f9a%26responseType%3Dcode")
@@ -177,6 +177,10 @@ class EpicGamesStoreService(OnlineService):
                 self.session_data = json.loads(token_file.read())
         else:
             self.session_data = {}
+
+    @property
+    def token_path(self):
+        return os.path.join(settings.CACHE_DIR, self._format_props(self.token_path_tmpl))
 
     @property
     def http_basic_auth(self):

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -60,7 +60,7 @@ class FlathubService(BaseService):
     }
     default_format = "banner"
     api_url = "https://flathub.org/api/v1/apps/category/Game"
-    cache_path = os.path.join(settings.CACHE_DIR, "flathub-library.json")
+    cache_path_tmpl = "{id}-library.json"
 
     branch = "stable"
     arch = "x86_64"
@@ -71,13 +71,6 @@ class FlathubService(BaseService):
     }
     runner = "flatpak"
     game_class = FlathubGame
-
-    def wipe_game_cache(self):
-        """Wipe the game cache, allowing it to be reloaded"""
-        if system.path_exists(self.cache_path):
-            logger.debug("Deleting %s cache %s", self.id, self.cache_path)
-            os.remove(self.cache_path)
-        super().wipe_game_cache()
 
     def get_flatpak_cmd(self):
         flatpak_abspath = shutil.which("flatpak")

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -54,7 +54,7 @@ class FlathubGame(ServiceGame):
 class FlathubService(BaseService):
     """Service class for Flathub"""
 
-    id = "flathub"
+    type = "flathub"
     name = _("Flathub")
     icon = "flathub"
     medias = {

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -19,7 +19,6 @@ from lutris.util.strings import slugify
 
 class FlathubBanner(ServiceMedia):
     """Standard size of a Flathub banner"""
-    service = "flathub"
     size = (128, 128)
     dest_path = os.path.join(settings.CACHE_DIR, "flathub/banners")
     file_pattern = "%s.png"
@@ -32,12 +31,11 @@ class FlathubBanner(ServiceMedia):
 
 class FlathubGame(ServiceGame):
     """Representation of a Flathub game"""
-    service = "flathub"
 
     @classmethod
-    def new_from_flathub_game(cls, flathub_game):
+    def new_from_flathub_game(cls, service_id, flathub_game):
         """Return a Flathub game instance from the API info"""
-        service_game = FlathubGame()
+        service_game = cls(service_id)
         service_game.appid = flathub_game["flatpakAppId"]
         service_game.slug = slugify(flathub_game["name"])
         service_game.lutris_slug = slugify(flathub_game["name"])
@@ -96,7 +94,7 @@ class FlathubService(BaseService):
         entries = response.json()
         flathub_games = []
         for game in entries:
-            flathub_games.append(FlathubGame.new_from_flathub_game(game))
+            flathub_games.append(FlathubGame.new_from_flathub_game(self.id, game))
         for game in flathub_games:
             game.save()
         return flathub_games

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -23,7 +23,6 @@ from lutris.util.strings import human_size, slugify
 
 class GogSmallBanner(ServiceMedia):
     """Small size game logo"""
-    service = "gog"
     size = (100, 60)
     dest_path = os.path.join(settings.CACHE_DIR, "gog/banners/small")
     file_pattern = "%s.jpg"
@@ -48,12 +47,11 @@ class GogLargeBanner(GogSmallBanner):
 
 class GOGGame(ServiceGame):
     """Representation of a GOG game"""
-    service = "gog"
 
     @classmethod
-    def new_from_gog_game(cls, gog_game):
+    def new_from_gog_game(cls, service_id, gog_game):
         """Return a GOG game instance from the API info"""
-        service_game = cls()
+        service_game = cls(service_id)
         service_game.appid = str(gog_game["id"])
         service_game.slug = gog_game["slug"]
         service_game.name = gog_game["title"]
@@ -256,7 +254,7 @@ class GOGService(OnlineService):
         return games
 
     def get_service_game(self, gog_game):
-        return GOGGame.new_from_gog_game(gog_game)
+        return GOGGame.new_from_gog_game(self.id, gog_game)
 
     def get_products_page(self, page=1, search=None):
         """Return a single page of games"""

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -47,14 +47,13 @@ class GogLargeBanner(GogSmallBanner):
 
 
 class GOGGame(ServiceGame):
-
     """Representation of a GOG game"""
     service = "gog"
 
     @classmethod
     def new_from_gog_game(cls, gog_game):
         """Return a GOG game instance from the API info"""
-        service_game = GOGGame()
+        service_game = cls()
         service_game.appid = str(gog_game["id"])
         service_game.slug = gog_game["slug"]
         service_game.name = gog_game["title"]
@@ -65,7 +64,7 @@ class GOGGame(ServiceGame):
 class GOGService(OnlineService):
     """Service class for GOG"""
 
-    id = "gog"
+    type = "gog"
     name = _("GOG")
     icon = "gog"
     has_extras = True
@@ -89,8 +88,8 @@ class GOGService(OnlineService):
     token_path = os.path.join(settings.CACHE_DIR, ".gog.token")
     cache_path = os.path.join(settings.CACHE_DIR, "gog-library.json")
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, id):
+        super().__init__(id)
 
         gog_locales = {
             "en": "en-US",
@@ -133,7 +132,7 @@ class GOGService(OnlineService):
         if not self.is_connected():
             logger.error("User not connected to GOG")
             return
-        games = [GOGGame.new_from_gog_game(game) for game in self.get_library()]
+        games = [self.get_service_game(game) for game in self.get_library()]
         for game in games:
             game.save()
         self.match_games()

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -67,6 +67,7 @@ class GOGService(OnlineService):
     icon = "gog"
     has_extras = True
     drm_free = True
+    multi_account = True
     medias = {
         "banner_small": GogSmallBanner,
         "banner": GogMediumBanner,

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -82,9 +82,9 @@ class GOGService(OnlineService):
     redirect_uri = "https://embed.gog.com/on_login_success?origin=client"
 
     login_success_url = "https://www.gog.com/on_login_success"
-    cookies_path = os.path.join(settings.CACHE_DIR, ".gog.auth")
-    token_path = os.path.join(settings.CACHE_DIR, ".gog.token")
-    cache_path = os.path.join(settings.CACHE_DIR, "gog-library.json")
+    cache_path_tmpl = "{id}-library.json"
+    cookies_path_tmpl = ".{id}.auth"
+    token_path_tmpl = ".{id}.token"
 
     def __init__(self, id):
         super().__init__(id)
@@ -98,6 +98,10 @@ class GOGService(OnlineService):
             "zh": "zh-Hans",
         }
         self.locale = gog_locales.get(i18n.get_lang(), "en-US")
+
+    @property
+    def token_path(self):
+        return os.path.join(settings.CACHE_DIR, self._format_props(self.token_path_tmpl))
 
     @property
     def login_url(self):

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -71,9 +71,8 @@ class HumbleBundleService(OnlineService):
     login_url = "https://www.humblebundle.com/login?goto=/home/library"
     redirect_uri = "https://www.humblebundle.com/home/library"
 
-    cookies_path = os.path.join(settings.CACHE_DIR, ".humblebundle.auth")
-    token_path = os.path.join(settings.CACHE_DIR, ".humblebundle.token")
-    cache_path = os.path.join(settings.CACHE_DIR, "humblebundle/library/")
+    cache_path_tmpl = "{id}/library/"
+    cookies_path_tmpl = ".{id}.auth"
 
     supported_platforms = ("linux", "windows")
 

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -22,7 +22,6 @@ from lutris.util.strings import slugify
 
 class HumbleBundleIcon(ServiceMedia):
     """HumbleBundle icon"""
-    service = "humblebundle"
     size = (70, 70)
     dest_path = os.path.join(settings.CACHE_DIR, "humblebundle/icons")
     file_pattern = "%s.png"
@@ -40,12 +39,11 @@ class HumbleBigIcon(HumbleBundleIcon):
 
 class HumbleBundleGame(ServiceGame):
     """Service game for DRM free Humble Bundle games"""
-    service = "humblebundle"
 
     @classmethod
-    def new_from_humble_game(cls, humble_game):
+    def new_from_humble_game(cls, service_id, humble_game):
         """Converts a game from the API to a service game usable by Lutris"""
-        service_game = HumbleBundleGame()
+        service_game = cls(service_id)
         service_game.appid = humble_game["machine_name"]
         service_game.slug = humble_game["machine_name"]
         service_game.name = humble_game["human_name"]
@@ -120,7 +118,7 @@ class HumbleBundleService(OnlineService):
         for game in library:
             if game["human_name"] in seen:
                 continue
-            humble_games.append(HumbleBundleGame.new_from_humble_game(game))
+            humble_games.append(HumbleBundleGame.new_from_humble_game(self.id, game))
             seen.add(game["human_name"])
         for game in humble_games:
             game.save()

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -56,7 +56,7 @@ class HumbleBundleGame(ServiceGame):
 class HumbleBundleService(OnlineService):
     """Service for Humble Bundle"""
 
-    id = "humblebundle"
+    type = "humblebundle"
     _matcher = "humble"
     name = _("Humble Bundle")
     icon = "humblebundle"

--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -73,7 +73,7 @@ class ItchIoGameTraits():
 class ItchIoService(OnlineService):
     """Service class for itch.io"""
 
-    id = "itchio"
+    type = "itchio"
     # According to their branding, "itch.io" is supposed to be all lowercase
     name = _("itch.io")
     icon = "itchio"

--- a/lutris/services/lutris.py
+++ b/lutris/services/lutris.py
@@ -35,7 +35,7 @@ class LutrisGame(ServiceGame):
 class LutrisService(OnlineService):
     """Service for Lutris games"""
 
-    id = "lutris"
+    type = "lutris"
     name = _("Lutris")
     icon = "lutris"
     online = True

--- a/lutris/services/lutris.py
+++ b/lutris/services/lutris.py
@@ -95,8 +95,12 @@ class LutrisService(OnlineService):
 
     api_url = settings.SITE_URL + "/api"
     login_url = settings.SITE_URL + "/api/accounts/token"
-    cache_path = os.path.join(settings.CACHE_DIR, "lutris")
-    token_path = os.path.join(settings.CACHE_DIR, "auth-token")
+    cache_path_tmpl = "{id}"
+    token_path_tmpl = "auth-token"
+
+    @property
+    def token_path(self):
+        return os.path.join(settings.CACHE_DIR, self._format_props(self.token_path_tmpl))
 
     @property
     def credential_files(self):

--- a/lutris/services/mame.py
+++ b/lutris/services/mame.py
@@ -7,6 +7,6 @@ from lutris.services.base import BaseService
 
 class MAMEService(BaseService):
     """Service class for MAME"""
-    id = "mame"
+    type = "mame"
     name = _("MAME")
     icon = "mame"

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -49,7 +49,6 @@ class OriginLauncher:
 
 
 class OriginPackArtSmall(ServiceMedia):
-    service = "origin"
     file_pattern = "%s.jpg"
     file_format = "jpeg"
     size = (63, 89)
@@ -73,11 +72,10 @@ class OriginPackArtLarge(OriginPackArtSmall):
 
 
 class OriginGame(ServiceGame):
-    service = "origin"
 
     @classmethod
-    def new_from_api(cls, offer):
-        origin_game = OriginGame()
+    def new_from_api(cls, service_id, offer):
+        origin_game = cls(service_id)
         origin_game.appid = offer["offerId"]
         origin_game.slug = offer["gameNameFacetKey"]
         origin_game.name = offer["i18n"]["displayName"]
@@ -250,7 +248,7 @@ class OriginService(OnlineService):
         logger.info("Retrieved %s games from Origin library", len(games))
         origin_games = []
         for game in games:
-            origin_game = OriginGame.new_from_api(game)
+            origin_game = OriginGame.new_from_api(self.id, game)
             origin_game.save()
             origin_games.append(origin_game)
         return origin_games

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -125,7 +125,7 @@ class LegacyRenegotiationHTTPAdapter(requests.adapters.HTTPAdapter):
 class OriginService(OnlineService):
     """Service class for EA Origin"""
 
-    id = "origin"
+    type = "origin"
     name = _("Origin")
     icon = "origin"
     client_installer = "origin"
@@ -149,8 +149,8 @@ class OriginService(OnlineService):
     ) % redirect_uri
     login_user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0 QtWebEngine/5.8.0"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, id):
+        super().__init__(id)
 
         self.session = requests.session()
         self.session.mount("https://", LegacyRenegotiationHTTPAdapter())

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -135,9 +135,9 @@ class OriginService(OnlineService):
         "packArtLarge": OriginPackArtLarge,
     }
     default_format = "packArtMedium"
-    cache_path = os.path.join(settings.CACHE_DIR, "origin/cache/")
-    cookies_path = os.path.join(settings.CACHE_DIR, "origin/cookies")
-    token_path = os.path.join(settings.CACHE_DIR, "origin/auth_token")
+    cache_path_tmpl = "{id}/cache/"
+    cookies_path_tmpl = "{id}/cookies"
+    token_path_tmpl = "{id}/auth_token"
     redirect_uri = "https://www.origin.com/views/login.html"
     login_url = (
         "https://accounts.ea.com/connect/auth"
@@ -153,6 +153,10 @@ class OriginService(OnlineService):
         self.session = requests.session()
         self.session.mount("https://", LegacyRenegotiationHTTPAdapter())
         self.access_token = self.load_access_token()
+
+    @property
+    def token_path(self):
+        return os.path.join(settings.CACHE_DIR, self._format_props(self.token_path_tmpl))
 
     @property
     def api_url(self):

--- a/lutris/services/service_game.py
+++ b/lutris/services/service_game.py
@@ -10,11 +10,12 @@ PGA_DB = settings.PGA_DB
 class ServiceGame:
     """Representation of a game from a 3rd party service"""
 
-    service = NotImplemented
     installer_slug = NotImplemented
     medias = (ServiceMedia, )
 
-    def __init__(self):
+    def __init__(self, service_id):
+        self.service = service_id
+
         self.appid = None  # External ID of the game on the 3rd party service
         self.game_id = None  # Internal Lutris ID
         self.runner = None  # Name of the runner

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -15,7 +15,6 @@ PGA_DB = settings.PGA_DB
 class ServiceMedia:
     """Information about the service's media format"""
 
-    service = NotImplemented
     size = NotImplemented
     source = "remote"  # set to local if the files don't need to be downloaded
     visible = True  # This media should be displayed as an option in the UI
@@ -26,7 +25,9 @@ class ServiceMedia:
     api_field = NotImplemented
     url_pattern = "%s"
 
-    def __init__(self):
+    def __init__(self, service_id):
+        self.service = service_id
+
         if self.dest_path and not system.path_exists(self.dest_path):
             os.makedirs(self.dest_path)
 

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -22,7 +22,6 @@ from lutris.util.strings import slugify
 
 
 class SteamBanner(ServiceMedia):
-    service = "steam"
     size = (184, 69)
     dest_path = os.path.join(settings.CACHE_DIR, "steam/banners")
     file_pattern = "%s.jpg"
@@ -32,7 +31,6 @@ class SteamBanner(ServiceMedia):
 
 
 class SteamCover(ServiceMedia):
-    service = "steam"
     size = (200, 300)
     dest_path = os.path.join(settings.CACHE_DIR, "steam/covers")
     file_pattern = "%s.jpg"
@@ -42,7 +40,6 @@ class SteamCover(ServiceMedia):
 
 
 class SteamBannerLarge(ServiceMedia):
-    service = "steam"
     size = (460, 215)
     dest_path = os.path.join(settings.CACHE_DIR, "steam/header")
     file_pattern = "%s.jpg"
@@ -53,15 +50,13 @@ class SteamBannerLarge(ServiceMedia):
 
 class SteamGame(ServiceGame):
     """ServiceGame for Steam games"""
-
-    service = "steam"
     installer_slug = "steam"
     runner = "steam"
 
     @classmethod
-    def new_from_steam_game(cls, steam_game, game_id=None):
+    def new_from_steam_game(cls, service_id, steam_game, game_id=None):
         """Return a Steam game instance from an AppManifest"""
-        game = cls()
+        game = cls(service_id)
         game.appid = steam_game["appid"]
         game.game_id = steam_game["appid"]
         game.name = steam_game["name"]
@@ -101,7 +96,7 @@ class SteamService(BaseService):
         for steam_game in steam_games:
             if steam_game["appid"] in self.excluded_appids:
                 continue
-            game = self.game_class.new_from_steam_game(steam_game)
+            game = self.game_class.new_from_steam_game(self.id, steam_game)
             game.save()
         self.match_games()
         return steam_games

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -72,7 +72,7 @@ class SteamGame(ServiceGame):
 
 
 class SteamService(BaseService):
-    id = "steam"
+    type = "steam"
     name = _("Steam")
     icon = "steam-client"
     medias = {

--- a/lutris/services/steamwindows.py
+++ b/lutris/services/steamwindows.py
@@ -21,7 +21,7 @@ class SteamWindowsGame(SteamGame):
 
 
 class SteamWindowsService(SteamService):
-    id = "steamwindows"
+    type = "steamwindows"
     name = _("Steam for Windows")
     runner = "wine"
     game_class = SteamWindowsGame

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -27,7 +27,6 @@ from lutris.util.wine.prefix import WinePrefixManager
 
 class UbisoftCover(ServiceMedia):
     """Ubisoft connect cover art"""
-    service = "ubisoft"
     size = (160, 186)
     dest_path = os.path.join(settings.CACHE_DIR, "ubisoft/covers")
     file_pattern = "%s.jpg"
@@ -63,12 +62,11 @@ class UbisoftCover(ServiceMedia):
 
 class UbisoftGame(ServiceGame):
     """Service game for games from Ubisoft connect"""
-    service = "ubisoft"
 
     @classmethod
-    def new_from_api(cls, payload):
+    def new_from_api(cls, service_id, payload):
         """Convert an Ubisoft game to a service game"""
-        service_game = cls()
+        service_game = cls(service_id)
         service_game.appid = payload["spaceId"] or payload["installId"]
         service_game.slug = slugify(payload["name"])
         service_game.name = payload["name"]
@@ -155,13 +153,13 @@ class UbisoftConnectService(OnlineService):
                             is_pc = True
                 if not is_pc:
                     continue
-            ubi_game = UbisoftGame.new_from_api(game)
+            ubi_game = UbisoftGame.new_from_api(self.id, game)
             ubi_game.save()
             ubi_games.append(ubi_game)
         configuration_data = self.get_configurations()
         config_parser = UbisoftParser()
         for game in config_parser.parse_games(configuration_data):
-            ubi_game = UbisoftGame.new_from_api(game)
+            ubi_game = UbisoftGame.new_from_api(self.id, game)
             ubi_game.save()
             ubi_games.append(ubi_game)
         return ubi_games

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -78,7 +78,7 @@ class UbisoftGame(ServiceGame):
 
 class UbisoftConnectService(OnlineService):
     """Service class for Ubisoft Connect"""
-    id = "ubisoft"
+    type = "ubisoft"
     name = _("Ubisoft Connect")
     icon = "ubisoft"
     runner = "wine"
@@ -105,8 +105,8 @@ class UbisoftConnectService(OnlineService):
     }
     default_format = "cover"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, id):
+        super().__init__(id)
         self.client = UbisoftConnectClient(self)
 
     def auth_lost(self):

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -84,9 +84,9 @@ class UbisoftConnectService(OnlineService):
     browser_size = (460, 690)
     login_window_width = 460
     login_window_height = 690
-    cookies_path = os.path.join(settings.CACHE_DIR, "ubisoft/.auth")
-    token_path = os.path.join(settings.CACHE_DIR, "ubisoft/.token")
-    cache_path = os.path.join(settings.CACHE_DIR, "ubisoft/library/")
+    cache_path_tmpl = "{id}/library/"
+    cookies_path_tmpl = "{id}/.auth"
+    token_path_tmpl = "{id}/.token"
     login_url = consts.LOGIN_URL
     redirect_uri = "https://connect.ubisoft.com/change_domain/"
     scripts = {
@@ -106,6 +106,10 @@ class UbisoftConnectService(OnlineService):
     def __init__(self, id):
         super().__init__(id)
         self.client = UbisoftConnectClient(self)
+
+    @property
+    def token_path(self):
+        return os.path.join(settings.CACHE_DIR, self._format_props(self.token_path_tmpl))
 
     def auth_lost(self):
         self.emit("service-logout")

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -31,7 +31,6 @@ def get_appid(app):
 
 
 class XDGMedia(ServiceMedia):
-    service = "xdg"
     source = "local"
     size = (64, 64)
     dest_path = os.path.join(settings.CACHE_DIR, "xdg/icons")
@@ -99,7 +98,7 @@ class XDGService(BaseService):
 
     def load(self):
         """Return the list of games stored in the XDG menu."""
-        xdg_games = [XDGGame.new_from_xdg_app(app) for app in self.iter_xdg_games()]
+        xdg_games = [XDGGame.new_from_xdg_app(self.id, app) for app in self.iter_xdg_games()]
         for game in xdg_games:
             game.save()
         return xdg_games
@@ -129,7 +128,6 @@ class XDGService(BaseService):
 class XDGGame(ServiceGame):
     """XDG game (Linux game with a desktop launcher)"""
 
-    service = "xdg"
     runner = "linux"
     installer_slug = "desktopapp"
 
@@ -142,9 +140,9 @@ class XDGGame(ServiceGame):
         return icon.to_string()
 
     @classmethod
-    def new_from_xdg_app(cls, xdg_app):
+    def new_from_xdg_app(cls, service_id, xdg_app):
         """Create a service game from a XDG entry"""
-        service_game = cls()
+        service_game = cls(service_id)
         service_game.name = xdg_app.get_display_name()
         service_game.icon = cls.get_app_icon(xdg_app)
         service_game.appid = get_appid(xdg_app)

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -40,7 +40,7 @@ class XDGMedia(ServiceMedia):
 
 
 class XDGService(BaseService):
-    id = "xdg"
+    type = "xdg"
     name = _("Local")
     icon = "linux"
     online = False


### PR DESCRIPTION
Adds the hidden ability to associate more than one instance of some service accounts (individually whitelisted where it makes sense) and whitelists GoG for this which I could actually test and confirm working.

Caveats / Todos:

  * [ ] Currently all GOG accounts show up with the same label in the UI
     * It should probably include the account user name or email address? But should it do this always or only if there is more than one account of the given type?
  * [ ] There is currently no UI to add further accounts, instead one has to add lines of the form *gog\~\<some-extra-identifier\> = True* to the *[services]* section of the configuration file
     * For testing this is good-enough, I think, and how to actually integrate this capability nicely into the settings screen will need some serious consideration that could perhaps be left for a future date.
  * [ ] As mentioned, this is currently GOG-only since that is all I could test, but with the changes included here any of the other launcherless online-service should *just work* within the limitations outlined above unless I missed something somewhere

Related to #4301 (although it doesn’t do anything for Epic launcher) – maybe there is a better issue somewhere?