### PR TITLE
Header bar for the Preferences Dialog

### DIFF
--- a/lutris/gui/config/add_game_dialog.py
+++ b/lutris/gui/config/add_game_dialog.py
@@ -24,6 +24,5 @@ class AddGameDialog(GameDialogCommon):
         )
         self.build_notebook()
         self.build_tabs("game")
-        self.build_action_area(self.on_save)
         self.name_entry.grab_focus()
         self.show_all()

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -47,7 +47,8 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         self.runner_dropdown = None
         self.image_buttons = {}
         self.option_page_indices = set()
-        self.advanced_switch = None
+        self.advanced_switch_widgets = []
+        self.header_bar_widgets = []
         self.game_box = None
         self.system_box = None
         self.runner_name = None
@@ -94,10 +95,15 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         self._build_system_tab(config_level)
         self.update_advanced_switch_visibility(self.notebook.get_current_page())
 
+    def set_header_bar_controls_visibility(self, value):
+        for w in self.header_bar_widgets:
+            w.set_visible(value)
+
     def update_advanced_switch_visibility(self, current_page_index):
-        if self.advanced_switch and self.notebook:
+        if self.notebook:
             show_switch = current_page_index in self.option_page_indices
-            self.advanced_switch.set_visible(show_switch)
+            for w in self.advanced_switch_widgets:
+                w.set_visible(show_switch)
 
     def _build_info_tab(self):
         info_box = Gtk.VBox()
@@ -414,11 +420,12 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         # Advanced settings toggle
         switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
                              spacing=5,
-                             no_show_all=True)
+                             no_show_all=True,
+                             visible=True)
         switch_box.set_tooltip_text(_("Show advanced options"))
 
-        switch_label = Gtk.Label(_("Advanced"), visible=True)
-        switch = Gtk.Switch(visible=True)
+        switch_label = Gtk.Label(_("Advanced"), no_show_all=True, visible=True)
+        switch = Gtk.Switch(no_show_all=True, visible=True)
         switch.set_state(settings.read_setting("show_advanced_options") == "True")
         switch.connect("state_set", lambda _w, s:
                        self.on_show_advanced_options_toggled(bool(s)))
@@ -429,8 +436,10 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         header_bar = self.get_header_bar()
         header_bar.pack_end(switch_box)
 
-        self.advanced_switch = switch_box
-        self.action_widgets = [cancel_button, save_button, switch_box]
+        # These lists need to be distict, so they can be separately
+        # hidden or shown without interfering with each other.
+        self.advanced_switch_widgets = [switch_label, switch]
+        self.header_bar_widgets = [cancel_button, save_button, switch_box]
 
         if self.notebook:
             self.update_advanced_switch_visibilty(self.notebook.get_current_page())

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -59,6 +59,7 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         self.accelerators = Gtk.AccelGroup()
         self.add_accel_group(self.accelerators)
 
+        self.build_header_bar()
         self.connect("response", self.on_response)
 
     @staticmethod
@@ -398,20 +399,19 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
     def _add_notebook_tab(self, widget, label):
         return self.notebook.append_page(widget, Gtk.Label(label=label))
 
-    def build_action_area(self, button_callback):
+    def build_header_bar(self):
         # Buttons
         cancel_button = self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         cancel_button.set_valign(Gtk.Align.CENTER)
 
         save_button = self.add_styled_button(_("Save"), Gtk.ResponseType.NONE, css_class="suggested-action")
         save_button.set_valign(Gtk.Align.CENTER)
-        save_button.connect("clicked", button_callback)
+        save_button.connect("clicked", self.on_save)
 
         key, mod = Gtk.accelerator_parse("<Control>s")
         save_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
 
         # Advanced settings toggle
-
         switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
                              spacing=5,
                              no_show_all=True)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -95,15 +95,15 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         self._build_system_tab(config_level)
         self.update_advanced_switch_visibility(self.notebook.get_current_page())
 
-    def set_header_bar_controls_visibility(self, value):
-        for w in self.header_bar_widgets:
-            w.set_visible(value)
+    def set_header_bar_widgets_visbility(self, value):
+        for widget in self.header_bar_widgets:
+            widget.set_visible(value)
 
     def update_advanced_switch_visibility(self, current_page_index):
         if self.notebook:
             show_switch = current_page_index in self.option_page_indices
-            for w in self.advanced_switch_widgets:
-                w.set_visible(show_switch)
+            for widget in self.advanced_switch_widgets:
+                widget.set_visible(show_switch)
 
     def _build_info_tab(self):
         info_box = Gtk.VBox()

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -27,8 +27,8 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
     """Base class for config dialogs"""
     no_runner_label = _("Select a runner in the Game Info tab")
 
-    def __init__(self, title, parent=None, use_header_bar=True):
-        super().__init__(title, parent=parent, border_width=0, use_header_bar=use_header_bar)
+    def __init__(self, title, parent=None):
+        super().__init__(title, parent=parent, border_width=0, use_header_bar=True)
         self.set_default_size(DIALOG_WIDTH, DIALOG_HEIGHT)
         self.vbox.set_border_width(0)
 
@@ -399,9 +399,6 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
         return self.notebook.append_page(widget, Gtk.Label(label=label))
 
     def build_action_area(self, button_callback):
-        self.action_area.set_layout(Gtk.ButtonBoxStyle.END)
-        self.action_area.set_border_width(10)
-
         # Buttons
         cancel_button = self.add_button(_("Cancel"), Gtk.ResponseType.CANCEL)
         cancel_button.set_valign(Gtk.Align.CENTER)
@@ -415,34 +412,28 @@ class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
 
         # Advanced settings toggle
 
-        if self.props.use_header_bar:
-            switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
-                                 spacing=5,
-                                 no_show_all=True)
-            switch_box.set_tooltip_text(_("Show advanced options"))
+        switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
+                             spacing=5,
+                             no_show_all=True)
+        switch_box.set_tooltip_text(_("Show advanced options"))
 
-            switch_label = Gtk.Label(_("Advanced"), visible=True)
-            switch = Gtk.Switch(visible=True)
-            switch.set_state(settings.read_setting("show_advanced_options") == "True")
-            switch.connect("state_set", lambda _w, s:
-                           self.on_show_advanced_options_toggled(bool(s)))
+        switch_label = Gtk.Label(_("Advanced"), visible=True)
+        switch = Gtk.Switch(visible=True)
+        switch.set_state(settings.read_setting("show_advanced_options") == "True")
+        switch.connect("state_set", lambda _w, s:
+                       self.on_show_advanced_options_toggled(bool(s)))
 
-            switch_box.pack_start(switch_label, False, False, 0)
-            switch_box.pack_end(switch, False, False, 0)
+        switch_box.pack_start(switch_label, False, False, 0)
+        switch_box.pack_end(switch, False, False, 0)
 
-            header_bar = self.get_header_bar()
-            header_bar.pack_end(switch_box)
+        header_bar = self.get_header_bar()
+        header_bar.pack_end(switch_box)
 
-            self.advanced_switch = switch_box
-            self.update_advanced_switch_visibility(self.notebook.get_current_page())
-        else:
-            checkbox = Gtk.CheckButton(label=_("Show advanced options"))
-            checkbox.set_active(settings.read_setting("show_advanced_options") == "True")
-            checkbox.connect("toggled", lambda *x:
-                             self.on_show_advanced_options_toggled(bool(checkbox.get_active())))
-            checkbox.set_halign(Gtk.Align.START)
-            self.action_area.pack_start(checkbox, True, True, 0)
-            self.action_area.set_child_secondary(checkbox, True)
+        self.advanced_switch = switch_box
+        self.action_widgets = [cancel_button, save_button, switch_box]
+
+        if self.notebook:
+            self.update_advanced_switch_visibilty(self.notebook.get_current_page())
 
     def on_show_advanced_options_toggled(self, is_active):
         settings.write_setting("show_advanced_options", is_active)

--- a/lutris/gui/config/edit_game.py
+++ b/lutris/gui/config/edit_game.py
@@ -14,5 +14,4 @@ class EditGameConfigDialog(GameDialogCommon):
         self.runner_name = game.runner_name
         self.build_notebook()
         self.build_tabs("game")
-        self.build_action_area(self.on_save)
         self.show_all()

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -76,7 +76,7 @@ class PreferencesDialog(GameDialogCommon):
             generator()
         
         show_actions = stack_id == "system-stack"
-        self.set_header_bar_controls_visibility(show_actions)
+        self.set_header_bar_widgets_visbility(show_actions)
         self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -76,11 +76,7 @@ class PreferencesDialog(GameDialogCommon):
             generator()
         
         show_actions = stack_id == "system-stack"
-        for w in self.action_widgets:
-            if show_actions:
-                w.show()
-            else:
-                w.hide()
+        self.set_header_bar_controls_visibility(show_actions)
         self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -15,7 +15,7 @@ from lutris.gui.config.sysinfo_box import SysInfoBox
 # pylint: disable=no-member
 class PreferencesDialog(GameDialogCommon):
     def __init__(self, parent=None):
-        super().__init__(_("Lutris settings"), parent=parent, use_header_bar=True)
+        super().__init__(_("Lutris settings"), parent=parent)
         self.set_border_width(0)
         self.set_default_size(1010, 600)
         self.lutris_config = LutrisConfig()

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -65,7 +65,6 @@ class PreferencesDialog(GameDialogCommon):
             self.build_scrolled_window(self.system_box),
             "system-stack"
         )
-        self.build_action_area(self.on_save)
 
     def on_sidebar_activated(self, _listbox, row):
         stack_id = row.get_children()[0].stack_id

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -15,7 +15,7 @@ from lutris.gui.config.sysinfo_box import SysInfoBox
 # pylint: disable=no-member
 class PreferencesDialog(GameDialogCommon):
     def __init__(self, parent=None):
-        super().__init__(_("Lutris settings"), parent=parent, use_header_bar=False)
+        super().__init__(_("Lutris settings"), parent=parent, use_header_bar=True)
         self.set_border_width(0)
         self.set_default_size(1010, 600)
         self.lutris_config = LutrisConfig()
@@ -69,17 +69,20 @@ class PreferencesDialog(GameDialogCommon):
 
     def on_sidebar_activated(self, _listbox, row):
         stack_id = row.get_children()[0].stack_id
-
+        
         generator = self.page_generators.get(stack_id)
-
+        
         if generator:
             del self.page_generators[stack_id]
             generator()
-
-        if stack_id == "system-stack":
-            self.action_area.show_all()
-        else:
-            self.action_area.hide()
+        
+        show_actions = stack_id == "system-stack"
+        for w in self.action_widgets:
+            if show_actions:
+                w.show()
+            else:
+                w.hide()
+        self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 
     def get_sidebar_button(self, stack_id, text, icon_name):

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -68,13 +68,13 @@ class PreferencesDialog(GameDialogCommon):
 
     def on_sidebar_activated(self, _listbox, row):
         stack_id = row.get_children()[0].stack_id
-        
+
         generator = self.page_generators.get(stack_id)
-        
+
         if generator:
             del self.page_generators[stack_id]
             generator()
-        
+
         show_actions = stack_id == "system-stack"
         self.set_header_bar_widgets_visbility(show_actions)
         self.get_header_bar().set_show_close_button(not show_actions)

--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -14,7 +14,6 @@ class RunnerConfigDialog(GameDialogCommon):
         self.lutris_config = LutrisConfig(runner_slug=self.runner_name)
         self.build_notebook()
         self.build_tabs("runner")
-        self.build_action_area(self.on_save)
         self.show_all()
 
     def on_save(self, wigdet, data=None):


### PR DESCRIPTION
So I've gone back and forth on whether this is a good idea, and nobody wants to discuss this. I'll throw out this PR and show you what it looks like.

What is clear to me so that the current code is over-complicated by supporting both header bars (for the configuration dialogs) and action areas (for the preference dialog). This PR goes over to just header-bars and eliminates the action-area support. Thus:
![Screenshot from 2022-11-06 03-56-35](https://user-images.githubusercontent.com/6507403/200163224-9e3a2461-c497-42c1-9e42-56aa1ed63353.png)
That's a screenshot from Ubuntu, which I need to illustrate what happens when you aren't on that section:
![Screenshot from 2022-11-06 03-56-08](https://user-images.githubusercontent.com/6507403/200163263-df94d037-5212-4be7-831a-7a6f3daf767f.png)
Looks the same, but with the standard window controls instead of those buttons. Great. But here's what Lutris used to look like:
![Screenshot from 2022-11-06 03-57-02](https://user-images.githubusercontent.com/6507403/200163287-21f2077c-c322-44ed-99f6-dafeb2d17a08.png)
It used to have only a close box, though it was resizable. I can override this, but I'd rather use the system default. Putting close on the right if all other windows have it on the left would be very annoying.

*But*- and here's the thing- the title bar used to be slightly thinner. It's not *very* noticeable, but some people are quite sensitive to this. Indeed, I expect people won't object to the maximize button nearly as much as a few pixels of wasted white-space. It is wasted, but there seem to be no way for a window to have a (thicker) header bar sometimes, and a (thinner) title bar at other times.

That's going to trigger some people. But their tears are delicious, and the code is clearly better this way. So perhaps we should just do it.