### PR TITLE
Prevent crash on systems without `locale`

### DIFF
--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -431,9 +431,16 @@ def get_disk_size(path):
 
 def get_locale_list():
     """Return list of available locales"""
-    with subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE) as locale_getter:
-        output = locale_getter.communicate()
-    locales = output[0].decode('ASCII').split()  # locale names use only ascii characters
+    try:
+        with subprocess.Popen(['locale', '-a'], stdout=subprocess.PIPE) as locale_getter:
+            output = locale_getter.communicate()
+        locales = output[0].decode('ASCII').split()  # locale names use only ascii characters
+    except FileNotFoundError:
+        lang = os.environ.get('LANG', '')
+        if lang:
+            locales = [lang]
+        else:
+            locales = []
     return locales
 
 


### PR DESCRIPTION
Some systems, like those that use musl libc, do not have the `locale` program. This change fixes a crash in that case.

Methodology:
1. try to run `locale -a`, if success, use that output
2. if that fails, check the environment variable `LANG`
3. if `LANG` is empty or unset, return an empty locale list

All cases of this were tested on void linux musl

see also:
- void-linux/void-packages#39210
- https://github.com/void-linux/void-packages/commit/c694d7e3330e628b34755844b59adba4e43d6154