### PR TITLE
Use the same app ID and genome ID as the web app (fixes #4534)

### DIFF
--- a/lutris/util/ubisoft/client.py
+++ b/lutris/util/ubisoft/client.py
@@ -9,7 +9,7 @@ from gettext import gettext as _
 import requests
 
 from lutris.util.log import logger
-from lutris.util.ubisoft.consts import CHROME_USERAGENT, CLUB_APPID, UBISOFT_APPID
+from lutris.util.ubisoft.consts import CHROME_USERAGENT, CLUB_APPID
 
 
 def parse_date(date_str):
@@ -105,7 +105,7 @@ class UbisoftConnectClient():
     def _do_options_request(self):
         self._do_request('options', "https://public-ubiservices.ubi.com/v3/profiles/sessions", headers={
             "Origin": "https://connect.ubisoft.com",
-            "Referer": f"https://connect.ubisoft.com/login?appId={UBISOFT_APPID}",
+            "Referer": f"https://connect.ubisoft.com/",
             "User-Agent": CHROME_USERAGENT,
         })
 

--- a/lutris/util/ubisoft/consts.py
+++ b/lutris/util/ubisoft/consts.py
@@ -12,11 +12,10 @@ CHROME_USERAGENT = (
     "Chrome/72.0.3626.121 Safari/537.36"
 )
 
-CLUB_GENOME_ID = "fbd6791c-a6c6-4206-a75e-77234080b87b"
-UBISOFT_APPID = "b8fde481-327d-4031-85ce-7c10a202a700"
+CLUB_GENOME_ID = "85c31714-0941-4876-a18d-2c7e9dce8d40"
 CLUB_APPID = "314d4fef-e568-454a-ae06-43e3bece12a6"
 
 LOGIN_URL = (
-    f"https://connect.ubisoft.com/login?appId={UBISOFT_APPID}&genomeId={CLUB_GENOME_ID}"
+    f"https://connect.ubisoft.com/login?appId={CLUB_APPID}&genomeId={CLUB_GENOME_ID}"
     "&lang=en-US&nextUrl=https:%2F%2Fconnect.ubisoft.com%2Fready"
 )


### PR DESCRIPTION
This fixes #4534 by using the same app ID and genome ID as Ubisoft's web app / login page.