### PR TITLE
Prevent segmentation fault when updating Steam games

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -440,7 +440,10 @@ class LutrisWindow(Gtk.ApplicationWindow):  # pylint: disable=too-many-public-me
                 self.show_label(_("No games found"))
 
     def update_store(self, *_args, **_kwargs):
-        self.game_store.store.clear()
+        count = self.game_store.store.iter_n_children()
+        if count > 0:
+            self.redraw_view()
+            return False
         self.hide_overlay()
         games = self.get_games_from_filters()
         logger.debug("Showing %d games", len(games))


### PR DESCRIPTION
During a Steam update, GTK fails with memory corruption and segfault (339 Steam games).

This problem was already reported and analyzed in <https://github.com/lutris/lutris/issues/3731#issuecomment-1002958248> (2). It is also reported in <https://github.com/lutris/lutris/issues/3959> and <https://github.com/lutris/lutris/issues/4512>.

In my case this also happens sporadically with approximately 105 GOG games.

In order to be as helpful as possible, some logfiles from different versions are attached to show that the problem does not depend on Linux distribution or Python version.

| Lutris Version       | Python Version | Ubuntu Version |
|----------------------|----------------|----------------|
| lutris-master-0.5.11 | python3.10     | ubuntu-22.04   |
| lutris-master-0.5.11 | python3.6.9    | ubuntu-18.04   |
| lutris-ppa-0.5.10.1  | python3.6.9    | ubuntu-18.04   |

- [lutris-master-0.5.11-steam-update-python3.6.9-ubuntu-18.04.log](https://github.com/lutris/lutris/files/9651552/lutris-master-0.5.11-steam-update-python3.6.9-ubuntu-18.04.log)
- [lutris-ppa-0.5.10.1-steam-update-python3.6.9-ubuntu-18.04.log](https://github.com/lutris/lutris/files/9651553/lutris-ppa-0.5.10.1-steam-update-python3.6.9-ubuntu-18.04.log)
- [lutris-master-0.5.11-steam-update-python3.10-ubuntu-22.04.log](https://github.com/lutris/lutris/files/9651554/lutris-master-0.5.11-steam-update-python3.10-ubuntu-22.04.log)

This pull request is merely an illustration of the observed behavior and an extremely simple remedy. It is not intended to be merged into the master branch unmodified. However, together with <https://github.com/lutris/lutris/pull/4527>, advanced users can easily create a temporary fix until a solution becomes available.

The segmentation fault happens in *LutrisWindow.update\_store* during the call to

``` py
self.game_store.store.clear()
```

since the "clear" debug output appears in the log file, while "hide\_overlay" from the modified method *LutrisWindow.update\_store* is never shown

``` py
def update_store(self, *_args, **_kwargs):
    logger.debug("clear")
    self.game_store.store.clear()
    logger.debug("hide_overlay")
    self.hide_overlay()
    games = self.get_games_from_filters()
    logger.debug("Showing %d games", len(games))
    self.view.service = self.service.id if self.service else None
    GLib.idle_add(self.update_revealer)
    for game in games:
        self.game_store.add_game(game)
    if not games:
        self.show_empty_label()
    self.search_timer_id = None
    return False
```

Modifying *SteamService.reload* by adding

``` py
self.emit("service-games-loaded")
return
```

makes sure, that nothing actually happens except for a call to *LutrisWindow.update\_store*

``` py
def reload(self):
    """Refresh the service's games"""
    self.emit("service-games-load")
    self.emit("service-games-loaded")
    return
    try:
        self.wipe_game_cache()
        self.load()
        self.load_icons()
        self.add_installed_games()
    finally:
        self.emit("service-games-loaded")
```

This already triggers the segmentation fault, so it is not necessary to look for a Steam specific error.

Playing with the number of games actually displayed

``` py
_limit = 50
#_limit = 0
for _i, game in enumerate(games):
    if _limit and  _i >= _limit:
        break
```

in *LutrisWindow.update\_store*

``` py
def update_store(self, *_args, **_kwargs):
    logger.debug("clear")
    self.game_store.store.clear()
    logger.debug("hide_overlay")
    self.hide_overlay()
    games = self.get_games_from_filters()
    logger.debug("Showing %d games", len(games))
    self.view.service = self.service.id if self.service else None
    GLib.idle_add(self.update_revealer)
    _limit = 50
    #_limit = 0
    for _i, game in enumerate(games):
        if _limit and  _i >= _limit:
            break
        self.game_store.add_game(game)
    if not games:
        self.show_empty_label()
    self.search_timer_id = None
    return False
```

shows that the segmentation fault already happens with approximately 50 games displayed.

Eliminating the call to *self.game\_store.store.clear*

``` diff
-        self.game_store.store.clear()
+        count = self.game_store.store.iter_n_children()
+        if count > 0:
+            self.redraw_view()
```

prevents the segementation faults reliably only if <https://github.com/lutris/lutris/pull/4527> is also applied. Otherwise, the segementation fault is only delayed for about 10 successive updates.
