### PR TITLE
Added workaround on fuel.json response parsing

### DIFF
--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -561,7 +561,15 @@ class AmazonService(OnlineService):
             raise UnavailableGameError(_(
                 "Unable to get fuel.json file, please check your Amazon credentials and internet connectivity")) from ex
 
-        res_json = request.json
+        try:
+          res_json = request.json
+        except Exception as ex:
+          try:
+            res_json = json.loads(request.content.decode('utf-8').replace("'", '"'))
+          except:
+            logger.error("Unparseable json response from %s:\n%s", fuel_url, request.content)
+            raise UnavailableGameError(_(
+                "Invalid JSON response from Amazon APIs")) from ex
 
         if res_json["Main"] is None or res_json["Main"]["Command"] is None:
             return None, None


### PR DESCRIPTION
The following games:

* Indiana Jones and the Last Crusade
* The Curse of Monkey Island
* Zak McKracken and the Alien Mindbenders

can't be installed because the json response is badly formatted, raising the exception:

```
DEBUG    2022-12-28 22:45:28,406 [application.on_game_install:660]:JSON response from https://client.legacy-app.games.a2z.com/presigned/assets/... omitted...  could not be decoded: '{
 "SchemaVersion":  "2",
 "PostInstall": [  ],
 "Main": {
   "Command": "Co'
```

The complete response is the following:

```json
{
 "SchemaVersion":  "2",
 "PostInstall": [  ],
 "Main": {
   "Command": "Common\\ScummVM\\scummvm.exe",
   "Args": ['-c', 'zak.ini', 'zak-fdd']
 }
}
```

The single quotes in the "Args" array are breaking the JSON parser.
The current PR adds the exception catching and tries to workaround the json format error by substituting the single quotes with double quotes. If it still fails, it raises a more proper message in the logs and a runtime exception for Lutris GUI.