### PR TITLE
Icons are now extracted from executables

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -11,7 +11,7 @@ from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.config import DIALOG_HEIGHT, DIALOG_WIDTH
 from lutris.gui.config.boxes import GameBox, RunnerBox, SystemBox
-from lutris.gui.dialogs import ModelessDialog, DirectoryDialog, ErrorDialog, QuestionDialog
+from lutris.gui.dialogs import DirectoryDialog, ErrorDialog, ModelessDialog, QuestionDialog
 from lutris.gui.widgets.common import Label, NumberEntry, SlugEntry, VBox
 from lutris.gui.widgets.notifications import send_notification
 from lutris.gui.widgets.utils import BANNER_SIZE, ICON_SIZE, get_pixbuf
@@ -455,7 +455,7 @@ class GameDialogCommon(ModelessDialog):
         runner = runner_class(self.lutris_config)
 
         # extract icon for wine games
-        if (self.runner_name == 'wine'):
+        if (self.runner_name == 'wine') and not self.game.has_custom_icon:
             runner.extract_icon_exe(self.slug)
 
         self.game.name = name

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -454,6 +454,10 @@ class GameDialogCommon(ModelessDialog):
         runner_class = runners.import_runner(self.runner_name)
         runner = runner_class(self.lutris_config)
 
+        # extract icon for wine games
+        if (self.runner_name == 'wine'):
+            runner.extract_icon_exe(self.slug)
+
         self.game.name = name
         self.game.slug = self.slug
         self.game.year = year

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -11,7 +11,7 @@ from gi.repository import GLib, Gtk
 from lutris import api, settings
 from lutris.database.games import get_games_by_runner
 from lutris.game import Game
-from lutris.gui.dialogs import ModelessDialog, Dialog, ErrorDialog, QuestionDialog
+from lutris.gui.dialogs import Dialog, ErrorDialog, ModelessDialog, QuestionDialog
 from lutris.util import jobs, system
 from lutris.util.downloader import Downloader
 from lutris.util.extract import extract_archive

--- a/lutris/migrations/retrieve_discord_appids.py
+++ b/lutris/migrations/retrieve_discord_appids.py
@@ -1,7 +1,7 @@
 from lutris import settings
-from lutris.util.log import logger
 from lutris.api import get_api_games
 from lutris.database.games import get_games, sql
+from lutris.util.log import logger
 
 
 def migrate():

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -29,6 +29,7 @@ from lutris.util.wine.wine import (
     get_overrides_env, get_proton_paths, get_real_executable, get_wine_version, get_wine_versions, is_esync_limit_set,
     is_fsync_supported, is_gstreamer_build, is_version_esync, is_version_fsync
 )
+from utils.extract_icon import ExtractIcon
 
 DEFAULT_WINE_PREFIX = "~/.wine"
 MIN_SAFE_VERSION = "7.0"  # Wine installers must run with at least this version
@@ -1017,3 +1018,30 @@ class wine(Runner):
 
         # Relative path
         return path
+    
+    def extract_icon_exe(self, game_slug):
+        """Extracts the 128*128 icon from EXE and saves it, if not resizes the biggest icon found.
+            returns true if an icon is saved, false if not"""
+        wantedsize = (128,128)
+        if not self.game_exe:
+            return False
+        extractor = ExtractIcon(self.game_exe)
+        groups = extractor.get_group_icons()
+
+        icons = []
+        biggestsize = (0,0)
+        for i in range(len(groups[0])):
+            icons[i] = extractor.export(groups[0], i)
+            if (icons[i].size > biggestsize) :
+                biggesticon = i
+                biggestsize = icons[i].size
+            elif (icons[i].size == wantedsize) :
+                icons[i].save(settings.ICON_PATH + "lutris_" + game_slug + ".png")
+                return True
+
+        if 'biggesticon' in locals():
+            resized = icons[biggesticon].resize(wantedsize)
+            resized.save(settings.ICON_PATH + "lutris_" + game_slug + ".png")
+            return True
+
+        return False

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1018,30 +1018,33 @@ class wine(Runner):
 
         # Relative path
         return path
-    
+
     def extract_icon_exe(self, game_slug):
         """Extracts the 128*128 icon from EXE and saves it, if not resizes the biggest icon found.
             returns true if an icon is saved, false if not"""
-        wantedsize = (128,128)
-        if not self.game_exe:
+        wantedsize = (128, 128)
+        pathtoicon = settings.ICON_PATH + "/lutris_" + game_slug + ".png"
+        if not self.game_exe or os.path.exists(pathtoicon):
             return False
+
         extractor = ExtractIcon(self.game_exe)
         groups = extractor.get_group_icons()
 
         icons = []
-        biggestsize = (0,0)
+        biggestsize = (0, 0)
+        biggesticon = -1
         for i in range(len(groups[0])):
             icons.append(extractor.export(groups[0], i))
-            if (icons[i].size > biggestsize) :
+            if (icons[i].size > biggestsize):
                 biggesticon = i
                 biggestsize = icons[i].size
-            elif (icons[i].size == wantedsize) :
-                icons[i].save(settings.ICON_PATH + "/lutris_" + game_slug + ".png")
+            elif (icons[i].size == wantedsize):
+                icons[i].save(pathtoicon)
                 return True
 
-        if 'biggesticon' in locals():
+        if (biggesticon >= 0):
             resized = icons[biggesticon].resize(wantedsize)
-            resized.save(settings.ICON_PATH + "/lutris_" + game_slug + ".png")
+            resized.save(pathtoicon)
             return True
 
         return False

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1031,17 +1031,17 @@ class wine(Runner):
         icons = []
         biggestsize = (0,0)
         for i in range(len(groups[0])):
-            icons[i] = extractor.export(groups[0], i)
+            icons.append(extractor.export(groups[0], i))
             if (icons[i].size > biggestsize) :
                 biggesticon = i
                 biggestsize = icons[i].size
             elif (icons[i].size == wantedsize) :
-                icons[i].save(settings.ICON_PATH + "lutris_" + game_slug + ".png")
+                icons[i].save(settings.ICON_PATH + "/lutris_" + game_slug + ".png")
                 return True
 
         if 'biggesticon' in locals():
             resized = icons[biggesticon].resize(wantedsize)
-            resized.save(settings.ICON_PATH + "lutris_" + game_slug + ".png")
+            resized.save(settings.ICON_PATH + "/lutris_" + game_slug + ".png")
             return True
 
         return False

--- a/utils/extract_icon.py
+++ b/utils/extract_icon.py
@@ -5,128 +5,132 @@ from builtins import range
 from PIL import Image
 
 # From https://github.com/firodj/extract-icon-py
+
+
 class ExtractIcon(object):
-	GRPICONDIRENTRY_format = ('GRPICONDIRENTRY',
-		('B,Width', 'B,Height','B,ColorCount','B,Reserved',
-		 'H,Planes','H,BitCount','I,BytesInRes','H,ID'))
-	GRPICONDIR_format = ('GRPICONDIR',
-		('H,Reserved', 'H,Type','H,Count'))
-	RES_ICON = 1
-	RES_CURSOR = 2
+    GRPICONDIRENTRY_format = ('GRPICONDIRENTRY',
+                              ('B,Width', 'B,Height', 'B,ColorCount', 'B,Reserved',
+                               'H,Planes', 'H,BitCount', 'I,BytesInRes', 'H,ID'))
+    GRPICONDIR_format = ('GRPICONDIR',
+                         ('H,Reserved', 'H,Type', 'H,Count'))
+    RES_ICON = 1
+    RES_CURSOR = 2
 
-	def __init__(self, filepath):
-		self.pe = pefile.PE(filepath)
+    def __init__(self, filepath):
+        self.pe = pefile.PE(filepath)
 
-	def find_resource_base(self, type):
-		rt_base_idx = [entry.id for
-			entry in self.pe.DIRECTORY_ENTRY_RESOURCE.entries].index(
-				pefile.RESOURCE_TYPE[type]
-		)
+    def find_resource_base(self, type):
+        rt_base_idx = [entry.id for
+                       entry in self.pe.DIRECTORY_ENTRY_RESOURCE.entries].index(
+            pefile.RESOURCE_TYPE[type]
+        )
 
-		if rt_base_idx is not None:
-			return self.pe.DIRECTORY_ENTRY_RESOURCE.entries[rt_base_idx]
+        if rt_base_idx is not None:
+            return self.pe.DIRECTORY_ENTRY_RESOURCE.entries[rt_base_idx]
 
-		return None
+        return None
 
-	def find_resource(self, type, res_index):
-		rt_base_dir = self.find_resource_base(type)
+    def find_resource(self, type, res_index):
+        rt_base_dir = self.find_resource_base(type)
 
-		if res_index < 0:
-			try:
-				idx = [entry.id for entry in rt_base_dir.directory.entries].index(-res_index)
-			except:
-				return None
-		else:
-			idx = res_index if res_index < len(rt_base_dir.directory.entries) else None
+        if res_index < 0:
+            try:
+                idx = [entry.id for entry in rt_base_dir.directory.entries].index(-res_index)
+            except:
+                return None
+        else:
+            idx = res_index if res_index < len(rt_base_dir.directory.entries) else None
 
-		if idx is None: return None
+        if idx is None:
+            return None
 
-		test_res_dir = rt_base_dir.directory.entries[idx]
-		res_dir = test_res_dir
-		if test_res_dir.struct.DataIsDirectory:
-			# another Directory
-			# probably language take the first one
-			res_dir = test_res_dir.directory.entries[0]
-		if res_dir.struct.DataIsDirectory:
-			# Ooooooooooiconoo no !! another Directory !!!
-			return None
+        test_res_dir = rt_base_dir.directory.entries[idx]
+        res_dir = test_res_dir
+        if test_res_dir.struct.DataIsDirectory:
+            # another Directory
+            # probably language take the first one
+            res_dir = test_res_dir.directory.entries[0]
+        if res_dir.struct.DataIsDirectory:
+            # Ooooooooooiconoo no !! another Directory !!!
+            return None
 
-		return res_dir
+        return res_dir
 
-	def get_group_icons(self):
-		rt_base_dir = self.find_resource_base('RT_GROUP_ICON')
-		groups = list()
-		for res_index in range(0, len(rt_base_dir.directory.entries)):
-			grp_icon_dir_entry = self.find_resource('RT_GROUP_ICON', res_index)
+    def get_group_icons(self):
+        rt_base_dir = self.find_resource_base('RT_GROUP_ICON')
+        groups = list()
+        for res_index in range(0, len(rt_base_dir.directory.entries)):
+            grp_icon_dir_entry = self.find_resource('RT_GROUP_ICON', res_index)
 
-			if not grp_icon_dir_entry:
-				continue
+            if not grp_icon_dir_entry:
+                continue
 
-			data_rva = grp_icon_dir_entry.data.struct.OffsetToData
-			size = grp_icon_dir_entry.data.struct.Size
-			data = self.pe.get_memory_mapped_image()[data_rva:data_rva+size]
-			file_offset = self.pe.get_offset_from_rva(data_rva)
+            data_rva = grp_icon_dir_entry.data.struct.OffsetToData
+            size = grp_icon_dir_entry.data.struct.Size
+            data = self.pe.get_memory_mapped_image()[data_rva:data_rva + size]
+            file_offset = self.pe.get_offset_from_rva(data_rva)
 
-			grp_icon_dir = pefile.Structure(self.GRPICONDIR_format, file_offset=file_offset)
-			grp_icon_dir.__unpack__(data)
+            grp_icon_dir = pefile.Structure(self.GRPICONDIR_format, file_offset=file_offset)
+            grp_icon_dir.__unpack__(data)
 
-			if grp_icon_dir.Reserved != 0 or grp_icon_dir.Type != self.RES_ICON:
-				continue
-			offset = grp_icon_dir.sizeof()
+            if grp_icon_dir.Reserved != 0 or grp_icon_dir.Type != self.RES_ICON:
+                continue
+            offset = grp_icon_dir.sizeof()
 
-			entries = list()
-			for idx in range(0, grp_icon_dir.Count):
-				grp_icon = pefile.Structure(self.GRPICONDIRENTRY_format, file_offset=file_offset+offset)
-				grp_icon.__unpack__(data[offset:])
-				offset += grp_icon.sizeof()
-				entries.append(grp_icon)
+            entries = list()
+            for idx in range(0, grp_icon_dir.Count):
+                grp_icon = pefile.Structure(self.GRPICONDIRENTRY_format, file_offset=file_offset + offset)
+                grp_icon.__unpack__(data[offset:])
+                offset += grp_icon.sizeof()
+                entries.append(grp_icon)
 
-			groups.append(entries)
-		return groups
+            groups.append(entries)
+        return groups
 
-	def get_icon(self, index):
-		icon_entry = self.find_resource('RT_ICON', -index)
-		if not icon_entry:
-			return None
+    def get_icon(self, index):
+        icon_entry = self.find_resource('RT_ICON', -index)
+        if not icon_entry:
+            return None
 
-		data_rva = icon_entry.data.struct.OffsetToData
-		size = icon_entry.data.struct.Size
-		data = self.pe.get_memory_mapped_image()[data_rva:data_rva+size]
+        data_rva = icon_entry.data.struct.OffsetToData
+        size = icon_entry.data.struct.Size
+        data = self.pe.get_memory_mapped_image()[data_rva:data_rva + size]
 
-		return data
+        return data
 
-	def export_raw(self, entries, index = None):
-		if index is not None:
-			entries = entries[index:index+1]
+    def export_raw(self, entries, index=None):
+        if index is not None:
+            entries = entries[index:index + 1]
 
-		ico = struct.pack('<HHH', 0, self.RES_ICON, len(entries))
-		data_offset = None
-		data = []
-		info = []
-		for grp_icon in entries:
-			if data_offset is None:
-				data_offset = len(ico) + ((grp_icon.sizeof()+2) * len(entries))
+        ico = struct.pack('<HHH', 0, self.RES_ICON, len(entries))
+        data_offset = None
+        data = []
+        info = []
+        for grp_icon in entries:
+            if data_offset is None:
+                data_offset = len(ico) + ((grp_icon.sizeof() + 2) * len(entries))
 
-			nfo = grp_icon.__pack__()[:-2] + struct.pack('<L', data_offset)
-			info.append( nfo )
+            nfo = grp_icon.__pack__()[:-2] + struct.pack('<L', data_offset)
+            info.append(nfo)
 
-			raw_data = self.get_icon(grp_icon.ID)
-			if not raw_data: continue
+            raw_data = self.get_icon(grp_icon.ID)
+            if not raw_data:
+                continue
 
-			data.append( raw_data )
-			data_offset += len(raw_data)
+            data.append(raw_data)
+            data_offset += len(raw_data)
 
-		raw = ico + b''.join(info + data)
-		return raw
+        raw = ico + b''.join(info + data)
+        return raw
 
-	def export(self, entries, index = None):
-		raw = self.export_raw(entries, index)
-		return Image.open(BytesIO(raw))
+    def export(self, entries, index=None):
+        raw = self.export_raw(entries, index)
+        return Image.open(BytesIO(raw))
 
-	def _get_bmp_header(self, data):
-		if data[0:4] == b'\x89PNG':
-			header = b''
-		else:
-			dib_size = struct.unpack('<L', data[0:4])[0]
-			header = b'BM' + struct.pack('<LLL', len(data) + 14, 0, 14 + dib_size)
-		return header
+    def _get_bmp_header(self, data):
+        if data[0:4] == b'\x89PNG':
+            header = b''
+        else:
+            dib_size = struct.unpack('<L', data[0:4])[0]
+            header = b'BM' + struct.pack('<LLL', len(data) + 14, 0, 14 + dib_size)
+        return header

--- a/utils/extract_icon.py
+++ b/utils/extract_icon.py
@@ -1,0 +1,132 @@
+import struct
+import pefile
+from io import BytesIO
+from builtins import range
+from PIL import Image
+
+# From https://github.com/firodj/extract-icon-py
+class ExtractIcon(object):
+	GRPICONDIRENTRY_format = ('GRPICONDIRENTRY',
+		('B,Width', 'B,Height','B,ColorCount','B,Reserved',
+		 'H,Planes','H,BitCount','I,BytesInRes','H,ID'))
+	GRPICONDIR_format = ('GRPICONDIR',
+		('H,Reserved', 'H,Type','H,Count'))
+	RES_ICON = 1
+	RES_CURSOR = 2
+
+	def __init__(self, filepath):
+		self.pe = pefile.PE(filepath)
+
+	def find_resource_base(self, type):
+		rt_base_idx = [entry.id for
+			entry in self.pe.DIRECTORY_ENTRY_RESOURCE.entries].index(
+				pefile.RESOURCE_TYPE[type]
+		)
+
+		if rt_base_idx is not None:
+			return self.pe.DIRECTORY_ENTRY_RESOURCE.entries[rt_base_idx]
+
+		return None
+
+	def find_resource(self, type, res_index):
+		rt_base_dir = self.find_resource_base(type)
+
+		if res_index < 0:
+			try:
+				idx = [entry.id for entry in rt_base_dir.directory.entries].index(-res_index)
+			except:
+				return None
+		else:
+			idx = res_index if res_index < len(rt_base_dir.directory.entries) else None
+
+		if idx is None: return None
+
+		test_res_dir = rt_base_dir.directory.entries[idx]
+		res_dir = test_res_dir
+		if test_res_dir.struct.DataIsDirectory:
+			# another Directory
+			# probably language take the first one
+			res_dir = test_res_dir.directory.entries[0]
+		if res_dir.struct.DataIsDirectory:
+			# Ooooooooooiconoo no !! another Directory !!!
+			return None
+
+		return res_dir
+
+	def get_group_icons(self):
+		rt_base_dir = self.find_resource_base('RT_GROUP_ICON')
+		groups = list()
+		for res_index in range(0, len(rt_base_dir.directory.entries)):
+			grp_icon_dir_entry = self.find_resource('RT_GROUP_ICON', res_index)
+
+			if not grp_icon_dir_entry:
+				continue
+
+			data_rva = grp_icon_dir_entry.data.struct.OffsetToData
+			size = grp_icon_dir_entry.data.struct.Size
+			data = self.pe.get_memory_mapped_image()[data_rva:data_rva+size]
+			file_offset = self.pe.get_offset_from_rva(data_rva)
+
+			grp_icon_dir = pefile.Structure(self.GRPICONDIR_format, file_offset=file_offset)
+			grp_icon_dir.__unpack__(data)
+
+			if grp_icon_dir.Reserved != 0 or grp_icon_dir.Type != self.RES_ICON:
+				continue
+			offset = grp_icon_dir.sizeof()
+
+			entries = list()
+			for idx in range(0, grp_icon_dir.Count):
+				grp_icon = pefile.Structure(self.GRPICONDIRENTRY_format, file_offset=file_offset+offset)
+				grp_icon.__unpack__(data[offset:])
+				offset += grp_icon.sizeof()
+				entries.append(grp_icon)
+
+			groups.append(entries)
+		return groups
+
+	def get_icon(self, index):
+		icon_entry = self.find_resource('RT_ICON', -index)
+		if not icon_entry:
+			return None
+
+		data_rva = icon_entry.data.struct.OffsetToData
+		size = icon_entry.data.struct.Size
+		data = self.pe.get_memory_mapped_image()[data_rva:data_rva+size]
+
+		return data
+
+	def export_raw(self, entries, index = None):
+		if index is not None:
+			entries = entries[index:index+1]
+
+		ico = struct.pack('<HHH', 0, self.RES_ICON, len(entries))
+		data_offset = None
+		data = []
+		info = []
+		for grp_icon in entries:
+			if data_offset is None:
+				data_offset = len(ico) + ((grp_icon.sizeof()+2) * len(entries))
+
+			nfo = grp_icon.__pack__()[:-2] + struct.pack('<L', data_offset)
+			info.append( nfo )
+
+			raw_data = self.get_icon(grp_icon.ID)
+			if not raw_data: continue
+
+			data.append( raw_data )
+			data_offset += len(raw_data)
+
+		raw = ico + b''.join(info + data)
+		return raw
+
+	def export(self, entries, index = None):
+		raw = self.export_raw(entries, index)
+		return Image.open(BytesIO(raw))
+
+	def _get_bmp_header(self, data):
+		if data[0:4] == b'\x89PNG':
+			header = b''
+		else:
+			dib_size = struct.unpack('<L', data[0:4])[0]
+			header = b'BM' + struct.pack('<LLL', len(data) + 14, 0, 14 + dib_size)
+		return header


### PR DESCRIPTION
Hello,
Wine games now keep their icons thanks to a new dependency "[pefile](https://github.com/erocarrera/pefile)".
Icons are extracted from the executable when adding (or configuring) a wine game, so I added the action in the on_save callback.
(closes #1318)