### PR TITLE
Avoid excessive LutrisWindow updates when deduplicating Steam games

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -257,11 +257,13 @@ class Game(GObject.Object):
             return
         self.emit("game-removed")
 
-    def delete(self):
+    def delete(self, no_signal=False):
         """Completely remove a game from the library"""
         if self.is_installed:
             raise RuntimeError("Uninstall the game before deleting")
         games_db.delete_game(self.id)
+        if no_signal:
+            return
         self.emit("game-removed")
 
     def set_platform_from_runner(self):

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -197,7 +197,7 @@ class SteamService(BaseService):
                 steam_game = Game(game_id)
                 if not steam_game.playtime:
                     steam_game.remove(no_signal=True)
-                    steam_game.delete()
+                    steam_game.delete(no_signal=True)
                     stats["deduped"] += 1
         logger.debug("%s Steam games deduplicated", stats["deduped"])
 


### PR DESCRIPTION
While investigation a <span class="title-ref">segmentation fault during Steam game update</span>, I came across an excessive amount of window updates during deduplication.

In `lutris/lutris/gui/lutriswindow.py`
(`/usr/lib/python3/dist-packages/lutris/gui/lutriswindow.py`), in method
*LutrisWindow.update\_store*

``` py
def update_store(self, *_args, **_kwargs):
    self.game_store.store.clear()
```

add a line with debugging output

``` py
def update_store(self, *_args, **_kwargs):
    logger.debug("running update_store")
    self.game_store.store.clear()
```

The log for a Steam update run with the above modification shows, that *LutrisWindow.update\_store* is called 20 times in rapid succession during the interval of 5.151 seconds from 02:31:16,481 to 02:31:21,632, roughly every 257 ms.

``` text
DEBUG    2022-09-27 02:31:16,061 [steam.add_installed_games:170]:271 Steam games detected and installed
DEBUG    2022-09-27 02:31:16,061 [steam.add_installed_games:171]:Games found in: /home/ws/.local/share/Steam/steamapps
WARNING  2022-09-27 02:31:16,120 [steam.add_installed_games:180]:Steam game %s has no AppID
WARNING  2022-09-27 02:31:16,189 [steam.add_installed_games:180]:Steam game %s has no AppID
DEBUG    2022-09-27 02:31:16,265 [steam.add_installed_games:185]:0 Steam games removed
DEBUG    2022-09-27 02:31:16,372 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-1017900-1664238673.yml
DEBUG    2022-09-27 02:31:16,481 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:16,608 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-813780-1664238675.yml
DEBUG    2022-09-27 02:31:16,790 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:16,897 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-346110-1664238675.yml
DEBUG    2022-09-27 02:31:17,043 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:17,208 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-25800-1664238673.yml
DEBUG    2022-09-27 02:31:17,351 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:17,546 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-398170-1664238675.yml
DEBUG    2022-09-27 02:31:17,676 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:17,805 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-288470-1664238674.yml
DEBUG    2022-09-27 02:31:17,964 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:18,125 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-214150-1664238674.yml
DEBUG    2022-09-27 02:31:18,372 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:18,479 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-4700-1664238675.yml
DEBUG    2022-09-27 02:31:18,596 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:18,729 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-1538570-1664238674.yml
DEBUG    2022-09-27 02:31:18,829 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:19,034 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-271260-1664238675.yml
DEBUG    2022-09-27 02:31:19,405 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:19,566 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-281990-1664238675.yml
DEBUG    2022-09-27 02:31:19,666 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:19,757 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-464920-1664238674.yml
DEBUG    2022-09-27 02:31:19,874 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:20,032 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-39520-1664238674.yml
DEBUG    2022-09-27 02:31:20,208 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:20,395 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-224960-1664238675.yml
DEBUG    2022-09-27 02:31:20,533 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:20,649 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-362960-1664238675.yml
DEBUG    2022-09-27 02:31:20,754 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:20,865 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-13210-1664238674.yml
DEBUG    2022-09-27 02:31:20,954 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:21,098 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-2850-1664238674.yml
DEBUG    2022-09-27 02:31:21,182 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:21,270 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-392160-1664238675.yml
DEBUG    2022-09-27 02:31:21,387 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:21,545 [config.remove:213]:Removed config /home/ws/.config/lutris/games/steam-268500-1664238675.yml
DEBUG    2022-09-27 02:31:21,632 [lutriswindow.update_store:443]:running update_store
DEBUG    2022-09-27 02:31:21,632 [steam.add_installed_games:202]:19 Steam games deduplicated
DEBUG    2022-09-27 02:31:21,632 [lutriswindow.update_store:443]:running update_store
```

To see the reason for the rapid succession, a traceback was added for each call of *LutrisWindow.update\_store*:

``` py
def update_store(self, *_args, **_kwargs):
    logger.debug("running update_store")
    import traceback
    traceback.print_stack()
    return False
    self.game_store.store.clear()
```

The output in logfile [excessive-updates-trace.log](https://github.com/lutris/lutris/files/9651389/excessive-updates-trace.log) shows that all calls except the last one originate from

``` text
File "/srv/install/linux/lutris/lutris/lutris/services/steam.py", line 200, in add_installed_games
```

This is the line `steam_game.delete()` in method *SteamService.add\_installed\_games*, where the Steam games are <span class="title-ref">deduped</span>

``` py
def add_installed_games(self):
    # [...]
    for appid in db_appids:
        game_ids = db_appids[appid]
        if len(game_ids) == 1:
            continue
        for game_id in game_ids:
            steam_game = Game(game_id)
            if not steam_game.playtime:
                steam_game.remove(no_signal=True)
                steam_game.delete()
                stats["deduped"] += 1
    logger.debug("%s Steam games deduplicated", stats["deduped"])
```

The last call is triggered by `self.emit("service-games-loaded")` in method *SteamService.reload*

``` py
def reload(self):
    """Refresh the service's games"""
    self.emit("service-games-load")
    try:
        self.wipe_game_cache()
        self.load()
        self.load_icons()
        self.add_installed_games()
    finally:
        self.emit("service-games-loaded")
```

Since that last call is unconditional, there is no negative impact, when the single deletions do not trigger the update. This requires an API modification for *Game.delete*, modeled after method *Game.remove*:

``` py
def delete(self, no_signal=False):
    """Completely remove a game from the library"""
    if self.is_installed:
        raise RuntimeError("Uninstall the game before deleting")
    games_db.delete_game(self.id)
    if no_signal:
        return
    self.emit("game-removed")
```
Log files:

- [excessive-updates.log](https://github.com/lutris/lutris/files/9651390/excessive-updates.log)
- [excessive-updates-trace.log](https://github.com/lutris/lutris/files/9651389/excessive-updates-trace.log)
