### PR TITLE
Pass the parent dialog to Game.launch()

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -613,7 +613,7 @@ class Application(Gtk.Application):
 
     @watch_errors(error_result=True)
     def on_game_launch(self, game):
-        game.launch()
+        game.launch(parent=self.window)
         return True  # Return True to continue handling the emission hook
 
     @watch_errors(error_result=True)

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -301,13 +301,14 @@ class Runner:  # pylint: disable=too-many-public-methods
             return False
         return True
 
-    def install_dialog(self):
+    def install_dialog(self, parent=None):
         """Ask the user if they want to install the runner.
 
         Return success of runner installation.
         """
         dialog = dialogs.QuestionDialog(
             {
+                "parent": parent,
                 "question": _("The required runner is not installed.\n"
                               "Do you wish to install it now?"),
                 "title": _("Required runner unavailable"),


### PR DESCRIPTION
So, I don't really like having UI code in Game, but I find that Lutris deliberately pops GTK dialogs from the command line to ask the user questions.

I could try to build a complex framework to move the dialogs that do this out of Game, but if Lutris is meant to pop dialogs from the command line, its hard to justify doing this.

Instead, this PR accepts a parent window as an argument to Game.launch() which allows those dialogs to be placed correctly. It must be passed through to Game.configure_game() via a closure, which is a little tricky but seems like the least bad choice here.

I still mean to minimize the error and warning dialogs in Game, but this PR will allow the question dialogs to work better.