### PR TITLE
Fix Steam Flatpak not appearing in sources

### DIFF
--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -30,6 +30,7 @@ class steam(Runner):
     human_name = _("Steam")
     platforms = [_("Linux")]
     runner_executable = "steam"
+    runner_executable_flatpak = "com.valvesoftware.Steam"
     game_options = [
         {
             "option": "appid",
@@ -162,7 +163,7 @@ class steam(Runner):
         runner_executable = self.runner_config.get("runner_executable")
         if runner_executable and os.path.isfile(runner_executable):
             return runner_executable
-        return system.find_executable(self.runner_executable)
+        return system.find_executable(self.runner_executable) or system.find_executable(self.runner_executable_flatpak)
 
     @property
     def working_dir(self):

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -233,6 +233,7 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
         """Return whether Steam is installed locally"""
         return (
             bool(system.find_executable("steam"))
+            or bool(system.find_executable("com.valvesoftware.Steam"))
             or os.path.exists(os.path.expanduser("~/.steam/steam/ubuntu12_32/steam"))
         )
 


### PR DESCRIPTION
- Fixes Steam not appearing in sources if Steam is flatpaked
- Fixes not being able to run games using flatpaked Steam
- ~~Adds a toggle to use either native or flatpak Steam~~

A Steam Flatpak Runner and Source might be better, but here's a workaround for now

Fixes #4449