### PR TITLE
Use Python 3.6+ compatible typing annotation syntax in Discord file

### DIFF
--- a/lutris/util/discord/client.py
+++ b/lutris/util/discord/client.py
@@ -1,16 +1,18 @@
+import typing as ty
+
 from pypresence import Presence
 
 from lutris.util.discord.base import DiscordRichPresenceBase
 
 
 class DiscordRichPresenceClient(DiscordRichPresenceBase):
-    rpc = None  # Presence Object
+    rpc: ty.Optional[Presence]  # Presence Object
 
     def __init__(self):
         self.playing = None
         self.rpc = None
 
-    def update(self, discord_id):
+    def update(self, discord_id: str) -> None:
         if self.rpc is not None:
             # Clear the old RPC before creating a new one
             self.clear()
@@ -22,7 +24,7 @@ class DiscordRichPresenceClient(DiscordRichPresenceBase):
         # Trigger an update making the status available
         self.rpc.update()
 
-    def clear(self):
+    def clear(self) -> None:
         if self.rpc is None:
             # Skip already deleted rpc
             return


### PR DESCRIPTION
Use Python 3.6+ compatible typing annotation syntax in “lutris/util/discord/client.py”, so that Lutris does not crash on startup on Python 3.9 and below if the `pypresence` package is importable

Like #4498, but actually retains the correct typing information.