### PR TITLE
PyGIWarning webconnect_dialog.py

### DIFF
--- a/lutris/gui/dialogs/webconnect_dialog.py
+++ b/lutris/gui/dialogs/webconnect_dialog.py
@@ -1,12 +1,11 @@
 """isort:skip_file"""
 from lutris.gui.dialogs import ModalDialog
-from gi.repository import WebKit2
 import os
 from gettext import gettext as _
 
 import gi
 gi.require_version("WebKit2", "4.0")
-
+from gi.repository import WebKit2
 
 DEFAULT_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64; rv:100.0) Gecko/20100101 Firefox/100.0"
 


### PR DESCRIPTION
PyGIWarning: WebKit2 was imported without specifying a version first. Use gi.require_version before import to ensure that the right version gets loaded.