### PR TITLE
Header bars for AddGamesWindow and InstallerWindow

### DIFF
--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -102,7 +102,7 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.cancel_button = Gtk.Button(_("Cancel"), use_underline=True)
         self.cancel_button.connect("clicked", self.on_cancel_clicked)
         key, mod = Gtk.accelerator_parse("Escape")
-        self.cancel_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
+        self.accelerators.connect(key, mod, Gtk.AccelFlags.VISIBLE, lambda *_args: self.destroy())
         header_bar.pack_start(self.cancel_button)
         header_bar.set_show_close_button(False)
 
@@ -112,7 +112,7 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         content_area.set_margin_left(18)
         content_area.set_spacing(12)
 
-        self.stack = NavigationStack(self.back_button)
+        self.stack = NavigationStack(self.back_button, cancel_button=self.cancel_button)
         content_area.pack_start(self.stack, True, True, 0)
 
         # Pre-create some controls so they can be used in signal handlers
@@ -624,16 +624,16 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
 
         self.continue_button.show()
         self.cancel_button.set_label(_("Cancel"))
-        self.cancel_button.show()
+        self.stack.set_cancel_allowed(True)
 
     def display_cancel_button(self, label=_("Cancel")):
         self.cancel_button.set_label(label)
-        self.cancel_button.show()
+        self.stack.set_cancel_allowed(True)
         self.continue_button.hide()
 
     def display_no_continue_button(self):
         self.continue_button.hide()
-        self.cancel_button.hide()
+        self.stack.set_cancel_allowed(False)
 
         if self.continue_handler:
             self.continue_button.disconnect(self.continue_handler)

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -76,8 +76,11 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.search_spinner = None
         self.text_query = None
         self.search_result_label = None
+
+        content_area = self.get_content_area()
+
         self.page_title_label = Gtk.Label(visible=True)
-        self.vbox.pack_start(self.page_title_label, False, False, 0)
+        content_area.pack_start(self.page_title_label, False, False, 0)
 
         self.accelerators = Gtk.AccelGroup()
         self.add_accel_group(self.accelerators)
@@ -103,14 +106,14 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         header_bar.pack_start(self.cancel_button)
         header_bar.set_show_close_button(False)
 
-        self.vbox.set_margin_top(18)
-        self.vbox.set_margin_bottom(18)
-        self.vbox.set_margin_right(18)
-        self.vbox.set_margin_left(18)
-        self.vbox.set_spacing(12)
+        content_area.set_margin_top(18)
+        content_area.set_margin_bottom(18)
+        content_area.set_margin_right(18)
+        content_area.set_margin_left(18)
+        content_area.set_spacing(12)
 
         self.stack = NavigationStack(self.back_button)
-        self.vbox.pack_start(self.stack, True, True, 0)
+        content_area.pack_start(self.stack, True, True, 0)
 
         # Pre-create some controls so they can be used in signal handlers
 

--- a/lutris/gui/dialogs/cache.py
+++ b/lutris/gui/dialogs/cache.py
@@ -10,7 +10,7 @@ from lutris.gui.widgets.common import FileChooserEntry
 class CacheConfigurationDialog(ModalDialog):
     def __init__(self, parent=None):
         super().__init__(
-            _("Cache configuration"),
+            _("Download cache configuration"),
             parent=parent,
             flags=Gtk.DialogFlags.MODAL,
             border_width=10

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -64,16 +64,18 @@ class InstallerWindow(ModelessDialog,
         self.accelerators = Gtk.AccelGroup()
         self.add_accel_group(self.accelerators)
 
-        self.vbox.set_margin_top(18)
-        self.vbox.set_margin_bottom(18)
-        self.vbox.set_margin_right(18)
-        self.vbox.set_margin_left(18)
-        self.vbox.set_spacing(12)
+        content_area = self.get_content_area()
+
+        content_area.set_margin_top(18)
+        content_area.set_margin_bottom(18)
+        content_area.set_margin_right(18)
+        content_area.set_margin_left(18)
+        content_area.set_spacing(12)
 
         # Header labels
 
         self.status_label = InstallerWindow.MarkupLabel()
-        self.vbox.pack_start(self.status_label, False, False, 0)
+        content_area.pack_start(self.status_label, False, False, 0)
 
         # Header bar buttons
 
@@ -97,14 +99,14 @@ class InstallerWindow(ModelessDialog,
 
         self.stack = NavigationStack(self.back_button)
         self.register_page_creators()
-        self.vbox.pack_start(self.stack, True, True, 0)
+        content_area.pack_start(self.stack, True, True, 0)
 
-        self.vbox.pack_start(Gtk.HSeparator(), False, False, 0)
+        content_area.pack_start(Gtk.HSeparator(), False, False, 0)
 
         # Action buttons
 
         self.action_buttons = Gtk.Box(spacing=6)
-        self.vbox.pack_end(self.action_buttons, False, False, 0)
+        content_area.pack_end(self.action_buttons, False, False, 0)
 
         self.cache_button = self.add_action_start_button(_("Cache"),
                                                          self.on_cache_clicked,

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -97,7 +97,7 @@ class InstallerWindow(ModelessDialog,
 
         # Navigation stack
 
-        self.stack = NavigationStack(self.back_button)
+        self.stack = NavigationStack(self.back_button, cancel_button=self.cancel_button)
         self.register_page_creators()
         content_area.pack_start(self.stack, True, True, 0)
 
@@ -229,9 +229,12 @@ class InstallerWindow(ModelessDialog,
             if confirm_cancel_dialog.result != Gtk.ResponseType.YES:
                 logger.debug("User aborted installation cancellation")
                 return
+
             self.installer_files_box.stop_all()
             if self.interpreter:
                 self.interpreter.revert(remove_game_dir=remove_checkbox.get_active())
+        else:
+            self.installer_files_box.stop_all()
 
         if self.interpreter:
             self.interpreter.cleanup()  # still remove temporary downloads in any case
@@ -927,7 +930,7 @@ class InstallerWindow(ModelessDialog,
         else:
             self.continue_handler = None
 
-        buttons = [self.continue_button, self.cancel_button] + (extra_buttons or [])
+        buttons = [self.continue_button] + (extra_buttons or [])
         self.display_buttons(buttons)
 
     def display_install_button(self, handler, sensitive=True):
@@ -937,7 +940,7 @@ class InstallerWindow(ModelessDialog,
                                      extra_buttons=[self.source_button])
 
     def display_cancel_button(self, extra_buttons=None):
-        self.display_buttons([self.cancel_button] + (extra_buttons or []))
+        self.display_buttons(extra_buttons or [])
 
     def display_buttons(self, buttons):
         """Shows exactly the buttons given, and hides the others. Updates the close button
@@ -956,8 +959,7 @@ class InstallerWindow(ModelessDialog,
 
         all_buttons = [self.cache_button,
                        self.source_button,
-                       self.continue_button,
-                       self.cancel_button]
+                       self.continue_button]
 
         for b in all_buttons:
             b.set_visible(b in buttons)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -76,7 +76,8 @@ class InstallerWindow(BaseApplicationWindow,
 
         # Action buttons
 
-        self.back_button = self.add_start_button(_("Back"), self.on_back_clicked, sensitive=False)
+        self.back_button = self.add_start_button(_("Back"), self.on_back_clicked)
+        self.back_button.set_no_show_all(True)
         key, mod = Gtk.accelerator_parse("<Alt>Left")
         self.back_button.add_accelerator("clicked", self.accelerators, key, mod, Gtk.AccelFlags.VISIBLE)
         key, mod = Gtk.accelerator_parse("<Alt>Home")

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -74,7 +74,7 @@ class InstallerWindow(ModelessDialog,
 
         # Header labels
 
-        self.status_label = InstallerWindow.MarkupLabel()
+        self.status_label = InstallerWindow.MarkupLabel(no_show_all=True)
         content_area.pack_start(self.status_label, False, False, 0)
 
         # Header bar buttons
@@ -261,6 +261,7 @@ class InstallerWindow(ModelessDialog,
     def set_status(self, text):
         """Display a short status text."""
         self.status_label.set_text(text)
+        self.status_label.set_visible(bool(text))
 
     def register_page_creators(self):
         self.stack.add_named_factory("choose_installer", self.create_choose_installer_page)
@@ -384,21 +385,21 @@ class InstallerWindow(ModelessDialog,
         self.continue_button.grab_focus()
 
     def create_destination_page(self):
-        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
-        vbox.pack_start(self.location_entry, False, False, 5)
+        vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+        vbox.pack_start(self.location_entry, False, False, 0)
 
         desktop_shortcut_button = Gtk.CheckButton(_("Create desktop shortcut"), visible=True)
         desktop_shortcut_button.connect("clicked", self.on_create_desktop_shortcut_clicked)
-        vbox.pack_start(desktop_shortcut_button, False, False, 5)
+        vbox.pack_start(desktop_shortcut_button, False, False, 0)
 
         menu_shortcut_button = Gtk.CheckButton(_("Create application menu shortcut"), visible=True)
         menu_shortcut_button.connect("clicked", self.on_create_menu_shortcut_clicked)
-        vbox.pack_start(menu_shortcut_button, False, False, 5)
+        vbox.pack_start(menu_shortcut_button, False, False, 0)
 
         if steam_shortcut.vdf_file_exists():
             steam_shortcut_button = Gtk.CheckButton(_("Create steam shortcut"), visible=True)
             steam_shortcut_button.connect("clicked", self.on_create_steam_shortcut_clicked)
-            vbox.pack_start(steam_shortcut_button, False, False, 5)
+            vbox.pack_start(steam_shortcut_button, False, False, 0)
         return vbox
 
     def present_destination_page(self):
@@ -987,11 +988,11 @@ class InstallerWindow(ModelessDialog,
     class MarkupLabel(Gtk.Label):
         """Label for installer window"""
 
-        def __init__(self, markup=None, selectable=True):
+        def __init__(self, markup=None, **kwargs):
             super().__init__(
                 label=markup,
                 use_markup=True,
                 wrap=True,
                 max_width_chars=80,
-                selectable=selectable)
+                **kwargs)
             self.set_alignment(0.5, 0)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -421,7 +421,8 @@ class InstallerWindow(ModelessDialog,
             if not self.interpreter.launch_install(self):
                 self.stack.navigation_reset()
 
-        self.load_spinner_page(_("Preparing Lutris for installation"), cancellable=False)
+        self.load_spinner_page(_("Preparing Lutris for installation"), cancellable=False,
+                               extra_buttons=[self.cache_button, self.source_button])
         GLib.idle_add(launch_install)
 
     @watch_errors()
@@ -652,7 +653,7 @@ class InstallerWindow(ModelessDialog,
     # Provides a generic progress spinner and displays a status. The back button
     # is disabled for this page.
 
-    def load_spinner_page(self, status, cancellable=True):
+    def load_spinner_page(self, status, cancellable=True, extra_buttons=None):
         def present_spinner_page():
             """Show a spinner in the middle of the view"""
 
@@ -663,9 +664,9 @@ class InstallerWindow(ModelessDialog,
             self.stack.present_page("spinner")
 
             if cancellable:
-                self.display_cancel_button()
+                self.display_cancel_button(extra_buttons=extra_buttons)
             else:
-                self.display_no_buttons()
+                self.display_buttons(extra_buttons or [])
 
             self.stack.set_back_allowed(False)
             return on_exit_page
@@ -949,9 +950,6 @@ class InstallerWindow(ModelessDialog,
 
     def display_eject_button(self):
         self.display_buttons([self.eject_button, self.cancel_button])
-
-    def display_no_buttons(self):
-        self.display_buttons([])
 
     def display_buttons(self, buttons):
         """Shows exactly the buttons given, and hides the others. Updates the close button

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -112,12 +112,12 @@ class InstallerWindow(ModelessDialog,
         self.menu_button.set_popover(Gtk.Popover(child=self.menu_box, can_focus=False, relative_to=self.menu_button))
         self.get_header_bar().pack_end(self.menu_button)
 
-        self.cache_button = self.add_menu_button(_("Cache"),
+        self.cache_button = self.add_menu_button(_("Configure download cache"),
                                                  self.on_cache_clicked,
                                                  tooltip=_(
                                                      "Change where Lutris downloads game installer files."))
 
-        self.source_button = self.add_menu_button(_("View source"), self.on_source_clicked)
+        self.source_button = self.add_menu_button(_("View installer source"), self.on_source_clicked)
 
         # Pre-create some UI bits we need to refer to in several places.
         # (We lazy allocate more of it, but these are a pain.)

--- a/lutris/gui/widgets/navigation_stack.py
+++ b/lutris/gui/widgets/navigation_stack.py
@@ -47,7 +47,7 @@ class NavigationStack(Gtk.Stack):
         self._update_back_button()
 
     def _update_back_button(self):
-        self.back_button.set_sensitive(self.back_allowed and self.navigation_stack)
+        self.back_button.set_visible(self.back_allowed and self.navigation_stack)
 
     def navigate_to_page(self, page_presenter):
         """Navigates to a page, by invoking 'page_presenter'.

--- a/lutris/gui/widgets/navigation_stack.py
+++ b/lutris/gui/widgets/navigation_stack.py
@@ -24,17 +24,19 @@ class NavigationStack(Gtk.Stack):
     from the page again.
     """
 
-    def __init__(self, back_button, **kwargs):
+    def __init__(self, back_button, cancel_button=None, **kwargs):
         super().__init__(**kwargs)
 
         self.back_button = back_button
+        self.cancel_button = cancel_button
         self.page_factories = {}
         self.stack_pages = {}
         self.navigation_stack = []
-        self.navigation_exit_hander = None
+        self.navigation_exit_handler = None
         self.current_page_presenter = None
         self.current_navigated_page_presenter = None
         self.back_allowed = True
+        self.cancel_allowed = True
 
     def add_named_factory(self, name, factory):
         """This specifies the factory functioin for the page named;
@@ -46,8 +48,15 @@ class NavigationStack(Gtk.Stack):
         self.back_allowed = is_allowed
         self._update_back_button()
 
+    def set_cancel_allowed(self, is_allowed=True):
+        """This turns the back button off, or back on."""
+        self.cancel_allowed = is_allowed
+        self._update_back_button()
+
     def _update_back_button(self):
-        self.back_button.set_visible(self.back_allowed and self.navigation_stack)
+        can_go_back = self.back_allowed and self.navigation_stack
+        self.back_button.set_visible(can_go_back)
+        self.cancel_button.set_visible(not can_go_back and self.cancel_allowed)
 
     def navigate_to_page(self, page_presenter):
         """Navigates to a page, by invoking 'page_presenter'.
@@ -115,14 +124,15 @@ class NavigationStack(Gtk.Stack):
         """Switches to a page. If 'navigated' is True, then when you navigate
         away from this page, it can go on the navigation stack. It should be
         False for 'temporary' pages that are not part of normal navigation."""
-        exit_handler = self.navigation_exit_hander
+        exit_handler = self.navigation_exit_handler
         self.set_transition_type(transition_type)
-        self.navigation_exit_hander = page_presenter()
+        self.navigation_exit_handler = page_presenter()
         self.current_page_presenter = page_presenter
         if navigated:
             self.current_navigated_page_presenter = page_presenter
         if exit_handler:
             exit_handler()
+        self._update_back_button()
 
     def discard_navigation(self):
         """This throws away the navigation history, so the back


### PR DESCRIPTION
This PR puts header bars on the AddGamesWindow and InstallerWindow, and tries to re-arrange the buttons to be more GNOME style. Let's look at a screenshot!
![image](https://user-images.githubusercontent.com/6507403/218267442-1dfaa1ed-d66c-4594-b629-96dccfdf2cd3.png)
It's the GNOMEiest!

Okay, okay, but I think the add games window looks good:
![image](https://user-images.githubusercontent.com/6507403/218266818-c5b8eef2-9c17-4d9a-886d-2cb997dd227f.png)
![image](https://user-images.githubusercontent.com/6507403/218266972-8990b685-8ea8-42f9-8a40-537ae969d37a.png)
Notice that you don't get Cancel and Back at the same time; the escape key still works. This is what I'm seeing other GNOME wizards do; the GNOME Boxes VM install wizard does this, for example. It keeps the clutter in the header bar down.

The installer window is a bigger change.
![image](https://user-images.githubusercontent.com/6507403/218267034-0a911ded-5a33-48a7-a30a-3ed0e3dbac37.png)
![image](https://user-images.githubusercontent.com/6507403/218267160-e86f7b44-917b-4b9b-9ebe-d7ddb6a7983f.png)
There were too many buttons to put them all in the header bar. "Cache" and "View source" go in a menu, which allows hem to have longer, clearer names. This is the worst part of the PR though, as the menu button bounces around as the "Continue" button appears and disappears. Room for improvement here, I think.

The "Eject" button was the last button down at the bottom, and it has moved to the "ask for disc" page, but it's laid out to look very much as it did before. The separator above the buttons has moved there too.