### PR TITLE
A Stop button for ImportGameDialog

### DIFF
--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -577,9 +577,8 @@ class AddGamesWindow(BaseApplicationWindow):  # pylint: disable=too-many-public-
         elif not os.path.isfile(path):
             ErrorDialog(_("No file exists at '%s'.") % path, parent=self)
         else:
-            dialog = ImportGameDialog([path], parent=self)
-            dialog.run()
-            dialog.destroy()
+            dialog = ImportGameDialog([path], parent=self.application.window)
+            dialog.show()
             self.destroy()
 
     # Add Local Game

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -70,7 +70,7 @@ class ModelessDialog(Dialog):
 
     def _clear_transient_for(self):
         # we need the parent set to be centered over the parent, but
-        # we don't want to be transient really- we want other windows
+        # we don't want to be transient really - we want other windows
         # able to come to the front.
         self.set_transient_for(None)
         return False

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -129,7 +129,6 @@ class AboutDialog(GtkBuilderDialog):
 
 
 class NoticeDialog(Gtk.MessageDialog):
-
     """Display a message to the user."""
 
     def __init__(self, message, secondary=None, parent=None):
@@ -148,7 +147,6 @@ class NoticeDialog(Gtk.MessageDialog):
 
 
 class WarningDialog(Gtk.MessageDialog):
-
     """Display a warning to the user, who responds with whether to proceed, like
     a QuestionDialog."""
 
@@ -168,7 +166,6 @@ class WarningDialog(Gtk.MessageDialog):
 
 
 class ErrorDialog(Gtk.MessageDialog):
-
     """Display an error message."""
 
     def __init__(self, message, secondary=None, parent=None):
@@ -189,7 +186,6 @@ class ErrorDialog(Gtk.MessageDialog):
 
 
 class QuestionDialog(Gtk.MessageDialog):
-
     """Ask the user a question."""
 
     YES = Gtk.ResponseType.YES
@@ -209,7 +205,6 @@ class QuestionDialog(Gtk.MessageDialog):
 
 
 class DirectoryDialog:
-
     """Ask the user to select a directory."""
 
     def __init__(self, message, default_path=None, parent=None):
@@ -230,7 +225,6 @@ class DirectoryDialog:
 
 
 class FileDialog:
-
     """Ask the user to select a file."""
 
     def __init__(self, message=None, default_path=None, mode="open", parent=None):
@@ -386,8 +380,8 @@ class ClientLoginDialog(GtkBuilderDialog):
     glade_file = "dialog-lutris-login.ui"
     dialog_object = "lutris-login"
     __gsignals__ = {
-        "connected": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_PYOBJECT, )),
-        "cancel": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_PYOBJECT, )),
+        "connected": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_PYOBJECT,)),
+        "cancel": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     def __init__(self, parent):
@@ -430,7 +424,6 @@ class ClientLoginDialog(GtkBuilderDialog):
 
 
 class InstallerSourceDialog(ModelessDialog):
-
     """Show install script source"""
 
     def __init__(self, code, name, parent):
@@ -461,7 +454,6 @@ class InstallerSourceDialog(ModelessDialog):
 
 
 class DontShowAgainDialog(Gtk.MessageDialog):
-
     """Display a message to the user and offer an option not to display this dialog again."""
 
     def __init__(
@@ -505,7 +497,6 @@ class DontShowAgainDialog(Gtk.MessageDialog):
 
 
 class WineNotInstalledWarning(DontShowAgainDialog):
-
     """Display a warning if Wine is not detected on the system"""
 
     def __init__(self, parent=None, cancellable=False):

--- a/lutris/gui/dialogs/game_import.py
+++ b/lutris/gui/dialogs/game_import.py
@@ -35,12 +35,18 @@ class ImportGameDialog(ModelessDialog):
         self.platform = None
         self.set_size_request(480, 240)
 
+        self.accelerators = Gtk.AccelGroup()
+        self.add_accel_group(self.accelerators)
+
         frame = Gtk.Frame(
             shadow_type=Gtk.ShadowType.ETCHED_IN,
             child=self.get_file_labels_listbox(files))
 
         self.get_content_area().pack_start(frame, True, True, 6)
+
         self.close_button = self.add_button(Gtk.STOCK_STOP, Gtk.ResponseType.CANCEL)
+        key, mod = Gtk.accelerator_parse("Escape")
+        self.close_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
         self.connect("response", self.on_response)
 
         self.show_all()

--- a/lutris/gui/dialogs/game_import.py
+++ b/lutris/gui/dialogs/game_import.py
@@ -7,7 +7,7 @@ from gi.repository import GLib, Gtk
 from lutris.config import write_game_config
 from lutris.database.games import add_game
 from lutris.game import Game
-from lutris.gui.dialogs import ModalDialog
+from lutris.gui.dialogs import ModelessDialog
 from lutris.scanners.default_installers import DEFAULT_INSTALLERS
 from lutris.scanners.lutris import get_path_cache
 from lutris.scanners.tosec import clean_rom_name, guess_platform, search_tosec_by_md5
@@ -18,7 +18,7 @@ from lutris.util.strings import gtk_safe, slugify
 from lutris.util.system import get_md5_hash, get_md5_in_zip
 
 
-class ImportGameDialog(ModalDialog):
+class ImportGameDialog(ModelessDialog):
     def __init__(self, files, parent=None) -> None:
         super().__init__(
             _("Import a game"),

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -215,8 +215,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """Handler for drop event"""
         file_paths = [unquote(urlparse(uri).path) for uri in data.get_uris()]
         dialog = ImportGameDialog(file_paths, parent=self)
-        dialog.run()
-        dialog.destroy()
+        dialog.show()
 
     def load_filters(self):
         """Load the initial filters when creating the view"""


### PR DESCRIPTION
This is a face-lift for the ImportGameDialog; it removes the 'Launch Game' checkbox in favor of a 'Launch' button for each ROM- this way you can import multiple ROMs and pick one to launch.

It also adds a 'Stop' button at the bottom to interrupt the search and import process. This button turns to 'Close' upon completion. When in the 'Stop' mode, it does not close the dialog.

It's also a modeless dialog now, like InstallerWindow and AddGamesDialog.

![image](https://user-images.githubusercontent.com/6507403/216473551-e8505334-649e-4e22-b47d-309c950c6a49.png)
