### PR TITLE
Check the version of the Vulkan API at startup

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -19,6 +19,7 @@ lutris (0.5.13) jammy; urgency=medium
   * Improve detection of DOSBox games on GOG
   * Added "Unspecified" Vulkan ICD option
   * Removed ResidualVM (now merged into ScummVM)
+  * Detect obsolete Vulkan drivers, warn and default to DXVK 1.x for them
   * Improved High-DPI support for custom media
   * Performance improvements
 

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -145,21 +145,21 @@ def check_vulkan():
         required_api_version = 1, 3, 0
         library_api_version = vkquery.get_vulkan_api_version_tuple()
         if library_api_version and library_api_version < required_api_version:
-            logger.warning("Vulkan reports an API version of %s.%s.%s. "
-                           "%s.%s.%s is required for the latest DXVK.",
-                           library_api_version[0], library_api_version[1], library_api_version[2],
-                           required_api_version[0], required_api_version[1], required_api_version[2])
+            logger.warning("Vulkan reports an API version of %s. "
+                           "%s is required for the latest DXVK.",
+                           vkquery.format_version_tuple(library_api_version),
+                           vkquery.format_version_tuple(library_api_version))
             setting = "dismiss-obsolete-vulkan-api-warning"
             if settings.read_setting(setting) != "True":
                 DontShowAgainDialog(
                     setting,
                     _("Obsolete vulkan libraries"),
                     secondary_message=_(
-                        "Lutris has detected that Vulkan API version %s.%s.%s is installed, "
-                        "but to use the latest DXVK version, %s.%s.%s is required."
+                        "Lutris has detected that Vulkan API version %s is installed, "
+                        "but to use the latest DXVK version, %s is required."
                     ) % (
-                        library_api_version[0], library_api_version[1], library_api_version[2],
-                        required_api_version[0], required_api_version[1], required_api_version[2]
+                        vkquery.format_version_tuple(library_api_version),
+                        vkquery.format_version_tuple(required_api_version)
                     )
                 )
                 return
@@ -167,22 +167,22 @@ def check_vulkan():
         max_dev_api_version = vkquery.get_max_device_api_version_tuple()
 
         if max_dev_api_version and max_dev_api_version < required_api_version:
-            logger.warning("Vulkan reports a best physical device API version of %s.%s.%s. "
-                           "%s.%s.%s is required for the latest DXVK.",
-                           max_dev_api_version[0], max_dev_api_version[1], max_dev_api_version[2],
-                           required_api_version[0], required_api_version[1], required_api_version[2])
+            logger.warning("Vulkan reports a best physical device API version of %s. "
+                           "%s is required for the latest DXVK.",
+                           vkquery.format_version_tuple(max_dev_api_version),
+                           vkquery.format_version_tuple(required_api_version))
             setting = "dismiss-obsolete-vulkan-api-warning"
             if settings.read_setting(setting) != "True":
                 DontShowAgainDialog(
                     setting,
                     _("Obsolete vulkan libraries"),
                     secondary_message=_(
-                        "Lutris has detected that the best device available supports Vulkan API %s.%s.%s, "
-                        "but to use the latest DXVK version, %s.%s.%s is required.\n\n"
+                        "Lutris has detected that the best device available supports Vulkan API %s, "
+                        "but to use the latest DXVK version, %s is required.\n\n"
                         "You may need to upgrade your drivers to a newer version."
                     ) % (
-                        max_dev_api_version[0], max_dev_api_version[1], max_dev_api_version[2],
-                        required_api_version[0], required_api_version[1], required_api_version[2]
+                        vkquery.format_version_tuple(max_dev_api_version),
+                        vkquery.format_version_tuple(required_api_version)
                     )
                 )
 

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -164,11 +164,12 @@ def check_vulkan():
                 )
                 return
 
-        max_dev_api_version = vkquery.get_max_device_api_version_tuple()
+        max_dev_name, max_dev_api_version = vkquery.get_best_device_info()
 
         if max_dev_api_version and max_dev_api_version < required_api_version:
-            logger.warning("Vulkan reports a best physical device API version of %s. "
+            logger.warning("Vulkan reports that the '%s' device has API version of %s. "
                            "%s is required for the latest DXVK.",
+                           max_dev_name,
                            vkquery.format_version_tuple(max_dev_api_version),
                            vkquery.format_version_tuple(required_api_version))
             setting = "dismiss-obsolete-vulkan-api-warning"
@@ -177,10 +178,11 @@ def check_vulkan():
                     setting,
                     _("Obsolete vulkan libraries"),
                     secondary_message=_(
-                        "Lutris has detected that the best device available supports Vulkan API %s, "
+                        "Lutris has detected that the best device available ('%s') supports Vulkan API %s, "
                         "but to use the latest DXVK version, %s is required.\n\n"
                         "You may need to upgrade your drivers to a newer version."
                     ) % (
+                        max_dev_name,
                         vkquery.format_version_tuple(max_dev_api_version),
                         vkquery.format_version_tuple(required_api_version)
                     )

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -142,12 +142,13 @@ def check_vulkan():
     if not vkquery.is_vulkan_supported():
         logger.warning("Vulkan is not available or your system isn't Vulkan capable")
     else:
-        required_vulkan_api_version = 1, 3, 0
-        api_version = vkquery.get_vulkan_api_version_tuple()
-        if api_version < required_vulkan_api_version:
-            logger.warning("Vulkan reports an API version of %s.%s.%s, but %s.%s.%s is required for the latest DXVK.",
-                           api_version[0], api_version[1], api_version[2], required_vulkan_api_version[0],
-                           required_vulkan_api_version[1], required_vulkan_api_version[2])
+        required_api_version = 1, 3, 0
+        library_api_version = vkquery.get_vulkan_api_version_tuple()
+        if library_api_version and library_api_version < required_api_version:
+            logger.warning("Vulkan reports an API version of %s.%s.%s. "
+                           "%s.%s.%s is required for the latest DXVK.",
+                           library_api_version[0], library_api_version[1], library_api_version[2],
+                           required_api_version[0], required_api_version[1], required_api_version[2])
             setting = "dismiss-obsolete-vulkan-api-warning"
             if settings.read_setting(setting) != "True":
                 DontShowAgainDialog(
@@ -155,11 +156,33 @@ def check_vulkan():
                     _("Obsolete vulkan libraries"),
                     secondary_message=_(
                         "Lutris has detected that Vulkan API version %s.%s.%s is installed, "
+                        "but to use the latest DXVK version, %s.%s.%s is required."
+                    ) % (
+                        library_api_version[0], library_api_version[1], library_api_version[2],
+                        required_api_version[0], required_api_version[1], required_api_version[2]
+                    )
+                )
+                return
+
+        max_dev_api_version = vkquery.get_max_device_api_version_tuple()
+
+        if max_dev_api_version and max_dev_api_version < required_api_version:
+            logger.warning("Vulkan reports a best physical device API version of %s.%s.%s. "
+                           "%s.%s.%s is required for the latest DXVK.",
+                           max_dev_api_version[0], max_dev_api_version[1], max_dev_api_version[2],
+                           required_api_version[0], required_api_version[1], required_api_version[2])
+            setting = "dismiss-obsolete-vulkan-api-warning"
+            if settings.read_setting(setting) != "True":
+                DontShowAgainDialog(
+                    setting,
+                    _("Obsolete vulkan libraries"),
+                    secondary_message=_(
+                        "Lutris has detected that the best device available supports Vulkan API %s.%s.%s, "
                         "but to use the latest DXVK version, %s.%s.%s is required.\n\n"
                         "You may need to upgrade your drivers to a newer version."
                     ) % (
-                        api_version[0], api_version[1], api_version[2],
-                        required_vulkan_api_version[0], required_vulkan_api_version[1], required_vulkan_api_version[2]
+                        max_dev_api_version[0], max_dev_api_version[1], max_dev_api_version[2],
+                        required_api_version[0], required_api_version[1], required_api_version[2]
                     )
                 )
 

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -141,6 +141,27 @@ def check_vulkan():
     """Reports if Vulkan is enabled on the system"""
     if not vkquery.is_vulkan_supported():
         logger.warning("Vulkan is not available or your system isn't Vulkan capable")
+    else:
+        required_vulkan_api_version = 1, 3, 0
+        api_version = vkquery.get_vulkan_api_version_tuple()
+        if api_version < required_vulkan_api_version:
+            logger.warning("Vulkan reports an API version of %s.%s.%s, but %s.%s.%s is required for the latest DXVK.",
+                           api_version[0], api_version[1], api_version[2], required_vulkan_api_version[0],
+                           required_vulkan_api_version[1], required_vulkan_api_version[2])
+            setting = "dismiss-obsolete-vulkan-api-warning"
+            if settings.read_setting(setting) != "True":
+                DontShowAgainDialog(
+                    setting,
+                    _("Obsolete vulkan libraries"),
+                    secondary_message=_(
+                        "Lutris has detected that Vulkan API version %s.%s.%s is installed, "
+                        "but to use the latest DXVK version, %s.%s.%s is required.\n\n"
+                        "You may need to upgrade your drivers to a newer version."
+                    ) % (
+                        api_version[0], api_version[1], api_version[2],
+                        required_vulkan_api_version[0], required_vulkan_api_version[1], required_vulkan_api_version[2]
+                    )
+                )
 
 
 def check_gnome():

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -27,7 +27,7 @@ from lutris.util.steam.shortcut import update_all_artwork
 from lutris.util.system import create_folder
 from lutris.util.wine.d3d_extras import D3DExtrasManager
 from lutris.util.wine.dgvoodoo2 import dgvoodoo2Manager
-from lutris.util.wine.dxvk import DXVKManager
+from lutris.util.wine.dxvk import DXVKManager, REQUIRED_VULKAN_API_VERSION
 from lutris.util.wine.dxvk_nvapi import DXVKNVAPIManager
 from lutris.util.wine.vkd3d import VKD3DManager
 
@@ -142,7 +142,7 @@ def check_vulkan():
     if not vkquery.is_vulkan_supported():
         logger.warning("Vulkan is not available or your system isn't Vulkan capable")
     else:
-        required_api_version = 1, 3, 0
+        required_api_version = REQUIRED_VULKAN_API_VERSION
         library_api_version = vkquery.get_vulkan_api_version_tuple()
         if library_api_version and library_api_version < required_api_version:
             logger.warning("Vulkan reports an API version of %s. "
@@ -156,7 +156,8 @@ def check_vulkan():
                     _("Obsolete vulkan libraries"),
                     secondary_message=_(
                         "Lutris has detected that Vulkan API version %s is installed, "
-                        "but to use the latest DXVK version, %s is required."
+                        "but to use the latest DXVK version, %s is required.\n\n"
+                        "DXVK 1.x will be used instead."
                     ) % (
                         vkquery.format_version_tuple(library_api_version),
                         vkquery.format_version_tuple(required_api_version)
@@ -176,11 +177,11 @@ def check_vulkan():
             if settings.read_setting(setting) != "True":
                 DontShowAgainDialog(
                     setting,
-                    _("Obsolete vulkan libraries"),
+                    _("Obsolete vulkan driver support"),
                     secondary_message=_(
                         "Lutris has detected that the best device available ('%s') supports Vulkan API %s, "
                         "but to use the latest DXVK version, %s is required.\n\n"
-                        "You may need to upgrade your drivers to a newer version."
+                        "DXVK 1.x will be used instead."
                     ) % (
                         max_dev_name,
                         vkquery.format_version_tuple(max_dev_api_version),

--- a/lutris/util/graphics/vkquery.py
+++ b/lutris/util/graphics/vkquery.py
@@ -4,7 +4,7 @@
 """Query Vulkan capabilities"""
 # Standard Library
 from ctypes import CDLL, POINTER, Structure, byref, c_char_p, c_int32, c_uint32, c_void_p, pointer, c_char, c_uint8, \
-    c_uint64, c_float, c_size_t, c_byte
+    c_uint64, c_float, c_size_t
 
 VkResult = c_int32  # enum (size == 4)
 VK_SUCCESS = 0

--- a/lutris/util/graphics/vkquery.py
+++ b/lutris/util/graphics/vkquery.py
@@ -3,19 +3,28 @@
 
 """Query Vulkan capabilities"""
 # Standard Library
-from ctypes import CDLL, POINTER, Structure, byref, c_char_p, c_int32, c_uint32, c_void_p, pointer
+from ctypes import CDLL, POINTER, Structure, byref, c_char_p, c_int32, c_uint32, c_void_p, pointer, c_char, c_uint8, \
+    c_uint64, c_float, c_size_t
 
 VkResult = c_int32  # enum (size == 4)
 VK_SUCCESS = 0
 VK_ERROR_INITIALIZATION_FAILED = -3
 
 VkStructureType = c_int32  # enum (size == 4)
+VkBool32 = c_uint32
 VK_STRUCTURE_TYPE_APPLICATION_INFO = 0
 VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO = 1
 
+VK_MAX_PHYSICAL_DEVICE_NAME_SIZE = 256
+VK_UUID_SIZE = 16
+
 VkInstanceCreateFlags = c_int32  # enum (size == 4)
+VkPhysicalDeviceType = c_int32  # enum (size == 4)
+VkSampleCountFlags = c_int32  # enum (size == 4)
 
 VkInstance = c_void_p  # handle (struct ptr)
+VkPhysicalDevice = c_void_p  # handle (struct ptr)
+VkDeviceSize = c_uint64
 
 
 def vk_make_version(major, minor, patch):
@@ -28,15 +37,15 @@ def vk_make_version(major, minor, patch):
 
 
 def vk_api_version_major(version):
-    return (version.value >> 22) & 0x7F
+    return (version >> 22) & 0x7F
 
 
 def vk_api_version_minor(version):
-    return (version.value >> 12) & 0x3FF
+    return (version >> 12) & 0x3FF
 
 
 def vk_api_version_patch(version):
-    return version.value & 0xFFF
+    return version & 0xFFF
 
 
 class VkApplicationInfo(Structure):
@@ -90,12 +99,146 @@ class VkInstanceCreateInfo(Structure):
         self.pApplicationInfo = pointer(app_info)
 
 
+class VkPhysicalDeviceLimits(Structure):
+    _fields_ = [
+        ("maxImageDimension1D", c_uint32),
+        ("maxImageDimension2D", c_uint32),
+        ("maxImageDimension3D", c_uint32),
+        ("maxImageDimensionCube", c_uint32),
+        ("maxImageArrayLayers", c_uint32),
+        ("maxTexelBufferElements", c_uint32),
+        ("maxUniformBufferRange", c_uint32),
+        ("maxStorageBufferRange", c_uint32),
+        ("maxPushConstantsSize", c_uint32),
+        ("maxMemoryAllocationCount", c_uint32),
+        ("maxSamplerAllocationCount", c_uint32),
+        ("bufferImageGranularity", VkDeviceSize),
+        ("sparseAddressSpaceSize", VkDeviceSize),
+        ("maxBoundDescriptorSets", c_uint32),
+        ("maxPerStageDescriptorSamplers", c_uint32),
+        ("maxPerStageDescriptorUniformBuffers", c_uint32),
+        ("maxPerStageDescriptorStorageBuffers", c_uint32),
+        ("maxPerStageDescriptorSampledImages", c_uint32),
+        ("maxPerStageDescriptorStorageImages", c_uint32),
+        ("maxPerStageDescriptorInputAttachments", c_uint32),
+        ("maxPerStageResources", c_uint32),
+        ("maxDescriptorSetSamplers", c_uint32),
+        ("maxDescriptorSetUniformBuffers", c_uint32),
+        ("maxDescriptorSetUniformBuffersDynamic", c_uint32),
+        ("maxDescriptorSetStorageBuffers", c_uint32),
+        ("maxDescriptorSetStorageBuffersDynamic", c_uint32),
+        ("maxDescriptorSetSampledImages", c_uint32),
+        ("maxDescriptorSetStorageImages", c_uint32),
+        ("maxDescriptorSetInputAttachments", c_uint32),
+        ("maxVertexInputAttributes", c_uint32),
+        ("maxVertexInputBindings", c_uint32),
+        ("maxVertexInputAttributeOffset", c_uint32),
+        ("maxVertexInputBindingStride", c_uint32),
+        ("maxVertexOutputComponents", c_uint32),
+        ("maxTessellationGenerationLevel", c_uint32),
+        ("maxTessellationPatchSize", c_uint32),
+        ("maxTessellationControlPerVertexInputComponents", c_uint32),
+        ("maxTessellationControlPerVertexOutputComponents", c_uint32),
+        ("maxTessellationControlPerPatchOutputComponents", c_uint32),
+        ("maxTessellationControlTotalOutputComponents", c_uint32),
+        ("maxTessellationEvaluationInputComponents", c_uint32),
+        ("maxTessellationEvaluationOutputComponents", c_uint32),
+        ("maxGeometryShaderInvocations", c_uint32),
+        ("maxGeometryInputComponents", c_uint32),
+        ("maxGeometryOutputComponents", c_uint32),
+        ("maxGeometryOutputVertices", c_uint32),
+        ("maxGeometryTotalOutputComponents", c_uint32),
+        ("maxFragmentInputComponents", c_uint32),
+        ("maxFragmentOutputAttachments", c_uint32),
+        ("maxFragmentDualSrcAttachments", c_uint32),
+        ("maxFragmentCombinedOutputResources", c_uint32),
+        ("maxComputeSharedMemorySize", c_uint32),
+        ("maxComputeWorkGroupCount", c_uint32 * 3),
+        ("maxComputeWorkGroupInvocations", c_uint32),
+        ("maxComputeWorkGroupSize", c_uint32 * 3),
+        ("subPixelPrecisionBits", c_uint32),
+        ("subTexelPrecisionBits", c_uint32),
+        ("mipmapPrecisionBits", c_uint32),
+        ("maxDrawIndexedIndexValue", c_uint32),
+        ("maxDrawIndirectCount", c_uint32),
+        ("maxSamplerLodBias", c_float),
+        ("maxSamplerAnisotropy", c_float),
+        ("maxViewports", c_uint32),
+        ("maxViewportDimensions", c_uint32 * 2),
+        ("viewportBoundsRange", c_float * 2),
+        ("viewportSubPixelBits", c_uint32),
+        ("minMemoryMapAlignment", c_size_t),
+        ("minTexelBufferOffsetAlignment", VkDeviceSize),
+        ("minUniformBufferOffsetAlignment", VkDeviceSize),
+        ("minStorageBufferOffsetAlignment", VkDeviceSize),
+        ("minTexelOffset", c_int32),
+        ("maxTexelOffset", c_uint32),
+        ("minTexelGatherOffset", c_int32),
+        ("maxTexelGatherOffset", c_uint32),
+        ("minInterpolationOffset", c_float),
+        ("maxInterpolationOffset", c_float),
+        ("subPixelInterpolationOffsetBits", c_uint32),
+        ("maxFrameBufferWidth", c_uint32),
+        ("maxFrameBufferHeight", c_uint32),
+        ("maxFrameBufferLayers", c_uint32),
+        ("frameBufferColorSampleCounts", VkSampleCountFlags),
+        ("frameBufferDepthSampleCounts", VkSampleCountFlags),
+        ("frameBufferStencilSampleCounts", VkSampleCountFlags),
+        ("frameBufferNoAttachmentsSampleCounts", VkSampleCountFlags),
+        ("maxColorAttachments", c_uint32),
+        ("sampledImageColorSampleCounts", VkSampleCountFlags),
+        ("sampledImageIntegerSampleCounts", VkSampleCountFlags),
+        ("sampledImageDepthSampleCounts", VkSampleCountFlags),
+        ("sampledImageStencilSampleCounts", VkSampleCountFlags),
+        ("storageImageSampleCounts", VkSampleCountFlags),
+        ("maxSampleMaskWords", c_uint32),
+        ("timestampComputeAndGraphics", VkBool32),
+        ("timestampPeriod", c_float),
+        ("maxClipDistances", c_uint32),
+        ("maxCullDistances", c_uint32),
+        ("maxCombinedClipAndCullDistances", c_uint32),
+        ("discreteQueuePriorities", c_uint32),
+        ("pointSizeRange", c_float * 2),
+        ("lineWidthRange", c_float * 2),
+        ("pointSizeGranularity", c_float),
+        ("lineWidthGranularity", c_float),
+        ("strictLines", VkBool32),
+        ("standardSampleLocations", VkBool32),
+        ("optimalBufferCopyOffsetAlignment", VkDeviceSize),
+        ("optimalBufferCopyRowPitchAlignment", VkDeviceSize),
+        ("nonCoherentAtomSize", VkDeviceSize)
+    ]
+
+
+class VkPhysicalDeviceSparseProperties(Structure):
+    _fields_ = [
+        ("residencyStandard2DBlockShape", VkBool32),
+        ("residencyStandard2DMultisampleBlockShape", VkBool32),
+        ("residencyStandard3DBlockShape", VkBool32),
+        ("residencyAlignedMipSize", VkBool32),
+        ("residencyNonResidentStrict", VkBool32)
+    ]
+
+
+class VkPhysicalDeviceProperties(Structure):
+    _fields_ = [
+        ("apiVersion", c_uint32),
+        ("driverVersion", c_uint32),
+        ("vendorID", c_uint32),
+        ("deviceID", c_uint32),
+        ("deviceName", c_char * VK_MAX_PHYSICAL_DEVICE_NAME_SIZE),
+        ("pipelineCacheUUID", c_uint8 * VK_UUID_SIZE),
+        ("limits", VkPhysicalDeviceLimits),
+        ("sparseProperties", VkPhysicalDeviceSparseProperties),
+        ("space", c_uint32 * 512)
+    ]
+
+
 def is_vulkan_supported():
     """
     Returns True iff vulkan library can be loaded, initialized,
     and reports at least one physical device available.
     """
-    vulkan = None
     try:
         vulkan = CDLL("libvulkan.so.1")
     except OSError:
@@ -131,9 +274,51 @@ def get_vulkan_api_version_tuple():
     version = c_uint32(0)
     result = enumerate_instance_version(byref(version))
     if result == VK_SUCCESS:
-        major = vk_api_version_major(version)
-        minor = vk_api_version_minor(version)
-        patch = vk_api_version_patch(version)
+        major = vk_api_version_major(version.value)
+        minor = vk_api_version_minor(version.value)
+        patch = vk_api_version_patch(version.value)
         return major, minor, patch
 
     return None
+
+
+def get_max_device_api_version_tuple():
+    """
+    Returns the greatest API version found among the physical devices
+    """
+    try:
+        vulkan = CDLL("libvulkan.so.1")
+    except OSError:
+        return False
+    app_info = VkApplicationInfo("vkinfo", version=(0, 1, 0))
+    create_info = VkInstanceCreateInfo(app_info)
+    instance = VkInstance()
+    result = vulkan.vkCreateInstance(byref(create_info), 0, byref(instance))
+    if result != VK_SUCCESS:
+        return None
+    dev_count = c_uint32(0)
+    result = vulkan.vkEnumeratePhysicalDevices(instance, byref(dev_count), 0)
+    if result != VK_SUCCESS or dev_count.value <= 0:
+        return None
+
+    devices = (VkPhysicalDevice * dev_count.value)()
+    result = vulkan.vkEnumeratePhysicalDevices(instance, byref(dev_count), byref(devices))
+    if result != VK_SUCCESS:
+        return None
+
+    versions = []
+    getPhysicalDeviceProperties = vulkan.vkGetPhysicalDeviceProperties
+    getPhysicalDeviceProperties.restype = None
+    getPhysicalDeviceProperties.argtypes = [VkPhysicalDevice, c_void_p]  # pointer(VkPhysicalDeviceProperties)]
+
+    for physical_device in devices:
+        dev_props = VkPhysicalDeviceProperties()
+        getPhysicalDeviceProperties(physical_device, byref(dev_props))
+
+        major = vk_api_version_major(dev_props.apiVersion)
+        minor = vk_api_version_minor(dev_props.apiVersion)
+        patch = vk_api_version_patch(dev_props.apiVersion)
+        versions.append((major, minor, patch))
+
+    vulkan.vkDestroyInstance(instance, 0)
+    return max(versions)

--- a/lutris/util/graphics/vkquery.py
+++ b/lutris/util/graphics/vkquery.py
@@ -283,7 +283,9 @@ def get_vulkan_api_version_tuple():
 
 def get_device_info():
     """
-    Returns the greatest API version found among the physical devices
+    Returns a dictionary of the physical devices known to Vulkan, omitting software
+    rendered devices. The keys are the device names, and the values are their API
+    version tuples.
     """
     try:
         vulkan = CDLL("libvulkan.so.1")
@@ -323,12 +325,18 @@ def get_device_info():
     return devices_dict
 
 
-def get_max_device_api_version_tuple():
-    """
-    Returns the greatest API version found among the physical devices
-    """
+def get_best_device_info():
+    """Returns the name and version tuple of the device with the highest
+    version; this is the best tuple from the get_device_info() method, so
+    the key element is the name, and the value element is a version tuple.
+    Go nested tuples!"""
     devices_dict = get_device_info()
-    return max(devices_dict.values())
+    by_version = sorted(
+        devices_dict.items(),
+        key=lambda t: t[1],
+        reverse=True
+    )
+    return by_version[0]
 
 
 def make_version_tuple(source_int):

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -496,7 +496,13 @@ def gather_system_info_str():
         graphics_dict["Vendor"] = "Unable to obtain glxinfo"
     # check Vulkan support
     if vkquery.is_vulkan_supported():
-        graphics_dict["Vulkan"] = "Supported"
+        graphics_dict["Vulkan Version"] = vkquery.format_version_tuple(vkquery.get_vulkan_api_version_tuple())
+
+        graphics_dict["Vulkan Drivers"] = ", ".join({
+            "%s (%s)" % (name, vkquery.format_version_tuple(version))
+            for name, version
+            in vkquery.get_device_info().items()
+        })
     else:
         graphics_dict["Vulkan"] = "Not Supported"
     system_info_readable["Graphics"] = graphics_dict

--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -45,8 +45,16 @@ class DLLManager:
         """Return version (latest known version if not provided)"""
         if self._version:
             return self._version
-        if self.versions:
-            return self.versions[0]
+        versions = self.versions
+        if versions:
+            recommended_versions = [v for v in versions if self.is_recommended_version(v)]
+            return recommended_versions[0] if recommended_versions else versions[0]
+
+    def is_recommended_version(self, version):
+        """True if the version given should be usable as the default; false if it
+        should not be the default, but may be selected by the user. If only
+        non-recommended versions exist, we'll still default to one of them, however."""
+        return True
 
     @property
     def path(self):

--- a/lutris/util/wine/dxvk.py
+++ b/lutris/util/wine/dxvk.py
@@ -2,6 +2,8 @@
 import os
 import shutil
 
+from lutris.util.graphics import vkquery
+
 from lutris import api
 from lutris.settings import RUNTIME_DIR
 from lutris.util.extract import extract_archive
@@ -10,13 +12,23 @@ from lutris.util.log import logger
 from lutris.util.system import create_folder, execute, remove_folder
 from lutris.util.wine.dll_manager import DLLManager
 
+REQUIRED_VULKAN_API_VERSION = 1, 3, 0
+
 
 class DXVKManager(DLLManager):
     component = "DXVK"
     base_dir = os.path.join(RUNTIME_DIR, "dxvk")
     versions_path = os.path.join(base_dir, "dxvk_versions.json")
-    managed_dlls = ("dxgi", "d3d11", "d3d10core", "d3d9", )
+    managed_dlls = ("dxgi", "d3d11", "d3d10core", "d3d9",)
     releases_url = "https://api.github.com/repos/lutris/dxvk/releases"
+    vulkan_api_version = vkquery.get_expected_api_version_tuple()
+
+    def is_recommended_version(self, version):
+        # DXVK 2.x and later require Vulkan 1.3, so if that iss lacking
+        # we default to 1.x.
+        if self.vulkan_api_version and self.vulkan_api_version < REQUIRED_VULKAN_API_VERSION:
+            return version.startswith("v1.")
+        return super().is_recommended_version(version)
 
     @staticmethod
     def is_managed_dll(dll_path):


### PR DESCRIPTION
We now have DXVK 2.1 in the runtime, but this can fail to work if older Vulkan drivers are present.

Here's a PR to check the Vulkan version, and avoid DXVK 2.x if it's too early.

It's rather elaborate- a bunch C interop. It checks the API version of libvulkan and also all physical devices (except software rendering devices).

If we do detect a problem, we'll change the default DXVK to the latest v1.x version; the user can still override this in their configuration. In addition, we show a don't-show-again warning:
![image](https://user-images.githubusercontent.com/6507403/227803788-09ca31c1-4ac9-4d14-b49b-4ffcec6b9a96.png)

In addition, I've expanded the 'Hardware Information' Lutris provides:
![Screenshot from 2023-03-26 06-14-35](https://user-images.githubusercontent.com/6507403/227769203-572b8150-bb15-4de4-a12d-33dd1e09e82a.png)

Resolves #4777 

In that thread, some users tested this and found that it did detect both an older libvulkan, and older drivers. It does not make DXVK 2 work, but defaults you to DXVK 1 and that may work for you.

One concern is whether the new interop code will work in 32 python. I don't see a reasonable way to test this. In theory, if I did it all correctly, it will work.