### PR TITLE
fix: discord client code issue (Python 3.9: unsupported operand type(s) for |: 't…

### DIFF
--- a/lutris/util/discord/client.py
+++ b/lutris/util/discord/client.py
@@ -4,7 +4,7 @@ from lutris.util.discord.base import DiscordRichPresenceBase
 
 
 class DiscordRichPresenceClient(DiscordRichPresenceBase):
-    rpc: Presence | None  # Presence Object
+    rpc: Presence  # Presence Object
 
     def __init__(self):
         self.playing = None


### PR DESCRIPTION
…ype' and 'NoneType')

Traceback (most recent call last):
  File "/ara/devel/sandbox/lutris/venv/bin/lutris", line 7, in <module>
    exec(compile(f.read(), __file__, 'exec'))
  File "/ara/devel/sandbox/lutris/bin/lutris", line 52, in <module>
    from lutris.gui.application import Application  # pylint: disable=no-name-in-module
  File "/ara/devel/sandbox/lutris/lutris/gui/application.py", line 39, in <module>
    from lutris.game import Game, export_game, import_game
  File "/ara/devel/sandbox/lutris/lutris/game.py", line 25, in <module>
    from lutris.util import audio, discord, extract, jobs, linux, strings, system, xdgshortcuts
  File "/ara/devel/sandbox/lutris/lutris/util/discord/__init__.py", line 3, in <module>
    from .rpc import client
  File "/ara/devel/sandbox/lutris/lutris/util/discord/rpc.py", line 12, in <module>
    from lutris.util.discord.client import DiscordRichPresenceClient
  File "/ara/devel/sandbox/lutris/lutris/util/discord/client.py", line 6, in <module>
    class DiscordRichPresenceClient(DiscordRichPresenceBase):
  File "/ara/devel/sandbox/lutris/lutris/util/discord/client.py", line 7, in DiscordRichPresenceClient
    rpc: Presence | None  # Presence Object
TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'
python-BaseException