### PR TITLE
Inform users of deb-get installation option

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,6 +27,26 @@ can use the following command:
 
 `gdb -ex r --args "/usr/bin/python3" "./bin/lutris"`
 
+Debian and Ubuntu based distros
+===============================
+
+For users of Debian and Ubuntu based distributions, you can also install and
+update the `.deb` packages we publish in our GitHub releases page using [deb-get](https://github.com/wimpysworld/deb-get).
+
+First install `deb-get` using these commands in a terminal::
+
+    sudo apt install curl
+    curl -sL https://raw.githubusercontent.com/wimpysworld/deb-get/main/deb-get | sudo -E bash -s install deb-get
+
+Then install Lutris using the following command in terminal::
+
+    deb-get install lutris
+
+Once Lutris is installed it can be kept upto date using::
+
+    deb-get update
+    deb-get upgrade
+
 Installer scripts
 =================
 


### PR DESCRIPTION
wimpysworld/deb-get#579

This PR is part of a Hacktoberfest 2022 mini-event at the [deb-get](https://github.com/wimpysworld/deb-get/)  project to inform users of Lutris that for debian/ubuntu distros there is an easy way to install and update this popular tool.
With `deb-get` installed former user of the PPA can easily adopt a similar routine update practice tracking the latest github release of your project. 

A pending PR there will shortly move the source from the deprecated unsupported PPA to track the github releases instead. This will potentially replace the simple and reliable up-to-date experience that former PPA users valued, and also extend it to debian and debian-derived distributions. (I referenced deb-get on  #4296 and that refers to #4558 so the former PPA users who read issues will hopefully find out)

I hope you find this appropriate and valuable.  Thanks.