### PR TITLE
Initial commit of publish PPA GitHub workflow. (Closes #4296)

### DIFF
--- a/.github/scripts/build-sign-ubuntu.sh
+++ b/.github/scripts/build-sign-ubuntu.sh
@@ -1,0 +1,77 @@
+#!/bin/bash -e
+# This script is intended to be run as part of a GitHub workflow where we
+# build multiple times under different OS versions, which _may_ produce
+# differences in the built packages.
+#
+# It expects the following environment variables:
+# 	PPA_GPG_PRIVATE_KEY
+#		Private key with access to the Ubuntu PPA.
+#	PPA_GPG_PASSPHRASE
+#		Decrypts the above private key.
+
+# This gets the Ubuntu codename & version from the local OS.
+OS_CODENAME="$(grep 'VERSION_CODENAME=' /etc/os-release | cut -f2 -d'=' | tr -d '"')"
+OS_VERSION="$(grep 'VERSION_ID=' /etc/os-release | cut -f2 -d'=' | tr -d '"')"
+
+# Get the base Lutris version in the same way that the Makefile does.
+LUTRIS_VERSION=$(grep "__version__" lutris/__init__.py | cut -d" " -f 3 | sed 's|"\(.*\)"|\1|')
+
+# Creates a GPG keyring using the key passed from the GitHub workflow.
+echo "::group::Importing GPG private key..."
+PPA_GPG_KEY_ID=$(echo "${PPA_GPG_PRIVATE_KEY}" | gpg --import-options show-only --import | sed -n '2s/^\s*//p')
+export PPA_GPG_KEY_ID
+echo "${PPA_GPG_KEY_ID}"
+echo "${PPA_GPG_PRIVATE_KEY}" | gpg --batch --passphrase "${PPA_GPG_PASSPHRASE}" --import
+echo "::endgroup::"
+
+# May as well since we don't need after at this point.
+unset PPA_GPG_PRIVATE_KEY
+
+# Version numbers are recommended to follow the guide at:
+# https://help.launchpad.net/Packaging/PPA/BuildingASourcePackage#Versioning
+#
+# The basic format is:
+# <lutris_version>-<lutris_revision>ubuntu<ubuntu_specific_revision>ppa<ppa_revision>~ubuntu<ubuntu_version>
+#
+# ex. 0.5.12-0ubuntu1 (for just the package version)
+# ex. 0.5.12-0ubuntu1ppa1~ubuntu22.04 (for a package version meant for jammy)
+# ex. 0.5.12-0ubuntu1ppa1~ubuntu20.04 (for a package version meant for focal)
+# etc...
+#
+PPA_VERSION="ppa1~ubuntu${OS_VERSION}"
+
+# If the Lutris version doesn't have a revision, we add revision 0.
+LUTRIS_DEBIAN_VERSION="${LUTRIS_VERSION}"
+if [[ "${LUTRIS_VERSION}" = "${LUTRIS_VERSION/-*/}" ]]; then
+    LUTRIS_DEBIAN_VERSION="${LUTRIS_DEBIAN_VERSION}-0"
+fi
+
+# Finally, add an ubuntu revision, so that other packages can override ours
+# without bumping the actual version number.
+LUTRIS_DEBIAN_VERSION="${LUTRIS_DEBIAN_VERSION}ubuntu1"
+
+# Does an initial make process for creating a debian source package.
+echo "::group::Building deb for: $OS_VERSION ($OS_CODENAME)"
+debmake -n -p lutris -u "${LUTRIS_VERSION}" -b":python3"
+
+# Updates debian/control file based on current environment.
+sudo mk-build-deps --install \
+    --tool='apt-get -o Debug::pkgProblemResolver=yes --no-install-recommends --yes' \
+    debian/control
+
+# Update the changelog entry. Specifically we change the top most
+# changelog entry codename to match our current OS and the version
+# number to match the Debian+PPA version scheme described above.
+sed -i"" \
+    -re"1s/\s\w+;/ ${OS_CODENAME};/" \
+    -re"1s/${LUTRIS_VERSION}/${LUTRIS_DEBIAN_VERSION}${PPA_VERSION}/" \
+    debian/changelog
+
+# Builds and signs the debian package files.
+# PPA_GPG_KEY_ID and PPA_GPG_PASSPHRASE environment variables must be defined
+# by this point.
+make github-ppa
+echo "::endgroup::"
+
+# Clean up build dependencies.
+sudo rm -f lutris-build-deps*

--- a/.github/workflows/publish-lutris-ppa.yml
+++ b/.github/workflows/publish-lutris-ppa.yml
@@ -1,0 +1,57 @@
+# Inspired by
+# https://github.com/yuezk/GlobalProtect-openconnect/blob/master/.github/workflows/build.yml
+name: Publish Lutris PPA
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  release-ppa:
+    strategy:
+      matrix:
+        os: [ ubuntu-22.04, ubuntu-20.04 ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      # Checkout repository
+      - uses: actions/checkout@v2
+
+      # Dependencies for the build process to generate .deb packages.
+      - name: Install Dependencies
+        run: |
+          sudo apt update
+          sudo apt install \
+            debhelper \
+            debmake \
+            devscripts \
+            dh-python \
+            meson \
+            equivs \
+            git-buildpackage
+
+      # This builds and signs the debian package for each OS in matrix.os
+      # This script also recalculates dependencies based on the current
+      # OS and can potentially produce different package control files,
+      # but these files are not kept.
+      #
+      # Signing packages uses the secrets referenced below and passes
+      # them through the below script and into the make "github-ppa"
+      # Makefile directive.
+      #
+      # It would probably be a good idea to have a unique GPG just for
+      # this process, but whatever GPG key is passed here _must_ be
+      # registered on the PPA as an authorized key.
+      - name: Build Debian Package
+        env:
+          PPA_GPG_PRIVATE_KEY: ${{ secrets.PPA_GPG_PRIVATE_KEY }}
+          PPA_GPG_PASSPHRASE: ${{ secrets.PPA_GPG_PASSPHRASE }}
+        run: |
+          ./.github/scripts/build-sign-ubuntu.sh
+
+      # Pushes the build to the PPA.
+      - name: Publish to PPA
+        run: |
+          dput ppa:lutris-team/lutris ../*.changes

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,36 @@
 VERSION=`grep "__version__" lutris/__init__.py | cut -d" " -f 3 | sed 's|"\(.*\)"|\1|'`
 GITBRANCH ?= master
+# Default GPG key ID to use for package signing.
+PPA_GPG_KEY_ID ?= 82D96E430A1F1C0F0502747E37B90EDD4E3EFAE4
 PYTHON:=$(shell which python3)
 PIP:=$(PYTHON) -m pip
 
 all:
 	export GITBRANCH=master
 	debuild
+	debclean
+
+# The same as all, but requires two environment variables related to
+# package signing.
+# 	PPA_GPG_KEY_ID
+#		Key ID used to sign the .deb package files.
+#	PPA_GPG_PASSPHRASE
+#		Decrypts the private key associated with GPG_KEY_ID.
+#
+# When running from a GitHub workflow.  The above environment variables
+# are passed in from .github/scripts/build-sign-ubuntu.sh and that script
+# receives those variables from the .github/workflows/publish-lutris-ppa.yml
+# which receives them from the repository secrets.
+github-ppa:
+	export GITBRANCH=master
+	# Automating builds for different Ubuntu codenames manipulates the
+	# version string, and so that lintian check is suppressed.  Also note
+	# that all parameters after "--lintian-opts" are passed to lintian
+	# so that _must_ be the last parameter.
+	echo "y" | debuild -S -sa \
+		-k"${PPA_GPG_KEY_ID}" \
+		-p"gpg --batch --passphrase "${PPA_GPG_PASSPHRASE}" --pinentry-mode loopback" \
+		--lintian-opts --suppress-tags malformed-debian-changelog-version
 	debclean
 
 build:


### PR DESCRIPTION
- Adds a new GitHub workflow that triggers on published releases.
- Adds a supporting Bash script to facilitate the building and signing process.
- Adds a new directive to the Makefile for passing a GPG key id to the make process through environment variables.

Two new repository secrets need to be created to allow these changes to function:
PPA_GPG_PRIVATE_KEY: Should contain the output of `gpg -a --export-secret-keys <keyid>`.
PPA_GPG_PASSPHRASE: Must be the passphrase that unlocks the above private key.

The PPA_GPG_PRIVATE_KEY needs to be a key that has access to https://launchpad.net/~lutris-team and _probably_ should be a unique key that is only used for this purpose, but I'll leave that up to @strycore .