### PR TITLE
Improved Launch Config Support for the command line and shortcuts (aka Tilting at Windmills)

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -76,7 +76,8 @@ disable=
     wrong-import-position,
     import-outside-toplevel,
     duplicate-code,
-    consider-using-f-string
+    consider-using-f-string,
+    no-self-use
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.pylintrc
+++ b/.pylintrc
@@ -76,8 +76,7 @@ disable=
     wrong-import-position,
     import-outside-toplevel,
     duplicate-code,
-    consider-using-f-string,
-    no-self-use
+    consider-using-f-string
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/lutris/api.py
+++ b/lutris/api.py
@@ -290,3 +290,42 @@ def parse_installer_url(url):
         "appid": appid,
         "launch_config_name": launch_config_name
     }
+
+
+def format_installer_url(installer_info):
+    """
+    Generates 'lutris:' urls, given the same dictionary that
+    parse_intaller_url returns.
+    """
+
+    game_slug = installer_info.get("game_slug")
+    revision = installer_info.get("revision")
+    action = installer_info.get("action")
+    service = installer_info.get("service")
+    appid = installer_info.get("appid")
+    launch_config_name = installer_info.get("launch_config_name")
+    parts = []
+
+    if action:
+        parts.append(action)
+    elif not launch_config_name:
+        raise ValueError("A 'lutris:' URL can contain a launch configuration name only if it has an action.")
+
+    if game_slug:
+        parts.append(game_slug)
+    else:
+        parts.append(service + ":" + appid)
+
+    if launch_config_name:
+        parts.append(launch_config_name)
+
+    parts = [urllib.parse.quote(str(part)) for part in parts]
+    path = "/".join(parts)
+
+    if revision:
+        query = urllib.parse.urlencode({"revision": str(revision)})
+    else:
+        query = ""
+
+    url = urllib.parse.urlunparse(("lutris", "", path, "", query, None))
+    return url

--- a/lutris/api.py
+++ b/lutris/api.py
@@ -243,6 +243,7 @@ def parse_installer_url(url):
     Parses `lutris:` urls, extracting any info necessary to install or run a game.
     """
     action = None
+    launch_config_name = None
     try:
         parsed_url = urllib.parse.urlparse(url, scheme="lutris")
     except Exception:  # pylint: disable=broad-except
@@ -258,8 +259,12 @@ def parse_installer_url(url):
     if url_path.startswith("lutris:"):
         url_path = url_path[7:]
 
-    url_parts = url_path.split("/")
-    if len(url_parts) == 2:
+    url_parts = [urllib.parse.unquote(part) for part in url_path.split("/")]
+    if len(url_parts) == 3:
+        action = url_parts[0]
+        game_slug = url_parts[1]
+        launch_config_name = url_parts[2]
+    elif len(url_parts) == 2:
         action = url_parts[0]
         game_slug = url_parts[1]
     elif len(url_parts) == 1:
@@ -282,5 +287,6 @@ def parse_installer_url(url):
         "revision": revision,
         "action": action,
         "service": service,
-        "appid": appid
+        "appid": appid,
+        "launch_config_name": launch_config_name
     }

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -69,17 +69,17 @@ def watch_game_errors(game_stop_result, game=None):
     send game-stop and make the game stopped as well. This simplifies handling cancellation.
     Also, if an error occurs and is emitted, the function returns this value, so callers
     can tell that the function failed.
+
+    If you do not provide a game object directly, it is assumed to be in the first argument to
+    the decorated method (which is 'self', typically).
     """
-    stable_game = game
+    captured_game = game
 
     def inner_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
             """Catch all exceptions and emit an event."""
-            if stable_game is None:
-                game = args[0]
-            else:
-                game = stable_game
+            game = captured_game if captured_game else args[0]
 
             try:
                 result = function(*args, **kwargs)

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -63,19 +63,24 @@ def watch_errors(error_result=None):
     return inner_decorator
 
 
-def watch_game_errors(game_stop_result):
+def watch_game_errors(game_stop_result, game=None):
     """Decorator used to catch exceptions and send events instead of propagating them normally.
     If 'game_stop_result' is not None, and the decorated function returns that, this will
     send game-stop and make the game stopped as well. This simplifies handling cancellation.
     Also, if an error occurs and is emitted, the function returns this value, so callers
     can tell that the function failed.
     """
+    stable_game = game
 
     def inner_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
             """Catch all exceptions and emit an event."""
-            game = args[0]
+            if stable_game is None:
+                game = args[0]
+            else:
+                game = stable_game
+
             try:
                 result = function(*args, **kwargs)
                 if game_stop_result is not None and result == game_stop_result and game.state != game.STATE_STOPPED:

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -91,7 +91,7 @@ def watch_game_errors(game_stop_result, game=None):
                 if game.state != game.STATE_STOPPED:
                     game.state = game.STATE_STOPPED
                     game.emit("game-stop")
-                game.emit("game-error", ex)
+                game.signal_error(ex)
                 return game_stop_result
 
         return wrapper

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -223,7 +223,7 @@ class Game(GObject.Object):
         True to indicate it handled it, that's it. If not, this fires
         game-unhandled-error, which is actually handled via an emission hook
         and should not be connected otherwise.
-        
+
         This allows special error handling to be set up for a partical Game, but
         there's always something."""
         handled = self.emit("game-error", error)

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -501,7 +501,7 @@ class Game(GObject.Object):
         return gameplay_info
 
     @watch_game_errors(game_stop_result=False)
-    def configure_game(self, launch_ui_delegate):  # noqa: C901
+    def configure_game(self, launch_ui_delegate):
         """Get the game ready to start, applying all the options
         This methods sets the game_runtime_config attribute.
         """

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -810,9 +810,8 @@ class Game(GObject.Object):
             if strings.lookup_string_in_text(error, self.game_thread.stdout):
                 raise RuntimeError(_("<b>Error: A different Wine version is already using the same Wine prefix.</b>"))
 
-    def write_script(self, script_path):
+    def write_script(self, script_path, ui_delegate):
         """Output the launch argument in a bash script"""
-        ui_delegate = Game.LaunchUIDelegate()
         gameplay_info = self.get_gameplay_info(ui_delegate)
         if not gameplay_info:
             # User cancelled; errors are raised as exceptions instead of this

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -64,7 +64,7 @@ class Game(GObject.Object):
         "game-installed": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
-    class UIDelegate:
+    class LaunchUIDelegate:
         """These objects provide UI for the game while it is being launched;
         one provided to the launch() method.
 
@@ -812,7 +812,7 @@ class Game(GObject.Object):
 
     def write_script(self, script_path):
         """Output the launch argument in a bash script"""
-        ui_delegate = Game.UIDelegate()
+        ui_delegate = Game.LaunchUIDelegate()
         gameplay_info = self.get_gameplay_info(ui_delegate)
         if not gameplay_info:
             # User cancelled; errors are raised as exceptions instead of this

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -12,7 +12,7 @@ from gettext import gettext as _
 
 from gi.repository import GLib, GObject, Gtk
 
-from lutris import runtime, settings
+from lutris import settings
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
@@ -51,7 +51,6 @@ class Game(GObject.Object):
 
     __gsignals__ = {
         "game-error": (GObject.SIGNAL_RUN_FIRST, None, (object, )),
-        "game-notice": (GObject.SIGNAL_RUN_FIRST, None, (str, str)),
         "game-launch": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -348,11 +347,6 @@ class Game(GObject.Object):
             installed = self.runner.install_dialog()
             if not installed:
                 return False
-
-        if self.runner.use_runtime():
-            runtime_updater = runtime.RuntimeUpdater()
-            if runtime_updater.is_updating():
-                self.emit("game-notice", _("Runtime currently updating"), _("Game might not work as expected"))
 
         return True
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -21,12 +21,14 @@ from lutris.database import sql
 from lutris.exceptions import GameConfigError, UnavailableRunnerError, watch_game_errors
 from lutris.runner_interpreter import export_bash_script, get_launch_parameters
 from lutris.runners import InvalidRunner, import_runner
+from lutris.runners.wine import get_wine_version
 from lutris.util import audio, discord, extract, jobs, linux, strings, system, xdgshortcuts
 from lutris.util.display import (
     DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, disable_compositing, enable_compositing, restore_gamma
 )
 from lutris.util.graphics.xephyr import get_xephyr_command
 from lutris.util.graphics.xrandr import turn_off_except
+from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import LOG_BUFFERS, logger
 from lutris.util.process import Process
 from lutris.util.savesync import sync_saves
@@ -86,6 +88,10 @@ class Game(GObject.Object):
             """
             if not game.runner.is_installed():
                 raise UnavailableRunnerError("The required runner '%s' is not installed." % game.runner.name)
+
+            if "wine" in game.runner_name and not get_wine_version() and not LINUX_SYSTEM.is_flatpak:
+                logger.warning("WINE is not installed.")
+
             return True
 
         def select_game_launch_config(self, game):

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -65,13 +65,32 @@ class Game(GObject.Object):
     }
 
     class UIDelegate:
+        """These objects provide UI for the game while it is being launched;
+        one provided to the launch() method.
+
+        The default implementation provide no UI and makes default choices for
+        the user, but LutrisWindow implements this to show dialogs and ask the
+        user questions.
+
+        If these methods throw any errors are reported via tha game-error signal;
+        that is not part of this delegate because errors can be report outside of
+        the launch() method, where no delegate is available.
+        """
+
         def check_game_launchable(self, game):
+            """See if the game can be launched. If there are adverse conditions,
+            this can warn the user and ask whether to launch. If this returs
+            False, the launch is cancelled. The default is to return True with no
+            actual checks.
+            """
             return True
 
         def select_game_launch_config(self, game):
             """Prompt the user for which launch config to use. Returns None
             if the user cancelled, an empty dict for the primary game configuration
             and the launch_config as a dict if one is selected.
+
+            The default is the select the primary game.
             """
             return {}  # primary game
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -68,9 +68,9 @@ class Game(GObject.Object):
         """These objects provide UI for the game while it is being launched;
         one provided to the launch() method.
 
-        The default implementation provide no UI and makes default choices for
-        the user, but LutrisWindow implements this to show dialogs and ask the
-        user questions.
+        The default implementation provides no UI and makes default choices for
+        the user, but DialogLaunchUIDelegate implements this to show dialogs and ask the
+        user questions. Windows then inherit from DialogLaunchUIDelegate.
 
         If these methods throw any errors are reported via tha game-error signal;
         that is not part of this delegate because errors can be report outside of

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -164,7 +164,7 @@ class GameActions:
 
     def on_game_launch(self, *_args):
         """Launch a game"""
-        self.game.launch()
+        self.game.launch(self.window)
 
     def get_running_game(self):
         ids = self.application.get_running_game_ids()

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -39,7 +39,6 @@ from lutris.command import exec_command
 from lutris.database import games as games_db
 from lutris.game import Game, export_game, import_game
 from lutris.installer import get_installers
-from lutris.gui.dialogs.download import simple_downloader
 from lutris.gui.dialogs import ErrorDialog, InstallOrPlayDialog, NoticeDialog, LutrisInitDialog
 from lutris.gui.dialogs.issue import IssueReportWindow
 from lutris.gui.installerwindow import InstallerWindow, InstallationKind
@@ -854,7 +853,8 @@ class Application(Gtk.Application):
         else:
             try:
                 runner = import_runner("wine")
-                runner().install(downloader=simple_downloader, version=version)
+                ui_delegate = Runner.InstallUIDelegate()
+                runner().install(ui_delegate, version=version)
                 print(f"Wine version '{version}' has been installed.")
             except (InvalidRunner, RunnerInstallationError) as ex:
                 print(ex.message)
@@ -884,7 +884,7 @@ Also, check that the version specified is in the correct format.
                 print(f"'{runner_name}' is already installed.")
             else:
                 ui_delegate = Runner.InstallUIDelegate()
-                runner.install(ui_delegate, version=None, downloader=simple_downloader, callback=None)
+                runner.install(ui_delegate, version=None, callback=None)
                 print(f"'{runner_name}' has been installed")
         except (InvalidRunner, RunnerInstallationError) as ex:
             print(ex.message)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -614,7 +614,8 @@ class Application(Gtk.Application):
                     self.do_shutdown()
                 return 0
             game = Game(db_game["id"])
-            game.launch()
+            ui_delegate = Game.UIDelegate()
+            game.launch(ui_delegate)
         else:
             Application.show_update_runtime_dialog()
             self.window.present()
@@ -624,7 +625,8 @@ class Application(Gtk.Application):
 
     @watch_errors(error_result=True)
     def on_game_launch(self, game):
-        game.launch()
+        ui_delegate = self.window or Game.UIDelegate()
+        game.launch(ui_delegate)
         return True  # Return True to continue handling the emission hook
 
     @watch_errors(error_result=True)
@@ -672,7 +674,8 @@ class Application(Gtk.Application):
 
             if game_id:
                 game = Game(game_id)
-                game.launch()
+                ui_delegate = self.window or Game.UIDelegate()
+                game.launch(ui_delegate)
             return True
         if not game.slug:
             raise ValueError("Invalid game passed: %s" % game)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -54,6 +54,7 @@ from lutris.util.steam.appmanifest import AppManifest, get_appmanifests
 from lutris.util.steam.config import get_steamapps_paths
 from lutris.services import get_enabled_services
 from lutris.database.services import ServiceGameCollection
+from lutris.runners.runner import Runner
 
 from .lutriswindow import LutrisWindow
 
@@ -614,7 +615,7 @@ class Application(Gtk.Application):
                     self.do_shutdown()
                 return 0
             game = Game(db_game["id"])
-            ui_delegate = Game.UIDelegate()
+            ui_delegate = Game.LaunchUIDelegate()
             game.launch(ui_delegate)
         else:
             Application.show_update_runtime_dialog()
@@ -625,7 +626,7 @@ class Application(Gtk.Application):
 
     @watch_errors(error_result=True)
     def on_game_launch(self, game):
-        ui_delegate = self.window or Game.UIDelegate()
+        ui_delegate = self.window or Game.LaunchUIDelegate()
         game.launch(ui_delegate)
         return True  # Return True to continue handling the emission hook
 
@@ -674,7 +675,7 @@ class Application(Gtk.Application):
 
             if game_id:
                 game = Game(game_id)
-                ui_delegate = self.window or Game.UIDelegate()
+                ui_delegate = self.window or Game.LaunchUIDelegate()
                 game.launch(ui_delegate)
             return True
         if not game.slug:
@@ -882,7 +883,8 @@ Also, check that the version specified is in the correct format.
             if runner.is_installed():
                 print(f"'{runner_name}' is already installed.")
             else:
-                runner.install(version=None, downloader=simple_downloader, callback=None)
+                ui_delegate = Runner.InstallUIDelegate()
+                runner.install(ui_delegate, version=None, downloader=simple_downloader, callback=None)
                 print(f"'{runner_name}' has been installed")
         except (InvalidRunner, RunnerInstallationError) as ex:
             print(ex.message)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -360,7 +360,12 @@ class Application(Gtk.Application):
         """Output a script to a file.
         The script is capable of launching a game without the client
         """
+        def on_error(game, error):
+            logger.exception("Unable to generate script: %s", error)
+            return True
+
         game = Game(db_game["id"])
+        game.connect("game-error", on_error)
         game.load_config()
         game.write_script(script_path, self.launch_ui_delegate)
 
@@ -618,7 +623,13 @@ class Application(Gtk.Application):
                 if not self.window.is_visible():
                     self.do_shutdown()
                 return 0
+
+            def on_error(game, error):
+                logger.exception("Unable to launch game: %s", error)
+                return True
+
             game = Game(db_game["id"])
+            game.connect("game-error", on_error)
             game.launch(self.launch_ui_delegate)
         else:
             Application.show_update_runtime_dialog()
@@ -680,7 +691,12 @@ class Application(Gtk.Application):
                 game_id = None
 
             if game_id:
+                def on_error(game, error):
+                    logger.exception("Unable to install game: %s", error)
+                    return True
+
                 game = Game(game_id)
+                game.connect("game-error", on_error)
                 game.launch(self.launch_ui_delegate)
             return True
         if not game.slug:

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -19,10 +19,11 @@ from lutris.runners import import_runner
 from lutris.services.lutris import LutrisBanner, LutrisCoverart, LutrisIcon, download_lutris_media
 from lutris.util.log import logger
 from lutris.util.strings import slugify
+from lutris.runners.runner import Runner
 
 
 # pylint: disable=too-many-instance-attributes, no-member
-class GameDialogCommon(ModelessDialog):
+class GameDialogCommon(ModelessDialog, Runner.DialogInstallUIDelegate):
     """Base class for config dialogs"""
     no_runner_label = _("Select a runner in the Game Info tab")
 

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -19,11 +19,11 @@ from lutris.runners import import_runner
 from lutris.services.lutris import LutrisBanner, LutrisCoverart, LutrisIcon, download_lutris_media
 from lutris.util.log import logger
 from lutris.util.strings import slugify
-from lutris.runners.runner import Runner
+from lutris.gui.dialogs.delegates import DialogInstallUIDelegate
 
 
 # pylint: disable=too-many-instance-attributes, no-member
-class GameDialogCommon(ModelessDialog, Runner.DialogInstallUIDelegate):
+class GameDialogCommon(ModelessDialog, DialogInstallUIDelegate):
     """Base class for config dialogs"""
     no_runner_label = _("Select a runner in the Game Info tab")
 

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -95,8 +95,9 @@ class RunnerBox(Gtk.Box):
     def on_install_clicked(self, widget):
         """Install a runner."""
         logger.debug("Install of %s requested", self.runner)
+        window = self.get_toplevel()
         try:
-            self.runner.install(downloader=simple_downloader)
+            self.runner.install(window, downloader=simple_downloader)
         except (
             runners.RunnerInstallationError,
             runners.NonInstallableRunnerError,

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -5,7 +5,6 @@ from gi.repository import GObject, Gtk
 from lutris import runners
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.dialogs import ErrorDialog, QuestionDialog
-from lutris.gui.dialogs.download import simple_downloader
 from lutris.gui.dialogs.runner_install import RunnerInstallDialog
 from lutris.gui.widgets.utils import ICON_SIZE, get_runtime_icon
 from lutris.util.log import logger
@@ -97,7 +96,7 @@ class RunnerBox(Gtk.Box):
         logger.debug("Install of %s requested", self.runner)
         window = self.get_toplevel()
         try:
-            self.runner.install(window, downloader=simple_downloader)
+            self.runner.install(window)
         except (
             runners.RunnerInstallationError,
             runners.NonInstallableRunnerError,

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -214,7 +214,7 @@ class FileDialog:
 
     """Ask the user to select a file."""
 
-    def __init__(self, message=None, default_path=None, mode="open"):
+    def __init__(self, message=None, default_path=None, mode="open", parent=None):
         self.filename = None
         if not message:
             message = _("Please choose a file")
@@ -224,7 +224,7 @@ class FileDialog:
             action = Gtk.FileChooserAction.OPEN
         dialog = Gtk.FileChooserNative.new(
             message,
-            None,
+            parent,
             action,
             _("_OK"),
             _("_Cancel"),

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -132,7 +132,7 @@ class NoticeDialog(Gtk.MessageDialog):
     """Display a message to the user."""
 
     def __init__(self, message, secondary=None, parent=None):
-        super().__init__(buttons=Gtk.ButtonsType.OK, parent=parent)
+        super().__init__(message_type=Gtk.MessageType.INFO, buttons=Gtk.ButtonsType.OK, parent=parent)
         self.set_markup(message)
         if secondary:
             self.format_secondary_text(secondary[:256])
@@ -140,7 +140,22 @@ class NoticeDialog(Gtk.MessageDialog):
         self.destroy()
 
 
+class WarningDialog(Gtk.MessageDialog):
+
+    """Display a warning to the user, who responds with whether to proceed, like
+    a QuestionDialog."""
+
+    def __init__(self, message, secondary=None, parent=None):
+        super().__init__(message_type=Gtk.MessageType.WARNING, buttons=Gtk.ButtonsType.OK_CANCEL, parent=parent)
+        self.set_markup(message)
+        if secondary:
+            self.format_secondary_text(secondary[:256])
+        self.result = self.run()
+        self.destroy()
+
+
 class ErrorDialog(Gtk.MessageDialog):
+
     """Display an error message."""
 
     def __init__(self, message, secondary=None, parent=None):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -436,13 +436,16 @@ class DontShowAgainDialog(Gtk.MessageDialog):
         secondary_message=None,
         parent=None,
         checkbox_message=None,
+        cancellable=False
     ):
         # pylint: disable=no-member
         if settings.read_setting(setting) == "True":
             logger.info("Dialog %s dismissed by user", setting)
             return
 
-        super().__init__(type=Gtk.MessageType.WARNING, buttons=Gtk.ButtonsType.OK, parent=parent)
+        buttons = Gtk.ButtonsType.OK_CANCEL if cancellable else Gtk.ButtonsType.OK
+
+        super().__init__(type=Gtk.MessageType.WARNING, buttons=buttons, parent=parent)
 
         self.set_default_response(Gtk.ResponseType.OK)
         self.set_markup("<b>%s</b>" % message)
@@ -459,8 +462,8 @@ class DontShowAgainDialog(Gtk.MessageDialog):
 
         content_area = self.get_content_area()
         content_area.pack_start(dont_show_checkbutton, False, False, 0)
-        self.run()
-        if dont_show_checkbutton.get_active():
+        self.result = self.run()
+        if self.result == Gtk.ResponseType.OK and dont_show_checkbutton.get_active():
             settings.write_setting(setting, True)
         self.destroy()
 
@@ -469,7 +472,7 @@ class WineNotInstalledWarning(DontShowAgainDialog):
 
     """Display a warning if Wine is not detected on the system"""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, cancellable=False):
         super().__init__(
             "hide-wine-systemwide-install-warning",
             _("Wine is not installed on your system."),
@@ -481,6 +484,7 @@ class WineNotInstalledWarning(DontShowAgainDialog):
                 "install Wine."
             ),
             parent=parent,
+            cancellable=cancellable
         )
 
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -321,8 +321,8 @@ class InstallOrPlayDialog(ModalDialog):
 
 
 class LaunchConfigSelectDialog(ModalDialog):
-    def __init__(self, game, configs, parent=None):
-        super().__init__(title=_("Select game to launch"), parent=parent, border_width=10)
+    def __init__(self, game, configs, title, parent=None, has_dont_show_again=False):
+        super().__init__(title=title, parent=parent, border_width=10)
         self.config_index = 0
         self.dont_show_again = False
         self.confirmed = False
@@ -344,9 +344,10 @@ class LaunchConfigSelectDialog(ModalDialog):
             _button.connect("toggled", self.on_button_toggled, i + 1)
             vbox.pack_start(_button, False, False, 0)
 
-        dont_show_checkbutton = Gtk.CheckButton(_("Do not ask again for this game."))
-        dont_show_checkbutton.connect("toggled", self.on_dont_show_checkbutton_toggled)
-        vbox.pack_end(dont_show_checkbutton, False, False, 6)
+        if has_dont_show_again:
+            dont_show_checkbutton = Gtk.CheckButton(_("Do not ask again for this game."))
+            dont_show_checkbutton.connect("toggled", self.on_dont_show_checkbutton_toggled)
+            vbox.pack_end(dont_show_checkbutton, False, False, 6)
 
         self.show_all()
         self.run()

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -14,6 +14,8 @@ from lutris.util.log import logger
 
 
 class DialogInstallUIDelegate(Runner.InstallUIDelegate):
+    """This provides UI for runner installation via dialogs."""
+
     def show_install_notice(self, message, secondary=None):
         dialogs.NoticeDialog(message, secondary, parent=self)
 
@@ -36,6 +38,8 @@ class DialogInstallUIDelegate(Runner.InstallUIDelegate):
 
 
 class DialogLaunchUIDelegate(Game.LaunchUIDelegate):
+    """This provides UI for game launch via dialogs."""
+
     def check_game_launchable(self, game):
         if not game.runner.is_installed():
             installed = game.runner.install_dialog(self)

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -1,0 +1,121 @@
+from gettext import gettext as _
+
+from gi.repository import Gdk, Gtk
+
+from lutris import runtime
+from lutris.game import Game
+from lutris.gui import dialogs
+from lutris.gui.dialogs.download import DownloadDialog
+from lutris.runners import wine
+from lutris.runners.runner import Runner
+from lutris.util.downloader import Downloader
+from lutris.util.linux import LINUX_SYSTEM
+from lutris.util.log import logger
+
+
+class DialogInstallUIDelegate(Runner.InstallUIDelegate):
+    def show_install_notice(self, message, secondary=None):
+        dialogs.NoticeDialog(message, secondary, parent=self)
+
+    def show_install_file_inquiry(self, question, title, message):
+        dlg = dialogs.QuestionDialog(
+            {
+                "parent": self,
+                "question": question,
+                "title": title,
+            }
+        )
+        if dlg.result == dlg.YES:
+            dlg = dialogs.FileDialog(message)
+            return dlg.filename
+
+    def download_install_file(self, url, destination):
+        dialog = DownloadDialog(url, destination, parent=self)
+        dialog.run()
+        return dialog.downloader.state == Downloader.COMPLETED
+
+
+class DialogLaunchUIDelegate(Game.LaunchUIDelegate):
+    def check_game_launchable(self, game):
+        if not game.runner.is_installed():
+            installed = game.runner.install_dialog(self)
+            if not installed:
+                return False
+
+        if game.runner.use_runtime():
+            runtime_updater = runtime.RuntimeUpdater()
+            if runtime_updater.is_updating():
+                logger.warning("Game launching with the runtime is updating")
+                dlg = dialogs.WarningDialog(_("Runtime currently updating"), _(
+                    "Game might not work as expected"), parent=self)
+                if dlg.result != Gtk.ResponseType.OK:
+                    return False
+
+        if "wine" in game.runner_name and not wine.get_wine_version() and not LINUX_SYSTEM.is_flatpak:
+            dlg = dialogs.WineNotInstalledWarning(parent=self, cancellable=True)
+            if dlg.result != Gtk.ResponseType.OK:
+                return False
+
+        return True
+
+    def select_game_launch_config(self, game):
+        game_config = game.config.game_level.get("game", {})
+        configs = game_config.get("launch_configs")
+
+        def get_preferred_config_index():
+            # Validate that the settings are still valid; we need the index to
+            # cope when two configs have the same name but we insist on a name
+            # match. Returns None if it can't find a match, and then the user
+            # must decide.
+            preferred_name = game_config.get("preferred_launch_config_name")
+            preferred_index = game_config.get("preferred_launch_config_index")
+
+            if preferred_index == 0 or preferred_name == Game.PRIMARY_LAUNCH_CONFIG_NAME:
+                return 0
+
+            if preferred_name:
+                if preferred_index:
+                    try:
+                        if configs[preferred_index - 1].get("name") == preferred_name:
+                            return preferred_index
+                    except IndexError:
+                        pass
+
+                for index, config in enumerate(configs):
+                    if config.get("name") == preferred_name:
+                        return index + 1
+
+            return None
+
+        def save_preferred_config(index):
+            name = configs[index - 1].get("name") if index > 0 else Game.PRIMARY_LAUNCH_CONFIG_NAME
+            game_config["preferred_launch_config_index"] = index
+            game_config["preferred_launch_config_name"] = name
+            game.config.save()
+
+        def reset_preferred_config():
+            game_config.pop("preferred_launch_config_index", None)
+            game_config.pop("preferred_launch_config_name", None)
+            game.config.save()
+
+        if not configs:
+            return {}  # use primary configuration
+
+        keymap = Gdk.Keymap.get_default()
+        if keymap.get_modifier_state() & Gdk.ModifierType.SHIFT_MASK:
+            config_index = None
+        else:
+            config_index = get_preferred_config_index()
+
+        if config_index is None:
+            dlg = dialogs.LaunchConfigSelectDialog(game, configs, parent=self)
+            if not dlg.confirmed:
+                return None  # no error here- the user cancelled out
+
+            config_index = dlg.config_index
+            if dlg.dont_show_again:
+                save_preferred_config(config_index)
+            else:
+                reset_preferred_config()
+
+        return configs[config_index - 1] if config_index > 0 else {}

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -122,7 +122,8 @@ class DialogLaunchUIDelegate(Game.LaunchUIDelegate):
             config_index = get_preferred_config_index()
 
         if config_index is None:
-            dlg = dialogs.LaunchConfigSelectDialog(game, configs, parent=self)
+            dlg = dialogs.LaunchConfigSelectDialog(game, configs, title=_(
+                "Select game to launch"), parent=self, has_dont_show_again=True)
             if not dlg.confirmed:
                 return None  # no error here- the user cancelled out
 

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -16,6 +16,14 @@ from lutris.util.log import logger
 class DialogInstallUIDelegate(Runner.InstallUIDelegate):
     """This provides UI for runner installation via dialogs."""
 
+    def check_wine_availability(self):
+        if not wine.get_wine_version() and not LINUX_SYSTEM.is_flatpak:
+            dlg = dialogs.WineNotInstalledWarning(parent=self, cancellable=True)
+            if dlg.result != Gtk.ResponseType.OK:
+                return False
+
+        return True
+
     def show_install_notice(self, message, secondary=None):
         dialogs.NoticeDialog(message, secondary, parent=self)
 

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -19,6 +19,16 @@ class DialogInstallUIDelegate(Runner.InstallUIDelegate):
     def show_install_notice(self, message, secondary=None):
         dialogs.NoticeDialog(message, secondary, parent=self)
 
+    def show_install_yesno_inquiry(self, question, title):
+        dialog = dialogs.QuestionDialog(
+            {
+                "parent": self,
+                "question": question,
+                "title": title,
+            }
+        )
+        return Gtk.ResponseType.YES == dialog.result
+
     def show_install_file_inquiry(self, question, title, message):
         dlg = dialogs.QuestionDialog(
             {

--- a/lutris/gui/dialogs/download.py
+++ b/lutris/gui/dialogs/download.py
@@ -23,6 +23,10 @@ class DownloadDialog(ModalDialog):
         self.show_all()
         self.dialog_progress_box.start()
 
+    @property
+    def downloader(self):
+        return self.dialog_progress_box.downloader
+
     def download_complete(self, _widget, _data):
         self.response(Gtk.ResponseType.OK)
         self.destroy()

--- a/lutris/gui/dialogs/download.py
+++ b/lutris/gui/dialogs/download.py
@@ -35,12 +35,3 @@ class DownloadDialog(ModalDialog):
         if response == Gtk.ResponseType.DELETE_EVENT:
             self.dialog_progress_box.downloader.cancel()
             self.destroy()
-
-
-def simple_downloader(url, destination, callback, callback_args=None):
-    """Basic downloader with a DownloadDialog"""
-    if not callback_args:
-        callback_args = {}
-    dialog = DownloadDialog(url, destination)
-    dialog.run()
-    return callback(**callback_args)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -9,6 +9,7 @@ from lutris.exceptions import UnavailableGameError, watch_errors
 from lutris.game import Game
 from lutris.gui.dialogs import DirectoryDialog, ErrorDialog, InstallerSourceDialog, QuestionDialog
 from lutris.gui.dialogs.cache import CacheConfigurationDialog
+from lutris.gui.dialogs.delegates import DialogInstallUIDelegate
 from lutris.gui.installer.files_box import InstallerFilesBox
 from lutris.gui.installer.script_picker import InstallerPicker
 from lutris.gui.widgets.common import FileChooserEntry, InstallerLabel
@@ -23,7 +24,7 @@ from lutris.util.strings import add_url_tags, gtk_safe, human_size
 from lutris.util.system import is_removeable
 
 
-class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-methods
+class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """GUI for the install process."""
 
     def __init__(
@@ -238,7 +239,7 @@ class InstallerWindow(BaseApplicationWindow):  # pylint: disable=too-many-public
     def launch_install(self):
         # This is a shim method to allow exceptions from
         # the interpret to be reported via watch_errors().
-        self.interpreter.launch_install()
+        self.interpreter.launch_install(self)
 
     def ask_for_disc(self, message, callback, requires):
         """Ask the user to do insert a CD-ROM."""

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -159,6 +159,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
                 if _script["version"] == installer_version:
                     script = _script
             self.interpreter = interpreter.ScriptInterpreter(script, self)
+            self.interpreter.connect("runners-installed", self.on_runners_ready)
         except MissingGameDependency as ex:
             dlg = QuestionDialog(
                 {
@@ -232,14 +233,15 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     def start_install(self):
         self.install_button.hide()
         self.source_button.hide()
-        self.interpreter.connect("runners-installed", self.on_runners_ready)
         GLib.idle_add(self.launch_install)
 
     @watch_errors()
     def launch_install(self):
         # This is a shim method to allow exceptions from
-        # the interpret to be reported via watch_errors().
-        self.interpreter.launch_install(self)
+        # the interpreter to be reported via watch_errors().
+        if not self.interpreter.launch_install(self):
+            self.install_button.show()
+            self.source_button.show()
 
     def ask_for_disc(self, message, callback, requires):
         """Ask the user to do insert a CD-ROM."""

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -24,11 +24,13 @@ from lutris.gui.widgets.game_bar import GameBar
 from lutris.gui.widgets.gi_composites import GtkTemplate
 from lutris.gui.widgets.sidebar import LutrisSidebar
 from lutris.gui.widgets.utils import load_icon_theme, open_uri
+from lutris.runners import wine
 # pylint: disable=no-member
 from lutris.services.base import BaseService
 from lutris.services.lutris import LutrisService
 from lutris.util import datapath
 from lutris.util.jobs import AsyncCall
+from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 from lutris.util.system import update_desktop_icons
 
@@ -880,7 +882,13 @@ class LutrisWindow(Gtk.ApplicationWindow, Game.UIDelegate):  # pylint: disable=t
     def on_watched_error(self, error):
         dialogs.ErrorDialog(str(error), parent=self)
 
-    def select_launch_config(self, game):
+    def check_game_launchable(self, game):
+        if ("wine" in game.runner_name and not wine.get_wine_version() and not LINUX_SYSTEM.is_flatpak):
+            dlg = dialogs.WineNotInstalledWarning(parent=self, cancellable=True)
+            return dlg.result == Gtk.ResponseType.OK
+        return True
+
+    def select_game_launch_config(self, game):
         game_config = game.config.game_level.get("game", {})
         configs = game_config.get("launch_configs")
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -878,10 +878,15 @@ class LutrisWindow(Gtk.ApplicationWindow, Game.UIDelegate):  # pylint: disable=t
         dialogs.ErrorDialog(str(error), parent=self)
 
     def check_game_launchable(self, game):
+        if not game.runner.is_installed():
+            installed = game.runner.install_dialog(parent=self)
+            if not installed:
+                return False
+
         if game.runner.use_runtime():
             runtime_updater = runtime.RuntimeUpdater()
             if runtime_updater.is_updating():
-                logger.warning("Game launching wil the runtime is updating")
+                logger.warning("Game launching with the runtime is updating")
                 dlg = dialogs.WarningDialog(_("Runtime currently updating"), _(
                     "Game might not work as expected"), parent=self)
                 if dlg.result != Gtk.ResponseType.OK:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -125,7 +125,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
         GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_collection_changed)
-        GObject.add_emission_hook(Game, "game-error", self.on_game_error)
+        GObject.add_emission_hook(Game, "game-unhandled_error", self.on_game_unhandled_error)
 
     def _init_actions(self):
         Action = namedtuple("Action", ("callback", "type", "enabled", "default", "accel"))
@@ -715,7 +715,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """Open the about dialog."""
         dialogs.AboutDialog(parent=self)
 
-    def on_game_error(self, game, error):
+    def on_game_unhandled_error(self, game, error):
         """Called when a game has sent the 'game-error' signal"""
         logger.exception("%s has encountered an error: %s", game, error, exc_info=error)
         dialogs.ErrorDialog(str(error), parent=self)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -25,6 +25,7 @@ from lutris.gui.widgets.gi_composites import GtkTemplate
 from lutris.gui.widgets.sidebar import LutrisSidebar
 from lutris.gui.widgets.utils import load_icon_theme, open_uri
 from lutris.runners import wine
+from lutris.runners.runner import Runner
 # pylint: disable=no-member
 from lutris.services.base import BaseService
 from lutris.services.lutris import LutrisService
@@ -36,7 +37,9 @@ from lutris.util.system import update_desktop_icons
 
 
 @GtkTemplate(ui=os.path.join(datapath.get(), "ui", "lutris-window.ui"))
-class LutrisWindow(Gtk.ApplicationWindow, Game.UIDelegate):  # pylint: disable=too-many-public-methods
+class LutrisWindow(Gtk.ApplicationWindow,
+                   Game.LaunchUIDelegate,
+                   Runner.DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """Handler class for main window signals."""
 
     default_view_type = "grid"
@@ -879,7 +882,7 @@ class LutrisWindow(Gtk.ApplicationWindow, Game.UIDelegate):  # pylint: disable=t
 
     def check_game_launchable(self, game):
         if not game.runner.is_installed():
-            installed = game.runner.install_dialog(parent=self)
+            installed = game.runner.install_dialog(self)
             if not installed:
                 return False
 

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -6,7 +6,9 @@ from gi.repository import GLib, GObject, Gtk, Pango
 from lutris import runners, services
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
+from lutris.exceptions import watch_errors
 from lutris.game import Game
+from lutris.gui import dialogs
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
@@ -205,19 +207,25 @@ class RunnerSidebarRow(SidebarRow):
         entries.append(("emblem-system-symbolic", _("Configure"), self.on_configure_runner, "configure"))
         return entries
 
+    @watch_errors()
     def on_run_runner(self, *_args):
         """Runs the runner without no game."""
         self.runner.run(self.get_toplevel())
 
+    @watch_errors()
     def on_configure_runner(self, *_args):
         """Show runner configuration"""
         self.application.show_window(RunnerConfigDialog, runner=self.runner)
 
+    @watch_errors()
     def on_manage_versions(self, *_args):
         """Manage runner versions"""
         dlg_title = _("Manage %s versions") % self.runner.name
         self.application.show_window(RunnerInstallDialog, title=dlg_title,
                                      runner=self.runner, parent=self.get_toplevel())
+
+    def on_watched_error(self, error):
+        dialogs.ErrorDialog(str(error), parent=self.get_toplevel())
 
 
 class SidebarHeader(Gtk.Box):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -201,9 +201,13 @@ class RunnerSidebarRow(SidebarRow):
                 "manage-versions"
             ))
         if self.runner.runnable_alone:
-            entries.append(("media-playback-start-symbolic", _("Run"), self.runner.run, "run"))
+            entries.append(("media-playback-start-symbolic", _("Run"), self.on_run_runner, "run"))
         entries.append(("emblem-system-symbolic", _("Configure"), self.on_configure_runner, "configure"))
         return entries
+
+    def on_run_runner(self, *_args):
+        """Runs the runner without no game."""
+        self.runner.run(self.get_toplevel())
 
     def on_configure_runner(self, *_args):
         """Show runner configuration"""

--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -79,7 +79,7 @@ class LutrisStatusIcon:
         """Callback to show or hide the window"""
         app_window = self.application.window
         if app_window.get_visible():
-            # If the wndow has any transients, hiding it will hide them too
+            # If the window has any transients, hiding it will hide them too
             # never to be shown again, which is broken. So we don't allow that.
             windows = Gtk.Window.list_toplevels()
             for w in windows:
@@ -115,7 +115,8 @@ class LutrisStatusIcon:
         return installed_games
 
     def on_game_selected(self, _widget, game_id):
-        Game(game_id).launch()
+        ui_delegate = self.application.window or Game.UIDelegate()
+        Game(game_id).launch(ui_delegate)
 
 
 class LutrisTray(Gtk.StatusIcon):

--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -115,7 +115,7 @@ class LutrisStatusIcon:
         return installed_games
 
     def on_game_selected(self, _widget, game_id):
-        ui_delegate = self.application.window or Game.UIDelegate()
+        ui_delegate = self.application.window or Game.LaunchUIDelegate()
         Game(game_id).launch(ui_delegate)
 
 

--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -115,7 +115,7 @@ class LutrisStatusIcon:
         return installed_games
 
     def on_game_selected(self, _widget, game_id):
-        ui_delegate = self.application.window or Game.LaunchUIDelegate()
+        ui_delegate = self.application.get_launch_ui_delegate()
         Game(game_id).launch(ui_delegate)
 
 

--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -115,8 +115,8 @@ class LutrisStatusIcon:
         return installed_games
 
     def on_game_selected(self, _widget, game_id):
-        ui_delegate = self.application.get_launch_ui_delegate()
-        Game(game_id).launch(ui_delegate)
+        launch_ui_delegate = self.application.get_launch_ui_delegate()
+        Game(game_id).launch(launch_ui_delegate)
 
 
 class LutrisTray(Gtk.StatusIcon):

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -8,13 +8,13 @@ from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
 from lutris.gui.dialogs import WineNotInstalledWarning
-from lutris.gui.dialogs.download import simple_downloader
 from lutris.installer import AUTO_EXE_PREFIX
 from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependency, ScriptingError
 from lutris.installer.installer import LutrisInstaller
 from lutris.installer.legacy import get_game_launcher
 from lutris.runners import InvalidRunner, NonInstallableRunnerError, RunnerInstallationError, import_runner, steam, wine
+from lutris.runners.runner import Runner
 from lutris.services.lutris import download_lutris_media
 from lutris.util import system
 from lutris.util.display import DISPLAY_MANAGER
@@ -257,9 +257,10 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         """Install runner required by the install script"""
         logger.debug("Installing %s", runner.name)
         try:
+            ui_delegate = Runner.InstallUIDelegate()
             runner.install(
+                ui_delegate,
                 version=self._get_runner_version(),
-                downloader=simple_downloader,
                 callback=self.install_runners,
             )
         except (NonInstallableRunnerError, RunnerInstallationError) as ex:

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -3,7 +3,6 @@ import os.path
 from gettext import gettext as _
 
 from lutris.config import LutrisConfig
-from lutris.gui.dialogs.download import DownloadDialog
 from lutris.runners.runner import Runner
 from lutris.util import display, extract, system
 
@@ -82,13 +81,12 @@ class atari800(Runner):
         },
     ]
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*_args):
             config_path = system.create_folder("~/.atari800")
             bios_archive = os.path.join(config_path, "atari800-bioses.zip")
-            dlg = DownloadDialog(self.bios_url, bios_archive)
-            dlg.run()
+            ui_delegate.download_install_file(self.bios_url, bios_archive)
             if not system.path_exists(bios_archive):
                 raise RuntimeError(_("Could not download Atari 800 BIOS archive"))
             extract.extract_archive(bios_archive, config_path)
@@ -99,7 +97,7 @@ class atari800(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version, downloader, on_runner_installed)
+        super().install(ui_delegate, version, on_runner_installed)
 
     def find_good_bioses(self, bios_path):
         """ Check for correct bios files """

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -83,15 +83,15 @@ class atari800(Runner):
         },
     ]
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
 
         def on_runner_installed(*_args):
             config_path = system.create_folder("~/.atari800")
             bios_archive = os.path.join(config_path, "atari800-bioses.zip")
-            dlg = DownloadDialog(self.bios_url, bios_archive)
+            dlg = DownloadDialog(self.bios_url, bios_archive, parent=parent)
             dlg.run()
             if not system.path_exists(bios_archive):
-                ErrorDialog(_("Could not download Atari 800 BIOS archive"))
+                ErrorDialog(_("Could not download Atari 800 BIOS archive"), parent=parent)
                 return
             extract.extract_archive(bios_archive, config_path)
             os.remove(bios_archive)
@@ -101,7 +101,7 @@ class atari800(Runner):
             if callback:
                 callback()
 
-        super().install(version, downloader, on_runner_installed)
+        super().install(version, downloader, on_runner_installed, parent=parent)
 
     def find_good_bioses(self, bios_path):
         """ Check for correct bios files """

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -81,12 +81,12 @@ class atari800(Runner):
         },
     ]
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*_args):
             config_path = system.create_folder("~/.atari800")
             bios_archive = os.path.join(config_path, "atari800-bioses.zip")
-            ui_delegate.download_install_file(self.bios_url, bios_archive)
+            install_ui_delegate.download_install_file(self.bios_url, bios_archive)
             if not system.path_exists(bios_archive):
                 raise RuntimeError(_("Could not download Atari 800 BIOS archive"))
             extract.extract_archive(bios_archive, config_path)
@@ -97,7 +97,7 @@ class atari800(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version, on_runner_installed)
+        super().install(install_ui_delegate, version, on_runner_installed)
 
     def find_good_bioses(self, bios_path):
         """ Check for correct bios files """

--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -3,7 +3,6 @@ import os.path
 from gettext import gettext as _
 
 from lutris.config import LutrisConfig
-from lutris.gui.dialogs import ErrorDialog
 from lutris.gui.dialogs.download import DownloadDialog
 from lutris.runners.runner import Runner
 from lutris.util import display, extract, system
@@ -83,16 +82,15 @@ class atari800(Runner):
         },
     ]
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
 
         def on_runner_installed(*_args):
             config_path = system.create_folder("~/.atari800")
             bios_archive = os.path.join(config_path, "atari800-bioses.zip")
-            dlg = DownloadDialog(self.bios_url, bios_archive, parent=parent)
+            dlg = DownloadDialog(self.bios_url, bios_archive)
             dlg.run()
             if not system.path_exists(bios_archive):
-                ErrorDialog(_("Could not download Atari 800 BIOS archive"), parent=parent)
-                return
+                raise RuntimeError(_("Could not download Atari 800 BIOS archive"))
             extract.extract_archive(bios_archive, config_path)
             os.remove(bios_archive)
             config = LutrisConfig(runner_slug="atari800")
@@ -101,7 +99,7 @@ class atari800(Runner):
             if callback:
                 callback()
 
-        super().install(version, downloader, on_runner_installed, parent=parent)
+        super().install(ui_delegate, version, downloader, on_runner_installed)
 
     def find_good_bioses(self, bios_path):
         """ Check for correct bios files """

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -93,7 +93,7 @@ class flatpak(Runner):
     def get_executable(self):
         return shutil.which("flatpak-spawn") or shutil.which("flatpak")
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
         raise NonInstallableRunnerError(
             _("Flatpak installation is not handled by Lutris.\n"
               "Install Flatpak with the package provided by your distribution.")

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -93,7 +93,7 @@ class flatpak(Runner):
     def get_executable(self):
         return shutil.which("flatpak-spawn") or shutil.which("flatpak")
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
         raise NonInstallableRunnerError(
             _("Flatpak installation is not handled by Lutris.\n"
               "Install Flatpak with the package provided by your distribution.")

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -93,7 +93,7 @@ class flatpak(Runner):
     def get_executable(self):
         return shutil.which("flatpak-spawn") or shutil.which("flatpak")
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
         raise NonInstallableRunnerError(
             _("Flatpak installation is not handled by Lutris.\n"
               "Install Flatpak with the package provided by your distribution.")

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -93,7 +93,7 @@ class flatpak(Runner):
     def get_executable(self):
         return shutil.which("flatpak-spawn") or shutil.which("flatpak")
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
         raise NonInstallableRunnerError(
             _("Flatpak installation is not handled by Lutris.\n"
               "Install Flatpak with the package provided by your distribution.")

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -127,7 +127,7 @@ class hatari(Runner):
         },
     ]
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             bios_path = system.create_folder("~/.hatari/bios")
@@ -146,7 +146,7 @@ class hatari(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version=version, downloader=downloader, callback=on_runner_installed)
+        super().install(ui_delegate, version=version, callback=on_runner_installed)
 
     def play(self):  # pylint: disable=too-many-branches
         params = [self.get_executable()]

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -5,7 +5,6 @@ from gettext import gettext as _
 
 # Lutris Modules
 from lutris.config import LutrisConfig
-from lutris.gui.dialogs import FileDialog, QuestionDialog
 from lutris.runners.runner import Runner
 from lutris.util import system
 
@@ -128,22 +127,17 @@ class hatari(Runner):
         },
     ]
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
 
         def on_runner_installed(*args):
             bios_path = system.create_folder("~/.hatari/bios")
-            dlg = QuestionDialog(
-                {
-                    "parent": parent,
-                    "question": _("Do you want to select an Atari ST BIOS file?"),
-                    "title": _("Use BIOS file?"),
-                }
-            )
-            if dlg.result == dlg.YES:
-                bios_dlg = FileDialog(_("Select a BIOS file"), parent=parent)
-                bios_filename = bios_dlg.filename
-                if not bios_filename:
-                    return
+
+            bios_filename = ui_delegate.show_install_file_inquiry(
+                question=_("Do you want to select an Atari ST BIOS file?"),
+                title=_("Use BIOS file?"),
+                message=_("Select a BIOS file"))
+
+            if bios_filename:
                 shutil.copy(bios_filename, bios_path)
                 bios_path = os.path.join(bios_path, os.path.basename(bios_filename))
                 config = LutrisConfig(runner_slug="hatari")
@@ -152,7 +146,7 @@ class hatari(Runner):
             if callback:
                 callback()
 
-        super().install(version=version, downloader=downloader, callback=on_runner_installed)
+        super().install(ui_delegate, version=version, downloader=downloader, callback=on_runner_installed)
 
     def play(self):  # pylint: disable=too-many-branches
         params = [self.get_executable()]

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -127,12 +127,12 @@ class hatari(Runner):
         },
     ]
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             bios_path = system.create_folder("~/.hatari/bios")
 
-            bios_filename = ui_delegate.show_install_file_inquiry(
+            bios_filename = install_ui_delegate.show_install_file_inquiry(
                 question=_("Do you want to select an Atari ST BIOS file?"),
                 title=_("Use BIOS file?"),
                 message=_("Select a BIOS file"))
@@ -146,7 +146,7 @@ class hatari(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version=version, callback=on_runner_installed)
+        super().install(install_ui_delegate, version=version, callback=on_runner_installed)
 
     def play(self):  # pylint: disable=too-many-branches
         params = [self.get_executable()]

--- a/lutris/runners/hatari.py
+++ b/lutris/runners/hatari.py
@@ -128,18 +128,19 @@ class hatari(Runner):
         },
     ]
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
 
         def on_runner_installed(*args):
             bios_path = system.create_folder("~/.hatari/bios")
             dlg = QuestionDialog(
                 {
+                    "parent": parent,
                     "question": _("Do you want to select an Atari ST BIOS file?"),
                     "title": _("Use BIOS file?"),
                 }
             )
             if dlg.result == dlg.YES:
-                bios_dlg = FileDialog(_("Select a BIOS file"))
+                bios_dlg = FileDialog(_("Select a BIOS file"), parent=parent)
                 bios_filename = bios_dlg.filename
                 if not bios_filename:
                     return

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -144,7 +144,7 @@ class libretro(Runner):
         is_core_installed = system.path_exists(self.get_core_path(core))
         return self.is_retroarch_installed() and is_core_installed
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
         captured_super = super()  # super() does not work inside install_core()
 
         def install_core():
@@ -152,12 +152,12 @@ class libretro(Runner):
                 if callback:
                     callback()
             else:
-                captured_super.install(ui_delegate, version, callback)
+                captured_super.install(install_ui_delegate, version, callback)
 
         if not self.is_retroarch_installed():
-            captured_super.install(ui_delegate, version=None, callback=install_core)
+            captured_super.install(install_ui_delegate, version=None, callback=install_core)
         else:
-            captured_super.install(ui_delegate, version, callback)
+            captured_super.install(install_ui_delegate, version, callback)
 
     def get_run_data(self):
         return {

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -144,7 +144,7 @@ class libretro(Runner):
         is_core_installed = system.path_exists(self.get_core_path(core))
         return self.is_retroarch_installed() and is_core_installed
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
         captured_super = super()  # super() does not work inside install_core()
 
         def install_core():
@@ -155,9 +155,9 @@ class libretro(Runner):
                 captured_super.install(version, downloader, callback)
 
         if not self.is_retroarch_installed():
-            captured_super.install(version=None, downloader=downloader, callback=install_core)
+            captured_super.install(version=None, downloader=downloader, callback=install_core, parent=parent)
         else:
-            captured_super.install(version, downloader, callback)
+            captured_super.install(version, downloader, callback, parent=parent)
 
     def get_run_data(self):
         return {

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -144,7 +144,7 @@ class libretro(Runner):
         is_core_installed = system.path_exists(self.get_core_path(core))
         return self.is_retroarch_installed() and is_core_installed
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
         captured_super = super()  # super() does not work inside install_core()
 
         def install_core():
@@ -152,12 +152,12 @@ class libretro(Runner):
                 if callback:
                     callback()
             else:
-                captured_super.install(version, downloader, callback)
+                captured_super.install(ui_delegate, version, downloader, callback)
 
         if not self.is_retroarch_installed():
-            captured_super.install(version=None, downloader=downloader, callback=install_core, parent=parent)
+            captured_super.install(ui_delegate, version=None, downloader=downloader, callback=install_core)
         else:
-            captured_super.install(version, downloader, callback, parent=parent)
+            captured_super.install(ui_delegate, version, downloader, callback)
 
     def get_run_data(self):
         return {

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -144,7 +144,7 @@ class libretro(Runner):
         is_core_installed = system.path_exists(self.get_core_path(core))
         return self.is_retroarch_installed() and is_core_installed
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
         captured_super = super()  # super() does not work inside install_core()
 
         def install_core():
@@ -152,12 +152,12 @@ class libretro(Runner):
                 if callback:
                     callback()
             else:
-                captured_super.install(ui_delegate, version, downloader, callback)
+                captured_super.install(ui_delegate, version, callback)
 
         if not self.is_retroarch_installed():
-            captured_super.install(ui_delegate, version=None, downloader=downloader, callback=install_core)
+            captured_super.install(ui_delegate, version=None, callback=install_core)
         else:
-            captured_super.install(ui_delegate, version, downloader, callback)
+            captured_super.install(ui_delegate, version, callback)
 
     def get_run_data(self):
         return {

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -223,12 +223,12 @@ class mame(Runner):  # pylint: disable=invalid-name
         self._platforms += [_("Arcade"), _("Nintendo Game & Watch")]
         return self._platforms
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
 
         def on_runner_installed(*args):
             AsyncCall(write_mame_xml, notify_mame_xml)
 
-        super().install(version=version, downloader=downloader, callback=on_runner_installed)
+        super().install(version=version, downloader=downloader, callback=on_runner_installed, parent=parent)
 
     @property
     def default_path(self):

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -223,12 +223,12 @@ class mame(Runner):  # pylint: disable=invalid-name
         self._platforms += [_("Arcade"), _("Nintendo Game & Watch")]
         return self._platforms
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
 
         def on_runner_installed(*args):
             AsyncCall(write_mame_xml, notify_mame_xml)
 
-        super().install(version=version, downloader=downloader, callback=on_runner_installed, parent=parent)
+        super().install(ui_delegate, version=version, downloader=downloader, callback=on_runner_installed)
 
     @property
     def default_path(self):

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -223,12 +223,12 @@ class mame(Runner):  # pylint: disable=invalid-name
         self._platforms += [_("Arcade"), _("Nintendo Game & Watch")]
         return self._platforms
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             AsyncCall(write_mame_xml, notify_mame_xml)
 
-        super().install(ui_delegate, version=version, callback=on_runner_installed)
+        super().install(install_ui_delegate, version=version, callback=on_runner_installed)
 
     @property
     def default_path(self):

--- a/lutris/runners/mame.py
+++ b/lutris/runners/mame.py
@@ -223,12 +223,12 @@ class mame(Runner):  # pylint: disable=invalid-name
         self._platforms += [_("Arcade"), _("Nintendo Game & Watch")]
         return self._platforms
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             AsyncCall(write_mame_xml, notify_mame_xml)
 
-        super().install(ui_delegate, version=version, downloader=downloader, callback=on_runner_installed)
+        super().install(ui_delegate, version=version, callback=on_runner_installed)
 
     @property
     def default_path(self):

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -93,7 +93,7 @@ class o2em(Runner):
                     return self.platforms[i]
         return ""
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
 
         def on_runner_installed(*args):
             if not system.path_exists(self.bios_path):
@@ -101,7 +101,7 @@ class o2em(Runner):
             if callback:
                 callback()
 
-        super().install(version, downloader, on_runner_installed)
+        super().install(version, downloader, on_runner_installed, parent=parent)
 
     def play(self):
         arguments = ["-biosdir=%s" % self.bios_path]

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -93,7 +93,7 @@ class o2em(Runner):
                     return self.platforms[i]
         return ""
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
 
         def on_runner_installed(*args):
             if not system.path_exists(self.bios_path):
@@ -101,7 +101,7 @@ class o2em(Runner):
             if callback:
                 callback()
 
-        super().install(version, downloader, on_runner_installed, parent=parent)
+        super().install(ui_delegate, version, downloader, on_runner_installed)
 
     def play(self):
         arguments = ["-biosdir=%s" % self.bios_path]

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -93,7 +93,7 @@ class o2em(Runner):
                     return self.platforms[i]
         return ""
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             if not system.path_exists(self.bios_path):
@@ -101,7 +101,7 @@ class o2em(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version, downloader, on_runner_installed)
+        super().install(ui_delegate, version, on_runner_installed)
 
     def play(self):
         arguments = ["-biosdir=%s" % self.bios_path]

--- a/lutris/runners/o2em.py
+++ b/lutris/runners/o2em.py
@@ -93,7 +93,7 @@ class o2em(Runner):
                     return self.platforms[i]
         return ""
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             if not system.path_exists(self.bios_path):
@@ -101,7 +101,7 @@ class o2em(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version, on_runner_installed)
+        super().install(install_ui_delegate, version, on_runner_installed)
 
     def play(self):
         arguments = ["-biosdir=%s" % self.bios_path]

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -207,22 +207,9 @@ class pico8(Runner):
             if not os.path.exists(enginePath):
                 downloadUrl = ("https://www.lexaloffle.com/bbs/" + self.runner_config.get("engine") + ".js")
                 system.create_folder(os.path.dirname(enginePath))
-                downloadCompleted = False
-
-                def on_downloaded_engine():
-                    nonlocal downloadCompleted
-                    downloadCompleted = True
-
-                dl = Downloader(downloadUrl, enginePath, True, callback=on_downloaded_engine)
+                dl = Downloader(downloadUrl, enginePath, True)
                 dl.start()
-                dl.thread.join()  # Doesn't actually wait until finished
-
-                # Waits for download to complete
-                while not os.path.exists(enginePath):
-                    if downloadCompleted or dl.state == Downloader.ERROR:
-                        logger.error("Could not download engine from %s", downloadUrl)
-                        return False
-                    sleep(0.1)
+                dl.join()
 
     def play(self):
         launch_info = {}

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -81,9 +81,9 @@ class pico8(Runner):
     def __repr__(self):
         return _("PICO-8 runner (%s)") % self.config
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
         opts = {}
-        opts["ui_delegate"] = ui_delegate
+        opts["install_ui_delegate"] = install_ui_delegate
         if callback:
             opts["callback"] = callback
         opts["dest"] = settings.RUNNER_DIR + "/pico8"

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -81,7 +81,7 @@ class pico8(Runner):
     def __repr__(self):
         return _("PICO-8 runner (%s)") % self.config
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
         opts = {}
         if callback:
             opts["callback"] = callback

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -81,7 +81,7 @@ class pico8(Runner):
     def __repr__(self):
         return _("PICO-8 runner (%s)") % self.config
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
         opts = {}
         if callback:
             opts["callback"] = callback

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -81,16 +81,13 @@ class pico8(Runner):
     def __repr__(self):
         return _("PICO-8 runner (%s)") % self.config
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
         opts = {}
+        opts["ui_delegate"] = ui_delegate
         if callback:
             opts["callback"] = callback
         opts["dest"] = settings.RUNNER_DIR + "/pico8"
         opts["merge_single"] = True
-        if downloader:
-            opts["downloader"] = downloader
-        else:
-            raise RuntimeError("Unsupported download for this runner")
         self.download_and_extract(DOWNLOAD_URL, **opts)
 
     @property

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -95,9 +95,9 @@ class redream(Runner):
         },
     ]
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
         def on_runner_installed(*args):
-            license_filename = ui_delegate.show_install_file_inquiry(
+            license_filename = install_ui_delegate.show_install_file_inquiry(
                 question=_("Do you want to select a premium license file?"),
                 title=_("Use premium version?"),
                 message=_("Use premium version?"))
@@ -108,7 +108,7 @@ class redream(Runner):
                 )
 
         super().install(
-            ui_delegate, version=version, callback=on_runner_installed
+            install_ui_delegate, version=version, callback=on_runner_installed
         )
 
     def play(self):

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -95,7 +95,7 @@ class redream(Runner):
         },
     ]
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
         def on_runner_installed(*args):
             license_filename = ui_delegate.show_install_file_inquiry(
                 question=_("Do you want to select a premium license file?"),
@@ -108,7 +108,7 @@ class redream(Runner):
                 )
 
         super().install(
-            ui_delegate, version=version, downloader=downloader, callback=on_runner_installed
+            ui_delegate, version=version, callback=on_runner_installed
         )
 
     def play(self):

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -3,7 +3,6 @@ import shutil
 from gettext import gettext as _
 
 from lutris import settings
-from lutris.gui.dialogs import FileDialog, QuestionDialog
 from lutris.runners.runner import Runner
 
 
@@ -96,26 +95,20 @@ class redream(Runner):
         },
     ]
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
         def on_runner_installed(*args):
-            dlg = QuestionDialog(
-                {
-                    "parent": parent,
-                    "question": _("Do you want to select a premium license file?"),
-                    "title": _("Use premium version?"),
-                }
-            )
-            if dlg.result == dlg.YES:
-                license_dlg = FileDialog(_("Select a license file"))
-                license_filename = license_dlg.filename
-                if not license_filename:
-                    return
+            license_filename = ui_delegate.show_install_file_inquiry(
+                question=_("Do you want to select a premium license file?"),
+                title=_("Use premium version?"),
+                message=_("Use premium version?"))
+
+            if license_filename:
                 shutil.copy(
                     license_filename, os.path.join(settings.RUNNER_DIR, "redream")
                 )
 
         super().install(
-            version=version, downloader=downloader, callback=on_runner_installed, parent=parent
+            ui_delegate, version=version, downloader=downloader, callback=on_runner_installed
         )
 
     def play(self):

--- a/lutris/runners/redream.py
+++ b/lutris/runners/redream.py
@@ -96,10 +96,11 @@ class redream(Runner):
         },
     ]
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
         def on_runner_installed(*args):
             dlg = QuestionDialog(
                 {
+                    "parent": parent,
                     "question": _("Do you want to select a premium license file?"),
                     "title": _("Use premium version?"),
                 }
@@ -114,7 +115,7 @@ class redream(Runner):
                 )
 
         super().install(
-            version=version, downloader=downloader, callback=on_runner_installed
+            version=version, downloader=downloader, callback=on_runner_installed, parent=parent
         )
 
     def play(self):

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -8,7 +8,6 @@ from gettext import gettext as _
 
 # Lutris Modules
 from lutris import settings
-from lutris.gui.dialogs import NoticeDialog
 from lutris.runners.runner import Runner
 from lutris.util import joypad, system
 
@@ -72,7 +71,7 @@ class reicast(Runner):
             },
         ]
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
 
         def on_runner_installed(*args):
             mapping_path = system.create_folder("~/.reicast/mappings")
@@ -81,9 +80,9 @@ class reicast(Runner):
                 shutil.copy(os.path.join(mapping_source, mapping_file), mapping_path)
 
             system.create_folder("~/.reicast/data")
-            NoticeDialog(_("You have to copy valid BIOS files to ~/.reicast/data before playing"), parent=parent)
+            ui_delegate.show_install_notice(_("You have to copy valid BIOS files to ~/.reicast/data before playing"))
 
-        super().install(version, downloader, on_runner_installed, parent=parent)
+        super().install(ui_delegate, version, downloader, on_runner_installed)
 
     def get_joypads(self):
         """Return list of joypad in a format usable in the options"""

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -72,7 +72,7 @@ class reicast(Runner):
             },
         ]
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
 
         def on_runner_installed(*args):
             mapping_path = system.create_folder("~/.reicast/mappings")
@@ -81,9 +81,9 @@ class reicast(Runner):
                 shutil.copy(os.path.join(mapping_source, mapping_file), mapping_path)
 
             system.create_folder("~/.reicast/data")
-            NoticeDialog(_("You have to copy valid BIOS files to ~/.reicast/data before playing"))
+            NoticeDialog(_("You have to copy valid BIOS files to ~/.reicast/data before playing"), parent=parent)
 
-        super().install(version, downloader, on_runner_installed)
+        super().install(version, downloader, on_runner_installed, parent=parent)
 
     def get_joypads(self):
         """Return list of joypad in a format usable in the options"""

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -71,7 +71,7 @@ class reicast(Runner):
             },
         ]
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             mapping_path = system.create_folder("~/.reicast/mappings")
@@ -82,7 +82,7 @@ class reicast(Runner):
             system.create_folder("~/.reicast/data")
             ui_delegate.show_install_notice(_("You have to copy valid BIOS files to ~/.reicast/data before playing"))
 
-        super().install(ui_delegate, version, downloader, on_runner_installed)
+        super().install(ui_delegate, version, on_runner_installed)
 
     def get_joypads(self):
         """Return list of joypad in a format usable in the options"""

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -71,7 +71,7 @@ class reicast(Runner):
             },
         ]
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             mapping_path = system.create_folder("~/.reicast/mappings")
@@ -80,9 +80,10 @@ class reicast(Runner):
                 shutil.copy(os.path.join(mapping_source, mapping_file), mapping_path)
 
             system.create_folder("~/.reicast/data")
-            ui_delegate.show_install_notice(_("You have to copy valid BIOS files to ~/.reicast/data before playing"))
+            install_ui_delegate.show_install_notice(
+                _("You have to copy valid BIOS files to ~/.reicast/data before playing"))
 
-        super().install(ui_delegate, version, on_runner_installed)
+        super().install(install_ui_delegate, version, on_runner_installed)
 
     def get_joypads(self):
         """Return list of joypad in a format usable in the options"""

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -10,8 +10,6 @@ from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
 from lutris.exceptions import GameConfigError, UnavailableLibrariesError
-from lutris.gui import dialogs
-from lutris.gui.dialogs.download import DownloadDialog
 from lutris.runners import RunnerInstallationError
 from lutris.util import strings, system
 from lutris.util.downloader import Downloader
@@ -483,27 +481,6 @@ class Runner:  # pylint: disable=too-many-public-methods
             downloader = Downloader(url, destination, overwrite=True)
             downloader.start()
             return downloader.join()
-
-    class DialogInstallUIDelegate(InstallUIDelegate):
-        def show_install_notice(self, message, secondary=None):
-            dialogs.NoticeDialog(message, secondary, parent=self)
-
-        def show_install_file_inquiry(self, question, title, message):
-            dlg = dialogs.QuestionDialog(
-                {
-                    "parent": self,
-                    "question": question,
-                    "title": title,
-                }
-            )
-            if dlg.result == dlg.YES:
-                dlg = dialogs.FileDialog(message)
-                return dlg.filename
-
-        def download_install_file(self, url, destination):
-            dialog = DownloadDialog(url, destination, parent=self)
-            dialog.run()
-            return dialog.downloader.state == Downloader.COMPLETED
 
     def install(self, ui_delegate, version=None, callback=None):
         """Install runner using package management systems."""

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -519,7 +519,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         if len(versions_for_arch) >= 1:
             return versions_for_arch[0]
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
         """Install runner using package management systems."""
         logger.debug(
             "Installing %s (version=%s, callback=%s)",
@@ -527,7 +527,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             version,
             callback,
         )
-        opts = {"ui_delegate": ui_delegate, "callback": callback}
+        opts = {"install_ui_delegate": install_ui_delegate, "callback": callback}
         if self.download_url:
             opts["dest"] = self.directory
             return self.download_and_extract(self.download_url, **opts)
@@ -547,7 +547,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         self.download_and_extract(runner["url"], **opts)
 
     def download_and_extract(self, url, dest=None, **opts):
-        ui_delegate = opts["ui_delegate"]
+        install_ui_delegate = opts["install_ui_delegate"]
         merge_single = opts.get("merge_single", False)
         callback = opts.get("callback")
         tarball_filename = os.path.basename(url)
@@ -555,7 +555,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         if not dest:
             dest = settings.RUNNER_DIR
 
-        ui_delegate.download_install_file(url, runner_archive)
+        install_ui_delegate.download_install_file(url, runner_archive)
         self.extract(archive=runner_archive, dest=dest, merge_single=merge_single, callback=callback)
 
     def extract(self, archive=None, dest=None, merge_single=None, callback=None):

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -43,6 +43,17 @@ class Runner:  # pylint: disable=too-many-public-methods
         ask the user questions. Windows then inherit from DialogLaunchUIDelegate.
         """
 
+        def check_wine_availability(self):
+            """Called to verify that wine is available, if it is required. May
+            return False to cancel the installation."""
+
+            from lutris.runners.wine import get_wine_version
+
+            if not get_wine_version() and not LINUX_SYSTEM.is_flatpak:
+                logger.warning("WINE is not installed.")
+
+            return True
+
         def show_install_notice(self, message, secondary=None):
             """Called to show an informational message to the user.
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -387,13 +387,14 @@ class Runner:  # pylint: disable=too-many-public-methods
             return False
         return True
 
-    def install_dialog(self):
+    def install_dialog(self, parent=None):
         """Ask the user if they want to install the runner.
 
         Return success of runner installation.
         """
         dialog = dialogs.QuestionDialog(
             {
+                "parent": parent,
                 "question": _("The required runner is not installed.\n"
                               "Do you wish to install it now?"),
                 "title": _("Required runner unavailable"),
@@ -406,9 +407,9 @@ class Runner:  # pylint: disable=too-many-public-methods
             try:
                 if hasattr(self, "get_version"):
                     version = self.get_version(use_default=False)  # pylint: disable=no-member
-                    self.install(downloader=simple_downloader, version=version)
+                    self.install(downloader=simple_downloader, version=version, parent=parent)
                 else:
-                    self.install(downloader=simple_downloader)
+                    self.install(downloader=simple_downloader, parent=parent)
             except RunnerInstallationError as ex:
                 ErrorDialog(ex.message)
 
@@ -472,7 +473,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         if len(versions_for_arch) >= 1:
             return versions_for_arch[0]
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
         """Install runner using package management systems."""
         logger.debug(
             "Installing %s (version=%s, downloader=%s, callback=%s)",

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -14,6 +14,7 @@ from lutris.gui import dialogs
 from lutris.gui.dialogs.download import DownloadDialog
 from lutris.runners import RunnerInstallationError
 from lutris.util import strings, system
+from lutris.util.downloader import Downloader
 from lutris.util.extract import ExtractFailure, extract_archive
 from lutris.util.http import HTTPError, Request
 from lutris.util.linux import LINUX_SYSTEM
@@ -479,8 +480,9 @@ class Runner:  # pylint: disable=too-many-public-methods
             return None
 
         def download_install_file(self, url, destination):
-            dialog = DownloadDialog(url, destination)
-            dialog.run()
+            downloader = Downloader(url, destination, overwrite=True)
+            downloader.start()
+            return downloader.join()
 
     class DialogInstallUIDelegate(InstallUIDelegate):
         def show_install_notice(self, message, secondary=None):
@@ -501,6 +503,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         def download_install_file(self, url, destination):
             dialog = DownloadDialog(url, destination, parent=self)
             dialog.run()
+            return dialog.downloader.state == Downloader.COMPLETED
 
     def install(self, ui_delegate, version=None, callback=None):
         """Install runner using package management systems."""

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -400,12 +400,12 @@ class Runner:  # pylint: disable=too-many-public-methods
         Reimplement in derived runner if need be."""
         return {"command": [self.get_executable()], "env": self.get_env()}
 
-    def run(self, *args):
+    def run(self, ui_delegate):
         """Run the runner alone."""
         if not self.runnable_alone:
             return
         if not self.is_installed():
-            if not self.install_dialog(Runner.InstallUIDelegate()):
+            if not self.install_dialog(ui_delegate):
                 logger.info("Runner install cancelled")
                 return
 

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -238,7 +238,7 @@ class steam(Runner):
         if steamapps_paths:
             return steamapps_paths[0]
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
         raise NonInstallableRunnerError(_(
             "Steam for Linux installation is not handled by Lutris.\n"
             "Please go to "

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -238,7 +238,7 @@ class steam(Runner):
         if steamapps_paths:
             return steamapps_paths[0]
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
         raise NonInstallableRunnerError(_(
             "Steam for Linux installation is not handled by Lutris.\n"
             "Please go to "

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -238,7 +238,7 @@ class steam(Runner):
         if steamapps_paths:
             return steamapps_paths[0]
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
         raise NonInstallableRunnerError(_(
             "Steam for Linux installation is not handled by Lutris.\n"
             "Please go to "

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -238,7 +238,7 @@ class steam(Runner):
         if steamapps_paths:
             return steamapps_paths[0]
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
         raise NonInstallableRunnerError(_(
             "Steam for Linux installation is not handled by Lutris.\n"
             "Please go to "

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -116,7 +116,7 @@ class vice(Runner):
             raise ValueError("Invalid machine '%s'" % machine) from ex
         return os.path.join(settings.RUNNER_DIR, "vice/bin/%s" % executable)
 
-    def install(self, ui_delegate, version=None, downloader=None, callback=None):
+    def install(self, ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             config_path = system.create_folder("~/.vice")
@@ -130,7 +130,7 @@ class vice(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version, downloader, on_runner_installed)
+        super().install(ui_delegate, version, on_runner_installed)
 
     def get_roms_path(self, machine=None):
         if not machine:

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -116,7 +116,7 @@ class vice(Runner):
             raise ValueError("Invalid machine '%s'" % machine) from ex
         return os.path.join(settings.RUNNER_DIR, "vice/bin/%s" % executable)
 
-    def install(self, version=None, downloader=None, callback=None, parent=None):
+    def install(self, ui_delegate, version=None, downloader=None, callback=None):
 
         def on_runner_installed(*args):
             config_path = system.create_folder("~/.vice")
@@ -130,7 +130,7 @@ class vice(Runner):
             if callback:
                 callback()
 
-        super().install(version, downloader, on_runner_installed, parent=parent)
+        super().install(ui_delegate, version, downloader, on_runner_installed)
 
     def get_roms_path(self, machine=None):
         if not machine:

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -116,7 +116,7 @@ class vice(Runner):
             raise ValueError("Invalid machine '%s'" % machine) from ex
         return os.path.join(settings.RUNNER_DIR, "vice/bin/%s" % executable)
 
-    def install(self, ui_delegate, version=None, callback=None):
+    def install(self, install_ui_delegate, version=None, callback=None):
 
         def on_runner_installed(*args):
             config_path = system.create_folder("~/.vice")
@@ -130,7 +130,7 @@ class vice(Runner):
             if callback:
                 callback()
 
-        super().install(ui_delegate, version, on_runner_installed)
+        super().install(install_ui_delegate, version, on_runner_installed)
 
     def get_roms_path(self, machine=None):
         if not machine:

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -116,7 +116,7 @@ class vice(Runner):
             raise ValueError("Invalid machine '%s'" % machine) from ex
         return os.path.join(settings.RUNNER_DIR, "vice/bin/%s" % executable)
 
-    def install(self, version=None, downloader=None, callback=None):
+    def install(self, version=None, downloader=None, callback=None, parent=None):
 
         def on_runner_installed(*args):
             config_path = system.create_folder("~/.vice")
@@ -130,7 +130,7 @@ class vice(Runner):
             if callback:
                 callback()
 
-        super().install(version, downloader, on_runner_installed)
+        super().install(version, downloader, on_runner_installed, parent=parent)
 
     def get_roms_path(self, machine=None):
         if not machine:

--- a/lutris/util/downloader.py
+++ b/lutris/util/downloader.py
@@ -1,4 +1,5 @@
 import os
+import threading
 import time
 
 import requests
@@ -31,14 +32,13 @@ class Downloader:
         COMPLETED
     ) = list(range(5))
 
-    def __init__(self, url, dest, overwrite=False, referer=None, callback=None):
+    def __init__(self, url, dest, overwrite=False, referer=None):
         self.url = url
         self.dest = dest
         self.overwrite = overwrite
         self.referer = referer
         self.stop_request = None
         self.thread = None
-        self.callback = callback
 
         # Read these after a check_progress()
         self.state = self.INIT
@@ -56,6 +56,7 @@ class Downloader:
         self.speed_check_time = 0
         self.time_left_check_time = 0
         self.file_pointer = None
+        self.progress_event = threading.Event()
 
     def __str__(self):
         return "downloader for %s" % self.url
@@ -68,7 +69,7 @@ class Downloader:
         if self.overwrite and os.path.isfile(self.dest):
             os.remove(self.dest)
         self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
-        self.thread = jobs.AsyncCall(self.async_download, self.download_cb)
+        self.thread = jobs.AsyncCall(self.async_download, None)
         self.stop_request = self.thread.stop_request
 
     def reset(self):
@@ -89,13 +90,34 @@ class Downloader:
         self.time_left_check_time = 0
         self.file_pointer = None
 
-    def check_progress(self):
+    def check_progress(self, blocking=False):
         """Append last downloaded chunk to dest file and store stats.
 
+        blocking: if true and still downloading, block until some progress is made.
         :return: progress (between 0.0 and 1.0)"""
+        if blocking and self.state in [self.INIT, self.DOWNLOADING] and self.progress_fraction < 1.0:
+            self.progress_event.wait()
+            self.progress_event.clear()
+
         if self.state not in [self.CANCELLED, self.ERROR]:
             self.get_stats()
         return self.progress_fraction
+
+    def join(self, progress_callback=None):
+        """Blocks waiting for the downlaod to complete.
+
+        'progress_callback' is invoked repeatedly as the download
+        proceeds, if given, and is passed the downloader itself.
+
+        Returns True on success, False if cancelled."""
+        while self.state == self.DOWNLOADING:
+            self.check_progress(blocking=True)
+            if progress_callback:
+                progress_callback(self)
+
+        if self.error:
+            raise self.error
+        return self.state == self.COMPLETED
 
     def cancel(self):
         """Request download stop and remove destination file."""
@@ -109,16 +131,38 @@ class Downloader:
         if os.path.isfile(self.dest):
             os.remove(self.dest)
 
-    def download_cb(self, _result, error):
-        if error:
-            logger.error("Download failed: %s", error)
-            self.state = self.ERROR
-            self.error = error
-            if self.file_pointer:
-                self.file_pointer.close()
-                self.file_pointer = None
-            return
+    def async_download(self):
+        try:
+            headers = requests.utils.default_headers()
+            headers["User-Agent"] = "Lutris/%s" % __version__
+            if self.referer:
+                headers["Referer"] = self.referer
+            response = requests.get(self.url, headers=headers, stream=True, timeout=30)
+            if response.status_code != 200:
+                logger.info("%s returned a %s error", self.url, response.status_code)
+            response.raise_for_status()
+            self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
+            self.progress_event.set()
+            for chunk in response.iter_content(chunk_size=1024):
+                if not self.file_pointer:
+                    break
+                if chunk:
+                    self.downloaded_size += len(chunk)
+                    self.file_pointer.write(chunk)
+                self.progress_event.set()
+            self.on_download_completed()
+        except Exception as ex:
+            self.on_download_failed(ex)
 
+    def on_download_failed(self, error):
+        logger.error("Download failed: %s", error)
+        self.state = self.ERROR
+        self.error = error
+        if self.file_pointer:
+            self.file_pointer.close()
+            self.file_pointer = None
+
+    def on_download_completed(self):
         if self.state == self.CANCELLED:
             return
 
@@ -132,25 +176,6 @@ class Downloader:
         self.state = self.COMPLETED
         self.file_pointer.close()
         self.file_pointer = None
-        if self.callback:
-            self.callback()
-
-    def async_download(self, stop_request=None):
-        headers = requests.utils.default_headers()
-        headers["User-Agent"] = "Lutris/%s" % __version__
-        if self.referer:
-            headers["Referer"] = self.referer
-        response = requests.get(self.url, headers=headers, stream=True, timeout=30)
-        if response.status_code != 200:
-            logger.info("%s returned a %s error", self.url, response.status_code)
-        response.raise_for_status()
-        self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
-        for chunk in response.iter_content(chunk_size=1024):
-            if not self.file_pointer:
-                break
-            if chunk:
-                self.downloaded_size += len(chunk)
-                self.file_pointer.write(chunk)
 
     def get_stats(self):
         """Calculate and store download stats."""

--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -5,6 +5,7 @@ import re
 import shlex
 import shutil
 
+from lutris.api import format_installer_url
 from lutris.game import Game
 from lutris.util import resources, system
 from lutris.util.log import logger
@@ -102,10 +103,11 @@ def remove_shortcut(game):
 def generate_shortcut(game, launch_config_name):
     lutris_binary = shutil.which("lutris")
 
-    if launch_config_name:
-        launch_options = f'lutris:rungameid/{game.id}/{launch_config_name}'
-    else:
-        launch_options = f'lutris:rungameid/{game.id}'
+    launch_options = format_installer_url({
+        "action": "rungameid",
+        "game_slug": game.id,
+        "launch_config_name": launch_config_name
+    })
 
     launch_options = shlex.quote(launch_options)
 

--- a/lutris/util/steam/vdf/vdict.py
+++ b/lutris/util/steam/vdf/vdict.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member
+# pylint: disable=no-member,unnecessary-dunder-call
 from collections import Counter
 
 _iter_values = 'values'

--- a/lutris/util/steam/vdf/vdict.py
+++ b/lutris/util/steam/vdf/vdict.py
@@ -1,4 +1,4 @@
-# pylint: disable=no-member,unnecessary-dunder-call
+# pylint: disable=no-member
 from collections import Counter
 
 _iter_values = 'values'

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -7,6 +7,7 @@ from textwrap import dedent
 
 from gi.repository import GLib
 
+from lutris.api import format_installer_url
 from lutris.settings import CACHE_DIR
 from lutris.util import system
 from lutris.util.linux import LINUX_SYSTEM
@@ -57,10 +58,11 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
     desktop_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP)
     lutris_executable = get_lutris_executable()
 
-    if launch_config_name:
-        url = f"lutris:rungameid/{game_id}/{launch_config_name}"
-    else:
-        url = f"lutris:rungameid/{game_id}"
+    url = format_installer_url({
+        "action": "rungameid",
+        "game_slug": game_id,
+        "launch_config_name": launch_config_name
+    })
 
     launcher_content = dedent(
         """

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -1,5 +1,6 @@
 """XDG shortcuts handling"""
 import os
+import shlex
 import shutil
 import stat
 from textwrap import dedent
@@ -51,23 +52,29 @@ def get_xdg_basename(game_slug, game_id, base_dir=None):
     return "net.lutris.{}-{}.desktop".format(game_slug, game_id)
 
 
-def create_launcher(game_slug, game_id, game_name, desktop=False, menu=False):
+def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desktop=False, menu=False):
     """Create a .desktop file."""
     desktop_dir = GLib.get_user_special_dir(GLib.UserDirectory.DIRECTORY_DESKTOP)
     lutris_executable = get_lutris_executable()
+
+    if launch_config_name:
+        url = f"lutris:rungameid/{game_id}/{launch_config_name}"
+    else:
+        url = f"lutris:rungameid/{game_id}"
+
     launcher_content = dedent(
         """
         [Desktop Entry]
         Type=Application
         Name={}
         Icon={}
-        Exec=env LUTRIS_SKIP_INIT=1 {} lutris:rungameid/{}
+        Exec=env LUTRIS_SKIP_INIT=1 {} {}
         Categories=Game
         """.format(
             game_name,
             "lutris_{}".format(game_slug),
             lutris_executable,
-            game_id
+            shlex.quote(url)
         )
     )
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -9,15 +9,25 @@ class TestInstallerUrls(TestCase):
         self.assertEqual(result['game_slug'], 'quake')
         self.assertEqual(result['revision'], None)
         self.assertEqual(result['action'], None)
+        self.assertEqual(result['launch_config_name'], None)
 
     def test_action_rungameid(self):
         result = parse_installer_url("lutris:rungameid/123")
         self.assertEqual(result['game_slug'], '123')
         self.assertEqual(result['revision'], None)
         self.assertEqual(result['action'], 'rungameid')
+        self.assertEqual(result['launch_config_name'], None)
 
     def test_action_rungame(self):
         result = parse_installer_url("lutris:rungame/quake")
         self.assertEqual(result['game_slug'], 'quake')
         self.assertEqual(result['revision'], None)
         self.assertEqual(result['action'], 'rungame')
+        self.assertEqual(result['launch_config_name'], None)
+
+    def test_action_rungame_launch_config(self):
+        result = parse_installer_url("lutris:rungame/quake/OpenGL%20Edition")
+        self.assertEqual(result['game_slug'], 'quake')
+        self.assertEqual(result['revision'], None)
+        self.assertEqual(result['action'], 'rungame')
+        self.assertEqual(result['launch_config_name'], 'OpenGL Edition')


### PR DESCRIPTION
Do you trust me?

This is a big PR. It disentangles a lot of the game and runner stuff from the UI. This in turn allows the command line to be different. It also allows the usual GUI to be improved a bit- and I have plans for more.

The idea is to replace references to the parent window with a 'UI delegate'- which is usually the window. But not from the command line! The actual dialog display is done by base classes (DialogLaunchUIDelegate and DialogInstalllUIDelegate) so it need not be repeated; various windows inherit from these.

The UI delegates are passed into various methods; much of the change here is just passing these guys around.

The UI delegate base classes provide trivial implementations that don't really show UI, except for some logging. The command line has a special delegate to pass along the launch config selection. This comes from new, improved "lutris:" URLs. Like so:

```
lutris lutris:rungame/fear/F.E.A.R.%20Extraction%20Point
lutris lutris:rungameid/3/F.E.A.R.%20Extraction%20Point
```
You must have the initial action path segment ("rungame") to do this; it's always the third path component that names the launch config. URL encoding is now supported as shown, though spaces-with-quotes will work too.

But wait there's more! When you create a shortcut you'll see this:
![image](https://user-images.githubusercontent.com/6507403/209656547-d4f309a0-2c88-443b-870c-f63311fc8aee.png)
And you can get a shortcut that specifies the launch config. The first option gives you the primary config ("lutris:rungameid/3" as before)

I've been able to make some further improvements here by re-arranging some of the sanity checks. The no-WINE warning looks like this:
![image](https://user-images.githubusercontent.com/6507403/209657069-59d1ab34-202d-4ea9-b0a1-0311a4ccd1fb.png)
You can cancel now, and the game does not launch. But from the command line, there is instead just a logger warning in this case.

Same story for the runner-not-installed prompt, but at the command line this is an error and prevents the game from starting.

The 'simple_downloader' function that was being passed around is no more; instead the InstallUIDelegate provides this functionality. The Downloader class now supports fully synchronous downloads, which the pico8 runner already tried to do with a hack. The command line will now use this to download runners bits, without progress reporting. We could supply progress reporting, but I didn't.

Beyond this, the command line error handler is different- it writes logger errors out, but does not pop a dialog. This is a little different- I split the "game-error" signal in two, so you can connect "game-error" and handle the error (and return True) and this will prevent a new "game-unhandled-error" signal from firing; this "game-unhandled-error" signal is the backstop handler that LutrisWindows hooks. I did this because a connected handler can't override an emission hook, and this is the best workaround I could figure out.

I think that ought to be enough for a PR! But I do have plans for more UI delegate trickery. I think the InstallerWindow should sport a 'Back' button to go back to earlier steps, and this should happen when errors occur that block an installation effort. I've not tried this yet, but it'll build on this PR.