### PR TITLE
The Last Stand of the ErrorDialog

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -587,7 +587,7 @@ class Game(GObject.Object):
         def death_watch_cb(all_died, error):
             """Called after the death watch to more firmly kill any survivors."""
             if error:
-                dialogs.ErrorDialog(str(error))
+                self.emit("game-error", error)
             elif not all_died:
                 self.kill_processes(signal.SIGKILL)
             # If we still can't kill everything, we'll still say we stopped it.

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -51,6 +51,7 @@ class Game(GObject.Object):
 
     __gsignals__ = {
         "game-error": (GObject.SIGNAL_RUN_FIRST, None, (object, )),
+        "game-notice": (GObject.SIGNAL_RUN_FIRST, None, (str, str)),
         "game-launch": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -322,7 +323,7 @@ class Game(GObject.Object):
         if self.runner.use_runtime():
             runtime_updater = runtime.RuntimeUpdater()
             if runtime_updater.is_updating():
-                dialogs.ErrorDialog(_("Runtime currently updating"), _("Game might not work as expected"))
+                self.emit("game-notice", _("Runtime currently updating"), _("Game might not work as expected"))
         if ("wine" in self.runner_name and not wine.get_wine_version() and not LINUX_SYSTEM.is_flatpak):
             dialogs.WineNotInstalledWarning(parent=None)
         return True

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -110,9 +110,11 @@ class NoticeDialog(Gtk.MessageDialog):
 
     """Display a message to the user."""
 
-    def __init__(self, message, parent=None):
+    def __init__(self, message, secondary=None, parent=None):
         super().__init__(buttons=Gtk.ButtonsType.OK, parent=parent)
         self.set_markup(message)
+        if secondary:
+            self.format_secondary_text(secondary[:256])
         self.run()
         self.destroy()
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -122,6 +122,7 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_collection_changed)
         GObject.add_emission_hook(Game, "game-error", self.on_game_error)
+        GObject.add_emission_hook(Game, "game-notice", self.on_game_notice)
 
     def _init_actions(self):
         Action = namedtuple("Action", ("callback", "type", "enabled", "default", "accel"))
@@ -716,6 +717,10 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
         logger.exception("%s has encountered an error: %s", game, error, exc_info=error)
         dialogs.ErrorDialog(str(error), parent=self)
         return True
+
+    def on_game_notice(self, game, message, secondary):
+        """Called when a game has sent the 'game-notice' signal"""
+        dialogs.NoticeDialog(message, secondary=secondary, parent=self)
 
     @GtkTemplate.Callback
     def on_add_game_button_clicked(self, *_args):


### PR DESCRIPTION
The end of the saga arrives! Project: *Get ErrorDialog out of Game, Part 5 - The Final Signal*

This removes the last two ErrorDialogs from the Game class.

One is used to handle errors from the death watch job that occurs when you use the "Stop" command; this is already using exceptions, but I have modified it to emit the game-error signal in response to the exception. As ever, this means the ErrorDialog ultimately produced gets to have a parent. Using the signal directly is simpler than trying to convince @watch_lutris_errors to work here.

The remaining ErrorDialog is more like a warning. It triggers if you run a game while the runtime is updating, but you then go ahead and run the game anyway. This PR replaces it with a NoticeDialog. To enable this, I've added support for a secondary message to that dialog, and I've added a "game-notice" signal that, like "game-error", signals LutrisWindow to provide the UI.

Using signals means that ~~if we do add command line 'play' and 'stop' options~~, for the existing 'rungame' command line command, we can redirect notice output to stderr, if we want to do that.

There are other dialogs in Game, but addressing them is going to be trickier- and more controversial- than ErrorDialog. So that's for another day.