### PR TITLE
A UI for custom cover art

### DIFF
--- a/lutris/database/schema.py
+++ b/lutris/database/schema.py
@@ -74,6 +74,10 @@ DATABASE = {
             "type": "INTEGER"
         },
         {
+            "name": "has_custom_coverart_big",
+            "type": "INTEGER"
+        },
+        {
             "name": "playtime",
             "type": "REAL"
         },

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -84,8 +84,10 @@ class Game(GObject.Object):
         self.year = game_data.get("year") or ""
         self.lastplayed = game_data.get("lastplayed") or 0
         self.custom_images = set()
-        if game_data.get("has_custom_banner"): self.custom_images.add("banner")
-        if game_data.get("has_custom_icon"): self.custom_images.add("icon")
+        if game_data.get("has_custom_banner"):
+            self.custom_images.add("banner")
+        if game_data.get("has_custom_icon"):
+            self.custom_images.add("icon")
         self.service = game_data.get("service")
         self.appid = game_data.get("service_id")
         self.playtime = game_data.get("playtime") or 0.0

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -83,8 +83,9 @@ class Game(GObject.Object):
         self.platform = game_data.get("platform") or ""
         self.year = game_data.get("year") or ""
         self.lastplayed = game_data.get("lastplayed") or 0
-        self.has_custom_banner = bool(game_data.get("has_custom_banner"))
-        self.has_custom_icon = bool(game_data.get("has_custom_icon"))
+        self.custom_images = set()
+        if game_data.get("has_custom_banner"): self.custom_images.add("banner")
+        if game_data.get("has_custom_icon"): self.custom_images.add("icon")
         self.service = game_data.get("service")
         self.appid = game_data.get("service_id")
         self.playtime = game_data.get("playtime") or 0.0
@@ -304,6 +305,8 @@ class Game(GObject.Object):
             service=self.service,
             service_id=self.appid,
             discord_id=self.discord_id,
+            has_custom_banner="banner" in self.custom_images,
+            has_custom_icon="icon" in self.custom_images,
         )
         self.emit("game-updated")
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -88,6 +88,8 @@ class Game(GObject.Object):
             self.custom_images.add("banner")
         if game_data.get("has_custom_icon"):
             self.custom_images.add("icon")
+        if game_data.get("has_custom_coverart_big"):
+            self.custom_images.add("coverart_big")
         self.service = game_data.get("service")
         self.appid = game_data.get("service_id")
         self.playtime = game_data.get("playtime") or 0.0
@@ -309,6 +311,7 @@ class Game(GObject.Object):
             discord_id=self.discord_id,
             has_custom_banner="banner" in self.custom_images,
             has_custom_icon="icon" in self.custom_images,
+            has_custom_coverart_big="coverart_big" in self.custom_images
         )
         self.emit("game-updated")
 

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -16,7 +16,7 @@ from lutris.gui.widgets.common import Label, NumberEntry, SlugEntry, VBox
 from lutris.gui.widgets.notifications import send_notification
 from lutris.gui.widgets.utils import get_pixbuf
 from lutris.runners import import_runner
-from lutris.services.lutris import LutrisBanner, LutrisIcon, LutrisCoverart, download_lutris_media
+from lutris.services.lutris import LutrisBanner, LutrisCoverart, LutrisIcon, download_lutris_media
 from lutris.util.log import logger
 from lutris.util.strings import slugify
 
@@ -508,4 +508,5 @@ class GameDialogCommon(ModelessDialog):
         self.game.custom_images.discard(image_type)
         if os.path.isfile(dest_path):
             os.remove(dest_path)
+        download_lutris_media(self.game.slug)
         self._set_image(image_type, self.image_buttons[image_type])

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -185,12 +185,8 @@ class GameDialogCommon(ModelessDialog):
 
         return box
 
-    def _set_image(self, image_format, image_button=None):
-        if image_button is None:
-            image_button = self.image_buttons[image_format]
-
+    def _set_image(self, image_format, image_button):
         service_media = self.service_medias[image_format]
-
         image = Gtk.Image()
         service_media = LutrisBanner() if image_format == "banner" else LutrisIcon()
         game_slug = self.slug or (self.game.slug if self.game else "")

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -242,9 +242,9 @@ class GameDialogCommon(ModelessDialog):
         download_lutris_media(slug)
 
         self.slug = slug
+        for image_type, image_button in self.image_buttons.items():
+            self._set_image(image_type, image_button)
         self.slug_entry.set_sensitive(False)
-        self._set_image("icon")
-        self._set_image("banner")
         self.slug_change_button.set_label(_("Change"))
 
     def on_move_clicked(self, _button):
@@ -492,7 +492,7 @@ class GameDialogCommon(ModelessDialog):
             self.game.custom_images.add(image_type)
             dest_path = service_media.get_absolute_path(slug)
             file_format = service_media.file_format
-            size = service_media.size
+            size = service_media.custom_media_storage_size
             pixbuf = get_pixbuf(image_path, size)
             # JPEG encoding looks rather better at high quality;
             # PNG encoding just ignores this option.

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -152,17 +152,18 @@ class GameDialogCommon(ModelessDialog):
         label = Label("")
         banner_box.pack_start(label, False, False, 0)
 
-        self._create_image_button(banner_box, "coverart_big", _("Remove custom cover art"))
-        self._create_image_button(banner_box, "banner", _("Remove custom banner"))
-        self._create_image_button(banner_box, "icon", _("Remove custom icon"))
+        self._create_image_button(banner_box, "coverart_big", _("Set custom cover art"), _("Remove custom cover art"))
+        self._create_image_button(banner_box, "banner", _("Set custom banner"), _("Remove custom banner"))
+        self._create_image_button(banner_box, "icon", _("Set custom icon"), _("Remove custom icon"))
 
         return banner_box
 
-    def _create_image_button(self, banner_box, image_type, reset_tooltip):
+    def _create_image_button(self, banner_box, image_type, image_tooltip, reset_tooltip):
         """This adds an image button and its reset button to the box given,
         and adds the image button to self.image_buttons for future reference."""
         image_button = Gtk.Button()
         self._set_image(image_type, image_button)
+        image_button.set_tooltip_text(image_tooltip)
         image_button.connect("clicked", self.on_custom_image_select, image_type)
         image_button.set_valign(Gtk.Align.CENTER)
         banner_box.pack_start(image_button, False, False, 0)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -17,7 +17,6 @@ from lutris.gui.widgets.notifications import send_notification
 from lutris.gui.widgets.utils import get_pixbuf
 from lutris.runners import import_runner
 from lutris.services.lutris import LutrisBanner, LutrisIcon, download_lutris_media
-from lutris.util import system
 from lutris.util.log import logger
 from lutris.util.strings import slugify
 
@@ -498,9 +497,7 @@ class GameDialogCommon(ModelessDialog):
             # PNG encoding just ignores this option.
             pixbuf.savev(dest_path, file_format, ["quality"], ["100"])
             self._set_image(image_type, self.image_buttons[image_type])
-
-            if image_type == "icon":
-                system.update_desktop_icons()
+            service_media.update_desktop()
 
         dialog.destroy()
 

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -159,6 +159,8 @@ class GameDialogCommon(ModelessDialog):
         return banner_box
 
     def _get_image_button(self, banner_box, image_type, reset_tooltip):
+        """This adds an image button and its reset button to the box given,
+        and returns the image button for future reference."""
         image_button = Gtk.Button()
         self._set_image(image_type, image_button)
         image_button.connect("clicked", self.on_custom_image_select, image_type)
@@ -487,10 +489,7 @@ class GameDialogCommon(ModelessDialog):
             slug = self.slug or self.game.slug
             image_path = dialog.get_filename()
             service_media = self.service_medias[image_type]
-            if image_type == "banner":
-                self.game.has_custom_banner = True
-            else:
-                self.game.has_custom_icon = True
+            self.game.custom_images.add(image_type)
             dest_path = service_media.get_absolute_path(slug)
             file_format = service_media.file_format
             size = service_media.size
@@ -507,15 +506,9 @@ class GameDialogCommon(ModelessDialog):
 
     def on_custom_image_reset_clicked(self, _widget, image_type):
         slug = self.slug or self.game.slug
-        if image_type == "banner":
-            self.game.has_custom_banner = False
-        elif image_type == "icon":
-            self.game.has_custom_icon = False
-        else:
-            raise ValueError("Unsupported image type %s" % image_type)
-
         service_media = self.service_medias[image_type]
         dest_path = service_media.get_absolute_path(slug)
+        self.game.custom_images.discard(image_type)
         if os.path.isfile(dest_path):
             os.remove(dest_path)
         self._set_image(image_type, self.image_buttons[image_type])

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -107,7 +107,7 @@ class StoreItem:
             return get_pixbuf(image_path, self.service_media.size, is_installed=self.installed)
         return self.service_media.get_pixbuf_for_game(
             self._game_data["slug"],
-            self.installed
+            is_installed=self.installed
         )
 
     @property

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -29,6 +29,7 @@ class AmazonBanner(ServiceMedia):
     size = (200, 112)
     dest_path = os.path.join(settings.CACHE_DIR, "amazon/banners")
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = "image"
     url_pattern = "%s"
 

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -45,6 +45,10 @@ class LutrisIcon(LutrisBanner):
     file_format = "png"
     api_field = 'icon_url'
 
+    @property
+    def custom_media_storage_size(self):
+        return (128, 128)
+
     def update_desktop(self):
         system.update_desktop_icons()
 

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -57,6 +57,10 @@ class LutrisCoverart(ServiceMedia):
     dest_path = settings.COVERART_PATH
     api_field = 'coverart'
 
+    @property
+    def config_ui_size(self):
+        return (66, 88)
+
 
 class LutrisCoverartMedium(LutrisCoverart):
     size = (176, 234)

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -45,6 +45,9 @@ class LutrisIcon(LutrisBanner):
     file_format = "png"
     api_field = 'icon_url'
 
+    def update_desktop(self):
+        system.update_desktop_icons()
+
 
 class LutrisCoverart(ServiceMedia):
     service = 'lutris'

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -15,6 +15,7 @@ from lutris.game import Game
 from lutris.gui.dialogs import NoticeDialog
 from lutris.gui.dialogs.webconnect_dialog import WebConnectDialog
 from lutris.gui.views.media_loader import download_media
+from lutris.gui.widgets.utils import BANNER_SIZE, ICON_SIZE
 from lutris.installer import get_installers
 from lutris.services.service_media import ServiceMedia
 from lutris.util import system
@@ -30,16 +31,18 @@ class AuthTokenExpired(Exception):
 
 class LutrisBanner(ServiceMedia):
     service = 'lutris'
-    size = (184, 69)
+    size = BANNER_SIZE
     dest_path = settings.BANNER_PATH
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = 'banner_url'
 
 
 class LutrisIcon(LutrisBanner):
-    size = (32, 32)
+    size = ICON_SIZE
     dest_path = settings.ICON_PATH
     file_pattern = "lutris_%s.png"
+    file_format = "png"
     api_field = 'icon_url'
 
 
@@ -47,6 +50,7 @@ class LutrisCoverart(ServiceMedia):
     service = 'lutris'
     size = (264, 352)
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     dest_path = settings.COVERART_PATH
     api_field = 'coverart'
 

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -18,6 +18,7 @@ class DolphinBanner(ServiceMedia):
     source = "local"
     size = (96, 32)
     file_pattern = "%s.png"
+    file_format = "jpeg"
     dest_path = os.path.join(settings.CACHE_DIR, "dolphin/banners/small")
 
 

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -34,6 +34,7 @@ class DieselGameMedia(ServiceMedia):
     service = "egs"
     remote_size = (200, 267)
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     min_logo_x = 300
     min_logo_y = 150
 
@@ -107,6 +108,7 @@ class DieselGameBoxLogo(DieselGameMedia):
     size = (200, 100)
     remote_size = size
     file_pattern = "%s.png"
+    file_format = "png"
     visible = False
     dest_path = os.path.join(settings.CACHE_DIR, "egs/game_logo")
     api_field = "DieselGameBoxLogo"

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -22,6 +22,7 @@ class FlathubBanner(ServiceMedia):
     size = (128, 128)
     dest_path = os.path.join(settings.CACHE_DIR, "flathub/banners")
     file_pattern = "%s.png"
+    file_format = "png"
     url_field = 'iconDesktopUrl'
 
     def get_media_url(self, details):

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -27,6 +27,7 @@ class GogSmallBanner(ServiceMedia):
     size = (100, 60)
     dest_path = os.path.join(settings.CACHE_DIR, "gog/banners/small")
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = "image"
     url_pattern = "https:%s_prof_game_100x60.jpg"
 

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -23,6 +23,7 @@ class HumbleBundleIcon(ServiceMedia):
     size = (70, 70)
     dest_path = os.path.join(settings.CACHE_DIR, "humblebundle/icons")
     file_pattern = "%s.png"
+    file_format = "png"
     api_field = "icon"
 
 

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -51,6 +51,7 @@ class OriginLauncher:
 class OriginPackArtSmall(ServiceMedia):
     service = "origin"
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     size = (63, 89)
     dest_path = os.path.join(settings.CACHE_DIR, "origin/pack-art-small")
     api_field = "packArtSmall"

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -23,6 +23,7 @@ class ServiceMedia:
     small_size = None
     dest_path = None
     file_pattern = NotImplemented
+    file_format = NotImplemented
     api_field = NotImplemented
     url_pattern = "%s"
 

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -92,8 +92,14 @@ class ServiceMedia:
             logger.error("Failed to download %s: %s", url, ex)
 
     @property
+    def custom_media_storage_size(self):
+        """The size this media is stored in when customized; we accept
+        whatever we get when we download the media, however."""
+        return self.size
+
+    @property
     def config_ui_size(self):
-        """This size this media should be shown at when in the configuration UI."""
+        """The size this media should be shown at when in the configuration UI."""
         return self.size
 
     def update_desktop(self):

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -42,9 +42,12 @@ class ServiceMedia:
         """Whether the icon for the specified slug exists locally"""
         return system.path_exists(self.get_absolute_path(slug))
 
-    def get_pixbuf_for_game(self, slug, is_installed=True):
+    def get_pixbuf_for_game(self, slug, size=None, is_installed=True):
+        if not size:
+            size = self.size
+
         image_abspath = self.get_absolute_path(slug)
-        return get_pixbuf(image_abspath, self.size, fallback=get_default_icon(self.size), is_installed=is_installed)
+        return get_pixbuf(image_abspath, size, fallback=get_default_icon(size), is_installed=is_installed)
 
     def get_media_url(self, details):
         if self.api_field not in details:
@@ -87,6 +90,11 @@ class ServiceMedia:
             return download_file(url, cache_path, raise_errors=True)
         except HTTPError as ex:
             logger.error("Failed to download %s: %s", url, ex)
+
+    @property
+    def config_ui_size(self):
+        """This size this media should be shown at when in the configuration UI."""
+        return self.size
 
     def update_desktop(self):
         """Update the desktop, if this media type appears there. Most don't."""

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -88,5 +88,8 @@ class ServiceMedia:
         except HTTPError as ex:
             logger.error("Failed to download %s: %s", url, ex)
 
+    def update_desktop(self):
+        """Update the desktop, if this media type appears there. Most don't."""
+
     def render(self):
         """Used if the media requires extra processing"""

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -26,6 +26,7 @@ class SteamBanner(ServiceMedia):
     size = (184, 69)
     dest_path = os.path.join(settings.CACHE_DIR, "steam/banners")
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = "appid"
     url_pattern = "http://cdn.akamai.steamstatic.com/steam/apps/%s/capsule_184x69.jpg"
 
@@ -35,6 +36,7 @@ class SteamCover(ServiceMedia):
     size = (200, 300)
     dest_path = os.path.join(settings.CACHE_DIR, "steam/covers")
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = "appid"
     url_pattern = "http://cdn.steamstatic.com/steam/apps/%s/library_600x900.jpg"
 
@@ -44,6 +46,7 @@ class SteamBannerLarge(ServiceMedia):
     size = (460, 215)
     dest_path = os.path.join(settings.CACHE_DIR, "steam/header")
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = "appid"
     url_pattern = "https://cdn.cloudflare.steamstatic.com/steam/apps/%s/header.jpg"
 

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -31,6 +31,7 @@ class UbisoftCover(ServiceMedia):
     size = (160, 186)
     dest_path = os.path.join(settings.CACHE_DIR, "ubisoft/covers")
     file_pattern = "%s.jpg"
+    file_format = "jpeg"
     api_field = "id"
     url_pattern = "https://ubiservices.cdn.ubi.com/%s/spaceCardAsset/boxArt_mobile.jpg?imwidth=320"
 

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -36,6 +36,7 @@ class XDGMedia(ServiceMedia):
     size = (64, 64)
     dest_path = os.path.join(settings.CACHE_DIR, "xdg/icons")
     file_pattern = "%s.png"
+    file_format = "png"
 
 
 class XDGService(BaseService):


### PR DESCRIPTION
This adds an image button for cover art, just like the ones for the banner and icon.

![image](https://user-images.githubusercontent.com/6507403/192096384-1a0298c3-cd3b-434c-940a-298cbd2de358.png)

This PR removes a bunch of if/else cascades in favor of dictionaries, sets, and "virtual" methods (what do you even call those in Python?); in this way I do not have to visit each if/else and add a new branch for each new media.

Also, I found the has_custom_icon and has_custom_banner flags are not saved or used. I imagine they could be useful, and were presumably meant for something, so I've added code to save them and added a flag for the cover-art. These flags are represented with a set in the Game object, but are separate columns in the PGA database.

Finally, the reset buttons will now reset to the Lutris.net default images, rather than removing the media and waiting for the automatic redownload timer to fix this.

Resolves #4506
