### PR TITLE
A Back button for InstallerWindow

### DIFF
--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -44,16 +44,17 @@ class UnavailableRunnerError(Exception):
     """Raised when a runner is not installed or not installed fully."""
 
 
-def watch_errors(error_result=None):
+def watch_errors(error_result=None, handler_object=None):
     """Decorator used to catch exceptions for GUI signal handlers. This
     catches any exception from the decorated function and calls
     on_watch_errors(error) on the first argument, which we presume to be self.
     and then the method will return 'error_result'"""
+    captured_handler_object = handler_object
 
     def inner_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            myself = args[0]
+            myself = captured_handler_object or args[0]
             try:
                 return function(*args, **kwargs)
             except Exception as ex:

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -14,15 +14,20 @@ class InstallerFilesBox(Gtk.ListBox):
         "files-available": (GObject.SIGNAL_RUN_LAST, None, ())
     }
 
-    def __init__(self, installer, parent):
+    def __init__(self):
         super().__init__()
-        self.parent = parent
-        self.installer = installer
-        self.installer_files = installer.files
+        self.installer = None
         self.ready_files = set()
         self.available_files = set()
         self.installer_files_boxes = {}
         self._file_queue = []
+
+    def load_installer(self, installer):
+        self.installer = installer
+
+        for child in self.get_children():
+            child.destroy()
+
         for installer_file in installer.files:
             installer_file_box = InstallerFileBox(installer_file)
             installer_file_box.connect("file-ready", self.on_file_ready)
@@ -95,7 +100,7 @@ class InstallerFilesBox(Gtk.ListBox):
         if self._file_queue:
             next_file_id = self._file_queue.pop()
             self.installer_files_boxes[next_file_id].start()
-        if len(self.available_files) == len(self.installer_files):
+        if len(self.available_files) == len(self.installer.files):
             logger.info("All files available")
             self.emit("files-available")
 
@@ -103,5 +108,5 @@ class InstallerFilesBox(Gtk.ListBox):
         """Return a mapping of the local files usable by the interpreter"""
         return {
             installer_file.id: installer_file.dest_file
-            for installer_file in self.installer_files
+            for installer_file in self.installer.files
         }

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -23,7 +23,13 @@ class InstallerFilesBox(Gtk.ListBox):
         self._file_queue = []
 
     def load_installer(self, installer):
+        self.stop_all()
+
         self.installer = installer
+        self.available_files.clear()
+        self.ready_files.clear()
+        self.installer_files_boxes.clear()
+        self._file_queue.clear()
 
         for child in self.get_children():
             child.destroy()
@@ -45,14 +51,18 @@ class InstallerFilesBox(Gtk.ListBox):
         of simultaneously downloaded files down to a maximum number"""
         started_downloads = 0
         for file_id, file_entry in self.installer_files_boxes.items():
-            if file_entry.provider == "download":
-                started_downloads += 1
-                if started_downloads <= self.max_downloads:
-                    file_entry.start()
+            if file_id not in self.available_files:
+                if file_entry.provider == "download":
+                    started_downloads += 1
+                    if started_downloads <= self.max_downloads:
+                        file_entry.start()
+                    else:
+                        self._file_queue.append(file_id)
                 else:
-                    self._file_queue.append(file_id)
-            else:
-                file_entry.start()
+                    file_entry.start()
+        if len(self.available_files) == len(self.installer.files):
+            logger.info("All files remain available")
+            self.emit("files-available")
 
     def stop_all(self):
         """Stops all ongoing files gathering.

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -49,6 +49,12 @@ class InstallerFilesBox(Gtk.ListBox):
     def start_all(self):
         """Iterates through installer files while keeping the number
         of simultaneously downloaded files down to a maximum number"""
+
+        if len(self.available_files) == len(self.installer.files):
+            logger.info("All files remain available")
+            self.emit("files-available")
+            return
+
         started_downloads = 0
         for file_id, file_entry in self.installer_files_boxes.items():
             if file_id not in self.available_files:
@@ -60,9 +66,6 @@ class InstallerFilesBox(Gtk.ListBox):
                         self._file_queue.append(file_id)
                 else:
                     file_entry.start()
-        if len(self.available_files) == len(self.installer.files):
-            logger.info("All files remain available")
-            self.emit("files-available")
 
     def stop_all(self):
         """Stops all ongoing files gathering.

--- a/lutris/gui/installer/script_box.py
+++ b/lutris/gui/installer/script_box.py
@@ -61,6 +61,8 @@ class InstallerScriptBox(Gtk.VBox):
 
         install_button = Gtk.Button(_("Install"))
         install_button.connect("clicked", self.on_install_clicked)
+        style_context = install_button.get_style_context()
+        style_context.add_class("suggested-action")
         align.add(install_button)
         return align
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -830,8 +830,17 @@ class InstallerWindow(BaseApplicationWindow,
                                 continue_button_label=_("Continue"),
                                 sensitive=True,
                                 extra_buttons=None):
+        """This shows the continue button, plus any extra buttons you indicate.
+        This will also set the label and sensitivity of the continue button.
+
+        Finallly, you cna provide the clicked handler for the button,
+        though that can be None to leave it disconnected.
+
+        We call this repeatedly, as we arrive at each page. Each call disconnects
+        the previous clicked handler and connects the new one.
+        """
         buttons = [self.continue_button] + (extra_buttons or [])
-        self.present_buttons(buttons)
+        self.display_buttons(buttons)
 
         self.continue_button.set_label(continue_button_label)
         self.continue_button.set_sensitive(sensitive)
@@ -844,23 +853,22 @@ class InstallerWindow(BaseApplicationWindow,
             self.continue_handler = None
 
     def display_install_button(self, handler, sensitive=True, extra_buttons=None):
+        """Displays the continue button, but labels it 'Install'."""
         self.display_continue_button(handler, continue_button_label=_(
             "_Install"), sensitive=sensitive,
             extra_buttons=[self.source_button] + (extra_buttons or []))
 
     def display_cancel_button(self):
-        self.present_buttons([self.cancel_button])
+        self.display_buttons([self.cancel_button])
 
     def display_eject_button(self):
-        self.present_buttons([self.eject_button, self.cancel_button])
+        self.display_buttons([self.eject_button, self.cancel_button])
 
     def display_no_buttons(self):
-        self.present_buttons([])
+        self.display_buttons([])
 
-        if self.continue_handler:
-            self.continue_button.disconnect(self.continue_handler)
-
-    def present_buttons(self, buttons):
+    def display_buttons(self, buttons):
+        """Shows exactly the buttons given, and hides the others."""
         all_buttons = [self.cancel_button,
                        self.eject_button,
                        self.source_button,
@@ -972,7 +980,7 @@ class InstallerWindow(BaseApplicationWindow,
             self._go_to_page(page_presenter, navigated, Gtk.StackTransitionType.NONE)
 
         def _go_to_page(self, page_presenter, navigated, transition_type):
-            """Switches to a page if 'navigated' is True, then when you navigate
+            """Switches to a page. If 'navigated' is True, then when you navigate
             away from this page, it can go on the navigation stack. It should be
             False for 'temporary' pages that are not part of normal navigation."""
             exit_handler = self.navigation_exit_hander
@@ -1008,7 +1016,7 @@ class InstallerWindow(BaseApplicationWindow,
             return self.stack_pages[name]
 
         def present_replacement_page(self, name, page):
-            """This display a page that is given, rather than lazy-creating one. It
+            """This displays a page that is given, rather than lazy-creating one. It
             still needs a name, but if you re-use a name this will replace the old page.
 
             This is useful for pages that need special initialization each time they

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -52,7 +52,7 @@ class InstallerWindow(BaseApplicationWindow,
     ):
         BaseApplicationWindow.__init__(self, application=application)
         ScriptInterpreter.InterpreterUIDelegate.__init__(self, service, appid)
-        self.set_default_size(540, 320)
+        self.set_default_size(740, 460)
         self.installers = installers
         self.config = {}
         self.install_in_progress = False

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -648,7 +648,6 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     # This page asks the user for a disc; it also has a callback used when
     # the user selects a disc. Again, this is summoned by the installer script.
 
-    # TODO: restore previous page?
     def load_ask_for_disc_page(self, message, installer, callback, requires):
         def present_ask_for_disc_page():
             """Ask the user to do insert a CD-ROM."""

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -26,7 +26,7 @@ from lutris.util.system import is_removeable
 
 class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """GUI for the install process.
-    
+
     This window is divided into pages; as you go through the install each page
     is created and displayed to you. You can also go back and visit previous pages
     again. Going *forward* triggers installation work- it does not all way until the
@@ -73,7 +73,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
                                                   tooltip=_("Change where Lutris downloads game installer files."))
 
         self.close_button = self.add_end_button(_("_Close"), self.on_destroy)
-        self.play_button = self.add_end_button(_("_Launch"), self.launch_game)
+        self.play_button = self.add_end_button(_("_Launch"), self.on_launch_clicked)
         self.continue_button = self.add_end_button(_("_Continue"))
         self.source_button = self.add_end_button(_("_View source"), self.on_source_clicked)
         self.eject_button = self.add_end_button(_("_Eject"), self.on_eject_clicked)
@@ -147,16 +147,6 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     @watch_errors()
     def on_back_clicked(self, _button):
         self.stack.navigate_back()
-
-    def launch_game(self, widget, _data=None):
-        """Launch a game after it's been installed."""
-        widget.set_sensitive(False)
-        self.on_destroy(widget)
-        game = Game(self.interpreter.installer.game_id)
-        if game.id:
-            game.emit("game-launch")
-        else:
-            logger.error("Game has no ID, launch button should not be drawn")
 
     def on_destroy(self, _widget, _data=None):
         """destroy event handler"""
@@ -730,6 +720,16 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.set_status(status)
         self.stack.present_page("nothing")
         self.display_close_button(show_play_button=bool(game_id))
+
+    def on_launch_clicked(self, widget, _data=None):
+        """Launch a game after it's been installed."""
+        widget.set_sensitive(False)
+        self.on_destroy(widget)
+        game = Game(self.interpreter.installer.game_id)
+        if game.id:
+            game.emit("game-launch")
+        else:
+            logger.error("Game has no ID, launch button should not be drawn")
 
     def on_window_focus(self, _widget, *_args):
         """Remove urgency hint (flashing indicator) when window receives focus"""

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -270,6 +270,7 @@ class InstallerWindow(BaseApplicationWindow,
         self.set_status("")
         self.stack.present_page("choose_installer")
         self.display_cancel_button()
+        self.cache_button.set_sensitive(True)
 
     @watch_errors()
     def on_installer_selected(self, _widget, installer_version):
@@ -356,6 +357,7 @@ class InstallerWindow(BaseApplicationWindow,
         self.stack.present_page("destination")
         self.display_continue_button(self.on_destination_confirmed,
                                      extra_buttons=[self.source_button])
+        self.cache_button.set_sensitive(True)
 
     @watch_errors()
     def on_destination_confirmed(self, _button=None):
@@ -463,6 +465,7 @@ class InstallerWindow(BaseApplicationWindow,
         ))
         self.stack.present_page("extras")
         self.display_continue_button(on_continue, extra_buttons=[self.source_button])
+        self.cache_button.set_sensitive(True)
 
     @watch_errors()
     def on_extra_toggled(self, _widget, path, model):
@@ -551,7 +554,7 @@ class InstallerWindow(BaseApplicationWindow,
 
         self.set_status(_(
             "Please review the files needed for the installation then click 'Continue'"))
-        self.cache_button.set_sensitive(True)
+        self.cache_button.set_sensitive(False)
         self.stack.present_page("installer_files")
         self.display_install_button(self.on_files_confirmed, sensitive=self.installer_files_box.is_ready)
 
@@ -689,6 +692,7 @@ class InstallerWindow(BaseApplicationWindow,
             combobox.add_attribute(renderer_text, "text", 1)
             combobox.set_id_column(0)
             combobox.set_halign(Gtk.Align.CENTER)
+            combobox.set_valign(Gtk.Align.START)
             combobox.set_active_id(preselect)
             combobox.connect("changed", self.on_input_menu_changed)
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -787,6 +787,7 @@ class InstallerWindow(BaseApplicationWindow,
         self.stack.present_page("nothing")
         self.display_continue_button(self.on_launch_clicked,
                                      continue_button_label=_("_Launch"),
+                                     suggested_action=False,
                                      extra_buttons=[self.close_button])
 
     def on_launch_clicked(self, button):
@@ -829,6 +830,7 @@ class InstallerWindow(BaseApplicationWindow,
     def display_continue_button(self, handler,
                                 continue_button_label=_("Continue"),
                                 sensitive=True,
+                                suggested_action=True,
                                 extra_buttons=None):
         """This shows the continue button, plus any extra buttons you indicate.
         This will also set the label and sensitivity of the continue button.
@@ -844,6 +846,14 @@ class InstallerWindow(BaseApplicationWindow,
 
         self.continue_button.set_label(continue_button_label)
         self.continue_button.set_sensitive(sensitive)
+
+        style_context = self.continue_button.get_style_context()
+
+        if suggested_action:
+            style_context.add_class("suggested-action")
+        else:
+            style_context.remove_class("suggested-action")
+
         if self.continue_handler:
             self.continue_button.disconnect(self.continue_handler)
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -365,13 +365,6 @@ class InstallerWindow(BaseApplicationWindow,
         def launch_install():
             # This is a shim method to allow exceptions from
             # the interpreter to be reported via watch_errors().
-
-            # At this point we start making changes, like creating the game
-            # directory.
-            #
-            # From here out, we'll require confirmation to close this window.
-            self.install_in_progress = True
-
             if not self.interpreter.launch_install(self):
                 self.stack.navigation_reset()
 
@@ -595,6 +588,7 @@ class InstallerWindow(BaseApplicationWindow,
         GLib.idle_add(self.launch_installer_commands)
 
     def launch_installer_commands(self):
+        self.install_in_progress = True
         self.load_spinner_page(_("Installing game data"))
         self.stack.discard_navigation()  # once we really start installing, no going back!
         self.interpreter.launch_installer_commands()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -72,7 +72,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.cache_button = self.add_start_button(_("Cache"), self.on_cache_clicked,
                                                   tooltip=_("Change where Lutris downloads game installer files."))
 
-        self.close_button = self.add_end_button(_("_Close"), self.on_destroy)
+        self.close_button = self.add_end_button(_("_Close"), self.on_close_clicked)
         self.continue_button = self.add_end_button(_("_Continue"))
         self.source_button = self.add_end_button(_("_View source"), self.on_source_clicked)
         self.eject_button = self.add_end_button(_("_Eject"), self.on_eject_clicked)
@@ -147,17 +147,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     def on_back_clicked(self, _button):
         self.stack.navigate_back()
 
-    def on_destroy(self, _widget, _data=None):
-        """destroy event handler"""
-        if self.install_in_progress:
-            if self.on_cancel_clicked(_widget):
-                return True
-        else:
-            if self.interpreter:
-                self.interpreter.cleanup()
-            self.destroy()
-
-    def on_cancel_clicked(self, _widget=None):
+    def on_cancel_clicked(self, _button=None):
         """Ask a confirmation before cancelling the install"""
         widgets = []
 
@@ -726,12 +716,22 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     def on_launch_clicked(self, button):
         """Launch a game after it's been installed."""
         button.set_sensitive(False)
-        self.on_destroy(button)
+        self.on_close_clicked(button)
         game = Game(self.interpreter.installer.game_id)
         if game.id:
             game.emit("game-launch")
         else:
             logger.error("Game has no ID, launch button should not be drawn")
+
+    def on_close_clicked(self, button):
+        """Close the window. During an install this is equivalent the 'Cancel' button."""
+        if self.install_in_progress:
+            if self.on_cancel_clicked(button):
+                return True
+        else:
+            if self.interpreter:
+                self.interpreter.cleanup()
+            self.destroy()
 
     def on_window_focus(self, _widget, *_args):
         """Remove urgency hint (flashing indicator) when window receives focus"""

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -453,7 +453,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     def on_extras_ready(self, *args):
         if not self.load_installer_files_page():
             logger.debug("Installer doesn't require files")
-            self.interpreter.launch_installer_commands()
+            self.launch_installer_commands()
 
     # Installer Files & Downloading Page
 
@@ -522,6 +522,9 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         """All files are available, continue the install"""
         logger.info("All files are available, continuing install")
         self.interpreter.game_files = widget.get_game_files()
+        self.launch_installer_commands()
+
+    def launch_installer_commands(self):
         self.load_spinner_page(_("Installing game data"))
         self.stack.discard_navigation()  # once we really start installing, no going back!
         self.interpreter.launch_installer_commands()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -25,7 +25,18 @@ from lutris.util.system import is_removeable
 
 
 class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
-    """GUI for the install process."""
+    """GUI for the install process.
+    
+    This window is divided into pages; as you go through the install each page
+    is created and displayed to you. You can also go back and visit previous pages
+    again. Going *forward* triggers installation work- it does not all way until the
+    very end.
+
+    Most pages are defined by a load_X_page() function that initializes the page
+    when arriving at it, and which presents it. But this uses a present_X_page() page
+    that shows the page (and is used alone for the 'Back' button), and this in turn
+    uses a create_X_page() function to create the page the first time it is visited.
+    """
 
     def __init__(
         self,
@@ -104,7 +115,6 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         # And... go!
         self.show_all()
 
-        self.install_in_progress = True
         self.load_choose_installer_page()
         self.present()
 
@@ -325,6 +335,12 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         # This is a shim method to allow exceptions from
         # the interpreter to be reported via watch_errors().
         try:
+            # At this point we start making changes, like creating the game
+            # directory.
+            #
+            # From here out, we'll require confirmation to close this window.
+            self.install_in_progress = True
+
             if not self.interpreter.launch_install(self):
                 self.stack.navigate_reset()
         except Exception as ex:

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -902,7 +902,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
                 self.navigation_stack.append(self.current_navigated_page_presenter)
                 self._update_back_button()
 
-            self._go_to_page(page_presenter, True, transition_type=Gtk.StackTransitionType.SLIDE_LEFT)
+            self._go_to_page(page_presenter, True, Gtk.StackTransitionType.SLIDE_LEFT)
 
         def jump_to_page(self, page_presenter):
             """Jumps to a page, without updating navigation state.
@@ -910,11 +910,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
             This does not disturb the behavior of navigate_back().
             This does invoke the exit handler of the current page.
             """
-            self._go_to_page(page_presenter, False, transition_type=Gtk.StackTransitionType.SLIDE_LEFT)
-
-        def jump_back_to_page(self, page_presenter):
-            """Jumps to a page, but with the reverse animation."""
-            self._go_to_page(page_presenter, False, transition_type=Gtk.StackTransitionType.SLIDE_RIGHT)
+            self._go_to_page(page_presenter, False, Gtk.StackTransitionType.NONE)
 
         def navigate_back(self):
             """This navigates to the previous page, if any. This will invoke the
@@ -923,7 +919,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
             if self.navigation_stack:
                 try:
                     back_to = self.navigation_stack.pop()
-                    self._go_to_page(back_to, True, transition_type=Gtk.StackTransitionType.SLIDE_RIGHT)
+                    self._go_to_page(back_to, True, Gtk.StackTransitionType.SLIDE_RIGHT)
                 finally:
                     self._update_back_button()
 
@@ -937,7 +933,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
             This does not disturb the navigation stack."""
             page_presenter, navigated_presenter = state
             navigated = page_presenter == navigated_presenter
-            self._go_to_page(page_presenter, navigated, transition_type=Gtk.StackTransitionType.SLIDE_RIGHT)
+            self._go_to_page(page_presenter, navigated, Gtk.StackTransitionType.NONE)
 
         def _go_to_page(self, page_presenter, navigated, transition_type):
             """Switches to a page if 'navigated' is True, then when you navigate

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -201,6 +201,8 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.stack.add_named_factory("nothing", lambda *x: Gtk.Box())
 
     # Choose Installer Page
+    #
+    # This page offers a choice of installer scripts to run.
 
     def load_choose_installer_page(self):
         self.validate_scripts()
@@ -266,6 +268,9 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
                     raise ScriptingError(_('Missing field "%s" in install script') % item)
 
     # Destination Page
+    #
+    # This page selects the directory where the game will be installed,
+    # as well as few other minor options.
 
     def load_destination_page(self):
         """Stage where we select the install directory."""
@@ -346,6 +351,12 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.load_extras_page()
 
     # Extras Page
+    #
+    # This pages offers to download the extras that come with the game; the
+    # user specifies the specific extras desired.
+    #
+    # If there are no extras, the page triggers as if the user had clicked 'Continue',
+    # moving on to pre-installation, then the installer files page.
 
     def load_extras_page(self):
         def get_extra_label(extra):
@@ -462,6 +473,10 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
             self.launch_installer_commands()
 
     # Installer Files & Downloading Page
+    #
+    # This page shows the files that are needed, and can download them. The user can
+    # also select pre-existing files. The downloading page uses the same page widget,
+    # but different buttons at the bottom.
 
     def load_installer_files_page(self):
         try:
@@ -536,6 +551,9 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.interpreter.launch_installer_commands()
 
     # Spinner Page
+    #
+    # Provides a generic progress spinner and displays a status. The back button
+    # is disabled for this page.
 
     def load_spinner_page(self, status):
         self.stack.jump_to_page(lambda *x: self.present_spinner_page(status))
@@ -558,6 +576,9 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         return on_exit_page
 
     # Log Page
+    #
+    # This page shos a LogTextView where an installer command can display
+    # output. This appears when summons by the installer script.
 
     def load_log_page(self, command):
         command.set_log_buffer(self.log_buffer)
@@ -579,7 +600,12 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.display_no_buttons()
 
     # Input Menu Page
+    #
+    # This page shows a list of choices to the user, and calls
+    # back into a callback when the user makes a choice. This is summoned
+    # by the installer script as well.
 
+    # TODO: restore previous page?
     def load_input_menu_page(self, alias, options, preselect, callback):
         def present_input_menu_page():
             """Display an input request as a dropdown menu with options."""
@@ -615,7 +641,11 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.continue_button.set_sensitive(bool(combobox.get_active_id()))
 
     # Ask for Disc Page
+    #
+    # This page asks the user for a disc; it also has a callback used when
+    # the user selects a disc. Again, this is summoned by the installer script.
 
+    # TODO: restore previous page?
     def load_ask_for_disc_page(self, message, installer, callback, requires):
         def present_ask_for_disc_page():
             """Ask the user to do insert a CD-ROM."""
@@ -670,6 +700,9 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.interpreter.eject_wine_disc()
 
     # Error Message Page
+    #
+    # This is used to display an error; such a error halts the installation,
+    # and isn't recoverable. Used by the installer script.
 
     def load_error_message_page(self, message):
         self.stack.navigate_to_page(lambda *x: self.present_error_page(message))
@@ -681,6 +714,11 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.display_cancel_button()
 
     # Finished Page
+    #
+    # This is used to inidcate that the install is complete. The user
+    # can launch the game a this point, or just close out of the window.
+    #
+    # Loading this page does some final installation steps before the UI updates.
 
     def load_finish_install_page(self, game_id, status):
         if self.config.get("create_desktop_shortcut"):

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -189,6 +189,7 @@ class InstallerWindow(BaseApplicationWindow,
 
     def on_watched_error(self, error):
         ErrorDialog(str(error), parent=self)
+        self.stack.navigation_reset()
 
     def set_status(self, text):
         """Display a short status text."""
@@ -976,6 +977,11 @@ class InstallerWindow(BaseApplicationWindow,
                     self._go_to_page(back_to, True, Gtk.StackTransitionType.SLIDE_RIGHT)
                 finally:
                     self._update_back_button()
+
+        def navigation_reset(self):
+            if self.current_navigated_page_presenter:
+                if self.current_page_presenter != self.current_navigated_page_presenter:
+                    self._go_to_page(self.current_navigated_page_presenter, True, Gtk.StackTransitionType.SLIDE_RIGHT)
 
         def save_current_page(self):
             """Returns a tuple containing information about the current page,

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -119,6 +119,7 @@ class InstallerWindow(BaseApplicationWindow,
         self.installer_files_box.connect("files-ready", self.on_files_ready)
 
         self.log_buffer = Gtk.TextBuffer()
+        self.error_reporter = self.load_error_message_page
 
         # And... go!
         self.show_all()
@@ -227,7 +228,7 @@ class InstallerWindow(BaseApplicationWindow,
 
     def report_error(self, error):
         message = repr(error)
-        GLib.idle_add(self.load_error_message_page, message)
+        GLib.idle_add(self.error_reporter, message)
 
     def report_status(self, status):
         GLib.idle_add(self.set_status, status)
@@ -648,8 +649,17 @@ class InstallerWindow(BaseApplicationWindow,
     def present_log_page(self):
         """Creates a TextBuffer and attach it to a command"""
 
+        def on_exit_page():
+            self.error_reporter = saved_reporter
+
+        def on_error(error):
+            self.set_status(str(error))
+
+        saved_reporter = self.error_reporter
+        self.error_reporter = on_error
         self.stack.present_page("log")
         self.display_cancel_button()
+        return on_exit_page
 
     # Input Menu Page
     #

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -221,7 +221,7 @@ class InstallerWindow(BaseApplicationWindow,
         command.set_log_buffer(self.log_buffer)
         GLib.idle_add(self.load_log_page)
 
-    def being_disc_prompt(self, message, requires, installer, callback):
+    def begin_disc_prompt(self, message, requires, installer, callback):
         GLib.idle_add(self.load_ask_for_disc_page, message, requires, installer, callback, )
 
     def begin_input_menu(self, alias, options, preselect, callback):
@@ -692,8 +692,9 @@ class InstallerWindow(BaseApplicationWindow,
             def wrapped_callback(*args, **kwargs):
                 try:
                     callback(*args, **kwargs)
+                    self.stack.restore_current_page(previous_page)
                 except Exception as err:
-                    ErrorDialog(str(err), parent=self)
+                    self.load_error_message_page(str(err))
 
             vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
             label = InstallerWindow.MarkupLabel(message)
@@ -724,6 +725,7 @@ class InstallerWindow(BaseApplicationWindow,
             else:
                 self.display_cancel_button()
 
+        previous_page = self.stack.save_current_page()
         self.stack.jump_to_page(present_ask_for_disc_page)
 
     @watch_errors()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -376,12 +376,15 @@ class InstallerWindow(BaseApplicationWindow,
         """Set the installation target for the game."""
         self.interpreter.target_path = os.path.expanduser(entry.get_text())
 
+    @watch_errors()
     def on_create_desktop_shortcut_clicked(self, checkbutton):
         self.config["create_desktop_shortcut"] = checkbutton.get_active()
 
+    @watch_errors()
     def on_create_menu_shortcut_clicked(self, checkbutton):
         self.config["create_menu_shortcut"] = checkbutton.get_active()
 
+    @watch_errors()
     def on_create_steam_shortcut_clicked(self, checkbutton):
         self.config["create_steam_shortcut"] = checkbutton.get_active()
 
@@ -562,6 +565,7 @@ class InstallerWindow(BaseApplicationWindow,
         self.display_install_button(None, sensitive=False)
         return on_exit_page
 
+    @watch_errors()
     def on_files_ready(self, _widget, files_ready):
         """Toggle state of continue button based on ready state"""
         self.display_install_button(self.on_files_confirmed, sensitive=files_ready)
@@ -698,6 +702,7 @@ class InstallerWindow(BaseApplicationWindow,
         previous_page = self.stack.save_current_page()
         self.stack.jump_to_page(present_input_menu_page)
 
+    @watch_errors()
     def on_input_menu_changed(self, combobox):
         """Enable continue button if a non-empty choice is selected"""
         self.continue_button.set_sensitive(bool(combobox.get_active_id()))
@@ -817,6 +822,7 @@ class InstallerWindow(BaseApplicationWindow,
                                      continue_button_label=_("_Launch"),
                                      suggested_action=False)
 
+    @watch_errors()
     def on_launch_clicked(self, button):
         """Launch a game after it's been installed."""
         button.set_sensitive(False)
@@ -827,6 +833,7 @@ class InstallerWindow(BaseApplicationWindow,
         else:
             logger.error("Game has no ID, launch button should not be drawn")
 
+    @watch_errors()
     def on_window_focus(self, _widget, *_args):
         """Remove urgency hint (flashing indicator) when window receives focus"""
         self.set_urgency_hint(False)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -415,19 +415,17 @@ class InstallerWindow(BaseApplicationWindow,
                 label += " (%s)" % ", ".join(_infos)
             return label
 
-        if self.interpreter.extras is None:
-            all_extras = self.interpreter.get_extras()
-            if all_extras:
-                self.extras_tree_store.clear()
-                for extra_source, extras in all_extras.items():
-                    parent = self.extras_tree_store.append(None, (None, None, None, extra_source))
-                    for extra in extras:
-                        self.extras_tree_store.append(parent, (False, False, extra["id"], get_extra_label(extra)))
+        all_extras = self.interpreter.get_extras()
+        if all_extras:
+            self.extras_tree_store.clear()
+            for extra_source, extras in all_extras.items():
+                parent = self.extras_tree_store.append(None, (None, None, None, extra_source))
+                for extra in extras:
+                    self.extras_tree_store.append(parent, (False, False, extra["id"], get_extra_label(extra)))
 
-                self.stack.navigate_to_page(self.present_extras_page)
-                return
-
-        self.on_extras_ready()
+            self.stack.navigate_to_page(self.present_extras_page)
+        else:
+            self.on_extras_ready()
 
     def create_extras_page(self):
         treeview = Gtk.TreeView(self.extras_tree_store)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -46,14 +46,13 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.installation_kind = installation_kind
         self.log_buffer = Gtk.TextBuffer()
 
-        button_box = Gtk.Box(spacing=6)
         self.back_button = Gtk.Button(_("Back"), sensitive=False)
         self.back_button.connect("clicked", self.on_back_clicked)
-        button_box.add(self.back_button)
+        self.action_buttons.add(self.back_button)
 
         self.cache_button = Gtk.Button(_("Cache"))
         self.cache_button.connect("clicked", self.on_cache_clicked)
-        button_box.add(self.cache_button)
+        self.action_buttons.add(self.cache_button)
 
         self.title_label = InstallerWindow.MarkupLabel(selectable=False)
         self.title_label.set_markup(_("<b>Install %s</b>") % gtk_safe(self.installers[0]["name"]))
@@ -63,31 +62,19 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
         self.vbox.add(self.status_label)
 
         self.stack = InstallerWindow.NavigationStack(self.back_button)
-        self.stack.add_named_factory("choose_installer", self.create_choose_installer_page)
-        self.stack.add_named_factory("destination", self.create_destination_page)
-        self.stack.add_named_factory("installer_files", self.create_installer_files_page)
-        self.stack.add_named_factory("extras", self.create_extras_page)
-        self.stack.add_named_factory("spinner", self.create_spinner_page)
-        self.stack.add_named_factory("log", self.create_log_page)
-        self.stack.add_named_factory("nothing", lambda *x: Gtk.Box())
+        self.register_page_creators()
         self.vbox.pack_start(self.stack, True, True, 0)
 
         self.vbox.add(Gtk.HSeparator())
 
-        self.action_buttons = Gtk.Box(spacing=6)
-        action_buttons_alignment = Gtk.Alignment.new(1, 0, 0, 0)
-        action_buttons_alignment.add(self.action_buttons)
-        button_box.pack_end(action_buttons_alignment, True, True, 0)
-        self.vbox.pack_start(button_box, False, True, 0)
-
+        self.close_button = self.add_button(_("_Close"), self.on_destroy)
+        self.play_button = self.add_button(_("_Launch"), self.launch_game)
+        self.continue_button = self.add_button(_("_Continue"))
+        self.source_button = self.add_button(_("_View source"), self.on_source_clicked)
+        self.eject_button = self.add_button(_("_Eject"), self.on_eject_clicked)
         self.cancel_button = self.add_button(
             _("C_ancel"), self.on_cancel_clicked, tooltip=_("Abort and revert the installation")
         )
-        self.eject_button = self.add_button(_("_Eject"), self.on_eject_clicked)
-        self.source_button = self.add_button(_("_View source"), self.on_source_clicked)
-        self.continue_button = self.add_button(_("_Continue"))
-        self.play_button = self.add_button(_("_Launch"), self.launch_game)
-        self.close_button = self.add_button(_("_Close"), self.on_destroy)
 
         self.continue_handler = None
 
@@ -125,7 +112,7 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
             button.set_tooltip_text(tooltip)
         if handler:
             button.connect("clicked", handler)
-        self.action_buttons.add(button)
+        self.action_buttons.pack_end(button, False, False, 0)
         return button
 
     @watch_errors()
@@ -200,6 +187,15 @@ class InstallerWindow(BaseApplicationWindow, DialogInstallUIDelegate):  # pylint
     def set_status(self, text):
         """Display a short status text."""
         self.status_label.set_text(text)
+
+    def register_page_creators(self):
+        self.stack.add_named_factory("choose_installer", self.create_choose_installer_page)
+        self.stack.add_named_factory("destination", self.create_destination_page)
+        self.stack.add_named_factory("installer_files", self.create_installer_files_page)
+        self.stack.add_named_factory("extras", self.create_extras_page)
+        self.stack.add_named_factory("spinner", self.create_spinner_page)
+        self.stack.add_named_factory("log", self.create_log_page)
+        self.stack.add_named_factory("nothing", lambda *x: Gtk.Box())
 
     # Choose Installer Page
 

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -216,6 +216,8 @@ class CommandsMixin:
         if choosen_option:
             self.user_inputs.append({"alias": alias, "value": choosen_option})
             self._iter_commands()
+        else:
+            raise RuntimeError("A required input option was not selected, so the installation can't continue.")
 
     def insert_disc(self, data):
         """Request user to insert an optical disc"""
@@ -248,7 +250,7 @@ class CommandsMixin:
                 self.game_disc = drive
                 self._iter_commands()
                 return
-        
+
         raise RuntimeError(_("The required file '%s' could not be located.") % requires)
 
     def mkdir(self, directory):

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -168,7 +168,7 @@ class CommandsMixin:
         )
         command.accepted_return_code = return_code
         command.start()
-        GLib.idle_add(self.parent.show_log, command)
+        GLib.idle_add(self.parent.load_log_page, command)
         self.heartbeat = GLib.timeout_add(1000, self._monitor_task, command)
         return "STOP"
 
@@ -207,7 +207,7 @@ class CommandsMixin:
         options = data["options"]
         preselect = self._substitute(data.get("preselect", ""))
         GLib.idle_add(
-            self.parent.show_input_menu,
+            self.parent.load_input_menu_page,
             alias,
             options,
             preselect,
@@ -238,7 +238,7 @@ class CommandsMixin:
               "containing the following file or folder:\n"
               "<i>%s</i>") % requires
         )
-        GLib.idle_add(self.parent.ask_for_disc, message,
+        GLib.idle_add(self.parent.load_ask_for_disc_page, message,
                       self.installer, self._find_matching_disc, requires)
         return "STOP"
 
@@ -441,7 +441,7 @@ class CommandsMixin:
         GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
         if isinstance(command, MonitoredCommand):
             # Monitor thread and continue when task has executed
-            GLib.idle_add(self.parent.show_log, command)
+            GLib.idle_add(self.parent.load_log_page, command)
             self.heartbeat = GLib.timeout_add(1000, self._monitor_task, command)
             return "STOP"
         return None

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -168,7 +168,7 @@ class CommandsMixin:
         )
         command.accepted_return_code = return_code
         command.start()
-        GLib.idle_add(self.parent.attach_logger, command)
+        GLib.idle_add(self.parent.present_log_page, command)
         self.heartbeat = GLib.timeout_add(1000, self._monitor_task, command)
         return "STOP"
 
@@ -208,7 +208,7 @@ class CommandsMixin:
         options = data["options"]
         preselect = self._substitute(data.get("preselect", ""))
         GLib.idle_add(
-            self.parent.input_menu,
+            self.parent.present_input_menu_page,
             alias,
             options,
             preselect,
@@ -242,7 +242,7 @@ class CommandsMixin:
         )
         if self.installer.runner == "wine":
             GLib.idle_add(self.parent.eject_button.show)
-        GLib.idle_add(self.parent.ask_for_disc, message, self._find_matching_disc, requires)
+        GLib.idle_add(self.parent.present_ask_for_disc_page, message, self._find_matching_disc, requires)
         return "STOP"
 
     def _find_matching_disc(self, _widget, requires, extra_path=None):
@@ -444,7 +444,7 @@ class CommandsMixin:
         GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
         if isinstance(command, MonitoredCommand):
             # Monitor thread and continue when task has executed
-            GLib.idle_add(self.parent.attach_logger, command)
+            GLib.idle_add(self.parent.present_log_page, command)
             self.heartbeat = GLib.timeout_add(1000, self._monitor_task, command)
             return "STOP"
         return None

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -209,9 +209,7 @@ class CommandsMixin:
         self.interpreter_ui_delegate.begin_input_menu(alias, options, preselect, self._on_input_menu_validated)
         return "STOP"
 
-    def _on_input_menu_validated(self, _widget, *args):
-        alias = args[0]
-        menu = args[1]
+    def _on_input_menu_validated(self, alias, menu):
         choosen_option = menu.get_active_id()
         if choosen_option:
             self.user_inputs.append({"alias": alias, "value": choosen_option})

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -168,7 +168,7 @@ class CommandsMixin:
         )
         command.accepted_return_code = return_code
         command.start()
-        GLib.idle_add(self.parent.present_log_page, command)
+        GLib.idle_add(self.parent.show_log, command)
         self.heartbeat = GLib.timeout_add(1000, self._monitor_task, command)
         return "STOP"
 
@@ -204,15 +204,13 @@ class CommandsMixin:
         self._check_required_params("options", data, "input_menu")
         identifier = data.get("id")
         alias = "INPUT_%s" % identifier if identifier else None
-        has_entry = data.get("entry")
         options = data["options"]
         preselect = self._substitute(data.get("preselect", ""))
         GLib.idle_add(
-            self.parent.present_input_menu_page,
+            self.parent.show_input_menu,
             alias,
             options,
             preselect,
-            has_entry,
             self._on_input_menu_validated,
         )
         return "STOP"
@@ -240,9 +238,8 @@ class CommandsMixin:
               "containing the following file or folder:\n"
               "<i>%s</i>") % requires
         )
-        if self.installer.runner == "wine":
-            GLib.idle_add(self.parent.eject_button.show)
-        GLib.idle_add(self.parent.present_ask_for_disc_page, message, self._find_matching_disc, requires)
+        GLib.idle_add(self.parent.present_ask_for_disc_page, message,
+                      self.installer, self._find_matching_disc, requires)
         return "STOP"
 
     def _find_matching_disc(self, _widget, requires, extra_path=None):
@@ -444,7 +441,7 @@ class CommandsMixin:
         GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
         if isinstance(command, MonitoredCommand):
             # Monitor thread and continue when task has executed
-            GLib.idle_add(self.parent.present_log_page, command)
+            GLib.idle_add(self.parent.show_log, command)
             self.heartbeat = GLib.timeout_add(1000, self._monitor_task, command)
             return "STOP"
         return None

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -14,7 +14,7 @@ from lutris import runtime
 from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import UnavailableRunnerError
+from lutris.exceptions import UnavailableRunnerError, watch_errors
 from lutris.game import Game
 from lutris.installer.errors import ScriptingError
 from lutris.runners import import_task
@@ -440,14 +440,16 @@ class CommandsMixin:
             return "STOP"
         return None
 
+    @watch_errors(error_result=False)
     def _monitor_task(self, command):
         if not command.is_running:
             logger.debug("Return code: %s", command.return_code)
             if command.return_code not in (str(command.accepted_return_code), "0"):
                 raise ScriptingError(_("Command exited with code %s") % command.return_code)
+
             self._iter_commands()
             return False
-        return True
+        return True  # keep checking
 
     def write_file(self, params):
         """Write text to a file."""

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -247,7 +247,9 @@ class CommandsMixin:
                 logger.debug("Found %s on cdrom %s", requires, drive)
                 self.game_disc = drive
                 self._iter_commands()
-                break
+                return
+        
+        raise RuntimeError(_("The required file '%s' could not be located.") % requires)
 
     def mkdir(self, directory):
         """Create directory"""

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -221,7 +221,6 @@ class CommandsMixin:
         choosen_option = menu.get_active_id()
         if choosen_option:
             self.user_inputs.append({"alias": alias, "value": choosen_option})
-            GLib.idle_add(self.parent.continue_button.hide)
             self._iter_commands()
 
     def insert_disc(self, data):
@@ -399,8 +398,6 @@ class CommandsMixin:
         passed to the runner task.
         """
         self._check_required_params("name", data, "task")
-        if self.parent:
-            GLib.idle_add(self.parent.cancel_button.set_sensitive, False)
         runner_name, task_name = self._get_task_runner_and_name(data.pop("name"))
 
         # Accept return codes other than 0
@@ -438,7 +435,6 @@ class CommandsMixin:
         command = task(**data)
         if command:
             command.accepted_return_code = return_code
-        GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
         if isinstance(command, MonitoredCommand):
             # Monitor thread and continue when task has executed
             GLib.idle_add(self.parent.load_log_page, command)

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -238,7 +238,7 @@ class CommandsMixin:
               "containing the following file or folder:\n"
               "<i>%s</i>") % requires
         )
-        GLib.idle_add(self.parent.present_ask_for_disc_page, message,
+        GLib.idle_add(self.parent.ask_for_disc, message,
                       self.installer, self._find_matching_disc, requires)
         return "STOP"
 

--- a/lutris/installer/errors.py
+++ b/lutris/installer/errors.py
@@ -18,6 +18,9 @@ class ScriptingError(Exception):
         logger.error(self.__str__())
 
     def __str__(self):
+        if self.faulty_data is None:
+            return self.message
+
         faulty_data = repr(self.faulty_data)
         return self.message + "\n%s" % faulty_data if faulty_data else ""
 

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -151,7 +151,6 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         installer_files = None
         installer_file_id = self.pop_user_provided_file()
         if not installer_file_id:
-            logger.warning("Could not find a file for this service")
             return
 
         try:

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -133,8 +133,8 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         return errors
 
     def get_user_provided_file(self):
-        """Return and remove the first user provided file, which is used for game stores"""
-        for index, file in enumerate(self.script_files):
+        """Return the first user provided file, which is used for game stores"""
+        for file in self.script_files:
             if file.url.startswith("N/A"):
                 return file.id
 

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -13,11 +13,18 @@ from lutris.util.strings import add_url_tags, gtk_safe
 class InstallerFile:
     """Representation of a file in the `files` sections of an installer"""
 
-    def __init__(self, game_slug, file_id, file_meta):
+    def __init__(self, game_slug, file_id, file_meta, dest_file = None):
         self.game_slug = game_slug
         self.id = file_id.replace("-", "_")  # pylint: disable=invalid-name
         self._file_meta = file_meta
-        self._dest_file = None  # Used to override the destination
+        self._dest_file = dest_file  # Used to override the destination
+
+    def copy(self):
+        """Copies this file object, so the copy can be modified safely."""
+        if isinstance(self._file_meta, dict):
+            return InstallerFile(self.game_slug, self.id, dict(self._file_meta), self.dest_file)
+        else:
+            return InstallerFile(self.game_slug, self.id, self._file_meta, self.dest_file)
 
     @property
     def url(self):

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -22,7 +22,7 @@ class InstallerFile:
     def copy(self):
         """Copies this file object, so the copy can be modified safely."""
         if isinstance(self._file_meta, dict):
-            return InstallerFile(self.game_slug, self.id, dict(self._file_meta), self.dest_file)
+            return InstallerFile(self.game_slug, self.id, self._file_meta.copy(), self.dest_file)
         else:
             return InstallerFile(self.game_slug, self.id, self._file_meta, self.dest_file)
 

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -13,7 +13,7 @@ from lutris.util.strings import add_url_tags, gtk_safe
 class InstallerFile:
     """Representation of a file in the `files` sections of an installer"""
 
-    def __init__(self, game_slug, file_id, file_meta, dest_file = None):
+    def __init__(self, game_slug, file_id, file_meta, dest_file=None):
         self.game_slug = game_slug
         self.id = file_id.replace("-", "_")  # pylint: disable=invalid-name
         self._file_meta = file_meta
@@ -23,8 +23,8 @@ class InstallerFile:
         """Copies this file object, so the copy can be modified safely."""
         if isinstance(self._file_meta, dict):
             return InstallerFile(self.game_slug, self.id, self._file_meta.copy(), self.dest_file)
-        else:
-            return InstallerFile(self.game_slug, self.id, self._file_meta, self.dest_file)
+
+        return InstallerFile(self.game_slug, self.id, self._file_meta, self.dest_file)
 
     @property
     def url(self):

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -306,7 +306,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         commands = self.installer.script.get("installer", [])
         if exception:
             logger.error("Last install command failed, show error")
-            self.parent.show_install_error_message(repr(exception))
+            self.parent.load_error_message_page(repr(exception))
         elif self.current_command < len(commands):
             try:
                 command = commands[self.current_command]
@@ -371,7 +371,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         else:
             status = (self.installer.script.get("install_complete_text") or _("Installation completed!"))
         download_lutris_media(self.installer.game_slug)
-        self.parent.finish_install(game_id, status)
+        self.parent.load_finish_install_page(game_id, status)
 
     def cleanup(self):
         """Clean up install dir after a successful install"""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -2,7 +2,7 @@
 import os
 from gettext import gettext as _
 
-from gi.repository import GLib, GObject
+from gi.repository import GObject
 
 from lutris import settings
 from lutris.config import LutrisConfig

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -7,6 +7,7 @@ from gi.repository import GObject
 from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
+from lutris.exceptions import watch_errors
 from lutris.installer import AUTO_EXE_PREFIX
 from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependency, ScriptingError
@@ -329,6 +330,10 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             )
         self._iter_commands()
 
+    def on_watched_error(self, error):
+        self.interpreter_ui_delegate.report_error(error)
+
+    @watch_errors()
     def _iter_commands(self, result=None, exception=None):
 
         if result == "STOP" or self.cancelled:

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -47,7 +47,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         def attach_log(self, command):
             """Called to attach the command to a log UI, so its log output can be viewed."""
 
-        def being_disc_prompt(self, message, requires, installer, callback):
+        def begin_disc_prompt(self, message, requires, installer, callback):
             """Called to prompt for a disc. When the disc is provided, the callback is invoked.
             The method returns immediately, however."""
             raise NotImplementedError()

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -303,7 +303,6 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         if result == "STOP" or self.cancelled:
             return
 
-        self.parent.set_status(_("Installing game data"))
         self.parent.present_spinner_page()
         self.parent.continue_button.hide()
 
@@ -367,18 +366,15 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
                 and not os.path.isfile(path)
                 and self.installer.runner not in ("web", "browser")
         ):
-            self.parent.set_status(
-                _(
-                    "The executable at path %s can't be found, please check the destination folder.\n"
-                    "Some parts of the installation process may have not completed successfully."
-                ) % path
-            )
+            status = _(
+                "The executable at path %s can't be found, please check the destination folder.\n"
+                "Some parts of the installation process may have not completed successfully."
+            ) % path
             logger.warning("No executable found at specified location %s", path)
         else:
-            install_complete_text = (self.installer.script.get("install_complete_text") or _("Installation completed!"))
-            self.parent.set_status(install_complete_text)
+            status = (self.installer.script.get("install_complete_text") or _("Installation completed!"))
         download_lutris_media(self.installer.game_slug)
-        self.parent.finish_install(game_id)
+        self.parent.finish_install(game_id, status)
 
     def cleanup(self):
         """Clean up install dir after a successful install"""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -303,9 +303,6 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         if result == "STOP" or self.cancelled:
             return
 
-        self.parent.present_spinner_page()
-        self.parent.continue_button.hide()
-
         commands = self.installer.script.get("installer", [])
         if exception:
             logger.error("Last install command failed, show error")

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -276,7 +276,6 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         try:
             runner = import_runner(runner_name)
         except InvalidRunner as err:
-            GLib.idle_add(self.parent.cancel_button.set_sensitive, True)
             raise ScriptingError(_("Invalid runner provided %s") % runner_name) from err
         return runner
 

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -190,10 +190,8 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
     def get_extras(self):
         """Get extras and store them to move them at the end of the install"""
         if not self.service or not self.service.has_extras:
-            self.extras = []
-            return self.extras
-        self.extras = self.service.get_extras(self.installer.service_appid)
-        return self.extras
+            return []
+        return self.service.get_extras(self.installer.service_appid)
 
     def launch_install(self, ui_delegate):
         """Launch the install process; returns False if cancelled by the user."""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -71,7 +71,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         self.game_dir_created = False  # Whether a game folder was created during the install
         # Extra files for installers, either None if the extras haven't been checked yet.
         # Or a list of IDs of extras to be downloaded during the install
-        self.extras = None
+        self.extras = []
         self.game_disc = None
         self.game_files = {}
         self.cancelled = False
@@ -312,7 +312,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         os.makedirs(self.cache_path, exist_ok=True)
 
         # Copy extras to game folder
-        if len(self.extras) and len(self.extras) == len(self.installer.files):
+        if self.extras and len(self.extras) == len(self.installer.files):
             # Reset the install script in case there are only extras.
             logger.warning("Installer with only extras and no game files")
             self.installer.script["installer"] = []

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -95,10 +95,6 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         if self.installer.creates_game_folder:
             self.target_path = self.get_default_target()
 
-        # Run variable substitution on the URLs
-        for file in self.installer.files:
-            file.set_url(self._substitute(file.url))
-
     @property
     def appid(self):
         logger.warning("Do not access appid from interpreter")

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -304,7 +304,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             return
 
         self.parent.set_status(_("Installing game data"))
-        self.parent.add_spinner()
+        self.parent.present_spinner_page()
         self.parent.continue_button.hide()
 
         commands = self.installer.script.get("installer", [])

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -93,7 +93,6 @@ class GOGService(OnlineService):
 
     def __init__(self):
         super().__init__()
-        self.selected_extras = None
 
         gog_locales = {
             "en": "en-US",
@@ -402,10 +401,10 @@ class GOGService(OnlineService):
                 })
         return download_links
 
-    def get_extra_files(self, downloads, installer):
+    def get_extra_files(self, downloads, installer, selected_extras):
         extra_files = []
         for extra in downloads["bonus_content"]:
-            if str(extra["id"]) not in self.selected_extras:
+            if str(extra["id"]) not in selected_extras:
                 continue
             links = self.query_download_links(extra)
             for link in links:
@@ -481,7 +480,7 @@ class GOGService(OnlineService):
             raise UnavailableGameError(_("Unable to determine correct file to launch installer"))
         return files
 
-    def get_installer_files(self, installer, installer_file_id):
+    def get_installer_files(self, installer, installer_file_id, selected_extras):
         try:
             downloads = self.get_downloads(installer.service_appid)
         except HTTPError as err:
@@ -491,8 +490,8 @@ class GOGService(OnlineService):
             files = self._format_links(installer, installer_file_id, links)
         else:
             files = []
-        if self.selected_extras:
-            for extra_file in self.get_extra_files(downloads, installer):
+        if selected_extras:
+            for extra_file in self.get_extra_files(downloads, installer, selected_extras):
                 files.append(extra_file)
         return files
 

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -215,7 +215,7 @@ class HumbleBundleService(OnlineService):
                 download_links.append(download)
         return download_links
 
-    def get_installer_files(self, installer, installer_file_id):
+    def get_installer_files(self, installer, installer_file_id, _selected_extras):
         """Replace the user provided file with download links from Humble Bundle"""
         try:
             link = get_humble_download_link(installer.service_appid, installer.runner)

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -112,7 +112,7 @@ class SteamService(BaseService):
         self.is_loading = False
         return steam_games
 
-    def get_installer_files(self, installer, installer_file_id):
+    def get_installer_files(self, installer, installer_file_id, _selected_extras):
         steam_uri = "$STEAM:%s:."
         appid = str(installer.script["game"]["appid"])
         return [


### PR DESCRIPTION
Do you fear commitment? I know you do! And until now, when you used the InstallerWindow, there was no turning back. Now, there is! A back button lets you revisit previous pages, make changes, and continue again.
![image](https://user-images.githubusercontent.com/6507403/210134617-c9b651c4-1f2f-4ae5-8ae4-907e499d7dc8.png)

But this was a much bigger PR than I had expected. It's almost a rewrite of InstallerWindow, with collateral changes to enable retries on various operations, so you can go back, make changes and have them take effect as you 'Continue' again.

You'll also notice that I got my blue and red crayons out again.

There are other changes. Consider this page:
![image](https://user-images.githubusercontent.com/6507403/210134653-97b4f621-aa92-4f27-9d0c-c4ec2c2e9afa.png)
Here we've got "Install" instead of "Continue"; until this point we've made no changes that we could revert (we might install runners). When you click "Install", the downloads runs and then the install begins. *Now* it will create the game's directory, WINE prefix, and so on. Until now, you can cancel out without confirmation. After this, you get the 'do you want to delete everything' dialog.
![image](https://user-images.githubusercontent.com/6507403/210134715-8789fe15-26e3-4a4f-9655-4ae4e9d2408e.png)
The 'Cancel' button is now 'Abort'; that will cancel downloading, stop the install, and offer to remove the game directory and all that. It only becomes "Close" at the very end.

The error handling is beefed up too with the power of backitude. If you try to install a Steam game without Steam, you get an error dialog, and then you are back to the choose-installer screen so you can pick GOG like a sensible person.

Here's a different error from "Dust: An Elysian Tale" which never bloody worked for me:
![image](https://user-images.githubusercontent.com/6507403/210134946-04615bd0-6a45-490f-91bd-fc55ee46caaa.png)
The log *remains* visible for this error, but there's no recovery. Aborting is the only option, though you can still keep the broken install as usual.

I've done a bunch of testing with this, and fixed many cases where errors caused the install to hang forever with no explicit error. I've really tried to fix that.

The installer-window is being controlled via a delegate, but it's a bit of a stub. I'd expect command line installs to just install, not pop up the InstallerWindow, but that's not here yet- you still get the window. But this is just a big bastard of a PR, I didn't think I should continue.