### PR TITLE
Attack of the Header Bars!

### DIFF
--- a/lutris/gui/config/add_game.py
+++ b/lutris/gui/config/add_game.py
@@ -26,5 +26,4 @@ class AddGameDialog(GameDialogCommon):
         self.build_tabs("game")
         self.build_action_area(self.on_save)
         self.name_entry.grab_focus()
-        self.connect("delete-event", self.on_cancel_clicked)
         self.show_all()

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -329,29 +329,38 @@ class GameDialogCommon(ModelessDialog):
         save_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
 
         # Advanced settings toggle
-        checkbox = Gtk.ToggleButton() if use_header_bar else Gtk.CheckButton()
-        if settings.read_setting("show_advanced_options") == "True":
-            checkbox.set_active(True)
-        checkbox.connect("toggled", self.on_show_advanced_options_toggled)
 
         if self.props.use_header_bar:
-            options_icon = Gtk.Image.new_from_icon_name("view-reveal-symbolic", Gtk.IconSize.MENU)
-            checkbox.set_image(options_icon)
-            checkbox.set_tooltip_text(_("Show advanced options"))
+            switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=5)
+            switch_box.set_tooltip_text(_("Show advanced options"))
 
+            switch_label = Gtk.Label(_("Advanced"))
+            switch = Gtk.Switch()
+            switch.set_state(settings.read_setting("show_advanced_options") == "True")
+            switch.connect("state_set", lambda _w, s:
+                           self.on_show_advanced_options_toggled(bool(s)))
+
+            switch_box.pack_start(switch_label, False, False, 0)
+            switch_box.pack_end(switch, False, False, 0)
             header_bar = self.get_header_bar()
-            header_bar.pack_end(checkbox)
+            header_bar.pack_end(switch_box)
+
+            self.advanced_toggle = switch
         else:
-            checkbox.set_label(_("Show advanced options"))
+            checkbox = Gtk.CheckButton(Label=_("Show advanced options"))
+            checkbox.set_active(settings.read_setting("show_advanced_options") == "True")
+            checkbox.connect("toggled", lambda *x:
+                             self.on_show_advanced_options_toggled(bool(checkbox.get_active())))
             checkbox.set_halign(Gtk.Align.START)
             self.action_area.pack_start(checkbox, True, True, 0)
             self.action_area.set_child_secondary(checkbox, True)
 
-    def on_show_advanced_options_toggled(self, checkbox):
-        value = bool(checkbox.get_active())
-        settings.write_setting("show_advanced_options", value)
+            self.advanced_toggle = checkbox
 
-        self._set_advanced_options_visible(value)
+    def on_show_advanced_options_toggled(self, is_active):
+        settings.write_setting("show_advanced_options", is_active)
+
+        self._set_advanced_options_visible(is_active)
 
     def _set_advanced_options_visible(self, value):
         """Change visibility of advanced options across all config tabs."""

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -312,29 +312,34 @@ class GameDialogCommon(ModelessDialog):
         self.action_area.set_layout(Gtk.ButtonBoxStyle.END)
         self.action_area.set_border_width(10)
 
-        # Advanced settings checkbox
-        checkbox = Gtk.CheckButton(label=_("Show advanced options"))
-        if settings.read_setting("show_advanced_options") == "True":
-            checkbox.set_active(True)
-        checkbox.connect("toggled", self.on_show_advanced_options_toggled)
-        checkbox.set_halign(Gtk.Align.START)
-
-        if self.props.use_header_bar:
-            checkbox.set_border_width(5)
-            self.vbox.pack_end(checkbox, False, False, 5)
-        else:
-            self.action_area.pack_start(checkbox, True, True, 0)
-            self.action_area.set_child_secondary(checkbox, True)
+        use_header_bar = self.props.use_header_bar
 
         # Buttons
         cancel_button = self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         cancel_button.set_valign(Gtk.Align.CENTER)
-        #cancel_button.set_halign(Gtk.Align.END)
 
         save_button = self.add_button(_("Save"), Gtk.ResponseType.OK)
         save_button.set_valign(Gtk.Align.CENTER)
-        #save_button.set_halign(Gtk.Align.END)
         save_button.connect("clicked", button_callback)
+
+        # Advanced settings toggle
+        checkbox = Gtk.ToggleButton() if use_header_bar else Gtk.CheckButton()
+        if settings.read_setting("show_advanced_options") == "True":
+            checkbox.set_active(True)
+        checkbox.connect("toggled", self.on_show_advanced_options_toggled)
+
+        if self.props.use_header_bar:
+            options_icon = Gtk.Image.new_from_icon_name("view-reveal-symbolic", Gtk.IconSize.MENU)
+            checkbox.set_image(options_icon)
+            checkbox.set_tooltip_text(_("Show advanced options"))
+
+            header_bar = self.get_header_bar()
+            header_bar.pack_end(checkbox)
+        else:
+            checkbox.set_label(_("Show advanced options"))
+            checkbox.set_halign(Gtk.Align.START)
+            self.action_area.pack_start(checkbox, True, True, 0)
+            self.action_area.set_child_secondary(checkbox, True)
 
     def on_show_advanced_options_toggled(self, checkbox):
         value = bool(checkbox.get_active())
@@ -410,7 +415,7 @@ class GameDialogCommon(ModelessDialog):
         self.show_all()
 
     def on_response(self, _widget, response):
-        if response == Gtk.ResponseType.CANCEL or response == Gtk.ResponseType.DELETE_EVENT:
+        if response in (Gtk.ResponseType.CANCEL, response == Gtk.ResponseType.DELETE_EVENT):
             # Reload the config to clean out any changes we may have made
             if self.game:
                 self.game.load_config()

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -52,6 +52,9 @@ class GameDialogCommon(ModelessDialog):
         self.lutris_config = None
         self.service_medias = {"icon": LutrisIcon(), "banner": LutrisBanner(), "coverart_big": LutrisCoverart()}
 
+        self.accelerators = Gtk.AccelGroup()
+        self.add_accel_group(self.accelerators)
+
         self.connect("response", self.on_response)
 
     @staticmethod
@@ -318,9 +321,12 @@ class GameDialogCommon(ModelessDialog):
         cancel_button = self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         cancel_button.set_valign(Gtk.Align.CENTER)
 
-        save_button = self.add_styled_button(_("Save"), Gtk.ResponseType.OK, css_class="suggested-action")
+        save_button = self.add_styled_button(_("Save"), Gtk.ResponseType.NONE, css_class="suggested-action")
         save_button.set_valign(Gtk.Align.CENTER)
         save_button.connect("clicked", button_callback)
+
+        key, mod = Gtk.accelerator_parse("<Control>s")
+        save_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
 
         # Advanced settings toggle
         checkbox = Gtk.ToggleButton() if use_header_bar else Gtk.CheckButton()
@@ -419,7 +425,8 @@ class GameDialogCommon(ModelessDialog):
             # Reload the config to clean out any changes we may have made
             if self.game:
                 self.game.load_config()
-        self.destroy()
+        if response != Gtk.ResponseType.NONE:
+            self.destroy()
 
     def is_valid(self):
         if not self.runner_name:

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -318,7 +318,7 @@ class GameDialogCommon(ModelessDialog):
         cancel_button = self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         cancel_button.set_valign(Gtk.Align.CENTER)
 
-        save_button = self.add_button(_("Save"), Gtk.ResponseType.OK)
+        save_button = self.add_styled_button(_("Save"), Gtk.ResponseType.OK, css_class="suggested-action")
         save_button.set_valign(Gtk.Align.CENTER)
         save_button.connect("clicked", button_callback)
 

--- a/lutris/gui/config/edit_game.py
+++ b/lutris/gui/config/edit_game.py
@@ -15,5 +15,4 @@ class EditGameConfigDialog(GameDialogCommon):
         self.build_notebook()
         self.build_tabs("game")
         self.build_action_area(self.on_save)
-        self.connect("delete-event", self.on_cancel_clicked)
         self.show_all()

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -15,7 +15,7 @@ from lutris.gui.config.sysinfo_box import SysInfoBox
 # pylint: disable=no-member
 class PreferencesDialog(GameDialogCommon):
     def __init__(self, parent=None):
-        super().__init__(_("Lutris settings"), parent=parent)
+        super().__init__(_("Lutris settings"), parent=parent, use_header_bar=False)
         self.set_border_width(0)
         self.set_default_size(1010, 600)
         self.lutris_config = LutrisConfig()


### PR DESCRIPTION
I love GNOME header bars. Don't judge me.

But if you do too, here's a PR to put a header bar on the game configuration dialog, which is just crying out for one.
![image](https://user-images.githubusercontent.com/6507403/195206539-6252d201-b348-45dd-b014-a8a500d98247.png)
This does not apply to the preferences dialog; the way it hides and shows the action area does not work with a header bar, so It'll have to use the action area unless we want to redesign it.

The "advanced" option now appears in the header bar too as a switch:
![image](https://user-images.githubusercontent.com/6507403/195206753-82279d2c-67b2-4f75-ab5c-18b5662ab30f.png)
It's only visible when an options tab is current. The shorter label is not as clear, but having it appear only on the tabs it applies on will help, and there's a tool-tip.

The save button is blue, but enter won't activate it. 'Ctrl-s' will, however. I figure that is safer.