### PR TITLE
A Back Button for AddGamesWindow

### DIFF
--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -345,7 +345,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
     def present_install_from_setup_page(self):
         self.title_label.set_markup(_("<b>Select setup file</b>"))
         self.stack.present_page("install_from_setup")
-        self.display_continue_button(self._on_install_setup_continue)
+        self.display_continue_button(self._on_install_setup_continue, label=_("Install"))
 
     @watch_errors()
     def _on_install_setup_continue(self, button):

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -68,7 +68,6 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.text_query = None
         self.result_label = None
         self.title_label = Gtk.Label(visible=True)
-        self.title_label.set_markup(f"<b>{self.title_text}</b>")
         self.vbox.pack_start(self.title_label, False, False, 12)
 
         back_button = Gtk.Button(_("Back"))
@@ -113,6 +112,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         return frame
 
     def present_inital_page(self):
+        self.title_label.set_markup(f"<b>{self.title_text}</b>")
         self.stack.present_page("initial")
 
     @watch_errors()
@@ -125,7 +125,6 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
     def search_installers(self):
         """Search installers with the Lutris API"""
-        self.title_label.set_markup(_("<b>Search Lutris.net</b>"))
         self.stack.navigate_to_page(self.present_search_installers_page)
 
     def create_search_installers_page(self):
@@ -151,6 +150,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         return vbox
 
     def present_search_installers_page(self):
+        self.title_label.set_markup(_("<b>Search Lutris.net</b>"))
         self.stack.present_page("search_installers")
         self.search_entry.grab_focus()
 
@@ -217,10 +217,10 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
     def scan_folder(self):
         """Scan a folder of already installed games"""
         def present_scan_folder_page():
+            self.title_label.set_markup("<b>Import games from a folder</b>")
             self.stack.present_page("scan_folder")
             AsyncCall(scan_directory, self._on_folder_scanned, script_dlg.folder)
 
-        self.title_label.set_markup("<b>Import games from a folder</b>")
         script_dlg = DirectoryDialog(_("Select folder to scan"), parent=self)
         if not script_dlg.folder:
             self.destroy()
@@ -235,6 +235,11 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
     @watch_errors()
     def _on_folder_scanned(self, result, error):
         def present_installed_games_page():
+            if installed or missing:
+                self.title_label.set_markup(_("<b>Games found</b>"))
+            else:
+                self.title_label.set_markup(_("<b>No games found</b>"))
+
             page = self.create_installed_games_page(installed, missing)
             self.stack.present_replacement_page("installed_games", page)
 
@@ -257,14 +262,11 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             installed_scroll = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.ETCHED_IN)
             installed_scroll.set_vexpand(True)
             installed_scroll.add(installed_listbox)
-            vbox.pack_end(installed_scroll, True, True, 0)
+            vbox.pack_start(installed_scroll, True, True, 0)
             for folder in installed:
                 installed_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
 
         if missing:
-            missing_label = self._get_label("No match found")
-            vbox.pack_end(missing_label, False, False, 0)
-
             missing_listbox = Gtk.ListBox()
             missing_scroll = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.ETCHED_IN)
             missing_scroll.set_vexpand(True)
@@ -273,13 +275,15 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             for folder in missing:
                 missing_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
 
+            missing_label = self._get_label("No match found")
+            vbox.pack_end(missing_label, False, False, 0)
+
         return vbox
 
     # Install from Setup
 
     def install_from_setup(self):
         """Install from a setup file"""
-        self.title_label.set_markup(_("<b>Select setup file</b>"))
         self.stack.navigate_to_page(self.present_install_from_setup_page)
 
     def create_install_from_setup_page(self):
@@ -295,6 +299,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         return vbox
 
     def present_install_from_setup_page(self):
+        self.title_label.set_markup(_("<b>Select setup file</b>"))
         self.stack.present_page("install_from_setup")
 
     @watch_errors()

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -69,14 +69,16 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.result_label = None
         self.continue_install_setup_button = None
         self.title_label = Gtk.Label(visible=True)
-        self.vbox.pack_start(self.title_label, False, False, 12)
+        self.vbox.pack_start(self.title_label, False, False, 0)
 
         back_button = Gtk.Button(_("Back"), sensitive=False)
         back_button.connect("clicked", self.on_back_clicked)
         self.action_buttons.pack_start(back_button, False, False, 0)
 
         self.stack = NavigationStack(back_button)
-        self.vbox.pack_start(self.stack, True, True, 12)
+        self.vbox.pack_start(self.stack, True, True, 0)
+
+        self.vbox.pack_start(Gtk.HSeparator(), False, False, 0)
 
         self.stack.add_named_factory("initial", self.create_initial_page)
         self.stack.add_named_factory("search_installers", self.create_search_installers_page)

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -88,7 +88,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.action_buttons.pack_end(self.continue_button, False, False, 0)
         self.continue_handler = None
 
-        self.cancel_button = Gtk.Button(_("_Cancel"), use_underline=True)
+        self.cancel_button = Gtk.Button(_("Cancel"), use_underline=True)
         self.cancel_button.connect("clicked", self.on_cancel_clicked)
         key, mod = Gtk.accelerator_parse("Escape")
         self.cancel_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
@@ -497,10 +497,10 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.continue_handler = self.continue_button.connect("clicked", handler)
 
         self.continue_button.show()
-        self.cancel_button.set_label(_("_Cancel"))
+        self.cancel_button.set_label(_("Cancel"))
         self.cancel_button.show()
 
-    def display_cancel_button(self, label=_("_Cancel")):
+    def display_cancel_button(self, label=_("Cancel")):
         self.cancel_button.set_label(label)
         self.cancel_button.show()
         self.continue_button.hide()

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -76,9 +76,13 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.accelerators = Gtk.AccelGroup()
         self.add_accel_group(self.accelerators)
 
-        back_button = Gtk.Button(_("Back"), sensitive=False)
-        back_button.connect("clicked", self.on_back_clicked)
-        self.action_buttons.pack_start(back_button, False, False, 0)
+        self.back_button = Gtk.Button(_("Back"), sensitive=False)
+        self.back_button.connect("clicked", self.on_back_clicked)
+        key, mod = Gtk.accelerator_parse("<Alt>Left")
+        self.back_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
+        key, mod = Gtk.accelerator_parse("<Alt>Home")
+        self.accelerators.connect(key, mod, Gtk.AccelFlags.VISIBLE, self.on_navigate_home)
+        self.action_buttons.pack_start(self.back_button, False, False, 0)
 
         self.continue_button = Gtk.Button(_("_Continue"), no_show_all=True, use_underline=True)
         self.action_buttons.pack_end(self.continue_button, False, False, 0)
@@ -90,7 +94,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.cancel_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
         self.action_buttons.pack_end(self.cancel_button, False, False, 0)
 
-        self.stack = NavigationStack(back_button)
+        self.stack = NavigationStack(self.back_button)
         self.vbox.pack_start(self.stack, True, True, 0)
 
         self.vbox.pack_start(Gtk.HSeparator(), False, False, 0)
@@ -121,6 +125,9 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
     def on_back_clicked(self, _widget):
         self.stack.navigate_back()
+
+    def on_navigate_home(self, _accel_group, _window, _keyval, _modifier):
+        self.stack.navigate_home()
 
     def on_cancel_clicked(self, _widget):
         self.destroy()

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -429,7 +429,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
         if LINUX_SYSTEM.is_64_bit:
             self.install_from_setup_32bit_prefix_checkbox = Gtk.CheckButton(
-                label=_("32-bit Wine prefix (not recommended)"))
+                label=_("32-bit Wine prefix"))
 
             grid.attach(self.install_from_setup_32bit_prefix_checkbox, 0, 3, 2, 1)
             self.install_from_setup_32bit_prefix_checkbox.set_valign(Gtk.Align.END)
@@ -508,7 +508,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.install_script_file_chooser.set_hexpand(True)
 
         explanation = _(
-            "Lutris install scripts are JSON files that guide Lutris through "
+            "Lutris install scripts are YAML files that guide Lutris through "
             "the installation process.\n\n"
             "They can be obtained on Lutris.net, or written by hand.\n\n"
             "When you click 'Install' below, the installer window will "
@@ -551,6 +551,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         explanation = _(
             "Lutris will identify a ROM via its MD5 hash and download game "
             "information from Lutris.net.\n\n"
+            "The ROM data used for this comes from the TOSEC project.\n\n"
             "When you click 'Install' below, the process of installing the game will "
             "begin."
         )

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -67,6 +67,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.search_spinner = None
         self.text_query = None
         self.result_label = None
+        self.continue_install_setup_button = None
         self.title_label = Gtk.Label(visible=True)
         self.vbox.pack_start(self.title_label, False, False, 12)
 
@@ -294,15 +295,24 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         vbox.add(label)
         entry = Gtk.Entry()
         vbox.add(entry)
-        button = Gtk.Button(_("Continue"))
-        button.connect("clicked", self._on_install_setup_continue, entry)
-        button.set_halign(Gtk.Align.END)
-        vbox.add(button)
+
+        self.continue_install_setup_button = Gtk.Button(_("Continue"))
+        self.continue_install_setup_button.connect("clicked", self._on_install_setup_continue, entry)
+
+        style_context = self.continue_install_setup_button.get_style_context()
+        style_context.add_class("suggested-action")
+
+        self.action_buttons.pack_end(self.continue_install_setup_button, False, False, 0)
         return vbox
 
     def present_install_from_setup_page(self):
+        def on_exit_page():
+            self.continue_install_setup_button.hide()
+
         self.title_label.set_markup(_("<b>Select setup file</b>"))
         self.stack.present_page("install_from_setup")
+        self.continue_install_setup_button.show()
+        return on_exit_page
 
     @watch_errors()
     def _on_install_setup_continue(self, button, entry):

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -285,10 +285,11 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.stack.navigate_to_page(self.present_scan_folder_page)
 
     def create_scan_folder_page(self):
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        grid = Gtk.Grid(row_spacing=6, column_spacing=6)
         label = self._get_label(_("Folder to scan"))
-        vbox.add(label)
-        vbox.add(self.scan_directory_chooser)
+        grid.attach(label, 0, 0, 1, 1)
+        grid.attach(self.scan_directory_chooser, 1, 0, 1, 1)
+        self.scan_directory_chooser.set_hexpand(True)
 
         explanation = _(
             "Lutris will search this folder for sub-folders that contain games it recognizes.\n\n"
@@ -297,8 +298,8 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             "be added at once."
         )
 
-        vbox.add(self._get_explanation_label(explanation))
-        return vbox
+        grid.attach(self._get_explanation_label(explanation), 0, 1, 2, 1)
+        return grid
 
     def present_scan_folder_page(self):
         self.title_label.set_markup("<b>Select folder to scan for games</b>")
@@ -469,10 +470,11 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.stack.navigate_to_page(self.present_install_from_script_page)
 
     def create_install_from_script_page(self):
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        grid = Gtk.Grid(row_spacing=6, column_spacing=6)
         label = self._get_label(_("Script file"))
-        vbox.add(label)
-        vbox.add(self.install_script_file_chooser)
+        grid.attach(label, 0, 0, 1, 1)
+        grid.attach(self.install_script_file_chooser, 1, 0, 1, 1)
+        self.install_script_file_chooser.set_hexpand(True)
 
         explanation = _(
             "Lutris install scripts are JSON files that guide Lutris through "
@@ -482,8 +484,8 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             "appear and load the script, and it will guide the process from there."
         )
 
-        vbox.add(self._get_explanation_label(explanation))
-        return vbox
+        grid.attach(self._get_explanation_label(explanation), 0, 1, 2, 1)
+        return grid
 
     def present_install_from_script_page(self):
         self.title_label.set_markup("<b>Select a Lutris installer</b>")

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -97,6 +97,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.stack.navigate_to_page(self.present_inital_page)
 
     def create_initial_page(self):
+        frame = Gtk.Frame(shadow_type=Gtk.ShadowType.ETCHED_IN)
         listbox = Gtk.ListBox()
         listbox.set_activate_on_single_click(True)
         for icon, next_icon, text, subtext, callback_name in self.sections:
@@ -105,7 +106,8 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
             listbox.add(row)
         listbox.connect("row-activated", self.on_row_activated)
-        return listbox
+        frame.add(listbox)
+        return frame
 
     def present_inital_page(self):
         self.stack.present_page("initial")
@@ -134,12 +136,15 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.result_label = self._get_label("")
         vbox.pack_start(self.result_label, False, False, 0)
         self.search_entry.connect("changed", self._on_search_updated)
-        self.search_listbox = Gtk.ListBox()
+
+        self.search_frame = Gtk.Frame(shadow_type=Gtk.ShadowType.ETCHED_IN)
+        self.search_listbox = Gtk.ListBox(visible=True)
         self.search_listbox.connect("row-activated", self._on_game_selected)
         scroll = Gtk.ScrolledWindow(visible=True)
         scroll.set_vexpand(True)
         scroll.add(self.search_listbox)
-        vbox.pack_start(scroll, True, True, 0)
+        self.search_frame.add(scroll)
+        vbox.pack_start(self.search_frame, True, True, 0)
         return vbox
 
     def present_search_installers_page(self):
@@ -194,7 +199,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             row = self._get_listbox_row("", gtk_safe(game['name']), f"{year}{platforms}")
             row.api_info = game
             self.search_listbox.add(row)
-        self.search_listbox.show()
+        self.search_frame.show()
 
     @watch_errors()
     def _on_game_selected(self, listbox, row):
@@ -239,26 +244,33 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.stack.navigate_to_page(present_installed_games_page)
 
     def create_installed_games_page(self, installed, missing):
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        installed_label = self._get_label("Installed games")
-        vbox.add(installed_label)
-        installed_listbox = Gtk.ListBox()
-        installed_scroll = Gtk.ScrolledWindow()
-        installed_scroll.set_vexpand(True)
-        installed_scroll.add(installed_listbox)
-        vbox.add(installed_scroll)
-        for folder in installed:
-            installed_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
 
-        missing_label = self._get_label("No match found")
-        vbox.add(missing_label)
-        missing_listbox = Gtk.ListBox()
-        missing_scroll = Gtk.ScrolledWindow()
-        missing_scroll.set_vexpand(True)
-        missing_scroll.add(missing_listbox)
-        vbox.add(missing_scroll)
-        for folder in missing:
-            missing_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
+        if installed:
+            installed_label = self._get_label("Installed games")
+            vbox.pack_start(installed_label, False, False, 0)
+
+            installed_listbox = Gtk.ListBox()
+            installed_scroll = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.ETCHED_IN)
+            installed_scroll.set_vexpand(True)
+            installed_scroll.add(installed_listbox)
+            vbox.pack_end(installed_scroll, True, True, 0)
+            for folder in installed:
+                installed_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
+
+        
+        if missing:
+            missing_label = self._get_label("No match found")
+            vbox.pack_end(missing_label, False, False, 0)
+
+            missing_listbox = Gtk.ListBox()
+            missing_scroll = Gtk.ScrolledWindow(shadow_type=Gtk.ShadowType.ETCHED_IN)
+            missing_scroll.set_vexpand(True)
+            missing_scroll.add(missing_listbox)
+            vbox.pack_end(missing_scroll, True, True, 0)
+            for folder in missing:
+                missing_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
+
         return vbox
 
     # Install from Setup

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -350,6 +350,11 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
     @watch_errors()
     def _on_install_setup_continue(self, button):
         name = self.install_from_setup_game_name_entry.get_text().strip()
+
+        if not name:
+            ErrorDialog(_("You must provide a name for the game you are installing."), parent=self)
+            return
+
         installer = {
             "name": name,
             "version": _("Setup file"),

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -226,10 +226,8 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             AsyncCall(scan_directory, self._on_folder_scanned, script_dlg.folder)
 
         script_dlg = DirectoryDialog(_("Select folder to scan"), parent=self)
-        if not script_dlg.folder:
-            self.destroy()
-            return
-        self.stack.jump_to_page(present_scan_folder_page)
+        if script_dlg.folder:
+            self.stack.jump_to_page(present_scan_folder_page)
 
     def create_scan_folder_page(self):
         spinner = Gtk.Spinner(visible=True)
@@ -249,7 +247,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
         if error:
             ErrorDialog(str(error), parent=self)
-            self.destroy()
+            self.stack.navigation_reset()
             return
 
         installed, missing = result
@@ -340,7 +338,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             installers = get_installers(installer_file=script_dlg.filename)
             application = Gio.Application.get_default()
             application.show_installer_window(installers)
-        self.destroy()
+            self.destroy()
 
     # Add Local Game
 

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -48,7 +48,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         ),
         (
             "list-add-symbolic",
-            "document-open-symbolic",
+            "view-more-horizontal-symbolic",
             _("Add locally installed game"),
             _("Manually configure a game available locally"),
             "add_local_game"
@@ -343,7 +343,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
     def install_from_script(self):
         """Install from a YAML file"""
-        script_dlg = FileDialog(_("Select a Lutris installer"))
+        script_dlg = FileDialog(_("Select a Lutris installer"), parent=self)
         if script_dlg.filename:
             installers = get_installers(installer_file=script_dlg.filename)
             application = Gio.Application.get_default()
@@ -354,8 +354,8 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
     def add_local_game(self):
         """Manually configure game"""
-        AddGameDialog(None)
-        self.destroy()
+        AddGameDialog(parent=self)
+        GLib.idle_add(self.destroy)  # defer destory so the game dialog can be centered first
 
     # Implementation
 

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -41,14 +41,14 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         ),
         (
             "x-office-document-symbolic",
-            None,
+            "document-open-symbolic",
             _("Install from a local install script"),
             _("Run a YAML install script"),
             "install_from_script"
         ),
         (
             "list-add-symbolic",
-            None,
+            "document-open-symbolic",
             _("Add locally installed game"),
             _("Manually configure a game available locally"),
             "add_local_game"

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -125,6 +125,10 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
 
     def search_installers(self):
         """Search installers with the Lutris API"""
+        if self.search_entry:
+            self.search_entry.set_text("")
+            self.result_label.set_text("")
+            self.search_frame.hide()
         self.stack.navigate_to_page(self.present_search_installers_page)
 
     def create_search_installers_page(self):

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -196,7 +196,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             "perform the installation."
         )
 
-        self.search_explanation_label = self._get_explaination_label(explanation)
+        self.search_explanation_label = self._get_explanation_label(explanation)
         vbox.add(self.search_explanation_label)
 
         self.search_frame = Gtk.Frame(shadow_type=Gtk.ShadowType.ETCHED_IN)
@@ -295,7 +295,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             "be added at once."
         )
 
-        vbox.add(self._get_explaination_label(explanation))
+        vbox.add(self._get_explanation_label(explanation))
         return vbox
 
     def present_scan_folder_page(self):
@@ -395,7 +395,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             "no special options."
         )
 
-        vbox.add(self._get_explaination_label(explanation))
+        vbox.add(self._get_explanation_label(explanation))
         return vbox
 
     def present_install_from_setup_page(self):
@@ -453,7 +453,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             "appear and load the script, and it will guide the process from there."
         )
 
-        vbox.add(self._get_explaination_label(explanation))
+        vbox.add(self._get_explanation_label(explanation))
         return vbox
 
     def present_install_from_script_page(self):
@@ -530,7 +530,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         label.set_alignment(0, 0.5)
         return label
 
-    def _get_explaination_label(self, markup):
+    def _get_explanation_label(self, markup):
         label = Gtk.Label(
             visible=True,
             margin_right=12,

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -71,7 +71,7 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         self.title_label = Gtk.Label(visible=True)
         self.vbox.pack_start(self.title_label, False, False, 12)
 
-        back_button = Gtk.Button(_("Back"))
+        back_button = Gtk.Button(_("Back"), sensitive=False)
         back_button.connect("clicked", self.on_back_clicked)
         self.action_buttons.pack_start(back_button, False, False, 0)
 

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -60,6 +60,9 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
     def __init__(self, application=None):
         super().__init__(application=application)
         self.set_default_size(640, 450)
+        self.search_entry = None
+        self.search_frame = None
+        self.search_listbox = None
         self.search_timer_id = None
         self.search_spinner = None
         self.text_query = None
@@ -258,7 +261,6 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
             for folder in installed:
                 installed_listbox.add(self._get_listbox_row("", gtk_safe(folder), ""))
 
-        
         if missing:
             missing_label = self._get_label("No match found")
             vbox.pack_end(missing_label, False, False, 0)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -77,6 +77,10 @@ class InstallerWindow(BaseApplicationWindow,
         # Action buttons
 
         self.back_button = self.add_start_button(_("Back"), self.on_back_clicked, sensitive=False)
+        key, mod = Gtk.accelerator_parse("<Alt>Left")
+        self.back_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
+        key, mod = Gtk.accelerator_parse("<Alt>Home")
+        self.accelerators.connect(key, mod, Gtk.AccelFlags.VISIBLE, self.on_navigate_home)
         self.cache_button = self.add_start_button(_("Cache"), self.on_cache_clicked,
                                                   tooltip=_("Change where Lutris downloads game installer files."))
 
@@ -157,6 +161,10 @@ class InstallerWindow(BaseApplicationWindow,
     @watch_errors()
     def on_back_clicked(self, _button):
         self.stack.navigate_back()
+
+    @watch_errors()
+    def on_navigate_home(self, _accel_group, _window, _keyval, _modifier):
+        self.stack.navigate_home()
 
     def on_destroy(self, _widget, _data=None):
         self.on_cancel_clicked()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -16,6 +16,7 @@ from lutris.gui.installer.script_picker import InstallerPicker
 from lutris.gui.widgets.common import FileChooserEntry
 from lutris.gui.widgets.log_text_view import LogTextView
 from lutris.gui.widgets.window import BaseApplicationWindow
+from lutris.gui.widgets.navigation_stack import NavigationStack
 from lutris.installer import InstallationKind, get_installers, interpreter
 from lutris.installer.errors import MissingGameDependency, ScriptingError
 from lutris.installer.interpreter import ScriptInterpreter
@@ -90,7 +91,7 @@ class InstallerWindow(BaseApplicationWindow,
 
         # Navigation stack
 
-        self.stack = InstallerWindow.NavigationStack(self.back_button)
+        self.stack = NavigationStack(self.back_button)
         self.register_page_creators()
         self.vbox.pack_start(self.stack, True, True, 0)
 
@@ -935,157 +936,3 @@ class InstallerWindow(BaseApplicationWindow,
                 max_width_chars=80,
                 selectable=selectable)
             self.set_alignment(0.5, 0)
-
-    class NavigationStack(Gtk.Stack):
-        """
-        This is a Stack widget that supports a back button and
-        lazy-creation of pages.
-
-        Pages should be set up via add_named_factory(), then displayed
-        with present_page().
-
-        However, you are meant to have 'present_X_page' functions
-        that you pass to navigate_to_page(); this tracks the pages
-        you visit, and when you navigate back,the presenter function
-        will be called again.
-
-        A presenter function can do more than just call present_page();
-        it can configure other aspects of the InstallerWindow. Packaging
-        all this into a presenter function keeps things in sync as you navigate.
-
-        A present function can return an exit function, called when you navigate away
-        from the page again.
-        """
-
-        def __init__(self, back_button, **kwargs):
-            super().__init__(**kwargs)
-
-            self.back_button = back_button
-            self.page_factories = {}
-            self.stack_pages = {}
-            self.navigation_stack = []
-            self.navigation_exit_hander = None
-            self.current_page_presenter = None
-            self.current_navigated_page_presenter = None
-            self.back_allowed = True
-
-        def add_named_factory(self, name, factory):
-            """This specifies the factory functioin for the page named;
-            this function takes no arguments, but returns the page's widget."""
-            self.page_factories[name] = factory
-
-        def set_back_allowed(self, is_allowed=True):
-            """This turns the back button off, or back on."""
-            self.back_allowed = is_allowed
-            self._update_back_button()
-
-        def _update_back_button(self):
-            self.back_button.set_sensitive(self.back_allowed and self.navigation_stack)
-
-        def navigate_to_page(self, page_presenter):
-            """Navigates to a page, by invoking 'page_presenter'.
-
-            In addition, this updates the navigation state so navigate_back()
-            and such work, they may call the presenter again.
-            """
-            if self.current_navigated_page_presenter:
-                self.navigation_stack.append(self.current_navigated_page_presenter)
-                self._update_back_button()
-
-            self._go_to_page(page_presenter, True, Gtk.StackTransitionType.SLIDE_LEFT)
-
-        def jump_to_page(self, page_presenter):
-            """Jumps to a page, without updating navigation state.
-
-            This does not disturb the behavior of navigate_back().
-            This does invoke the exit handler of the current page.
-            """
-            self._go_to_page(page_presenter, False, Gtk.StackTransitionType.NONE)
-
-        def navigate_back(self):
-            """This navigates to the previous page, if any. This will invoke the
-            current page's exit function, and the previous page's presenter function.
-            """
-            if self.navigation_stack:
-                try:
-                    back_to = self.navigation_stack.pop()
-                    self._go_to_page(back_to, True, Gtk.StackTransitionType.SLIDE_RIGHT)
-                finally:
-                    self._update_back_button()
-
-        def navigation_reset(self):
-            """This reverse the effect of jump_to_page(), returning to the last
-            page actually navigate to."""
-            if self.current_navigated_page_presenter:
-                if self.current_page_presenter != self.current_navigated_page_presenter:
-                    self._go_to_page(self.current_navigated_page_presenter, True, Gtk.StackTransitionType.SLIDE_RIGHT)
-
-        def save_current_page(self):
-            """Returns a tuple containing information about the current page,
-            to pass to restore_current_page()."""
-            return (self.current_page_presenter, self.current_navigated_page_presenter)
-
-        def restore_current_page(self, state):
-            """Restores the current page to the one in effect when the state was generated.
-            This does not disturb the navigation stack."""
-            page_presenter, navigated_presenter = state
-            navigated = page_presenter == navigated_presenter
-            self._go_to_page(page_presenter, navigated, Gtk.StackTransitionType.NONE)
-
-        def _go_to_page(self, page_presenter, navigated, transition_type):
-            """Switches to a page. If 'navigated' is True, then when you navigate
-            away from this page, it can go on the navigation stack. It should be
-            False for 'temporary' pages that are not part of normal navigation."""
-            exit_handler = self.navigation_exit_hander
-            self.set_transition_type(transition_type)
-            self.navigation_exit_hander = page_presenter()
-            self.current_page_presenter = page_presenter
-            if navigated:
-                self.current_navigated_page_presenter = page_presenter
-            if exit_handler:
-                exit_handler()
-
-        def discard_navigation(self):
-            """This throws away the navigation history, so the back
-            button is disabled. Previous pages before the current become
-            inaccessible."""
-            self.navigation_stack.clear()
-            self._update_back_button()
-
-        def present_page(self, name):
-            """This displays the page names, creating it if required. It
-            also calls show_all() on newly created pages.
-
-            This should be called by your presenter functions."""
-            if name not in self.stack_pages:
-                factory = self.page_factories[name]
-                page = factory()
-                page.show_all()
-
-                self.add_named(page, name)
-                self.stack_pages[name] = page
-
-            self.set_visible_child_name(name)
-            return self.stack_pages[name]
-
-        def present_replacement_page(self, name, page):
-            """This displays a page that is given, rather than lazy-creating one. It
-            still needs a name, but if you re-use a name this will replace the old page.
-
-            This is useful for pages that need special initialization each time they
-            appear, but generally such pages can't be returned to via the back
-            button. The caller must protect against this if required.
-            """
-            old_page = self.stack_pages.get(name)
-
-            if old_page != page:
-                if old_page:
-                    self.remove(old_page)
-
-                page.show_all()
-
-                self.add_named(page, name)
-                self.stack_pages[name] = page
-
-            self.set_visible_child_name(name)
-            return page

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -15,8 +15,8 @@ from lutris.gui.installer.files_box import InstallerFilesBox
 from lutris.gui.installer.script_picker import InstallerPicker
 from lutris.gui.widgets.common import FileChooserEntry
 from lutris.gui.widgets.log_text_view import LogTextView
-from lutris.gui.widgets.window import BaseApplicationWindow
 from lutris.gui.widgets.navigation_stack import NavigationStack
+from lutris.gui.widgets.window import BaseApplicationWindow
 from lutris.installer import InstallationKind, get_installers, interpreter
 from lutris.installer.errors import MissingGameDependency, ScriptingError
 from lutris.installer.interpreter import ScriptInterpreter

--- a/lutris/gui/widgets/navigation_stack.py
+++ b/lutris/gui/widgets/navigation_stack.py
@@ -20,7 +20,7 @@ class NavigationStack(Gtk.Stack):
     it can configure other aspects of the InstallerWindow. Packaging
     all this into a presenter function keeps things in sync as you navigate.
 
-    A present function can return an exit function, called when you navigate away
+    A presenter function can return an exit function, called when you navigate away
     from the page again.
     """
 
@@ -73,10 +73,22 @@ class NavigationStack(Gtk.Stack):
         """This navigates to the previous page, if any. This will invoke the
         current page's exit function, and the previous page's presenter function.
         """
-        if self.navigation_stack:
+        if self.navigation_stack and self.back_allowed:
             try:
                 back_to = self.navigation_stack.pop()
                 self._go_to_page(back_to, True, Gtk.StackTransitionType.SLIDE_RIGHT)
+            finally:
+                self._update_back_button()
+
+    def navigate_home(self):
+        """This navigates to the first page, effectively navigating back until it
+        can go no further back. It does not actually traverse the intermediate pages
+        though, but goes directly to the first."""
+        if self.navigation_stack and self.back_allowed:
+            try:
+                home = self.navigation_stack[0]
+                self.navigation_stack.clear()
+                self._go_to_page(home, True, Gtk.StackTransitionType.SLIDE_RIGHT)
             finally:
                 self._update_back_button()
 

--- a/lutris/gui/widgets/navigation_stack.py
+++ b/lutris/gui/widgets/navigation_stack.py
@@ -1,0 +1,158 @@
+"""Window used for game installers"""
+# pylint: disable=too-many-lines
+from gi.repository import Gtk
+
+
+class NavigationStack(Gtk.Stack):
+    """
+    This is a Stack widget that supports a back button and
+    lazy-creation of pages.
+
+    Pages should be set up via add_named_factory(), then displayed
+    with present_page().
+
+    However, you are meant to have 'present_X_page' functions
+    that you pass to navigate_to_page(); this tracks the pages
+    you visit, and when you navigate back,the presenter function
+    will be called again.
+
+    A presenter function can do more than just call present_page();
+    it can configure other aspects of the InstallerWindow. Packaging
+    all this into a presenter function keeps things in sync as you navigate.
+
+    A present function can return an exit function, called when you navigate away
+    from the page again.
+    """
+
+    def __init__(self, back_button, **kwargs):
+        super().__init__(**kwargs)
+
+        self.back_button = back_button
+        self.page_factories = {}
+        self.stack_pages = {}
+        self.navigation_stack = []
+        self.navigation_exit_hander = None
+        self.current_page_presenter = None
+        self.current_navigated_page_presenter = None
+        self.back_allowed = True
+
+    def add_named_factory(self, name, factory):
+        """This specifies the factory functioin for the page named;
+        this function takes no arguments, but returns the page's widget."""
+        self.page_factories[name] = factory
+
+    def set_back_allowed(self, is_allowed=True):
+        """This turns the back button off, or back on."""
+        self.back_allowed = is_allowed
+        self._update_back_button()
+
+    def _update_back_button(self):
+        self.back_button.set_sensitive(self.back_allowed and self.navigation_stack)
+
+    def navigate_to_page(self, page_presenter):
+        """Navigates to a page, by invoking 'page_presenter'.
+
+        In addition, this updates the navigation state so navigate_back()
+        and such work, they may call the presenter again.
+        """
+        if self.current_navigated_page_presenter:
+            self.navigation_stack.append(self.current_navigated_page_presenter)
+            self._update_back_button()
+
+        self._go_to_page(page_presenter, True, Gtk.StackTransitionType.SLIDE_LEFT)
+
+    def jump_to_page(self, page_presenter):
+        """Jumps to a page, without updating navigation state.
+
+        This does not disturb the behavior of navigate_back().
+        This does invoke the exit handler of the current page.
+        """
+        self._go_to_page(page_presenter, False, Gtk.StackTransitionType.NONE)
+
+    def navigate_back(self):
+        """This navigates to the previous page, if any. This will invoke the
+        current page's exit function, and the previous page's presenter function.
+        """
+        if self.navigation_stack:
+            try:
+                back_to = self.navigation_stack.pop()
+                self._go_to_page(back_to, True, Gtk.StackTransitionType.SLIDE_RIGHT)
+            finally:
+                self._update_back_button()
+
+    def navigation_reset(self):
+        """This reverse the effect of jump_to_page(), returning to the last
+        page actually navigate to."""
+        if self.current_navigated_page_presenter:
+            if self.current_page_presenter != self.current_navigated_page_presenter:
+                self._go_to_page(self.current_navigated_page_presenter, True, Gtk.StackTransitionType.SLIDE_RIGHT)
+
+    def save_current_page(self):
+        """Returns a tuple containing information about the current page,
+        to pass to restore_current_page()."""
+        return (self.current_page_presenter, self.current_navigated_page_presenter)
+
+    def restore_current_page(self, state):
+        """Restores the current page to the one in effect when the state was generated.
+        This does not disturb the navigation stack."""
+        page_presenter, navigated_presenter = state
+        navigated = page_presenter == navigated_presenter
+        self._go_to_page(page_presenter, navigated, Gtk.StackTransitionType.NONE)
+
+    def _go_to_page(self, page_presenter, navigated, transition_type):
+        """Switches to a page. If 'navigated' is True, then when you navigate
+        away from this page, it can go on the navigation stack. It should be
+        False for 'temporary' pages that are not part of normal navigation."""
+        exit_handler = self.navigation_exit_hander
+        self.set_transition_type(transition_type)
+        self.navigation_exit_hander = page_presenter()
+        self.current_page_presenter = page_presenter
+        if navigated:
+            self.current_navigated_page_presenter = page_presenter
+        if exit_handler:
+            exit_handler()
+
+    def discard_navigation(self):
+        """This throws away the navigation history, so the back
+        button is disabled. Previous pages before the current become
+        inaccessible."""
+        self.navigation_stack.clear()
+        self._update_back_button()
+
+    def present_page(self, name):
+        """This displays the page names, creating it if required. It
+        also calls show_all() on newly created pages.
+
+        This should be called by your presenter functions."""
+        if name not in self.stack_pages:
+            factory = self.page_factories[name]
+            page = factory()
+            page.show_all()
+
+            self.add_named(page, name)
+            self.stack_pages[name] = page
+
+        self.set_visible_child_name(name)
+        return self.stack_pages[name]
+
+    def present_replacement_page(self, name, page):
+        """This displays a page that is given, rather than lazy-creating one. It
+        still needs a name, but if you re-use a name this will replace the old page.
+
+        This is useful for pages that need special initialization each time they
+        appear, but generally such pages can't be returned to via the back
+        button. The caller must protect against this if required.
+        """
+        old_page = self.stack_pages.get(name)
+
+        if old_page != page:
+            if old_page:
+                self.remove(old_page)
+
+            page.show_all()
+
+            self.add_named(page, name)
+            self.stack_pages[name] = page
+
+        self.set_visible_child_name(name)
+        return page


### PR DESCRIPTION
Or, "InstallerWindow is not enough!"

This PR is a facelift for the AddGamesWindow using the NavigationStack from InstallerWindow. It now looks like this:
![image](https://user-images.githubusercontent.com/6507403/214961037-6399ba60-91f9-484b-88c1-2787a6540031.png)There's a back button, a cancel button, a border around the list, and now the one choice that directly opens another window gets a distinct icon. All others now go to a page, with further explanation on it.

The search page looks like this:
![image](https://user-images.githubusercontent.com/6507403/211691165-5689c6f6-3b1b-4764-b627-bc3e642fe16d.png)
More buttons, and explanatory text. I think it worth saying that the installer window is coming.

The 'install from setup' page looks like this:
![image](https://user-images.githubusercontent.com/6507403/214961196-dbabff79-208a-447e-9ce6-99fd10c39c69.png)This now features controls to specify the identifier, and to opt into a 32-bit Wine prefix (only on 64-bit systems). These settings are problematic to change after installation- you can't change what the Wine prefix is without rebuilding it, and the default directory name is the identifier. Resolves #4708. Settings you can conveniently alter after installation not included.

Also, the 'Continue' button has turned blue, says 'Install' and moved down to the lower right corner. And there's text to explain what this does.

When you click 'Scan folder', you get a new page:
![Screenshot from 2023-01-13 19-23-44](https://user-images.githubusercontent.com/6507403/212441006-acc6b038-071d-41c9-87d9-435cda65f4f6.png)
You can key in a path, or click browse for the file selector. I think the explanatory text is badly needed here, as I found it hard to understand this. Lets hope I figured it out correctly!

The 'imported games' page looks like this:
![image](https://user-images.githubusercontent.com/6507403/211676107-d9cfbd0c-4890-41fe-92ff-162fa1bd066c.png)
Mostly cosmetic changes, but there's a 'Close' button now. This is to suggest that you're done now, though you can still go back too.

The 'Install from Script' option gets this page:
![image](https://user-images.githubusercontent.com/6507403/212440946-ca34e167-e94a-44b4-9b68-a67e8416b5a5.png)
This tries to explain what a Lutris script is and where you could get one, and it explains that this is not a headless install; it just runs through the installer window.

And the dialog getrs a new "Import a ROM" option; here, which leads here:
![image](https://user-images.githubusercontent.com/6507403/214961466-3baf4614-0ec2-4190-9c2b-4a7a7e3cc5a4.png)
This then leads to the dialog you can also get via drag & drop; but having this here adds a bit of discoverability.