### PR TITLE
[chore] Add python 3.7 compatiblity with modern 484 syntax.

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -13,3 +13,4 @@ sections =
     FIRSTPARTY,
     LOCALFOLDER
 default_section=THIRDPARTY
+add_imports=from __future__ import annotations

--- a/lutris/__init__.py
+++ b/lutris/__init__.py
@@ -1,3 +1,5 @@
 """Main Lutris package"""
 
+from __future__ import annotations
+
 __version__ = "0.5.11"

--- a/lutris/api.py
+++ b/lutris/api.py
@@ -1,4 +1,6 @@
 """Functions to interact with the Lutris REST API"""
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/lutris/cache.py
+++ b/lutris/cache.py
@@ -1,4 +1,6 @@
 """Module for handling the PGA cache"""
+from __future__ import annotations
+
 import os
 import shutil
 

--- a/lutris/command.py
+++ b/lutris/command.py
@@ -1,4 +1,6 @@
 """Threading module, used to launch games while monitoring them."""
+from __future__ import annotations
+
 import contextlib
 import fcntl
 import io

--- a/lutris/config.py
+++ b/lutris/config.py
@@ -1,5 +1,7 @@
 """Handle the game, runner and global system configurations."""
 
+from __future__ import annotations
+
 import os
 import time
 from shutil import copyfile

--- a/lutris/database/categories.py
+++ b/lutris/database/categories.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lutris import settings
 from lutris.database import sql
 

--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import math
 import time
 from itertools import chain

--- a/lutris/database/schema.py
+++ b/lutris/database/schema.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lutris import settings
 from lutris.database import sql
 from lutris.util.log import logger

--- a/lutris/database/services.py
+++ b/lutris/database/services.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lutris import settings
 from lutris.database import sql
 from lutris.util.log import logger

--- a/lutris/database/sources.py
+++ b/lutris/database/sources.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris import settings

--- a/lutris/database/sql.py
+++ b/lutris/database/sql.py
@@ -1,4 +1,6 @@
 
+from __future__ import annotations
+
 import sqlite3
 import threading
 

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -1,4 +1,6 @@
 """Exception handling module"""
+from __future__ import annotations
+
 from functools import wraps
 from gettext import gettext as _
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -1,6 +1,8 @@
 """Module that actually runs the games."""
 
 # pylint: disable=too-many-public-methods
+from __future__ import annotations
+
 import json
 import os
 import shlex

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -2,6 +2,8 @@
 
 # Standard Library
 # pylint: disable=too-many-public-methods
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/gui/__init__.py
+++ b/lutris/gui/__init__.py
@@ -1,1 +1,3 @@
 """ Lutris GUI package """
+
+from __future__ import annotations

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gio, GLib, Gtk

--- a/lutris/gui/config/__init__.py
+++ b/lutris/gui/config/__init__.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 DIALOG_WIDTH = 845
 DIALOG_HEIGHT = 600

--- a/lutris/gui/config/add_game.py
+++ b/lutris/gui/config/add_game.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.config import LutrisConfig

--- a/lutris/gui/config/base_config_box.py
+++ b/lutris/gui/config/base_config_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import Gtk
 
 from lutris.gui.widgets.common import VBox

--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -1,6 +1,8 @@
 """Widget generators and their signal handlers"""
 # Standard Library
 # pylint: disable=no-member,too-many-public-methods
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -1,5 +1,7 @@
 """Shared config dialog stuff"""
 # pylint: disable=not-an-iterable
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 
@@ -11,7 +13,7 @@ from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.config import DIALOG_HEIGHT, DIALOG_WIDTH
 from lutris.gui.config.boxes import GameBox, RunnerBox, SystemBox
-from lutris.gui.dialogs import ModelessDialog, DirectoryDialog, ErrorDialog, QuestionDialog
+from lutris.gui.dialogs import DirectoryDialog, ErrorDialog, ModelessDialog, QuestionDialog
 from lutris.gui.widgets.common import Label, NumberEntry, SlugEntry, VBox
 from lutris.gui.widgets.notifications import send_notification
 from lutris.gui.widgets.utils import BANNER_SIZE, ICON_SIZE, get_pixbuf

--- a/lutris/gui/config/edit_game.py
+++ b/lutris/gui/config/edit_game.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.gui.config.common import GameDialogCommon

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gio, Gtk

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -1,4 +1,6 @@
 """Configuration dialog for client and system options"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gtk

--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.config import LutrisConfig

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import GObject, Gtk

--- a/lutris/gui/config/runners_box.py
+++ b/lutris/gui/config/runners_box.py
@@ -1,4 +1,6 @@
 """Add, remove and configure runners"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import GLib, Gtk

--- a/lutris/gui/config/services_box.py
+++ b/lutris/gui/config/services_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import GLib, GObject, Gtk

--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gdk, Gtk

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -1,4 +1,6 @@
 """Commonly used dialogs"""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/gui/dialogs/cache.py
+++ b/lutris/gui/dialogs/cache.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import GLib, Gtk

--- a/lutris/gui/dialogs/download.py
+++ b/lutris/gui/dialogs/download.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gtk

--- a/lutris/gui/dialogs/issue.py
+++ b/lutris/gui/dialogs/issue.py
@@ -1,4 +1,6 @@
 """GUI dialog for reporting issues"""
+from __future__ import annotations
+
 import json
 import os
 from gettext import gettext as _

--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -1,4 +1,6 @@
 """Window to show game logs"""
+from __future__ import annotations
+
 import os
 from datetime import datetime
 

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -1,5 +1,7 @@
 """Dialog used to install versions of a runner"""
 # pylint: disable=no-member
+from __future__ import annotations
+
 import gettext
 import os
 import re
@@ -11,7 +13,7 @@ from gi.repository import GLib, Gtk
 from lutris import api, settings
 from lutris.database.games import get_games_by_runner
 from lutris.game import Game
-from lutris.gui.dialogs import ModelessDialog, Dialog, ErrorDialog, QuestionDialog
+from lutris.gui.dialogs import Dialog, ErrorDialog, ModelessDialog, QuestionDialog
 from lutris.util import jobs, system
 from lutris.util.downloader import Downloader
 from lutris.util.extract import extract_archive

--- a/lutris/gui/dialogs/uninstall_game.py
+++ b/lutris/gui/dialogs/uninstall_game.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gtk, Pango

--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -1,4 +1,6 @@
 """Widgets for the installer window"""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import GObject, Gtk
 
 from lutris.gui.installer.file_box import InstallerFileBox

--- a/lutris/gui/installer/script_box.py
+++ b/lutris/gui/installer/script_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import Gtk

--- a/lutris/gui/installer/script_picker.py
+++ b/lutris/gui/installer/script_picker.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import GObject, Gtk
 
 from lutris.gui.installer.script_box import InstallerScriptBox

--- a/lutris/gui/installer/widgets.py
+++ b/lutris/gui/installer/widgets.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import Gtk, Pango
 
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -1,4 +1,6 @@
 """Window used for game installers"""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1,4 +1,6 @@
 """Main window for the Lutris interface."""
+from __future__ import annotations
+
 import os
 from collections import namedtuple
 from gettext import gettext as _

--- a/lutris/gui/views/__init__.py
+++ b/lutris/gui/views/__init__.py
@@ -1,4 +1,6 @@
 """Common values used for views"""
+from __future__ import annotations
+
 (
     COL_ID,
     COL_SLUG,

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import Gdk, GObject, Gtk
 
 from lutris.database.games import get_game_for_service

--- a/lutris/gui/views/grid.py
+++ b/lutris/gui/views/grid.py
@@ -1,5 +1,7 @@
 """Grid view for the main window"""
 # pylint: disable=no-member
+from __future__ import annotations
+
 from gi.repository import Gtk
 
 from lutris.gui.views import COL_ICON, COL_NAME

--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -1,4 +1,6 @@
 """TreeView based game list"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 # Third Party Libraries

--- a/lutris/gui/views/media_loader.py
+++ b/lutris/gui/views/media_loader.py
@@ -1,4 +1,6 @@
 """Loads game media in parallel"""
+from __future__ import annotations
+
 import concurrent.futures
 
 from lutris.util import system

--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -1,5 +1,7 @@
 """Store object for a list of games"""
 # pylint: disable=not-an-iterable
+from __future__ import annotations
+
 import time
 
 from gi.repository import GLib, GObject, Gtk

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -1,4 +1,6 @@
 """Game representation for views"""
+from __future__ import annotations
+
 import time
 
 from lutris.database.games import get_service_games

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import Gtk, Pango
 
 

--- a/lutris/gui/widgets/common.py
+++ b/lutris/gui/widgets/common.py
@@ -1,5 +1,7 @@
 """Misc widgets used in the GUI."""
 # Standard Library
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/gui/widgets/contextual_menu.py
+++ b/lutris/gui/widgets/contextual_menu.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import Gtk
 
 from lutris import runners

--- a/lutris/gui/widgets/download_progress_box.py
+++ b/lutris/gui/widgets/download_progress_box.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 from urllib.parse import urlparse
 

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from datetime import datetime
 from gettext import gettext as _
 

--- a/lutris/gui/widgets/gi_composites.py
+++ b/lutris/gui/widgets/gi_composites.py
@@ -9,6 +9,8 @@ https://github.com/virtuald/pygi-composite-templates/blob/master/gi_composites.p
 This should have landed in PyGObect and will be available without this shim in the future.
 See: https://gitlab.gnome.org/GNOME/pygobject/merge_requests/52
 """
+from __future__ import annotations
+
 #
 # Copyright (C) 2015 Dustin Spicuzza <dustin@virtualroadside.com>
 #
@@ -26,7 +28,6 @@ See: https://gitlab.gnome.org/GNOME/pygobject/merge_requests/52
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
 # USA
-
 # Standard Library
 import inspect
 import warnings

--- a/lutris/gui/widgets/log_text_view.py
+++ b/lutris/gui/widgets/log_text_view.py
@@ -1,4 +1,6 @@
 # Third Party Libraries
+from __future__ import annotations
+
 from gi.repository import Gtk
 
 

--- a/lutris/gui/widgets/notifications.py
+++ b/lutris/gui/widgets/notifications.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gi.repository import Gio
 
 from lutris.util.log import logger

--- a/lutris/gui/widgets/searchable_combobox.py
+++ b/lutris/gui/widgets/searchable_combobox.py
@@ -1,5 +1,7 @@
 """Extended combobox with search"""
 # pylint: disable=unsubscriptable-object
+from __future__ import annotations
+
 from gi.repository import GLib, GObject, Gtk
 
 from lutris.util.jobs import AsyncCall

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -1,4 +1,6 @@
 """Sidebar for the main window"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from gi.repository import GLib, GObject, Gtk, Pango

--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -1,4 +1,6 @@
 """AppIndicator based tray icon"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 import gi

--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -1,4 +1,6 @@
 """Various utilities using the GObject framework"""
+from __future__ import annotations
+
 import array
 import os
 

--- a/lutris/gui/widgets/window.py
+++ b/lutris/gui/widgets/window.py
@@ -1,4 +1,6 @@
 # Third Party Libraries
+from __future__ import annotations
+
 from gi.repository import Gtk
 
 

--- a/lutris/installer/__init__.py
+++ b/lutris/installer/__init__.py
@@ -1,4 +1,6 @@
 """Install script interpreter package."""
+from __future__ import annotations
+
 import yaml
 
 from lutris.api import get_game_installers, normalize_installer

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -1,4 +1,6 @@
 """Commands for installer scripts"""
+from __future__ import annotations
+
 import glob
 import json
 import multiprocessing

--- a/lutris/installer/errors.py
+++ b/lutris/installer/errors.py
@@ -1,4 +1,6 @@
 """Installer specific exceptions"""
+from __future__ import annotations
+
 import sys
 
 from lutris.gui.dialogs import ErrorDialog

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -1,4 +1,6 @@
 """Lutris installer class"""
+from __future__ import annotations
+
 import json
 import os
 from gettext import gettext as _

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -1,4 +1,6 @@
 """Manipulates installer files"""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 from urllib.parse import urlparse

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -1,4 +1,6 @@
 """Install a game by following its install script."""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/installer/legacy.py
+++ b/lutris/installer/legacy.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lutris.util import linux
 from lutris.util.log import logger
 

--- a/lutris/installer/steam_installer.py
+++ b/lutris/installer/steam_installer.py
@@ -1,4 +1,6 @@
 """Collection of installer files"""
+from __future__ import annotations
+
 import os
 import time
 from gettext import gettext as _

--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import importlib
 
 from lutris import settings

--- a/lutris/migrations/mess_to_mame.py
+++ b/lutris/migrations/mess_to_mame.py
@@ -1,4 +1,6 @@
 """Migrate MESS games to MAME"""
+from __future__ import annotations
+
 from lutris.database.games import get_games
 from lutris.game import Game
 

--- a/lutris/migrations/migrate_banners.py
+++ b/lutris/migrations/migrate_banners.py
@@ -1,4 +1,6 @@
 """Migrate banners from .local/share/lutris to .cache/lutris"""
+from __future__ import annotations
+
 import os
 
 from lutris import settings

--- a/lutris/migrations/migrate_hidden_ids.py
+++ b/lutris/migrations/migrate_hidden_ids.py
@@ -1,4 +1,6 @@
 """Move hidden games from settings to database"""
+from __future__ import annotations
+
 from lutris import settings
 from lutris.game import Game
 

--- a/lutris/migrations/migrate_steam_appids.py
+++ b/lutris/migrations/migrate_steam_appids.py
@@ -1,4 +1,6 @@
 """Set service ID for Steam games"""
+from __future__ import annotations
+
 from lutris import settings
 from lutris.database.games import get_games, sql
 

--- a/lutris/migrations/retrieve_discord_appids.py
+++ b/lutris/migrations/retrieve_discord_appids.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 from lutris import settings
-from lutris.util.log import logger
 from lutris.api import get_api_games
 from lutris.database.games import get_games, sql
+from lutris.util.log import logger
 
 
 def migrate():

--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -1,4 +1,6 @@
 """Transform runner parameters to data usable for runtime execution"""
+from __future__ import annotations
+
 import os
 import shlex
 import stat

--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -1,4 +1,6 @@
 """Runner loaders"""
+from __future__ import annotations
+
 from collections import defaultdict
 
 __all__ = [

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os.path
 from gettext import gettext as _

--- a/lutris/runners/commands/dosbox.py
+++ b/lutris/runners/commands/dosbox.py
@@ -1,5 +1,7 @@
 """DOSBox installer commands"""
 # Standard Library
+from __future__ import annotations
+
 import os
 
 # Lutris Modules

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -1,5 +1,7 @@
 """Wine commands for installers"""
 # pylint: disable=too-many-arguments
+from __future__ import annotations
+
 import os
 import shlex
 import time

--- a/lutris/runners/dolphin.py
+++ b/lutris/runners/dolphin.py
@@ -1,4 +1,6 @@
 """Dolphin runner"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 # Lutris Modules

--- a/lutris/runners/dosbox.py
+++ b/lutris/runners/dosbox.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 import shlex
 from gettext import gettext as _

--- a/lutris/runners/easyrpg.py
+++ b/lutris/runners/easyrpg.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 from gettext import gettext as _
 from os import path
 

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from gettext import gettext as _

--- a/lutris/runners/fsuae.py
+++ b/lutris/runners/fsuae.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from collections import defaultdict
 from gettext import gettext as _

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 import shutil
 from gettext import gettext as _

--- a/lutris/runners/json.py
+++ b/lutris/runners/json.py
@@ -1,4 +1,6 @@
 """Base class and utilities for JSON based runners"""
+from __future__ import annotations
+
 import json
 import os
 

--- a/lutris/runners/jzintv.py
+++ b/lutris/runners/jzintv.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -1,4 +1,6 @@
 """libretro runner"""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 from operator import itemgetter

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -1,5 +1,7 @@
 """Runner for Linux games"""
 # Standard Library
+from __future__ import annotations
+
 import os
 import stat
 from gettext import gettext as _

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -1,4 +1,6 @@
 """Runner for MAME"""
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/runners/mednafen.py
+++ b/lutris/runners/mednafen.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import subprocess
 from gettext import gettext as _
 

--- a/lutris/runners/mupen64plus.py
+++ b/lutris/runners/mupen64plus.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/runners/openmsx.py
+++ b/lutris/runners/openmsx.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 from gettext import gettext as _
 
 # Lutris Modules

--- a/lutris/runners/osmose.py
+++ b/lutris/runners/osmose.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 from gettext import gettext as _
 
 # Lutris Modules

--- a/lutris/runners/pcsx2.py
+++ b/lutris/runners/pcsx2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.runners.runner import Runner

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -1,4 +1,6 @@
 """Runner for the PICO-8 fantasy console"""
+from __future__ import annotations
+
 import json
 import math
 import os

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from gettext import gettext as _

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 import re
 import shutil

--- a/lutris/runners/residualvm.py
+++ b/lutris/runners/residualvm.py
@@ -1,5 +1,7 @@
 """ResidualVM runner"""
 # Standard Library
+from __future__ import annotations
+
 import os
 import subprocess
 from gettext import gettext as _

--- a/lutris/runners/rpcs3.py
+++ b/lutris/runners/rpcs3.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 from gettext import gettext as _
 
 # Lutris Modules

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -1,4 +1,6 @@
 """Base module for runners"""
+from __future__ import annotations
+
 import os
 import signal
 from gettext import gettext as _

--- a/lutris/runners/ryujinx.py
+++ b/lutris/runners/ryujinx.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import filecmp
 import os
 from gettext import gettext as _

--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import subprocess
 from gettext import gettext as _

--- a/lutris/runners/snes9x.py
+++ b/lutris/runners/snes9x.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 import subprocess
 import xml.etree.ElementTree as etree

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -1,4 +1,6 @@
 """Steam for Linux runner"""
+from __future__ import annotations
+
 import os
 import subprocess
 from gettext import gettext as _

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/runners/web.py
+++ b/lutris/runners/web.py
@@ -1,4 +1,6 @@
 """Run web based games"""
+from __future__ import annotations
+
 import os
 import string
 from gettext import gettext as _

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1,5 +1,7 @@
 """Wine runner"""
 # pylint: disable=too-many-lines
+from __future__ import annotations
+
 import os
 import shlex
 from gettext import gettext as _

--- a/lutris/runners/yuzu.py
+++ b/lutris/runners/yuzu.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import filecmp
 import os
 from gettext import gettext as _

--- a/lutris/runners/zdoom.py
+++ b/lutris/runners/zdoom.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -1,4 +1,6 @@
 """Runtime handling module"""
+from __future__ import annotations
+
 import concurrent.futures
 import os
 import time

--- a/lutris/scanners/lutris.py
+++ b/lutris/scanners/lutris.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.api import get_api_games, get_game_installers

--- a/lutris/scanners/retroarch.py
+++ b/lutris/scanners/retroarch.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.config import write_game_config

--- a/lutris/services/__init__.py
+++ b/lutris/services/__init__.py
@@ -1,4 +1,6 @@
 """Service package"""
+from __future__ import annotations
+
 import os
 
 from lutris import settings

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -1,4 +1,6 @@
 """Module for handling the Amazon service"""
+from __future__ import annotations
+
 import base64
 import hashlib
 import json

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -1,4 +1,6 @@
 """Generic service utilities"""
+from __future__ import annotations
+
 import os
 import shutil
 from gettext import gettext as _

--- a/lutris/services/battlenet.py
+++ b/lutris/services/battlenet.py
@@ -1,6 +1,8 @@
 """Battle.net service.
 Not ready yet.
 """
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.services.base import OnlineService

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 from gettext import gettext as _

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -1,4 +1,6 @@
 """Epic Games Store service"""
+from __future__ import annotations
+
 import json
 import os
 from gettext import gettext as _

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import subprocess

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -1,4 +1,6 @@
 """Module for handling the GOG service"""
+from __future__ import annotations
+
 import json
 import os
 import time

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -1,4 +1,6 @@
 """Manage Humble Bundle libraries"""
+from __future__ import annotations
+
 import concurrent.futures
 import json
 import os

--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -1,6 +1,8 @@
 """Itch.io service.
 Not ready yet.
 """
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.services.base import OnlineService

--- a/lutris/services/lutris.py
+++ b/lutris/services/lutris.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import urllib.parse

--- a/lutris/services/mame.py
+++ b/lutris/services/mame.py
@@ -1,5 +1,7 @@
 """MAME service
 Not ready yet"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.services.base import BaseService

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -1,4 +1,6 @@
 """EA Origin service."""
+from __future__ import annotations
+
 import json
 import os
 import random

--- a/lutris/services/scummvm.py
+++ b/lutris/services/scummvm.py
@@ -1,4 +1,6 @@
 """Legacy ScummVM 'service', has to be ported to the current architecture"""
+from __future__ import annotations
+
 import os
 import re
 from configparser import ConfigParser

--- a/lutris/services/service_game.py
+++ b/lutris/services/service_game.py
@@ -1,4 +1,6 @@
 """Service game module"""
+from __future__ import annotations
+
 from lutris import settings
 from lutris.database import sql
 from lutris.database.services import ServiceGameCollection

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import random

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -1,4 +1,6 @@
 """Steam service"""
+from __future__ import annotations
+
 import json
 import os
 from collections import defaultdict

--- a/lutris/services/steamwindows.py
+++ b/lutris/services/steamwindows.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from gettext import gettext as _
 

--- a/lutris/services/tosec.py
+++ b/lutris/services/tosec.py
@@ -1,5 +1,7 @@
 """TOSEC service
 Not ready yet"""
+from __future__ import annotations
+
 from gettext import gettext as _
 
 from lutris.services.base import BaseService

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -1,4 +1,6 @@
 """Ubisoft Connect service"""
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -1,4 +1,6 @@
 """XDG applications service"""
+from __future__ import annotations
+
 import json
 import os
 import re

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -1,4 +1,6 @@
 """Internal settings."""
+from __future__ import annotations
+
 import os
 import sys
 from gettext import gettext as _

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -1,4 +1,6 @@
 """Check to run at program start"""
+from __future__ import annotations
+
 import os
 import sqlite3
 import time

--- a/lutris/style_manager.py
+++ b/lutris/style_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import enum
 
 from gi.repository import Gio, GLib, GObject, Gtk

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -1,4 +1,6 @@
 """Options list for system config."""
+from __future__ import annotations
+
 import glob
 import os
 import subprocess

--- a/lutris/util/__init__.py
+++ b/lutris/util/__init__.py
@@ -1,6 +1,9 @@
 """ Misc common functions """
 
 
+from __future__ import annotations
+
+
 def selective_merge(base_obj, delta_obj):
     """ used by write_json """
     if not isinstance(base_obj, dict):

--- a/lutris/util/amazon/protobuf_decoder.py
+++ b/lutris/util/amazon/protobuf_decoder.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import struct
 from io import BytesIO
 

--- a/lutris/util/amazon/sds_proto2.py
+++ b/lutris/util/amazon/sds_proto2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from lutris.util.amazon.protobuf_decoder import (
     Message, type_bool, type_bytes, type_enum, type_int64, type_string, type_uint32
 )

--- a/lutris/util/audio.py
+++ b/lutris/util/audio.py
@@ -1,5 +1,7 @@
 """Whatever it is we want to do with audio module"""
 # Standard Library
+from __future__ import annotations
+
 import time
 
 # Lutris Modules

--- a/lutris/util/cookies.py
+++ b/lutris/util/cookies.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import time
 from http.cookiejar import Cookie, MozillaCookieJar, _warn_unhandled_exception
 

--- a/lutris/util/datapath.py
+++ b/lutris/util/datapath.py
@@ -1,5 +1,7 @@
 """Utility to get the path of Lutris assets"""
 # Standard Library
+from __future__ import annotations
+
 import os
 import sys
 

--- a/lutris/util/discord/__init__.py
+++ b/lutris/util/discord/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __all__ = ['client']
 
 from .rpc import client

--- a/lutris/util/discord/base.py
+++ b/lutris/util/discord/base.py
@@ -2,6 +2,8 @@
 Discord Rich Presence Base Objects
 
 """
+from __future__ import annotations
+
 from abc import ABCMeta
 
 

--- a/lutris/util/discord/client.py
+++ b/lutris/util/discord/client.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pypresence import Presence
 
 from lutris.util.discord.base import DiscordRichPresenceBase

--- a/lutris/util/discord/rpc.py
+++ b/lutris/util/discord/rpc.py
@@ -6,6 +6,8 @@ Otherwise, it will provide a dummy client that does nothing
 """
 
 
+from __future__ import annotations
+
 from lutris.util.discord.base import DiscordRPCNull
 
 try:

--- a/lutris/util/dolphin.py
+++ b/lutris/util/dolphin.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 from mmap import mmap
 
 

--- a/lutris/util/dolphin/cache_reader.py
+++ b/lutris/util/dolphin/cache_reader.py
@@ -1,4 +1,6 @@
 """Reads the Dolphin game database, stored in a binary format"""
+from __future__ import annotations
+
 import os
 
 from lutris.util.log import logger

--- a/lutris/util/downloader.py
+++ b/lutris/util/downloader.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import time
 

--- a/lutris/util/egs/egs_launcher.py
+++ b/lutris/util/egs/egs_launcher.py
@@ -1,4 +1,6 @@
 """Interact with an exiting EGS install"""
+from __future__ import annotations
+
 import json
 import os
 

--- a/lutris/util/extract.py
+++ b/lutris/util/extract.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import gzip
 import os
 import shutil

--- a/lutris/util/fileio.py
+++ b/lutris/util/fileio.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import re
 from collections import OrderedDict
 from configparser import RawConfigParser

--- a/lutris/util/game_finder.py
+++ b/lutris/util/game_finder.py
@@ -1,4 +1,6 @@
 """Automatically detects game executables in a folder"""
+from __future__ import annotations
+
 import os
 
 from lutris.util import magic, system

--- a/lutris/util/gamecontrollerdb.py
+++ b/lutris/util/gamecontrollerdb.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import os
 
 # Lutris Modules

--- a/lutris/util/gog.py
+++ b/lutris/util/gog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 

--- a/lutris/util/graphics/displayconfig.py
+++ b/lutris/util/graphics/displayconfig.py
@@ -1,4 +1,6 @@
 """DBus backed display management for Mutter"""
+from __future__ import annotations
+
 from collections import namedtuple
 
 import dbus

--- a/lutris/util/graphics/drivers.py
+++ b/lutris/util/graphics/drivers.py
@@ -2,6 +2,8 @@
 
 Everything in this module should rely on /proc or /sys only, no executable calls
 """
+from __future__ import annotations
+
 # Standard Library
 import os
 import re

--- a/lutris/util/graphics/glxinfo.py
+++ b/lutris/util/graphics/glxinfo.py
@@ -1,4 +1,6 @@
 """Parser for the glxinfo utility"""
+from __future__ import annotations
+
 from lutris.util.log import logger
 from lutris.util.system import read_process_output
 

--- a/lutris/util/graphics/vkquery.py
+++ b/lutris/util/graphics/vkquery.py
@@ -2,6 +2,8 @@
 # Vulkan detection by Patryk Obara (@dreamer)
 
 """Query Vulkan capabilities"""
+from __future__ import annotations
+
 # Standard Library
 from ctypes import CDLL, POINTER, Structure, byref, c_char_p, c_int32, c_uint32, c_void_p, pointer
 

--- a/lutris/util/graphics/xephyr.py
+++ b/lutris/util/graphics/xephyr.py
@@ -1,6 +1,9 @@
 """Xephyr utilities"""
 
 
+from __future__ import annotations
+
+
 def get_xephyr_command(display, config):
     """Return a configured Xephyr command"""
     xephyr_depth = "8" if config.get("xephyr") == "8bpp" else "16"

--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -1,4 +1,6 @@
 """XrandR based display management"""
+from __future__ import annotations
+
 import re
 import subprocess
 from collections import namedtuple

--- a/lutris/util/http.py
+++ b/lutris/util/http.py
@@ -1,4 +1,6 @@
 """HTTP utilities"""
+from __future__ import annotations
+
 import json
 import os
 import socket

--- a/lutris/util/i18n.py
+++ b/lutris/util/i18n.py
@@ -1,4 +1,6 @@
 """Language and translation utilities"""
+from __future__ import annotations
+
 import locale
 
 from lutris.util.log import logger

--- a/lutris/util/jobs.py
+++ b/lutris/util/jobs.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import sys
 import threading
 import traceback

--- a/lutris/util/joypad.py
+++ b/lutris/util/joypad.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import binascii
 import struct
 

--- a/lutris/util/libretro.py
+++ b/lutris/util/libretro.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.util.log import logger

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -1,4 +1,6 @@
 """Linux specific platform code"""
+from __future__ import annotations
+
 import json
 import os
 import platform

--- a/lutris/util/log.py
+++ b/lutris/util/log.py
@@ -1,4 +1,6 @@
 """Utility module for creating an application wide logger."""
+from __future__ import annotations
+
 import logging
 import logging.handlers
 import os

--- a/lutris/util/magic.py
+++ b/lutris/util/magic.py
@@ -16,6 +16,8 @@ Usage:
 
 """
 
+from __future__ import annotations
+
 import ctypes
 import ctypes.util
 import glob

--- a/lutris/util/mame/database.py
+++ b/lutris/util/mame/database.py
@@ -1,5 +1,7 @@
 """Utility functions for MAME"""
 # Standard Library
+from __future__ import annotations
+
 import json
 import os
 from xml.etree import ElementTree

--- a/lutris/util/mame/ini.py
+++ b/lutris/util/mame/ini.py
@@ -1,5 +1,7 @@
 """Manipulate MAME ini files"""
 # Lutris Modules
+from __future__ import annotations
+
 from lutris.util.system import path_exists
 
 

--- a/lutris/util/nvidia.py
+++ b/lutris/util/nvidia.py
@@ -1,5 +1,7 @@
 """Nvidia library detection from Proton"""
 
+from __future__ import annotations
+
 import os
 from ctypes import CDLL, POINTER, Structure, addressof, c_char_p, c_int, c_void_p, cast
 

--- a/lutris/util/process.py
+++ b/lutris/util/process.py
@@ -1,4 +1,6 @@
 """Class to manipulate a process"""
+from __future__ import annotations
+
 import os
 
 from lutris.util.log import logger

--- a/lutris/util/process_watcher.py
+++ b/lutris/util/process_watcher.py
@@ -1,4 +1,6 @@
 """Process management"""
+from __future__ import annotations
+
 import os
 import shlex
 import sys

--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -1,4 +1,6 @@
 """Utility module to handle media resources"""
+from __future__ import annotations
+
 import os
 
 from lutris import settings

--- a/lutris/util/retroarch/core_config.py
+++ b/lutris/util/retroarch/core_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 RECOMMENDED_CORES = {
     "mesen": {
         "platforms": ["nes"],

--- a/lutris/util/savesync.py
+++ b/lutris/util/savesync.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from time import time

--- a/lutris/util/settings.py
+++ b/lutris/util/settings.py
@@ -1,4 +1,6 @@
 # Standard Library
+from __future__ import annotations
+
 import configparser
 import os
 

--- a/lutris/util/shell.py
+++ b/lutris/util/shell.py
@@ -1,4 +1,6 @@
 """Controls execution of programs in separate shells"""
+from __future__ import annotations
+
 import os
 from textwrap import dedent
 

--- a/lutris/util/steam/appmanifest.py
+++ b/lutris/util/steam/appmanifest.py
@@ -1,4 +1,6 @@
 """Steam appmanifest file handling"""
+from __future__ import annotations
+
 import os
 import re
 

--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -1,4 +1,6 @@
 """Handle Steam configuration"""
+from __future__ import annotations
+
 import glob
 import os
 from collections import OrderedDict

--- a/lutris/util/steam/log.py
+++ b/lutris/util/steam/log.py
@@ -1,5 +1,7 @@
 """Steam log handling"""
 # Standard Library
+from __future__ import annotations
+
 import os
 import time
 

--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -1,4 +1,6 @@
 """Export lutris games to steam shortcuts"""
+from __future__ import annotations
+
 import binascii
 import os
 import re

--- a/lutris/util/steam/vdf/__init__.py
+++ b/lutris/util/steam/vdf/__init__.py
@@ -5,8 +5,9 @@ https://github.com/ValvePython/vdf
 
 MIT License
 """
-# pylint: disable=raise-missing-from
+from __future__ import annotations
 
+# pylint: disable=raise-missing-from
 __version__ = "3.2"
 __author__ = "Rossen Georgiev"
 

--- a/lutris/util/steam/vdf/vdict.py
+++ b/lutris/util/steam/vdf/vdict.py
@@ -1,4 +1,6 @@
 # pylint: disable=no-member
+from __future__ import annotations
+
 from collections import Counter
 
 _iter_values = 'values'

--- a/lutris/util/steam/vdfutils.py
+++ b/lutris/util/steam/vdfutils.py
@@ -1,5 +1,7 @@
 """Read and write VDF files"""
 # Lutris Modules
+from __future__ import annotations
+
 from lutris.util.log import logger
 
 

--- a/lutris/util/steam/watcher.py
+++ b/lutris/util/steam/watcher.py
@@ -1,6 +1,8 @@
 """Steam game library watcher"""
 # Third Party Libraries
 # pylint: disable=too-few-public-methods
+from __future__ import annotations
+
 from gi.repository import Gio, GLib
 
 # Lutris Modules

--- a/lutris/util/strings.py
+++ b/lutris/util/strings.py
@@ -1,5 +1,7 @@
 """String utilities"""
 # Standard Library
+from __future__ import annotations
+
 import math
 import re
 import shlex

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -1,4 +1,6 @@
 """System utilities"""
+from __future__ import annotations
+
 import hashlib
 import inspect
 import os

--- a/lutris/util/test_config.py
+++ b/lutris/util/test_config.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 import gi

--- a/lutris/util/timer.py
+++ b/lutris/util/timer.py
@@ -1,5 +1,7 @@
 """Timer module"""
 # Standard Library
+from __future__ import annotations
+
 import datetime
 
 

--- a/lutris/util/ubisoft/client.py
+++ b/lutris/util/ubisoft/client.py
@@ -1,6 +1,8 @@
 # Ubisoft Connect client adapted from the Galaxy integration by Rasmus Luund.
 # https://github.com/FriendsOfGalaxy/galaxy-integration-uplay
 
+from __future__ import annotations
+
 import json
 import time
 from datetime import datetime

--- a/lutris/util/ubisoft/consts.py
+++ b/lutris/util/ubisoft/consts.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 UBISOFT_REGISTRY = "SOFTWARE\\Ubisoft"
 STEAM_REGISTRY = "Software\\Valve\\Steam"
 UBISOFT_REGISTRY_LAUNCHER = "SOFTWARE\\Ubisoft\\Launcher"

--- a/lutris/util/ubisoft/helpers.py
+++ b/lutris/util/ubisoft/helpers.py
@@ -1,4 +1,6 @@
 
+from __future__ import annotations
+
 import os
 
 from lutris.util.log import logger

--- a/lutris/util/ubisoft/parser.py
+++ b/lutris/util/ubisoft/parser.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging as log
 import math
 

--- a/lutris/util/update_cache.py
+++ b/lutris/util/update_cache.py
@@ -1,4 +1,6 @@
 """Manage a cache file of execution times for updates"""
+from __future__ import annotations
+
 import json
 import os
 from datetime import datetime

--- a/lutris/util/urlhandler.py
+++ b/lutris/util/urlhandler.py
@@ -1,6 +1,8 @@
 """Unused handler registration but since someone reports problems with URL
 integration once in a while, it could prove itself useful."""
 # Standard Library
+from __future__ import annotations
+
 import os
 import sys
 

--- a/lutris/util/wine/cabinstall.py
+++ b/lutris/util/wine/cabinstall.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import re
 import shutil

--- a/lutris/util/wine/d3d_extras.py
+++ b/lutris/util/wine/d3d_extras.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.settings import RUNTIME_DIR

--- a/lutris/util/wine/dgvoodoo2.py
+++ b/lutris/util/wine/dgvoodoo2.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.settings import RUNTIME_DIR

--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -1,4 +1,6 @@
 """Injects sets of DLLs into a prefix"""
+from __future__ import annotations
+
 import json
 import os
 import shutil

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -1,4 +1,6 @@
 """DXVK helper module"""
+from __future__ import annotations
+
 import os
 
 from lutris.settings import RUNTIME_DIR

--- a/lutris/util/wine/dxvk_nvapi.py
+++ b/lutris/util/wine/dxvk_nvapi.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.settings import RUNTIME_DIR

--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -49,6 +49,8 @@ Linux release.
 
 This module's code is based on https://gist.github.com/openglfreak/715d5ab5902497378f1996061dbbf8ec
 """
+from __future__ import annotations
+
 import ctypes
 import errno
 import functools

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -1,4 +1,6 @@
 """Wine prefix management"""
+from __future__ import annotations
+
 import os
 
 from lutris.util import joypad, system

--- a/lutris/util/wine/registry.py
+++ b/lutris/util/wine/registry.py
@@ -1,4 +1,6 @@
 """Manipulate Wine registry files"""
+from __future__ import annotations
+
 import os
 import re
 from collections import OrderedDict

--- a/lutris/util/wine/vkd3d.py
+++ b/lutris/util/wine/vkd3d.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 
 from lutris.settings import RUNTIME_DIR

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -1,4 +1,6 @@
 """Utilities for manipulating Wine"""
+from __future__ import annotations
+
 import os
 from collections import OrderedDict
 from functools import lru_cache

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -1,4 +1,6 @@
 """XDG shortcuts handling"""
+from __future__ import annotations
+
 import os
 import shutil
 import stat

--- a/lutris/util/yaml.py
+++ b/lutris/util/yaml.py
@@ -1,6 +1,8 @@
 """Utility functions for YAML handling"""
 # Third Party Libraries
 # pylint: disable=no-member
+from __future__ import annotations
+
 import yaml
 
 # Lutris Modules


### PR DESCRIPTION
I noticed a fair bit of issues regarding python typing compatibility, and some commits removing typing.

Typing is great! You all should be able to type to your heart's content without worrying about compatibility.

This PR does that.

should supersede: https://github.com/lutris/lutris/pull/4498 and https://github.com/lutris/lutris/pull/4519
and allow you to revert: https://github.com/lutris/lutris/commit/cfe45f806d4f3d6ebdf7999cfe04ca527430a535

Note: not python 3.6 compatible.