### PR TITLE
Less hyperactive desktop integration

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -949,9 +949,9 @@ class wine(Runner):
 
     def sandbox(self, wine_prefix):
         if self.runner_config.get("sandbox", True):
-            wine_prefix.desktop_integration(desktop_dir=self.runner_config.get("sandbox_dir"))
+            wine_prefix.enable_desktop_integration_sandbox(desktop_dir=self.runner_config.get("sandbox_dir"))
         else:
-            wine_prefix.desktop_integration(restore=True)
+            wine_prefix.restore_desktop_integration()
 
     def play(self):  # pylint: disable=too-many-return-statements # noqa: C901
         game_exe = self.game_exe

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -150,7 +150,7 @@ class WinePrefixManager:
             self.enable_desktop_disintegration()
             return
 
-        if system.path_exists(user_dir):
+        if system.path_exists(user_dir) and self._get_desktop_integration_assignment() != desktop_dir:
             desktop_folders = self.get_desktop_folders()
             for item in desktop_folders:
                 path = os.path.join(user_dir, item)
@@ -169,11 +169,13 @@ class WinePrefixManager:
                 os.makedirs(src_path, exist_ok=True)
                 os.symlink(src_path, path)
 
+            self._set_desktop_integration_assignment(desktop_dir)
+
     def enable_desktop_disintegration(self):
         """Replace the desktop integration links with proper folders."""
         user_dir = self.user_dir
 
-        if system.path_exists(user_dir):
+        if system.path_exists(user_dir) and self._get_desktop_integration_assignment() != user_dir:
             desktop_folders = self.get_desktop_folders()
             for item in desktop_folders:
                 path = os.path.join(user_dir, item)
@@ -192,12 +194,15 @@ class WinePrefixManager:
                 else:
                     os.makedirs(path, exist_ok=True)
 
+            self._set_desktop_integration_assignment(user_dir)
+
     def restore_desktop_integration(self):
         """Replace WINE's desktop folders with links to the corresponding
         folders in your home directory."""
         user_dir = self.user_dir
+        home_dir = os.path.expanduser("~")
 
-        if system.path_exists(user_dir):
+        if system.path_exists(user_dir) and self._get_desktop_integration_assignment() != home_dir:
             desktop_folders = self.get_desktop_folders()
             for i, item in enumerate(desktop_folders):
                 path = os.path.join(user_dir, item)
@@ -214,6 +219,8 @@ class WinePrefixManager:
                 else:
                     os.symlink(src_path, path)
 
+            self._set_desktop_integration_assignment(home_dir)
+
     def _remove_desktop_folder(self, path, safe_path):
         """Removes the link or directory at 'path'; if it is a non-empty directory
         this will rename it to 'safe_path' instead of removing it entirely."""
@@ -225,6 +232,30 @@ class WinePrefixManager:
             except OSError:
                 # We can't delete nonempty dir, so we rename as wine do.
                 os.rename(path, safe_path)
+
+    def _get_desktop_integration_assignment(self):
+        setting_path = os.path.join(self.path, ".lutris_destkop_integration")
+        try:
+            if os.path.isfile(setting_path):
+                with open(setting_path, "r", encoding='utf-8') as f:
+                    return f.read()
+            else:
+                return ""
+        except Exception as ex:
+            logger.exception("Unable to read Lutris desktop integration setting: %s", ex)
+            return ""
+
+    def _set_desktop_integration_assignment(self, desktop_dir):
+        setting_path = os.path.join(self.path, ".lutris_destkop_integration")
+
+        try:
+            if desktop_dir:
+                with open(setting_path, "w", encoding='utf-8') as f:
+                    f.write(desktop_dir)
+            elif os.path.isfile(setting_path):
+                os.remove(setting_path)
+        except Exception as ex:
+            logger.exception("Unable to write Lutris desktop integration setting: %s", ex)
 
     def set_crash_dialogs(self, enabled):
         """Enable or diable Wine crash dialogs"""
@@ -281,7 +312,7 @@ class WinePrefixManager:
                 with open(assignment_path, "r", encoding='utf-8') as f:
                     assigned_dpi = int(f.read())
             except Exception as ex:
-                logger.exception("Unable to read lutris assigned DPI: %s", ex)
+                logger.exception("Unable to read Lutris assigned DPI: %s", ex)
                 return False
 
             for key_path in key_paths:


### PR DESCRIPTION
This PR cleans up the desktop integration (WINE sandbox) code so PyLint likes it, and also adds a feature- a setting tracking file like the DPI setting has.

A '.lutris_destkop_integration' file will be created in the WINE prefix that will contain the path to the WINE sandbox directory that Lutris last set up. This may be set to the actual WINE profile directory in the prefix (for no integration) or to your home directory (for non-sandboxed integration).

By storing this, we will detect when the sandbox setting changes and will reset the links or directories only then. This, in turn, means you can use winecfg.exe to configure this stuff manually, if you like.

Resolves #4613