### PR TITLE
Add 'Don't ask again' to Launch Config Select Dialog

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -79,3 +79,4 @@ Contributors:
     Yurii Kolesnykov
     Patryk Obara (@dreamer)
     hazelnot
+    danieljohnson2

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -49,6 +49,8 @@ class Game(GObject.Object):
     STATE_LAUNCHING = "launching"
     STATE_RUNNING = "running"
 
+    PRIMARY_LAUNCH_CONFIG_NAME = "(primary)"
+
     __gsignals__ = {
         "game-error": (GObject.SIGNAL_RUN_FIRST, None, (object, )),
         "game-notice": (GObject.SIGNAL_RUN_FIRST, None, (str, str)),
@@ -456,7 +458,7 @@ class Game(GObject.Object):
             keymap = Gdk.Keymap.get_default()
             if keymap.get_modifier_state() & Gdk.ModifierType.SHIFT_MASK:
                 config_name_to_save = None
-            elif preferred_launch_command_name == "(primary)":
+            elif preferred_launch_command_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
                 config_index = 0
             elif preferred_launch_command_name:
                 for index, config in enumerate(configs):
@@ -470,8 +472,10 @@ class Game(GObject.Object):
 
                 config_index = dlg.config_index
                 if dlg.dont_show_again:
-                    config_name_to_save = "(primary)" if config_index == 0 else configs[config_index - 1].get(
-                        "name")
+                    if config_index == 0:
+                        config_name_to_save = Game.PRIMARY_LAUNCH_CONFIG_NAME
+                    else:
+                        config_name_to_save = configs[config_index - 1].get("name")
 
             if config_index:  # index 0 for no command at all
                 config = configs[config_index - 1]

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -463,7 +463,8 @@ class Game(GObject.Object):
             elif preferred_launch_command_name:
                 for index, config in enumerate(configs):
                     if config.get("name") == preferred_launch_command_name:
-                        config_index = index
+                        config_index = index + 1
+                        break
 
             if config_index is None:
                 dlg = dialogs.LaunchConfigSelectDialog(self, configs)

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -448,10 +448,10 @@ class Game(GObject.Object):
             raise self.get_config_error(gameplay_info)
 
         config = self.select_launch_config()
-            
+
         if config is None:
             return {}  # no error here- the user cancelled out
-        
+
         if config:  # empty dict for primary configuration.
             self.runner.apply_launch_config(gameplay_info, config)
 
@@ -464,24 +464,42 @@ class Game(GObject.Object):
         """
         game_config = self.config.game_level.get("game", {})
         configs = game_config.get("launch_configs")
-        
+
         if not configs:
             return {}  # use primary configuration
 
         config_index = None
         preferred_launch_command_name = game_config.get("preferred_launch_command_name")
+        preferred_launch_command_index = game_config.get("preferred_launch_command_index")
+
+        def get_preferred_index():
+            # Validate that the settings are still valid; we need the index to
+            # cope when two configs have the same name but we insist on a name
+            # match. Returns None if it can't find a match, and then the user
+            # must decide.
+            if preferred_launch_command_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
+                return 0
+
+            if preferred_launch_command_name:
+                if preferred_launch_command_index:
+                    try:
+                        if configs[preferred_launch_command_index - 1].get("name") == preferred_launch_command_name:
+                            return preferred_launch_command_index
+                    except IndexError:
+                        pass
+
+                for index, config in enumerate(configs):
+                    if config.get("name") == preferred_launch_command_name:
+                        return index + 1
+            return None
+
         config_name_to_save = preferred_launch_command_name
-        
+
         keymap = Gdk.Keymap.get_default()
         if keymap.get_modifier_state() & Gdk.ModifierType.SHIFT_MASK:
             config_name_to_save = None
-        elif preferred_launch_command_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
-            config_index = 0
-        elif preferred_launch_command_name:
-            for index, config in enumerate(configs):
-                if config.get("name") == preferred_launch_command_name:
-                    config_index = index + 1
-                    break
+        else:
+            config_index = get_preferred_index()
 
         if config_index is None:
             dlg = dialogs.LaunchConfigSelectDialog(self, configs)
@@ -494,16 +512,17 @@ class Game(GObject.Object):
                     config_name_to_save = Game.PRIMARY_LAUNCH_CONFIG_NAME
                 else:
                     config_name_to_save = configs[config_index - 1].get("name")
-                
+
                 if preferred_launch_command_name != config_name_to_save:
                     if config_name_to_save:
                         game_config["preferred_launch_command_name"] = config_name_to_save
+                        game_config["preferred_launch_command_index"] = config_index
                     else:
                         del game_config["preferred_launch_command_name"]
+                        del game_config["preferred_launch_command_index"]
                     self.config.save()
-                    
+
         return configs[config_index - 1] if config_index > 0 else {}
-    
 
     @watch_game_errors(game_stop_result=False)
     def configure_game(self, _ignored, error=None):  # noqa: C901

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -157,17 +157,17 @@ class GameDialogCommon(ModelessDialog):
         box = Gtk.Box(spacing=12, margin_right=12, margin_left=12, visible=True)
 
         game_config = self.game.config.game_level.get("game", {})
-        preferred_launch_command_name = game_config.get("preferred_launch_command_name")
+        preferred_name = game_config.get("preferred_launch_config_name")
 
-        if preferred_launch_command_name:
+        if preferred_name:
             spacer = Gtk.Box()
             spacer.set_size_request(230, -1)
             box.pack_start(spacer, False, False, 0)
 
-            if preferred_launch_command_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
+            if preferred_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
                 text = _("The default launch option will be used for this game")
             else:
-                text = _("The '%s' launch option will be used for this game") % preferred_launch_command_name
+                text = _("The '%s' launch option will be used for this game") % preferred_name
             label = Gtk.Label(text)
             label.set_line_wrap(True)
             label.set_halign(Gtk.Align.START)
@@ -175,16 +175,17 @@ class GameDialogCommon(ModelessDialog):
             label.set_valign(Gtk.Align.CENTER)
             box.pack_start(label, True, True, 0)
             button = Gtk.Button(_("Reset"))
-            button.connect("clicked", self.on_reset_preferred_launch_command_clicked, box)
+            button.connect("clicked", self.on_reset_preferred_launch_config_clicked, box)
             button.set_valign(Gtk.Align.CENTER)
             box.pack_start(button, False, False, 0)
         else:
             box.hide()
         return box
 
-    def on_reset_preferred_launch_command_clicked(self, _button, launch_config_box):
+    def on_reset_preferred_launch_config_clicked(self, _button, launch_config_box):
         game_config = self.game.config.game_level.get("game", {})
-        del game_config["preferred_launch_command_name"]
+        del game_config["preferred_launch_config_name"]
+        del game_config["preferred_launch_config_index"]
         launch_config_box.hide()
 
     def _get_runner_box(self):

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -105,6 +105,7 @@ class GameDialogCommon(ModelessDialog):
         if self.game:
             info_box.pack_start(self._get_slug_box(), False, False, 6)
             info_box.pack_start(self._get_directory_box(), False, False, 6)
+            info_box.pack_start(self._get_launch_config_box(), False, False, 6)
 
         info_sw = self.build_scrolled_window(info_box)
         self._add_notebook_tab(info_sw, _("Game info"))
@@ -151,6 +152,40 @@ class GameDialogCommon(ModelessDialog):
         move_button.connect("clicked", self.on_move_clicked)
         box.pack_start(move_button, False, False, 0)
         return box
+
+    def _get_launch_config_box(self):
+        box = Gtk.Box(spacing=12, margin_right=12, margin_left=12, visible=True)
+
+        game_config = self.game.config.game_level.get("game", {})
+        preferred_launch_command_name = game_config.get("preferred_launch_command_name")
+
+        if preferred_launch_command_name:
+            spacer = Gtk.Box()
+            spacer.set_size_request(230, -1)
+            box.pack_start(spacer, False, False, 0)
+
+            if preferred_launch_command_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
+                text = _("The default launch option will be used for this game")
+            else:
+                text = _("The '%s' launch option will be used for this game") % preferred_launch_command_name
+            label = Gtk.Label(text)
+            label.set_line_wrap(True)
+            label.set_halign(Gtk.Align.START)
+            label.set_xalign(0.0)
+            label.set_valign(Gtk.Align.CENTER)
+            box.pack_start(label, True, True, 0)
+            button = Gtk.Button(_("Reset"))
+            button.connect("clicked", self.on_reset_preferred_launch_command_clicked, box)
+            button.set_valign(Gtk.Align.CENTER)
+            box.pack_start(button, False, False, 0)
+        else:
+            box.hide()
+        return box
+
+    def on_reset_preferred_launch_command_clicked(self, _button, launch_config_box):
+        game_config = self.game.config.game_level.get("game", {})
+        del game_config["preferred_launch_command_name"]
+        launch_config_box.hide()
 
     def _get_runner_box(self):
         runner_box = Gtk.Box(spacing=12, margin_right=12, margin_left=12)

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -309,6 +309,7 @@ class LaunchConfigSelectDialog(ModalDialog):
     def __init__(self, game, configs, parent=None):
         super().__init__(title=_("Select game to launch"), parent=parent, border_width=10)
         self.config_index = 0
+        self.dont_show_again = False
         self.confirmed = False
 
         self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
@@ -328,11 +329,18 @@ class LaunchConfigSelectDialog(ModalDialog):
             _button.connect("toggled", self.on_button_toggled, i + 1)
             vbox.pack_start(_button, False, False, 0)
 
+        dont_show_checkbutton = Gtk.CheckButton(_("Do not ask again for this game."))
+        dont_show_checkbutton.connect("toggled", self.on_dont_show_checkbutton_toggled)
+        vbox.pack_end(dont_show_checkbutton, False, False, 6)
+
         self.show_all()
         self.run()
 
     def on_button_toggled(self, _button, index):
         self.config_index = index
+
+    def on_dont_show_checkbutton_toggled(self, _button):
+        self.dont_show_again = _button.get_active()
 
     def on_response(self, _widget, response):
         self.confirmed = response == Gtk.ResponseType.OK


### PR DESCRIPTION
For some games, there is a dialog asking you to pick a launch configuration- every time you start the game.

This PR adds a 'Don't ask again' checkbox to this dialog. This choice is recorded in the game configuration .yml file.
![image](https://user-images.githubusercontent.com/6507403/198896787-d0b21df7-081e-4159-9023-fb5fd46490a9.png)
There is also a 'Reset' button in the configuration dialog to reset it.  You can also hold shift while starting a game to override the setting that way.
![image](https://user-images.githubusercontent.com/6507403/198896859-33642507-d2be-4941-a746-aff815bba0b8.png)
