### PR TITLE
Do we need stinking badges?

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,7 @@ lutris (0.5.13) jammy; urgency=medium
   * Group configuration options into sections
   * Added checkbox to stop asking for the launch config for a game
   * Support for launch-configs in shortcuts and the command line
+  * Show platform badges on banners and cover-art
   * The add-games window can now create 32-bit WINE prefixes
   * Add filter field to runner list
   * Show game count in search bar

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -9,7 +9,7 @@ from lutris.gui.widgets.common import VBox
 class PreferencesBox(VBox):
     settings_options = {
         "hide_client_on_game_start": _("Minimize client when a game is launched"),
-        "hide_text_under_icons": _("Hide text under icons (requires restart)"),
+        "hide_text_under_icons": _("Hide text under icons"),
         "hide_badges_on_icons": _("Hide badges on icons"),
         "show_tray_icon": _("Show Tray Icon"),
         "dark_theme": _("Use dark theme (requires dark theme variant for Gtk)"),

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -10,7 +10,7 @@ class PreferencesBox(VBox):
     settings_options = {
         "hide_client_on_game_start": _("Minimize client when a game is launched"),
         "hide_text_under_icons": _("Hide text under icons (requires restart)"),
-        "hide_badges_on_icons": _("Hide badges on icons (requires restart)"),
+        "hide_badges_on_icons": _("Hide badges on icons"),
         "show_tray_icon": _("Show Tray Icon"),
         "dark_theme": _("Use dark theme (requires dark theme variant for Gtk)"),
         "discord_rpc": _("Enable Discord Rich Presence for Available Games"),
@@ -60,11 +60,12 @@ class PreferencesBox(VBox):
     def _on_setting_change(self, widget, state, setting_key):
         """Save a setting when an option is toggled"""
         settings.write_setting(setting_key, state)
+        application = Gio.Application.get_default()
 
         if setting_key == "dark_theme":
-            application = Gio.Application.get_default()
             application.style_manager.is_config_dark = state
         elif setting_key == "show_tray_icon":
-            application = Gio.Application.get_default()
             if application.window.get_visible():
                 application.set_tray_icon()
+
+        self.get_toplevel().emit("settings-changed", setting_key)

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -10,6 +10,7 @@ class PreferencesBox(VBox):
     settings_options = {
         "hide_client_on_game_start": _("Minimize client when a game is launched"),
         "hide_text_under_icons": _("Hide text under icons (requires restart)"),
+        "hide_badges_on_icons": _("Hide badges on icons (requires restart)"),
         "show_tray_icon": _("Show Tray Icon"),
         "dark_theme": _("Use dark theme (requires dark theme variant for Gtk)"),
         "discord_rpc": _("Enable Discord Rich Presence for Available Games"),

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -1,7 +1,7 @@
 """Configuration dialog for client and system options"""
 from gettext import gettext as _
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 from lutris.config import LutrisConfig
 from lutris.gui.config.boxes import SystemBox
@@ -14,6 +14,10 @@ from lutris.gui.config.sysinfo_box import SysInfoBox
 
 # pylint: disable=no-member
 class PreferencesDialog(GameDialogCommon):
+    __gsignals__ = {
+        "settings-changed": (GObject.SIGNAL_RUN_LAST, None, (str, )),
+    }
+
     def __init__(self, parent=None):
         super().__init__(_("Lutris settings"), parent=parent)
         self.set_border_width(0)

--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -10,6 +10,7 @@ class SysInfoBox(Gtk.Box):
     settings_options = {
         "hide_client_on_game_start": _("Minimize client when a game is launched"),
         "hide_text_under_icons": _("Hide text under icons"),
+        "hide_badges_on_icons": _("Hide badges on icons"),
         "show_tray_icon": _("Show Tray Icon"),
     }
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -704,7 +704,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.update_action_state()
 
     def update_view_settings(self):
-        if self.current_view_type == "grid":
+        if self.current_view and self.current_view_type == "grid":
             show_badges = settings.read_setting("hide_badges_on_icons") != 'True'
             self.current_view.show_badges = show_badges and not bool(
                 self.filters.get("platform") or self.filters.get("runner"))
@@ -910,8 +910,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
     def on_settings_changed(self, dialog, settings_key):
         self.update_view_settings()
-        if self.current_view:
-            self.current_view.queue_draw()
         return True
 
     def is_game_displayed(self, game):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1,4 +1,5 @@
 """Main window for the Lutris interface."""
+# pylint:disable=too-many-lines
 import os
 import re
 from collections import namedtuple
@@ -691,17 +692,33 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
             self.current_view.connect("game-selected", self.on_game_selection_changed)
             self.current_view.connect("game-activated", self.on_game_activated)
+            self.views[view_type] = self.current_view
 
+        scrolledwindow = self.games_stack.get_child_by_name(view_type)
+
+        if not scrolledwindow:
             scrolledwindow = Gtk.ScrolledWindow()
+            self.games_stack.add_named(scrolledwindow, view_type)
+
+        if not scrolledwindow.get_child():
             scrolledwindow.add(self.current_view)
             scrolledwindow.show_all()
-            self.games_stack.add_named(scrolledwindow, view_type)
-            self.views[view_type] = self.current_view
 
         self.update_view_settings()
         self.games_stack.set_visible_child_name(view_type)
         self.update_store()
         self.update_action_state()
+
+    def rebuild_view(self, view_type):
+        """Discards the view named by 'view_type' and if it is the current view,
+        regenerates it. This is used to update view settings that can only be
+        set during view construction, and not updated later."""
+        if view_type in self.views:
+            scrolledwindow = self.games_stack.get_child_by_name(view_type)
+            scrolledwindow.remove(self.views[view_type])
+            del self.views["grid"]
+            if self.current_view_type == view_type:
+                self.redraw_view()
 
     def update_view_settings(self):
         if self.current_view and self.current_view_type == "grid":
@@ -909,7 +926,10 @@ class LutrisWindow(Gtk.ApplicationWindow,
         return False
 
     def on_settings_changed(self, dialog, settings_key):
-        self.update_view_settings()
+        if settings_key == "hide_text_under_icons":
+            self.rebuild_view("grid")
+        else:
+            self.update_view_settings()
         return True
 
     def is_game_displayed(self, game):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -30,6 +30,7 @@ from lutris.scanners.lutris import add_to_path_cache, get_missing_game_ids, remo
 # pylint: disable=no-member
 from lutris.services.base import BaseService
 from lutris.services.lutris import LutrisService
+from lutris.settings import SHOW_BADGES
 from lutris.util import datapath
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
@@ -697,6 +698,9 @@ class LutrisWindow(Gtk.ApplicationWindow,
             self.games_stack.add_named(scrolledwindow, view_type)
             self.views[view_type] = self.current_view
 
+        if view_type == "grid":
+            self.current_view.show_badges = SHOW_BADGES and not bool(
+                self.filters.get("platform") or self.filters.get("runner"))
         self.games_stack.set_visible_child_name(view_type)
         self.update_store()
         self.update_action_state()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -30,7 +30,6 @@ from lutris.scanners.lutris import add_to_path_cache, get_missing_game_ids, remo
 # pylint: disable=no-member
 from lutris.services.base import BaseService
 from lutris.services.lutris import LutrisService
-from lutris.settings import SHOW_BADGES
 from lutris.util import datapath
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
@@ -142,6 +141,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         GObject.add_emission_hook(Game, "game-installed", self.on_game_installed)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_removed)
         GObject.add_emission_hook(Game, "game-unhandled-error", self.on_game_unhandled_error)
+        GObject.add_emission_hook(PreferencesDialog, "settings-changed", self.on_settings_changed)
 
         # Finally trigger the initialization of the view here
         selected_category = settings.read_setting("selected_category", default="runner:all")
@@ -698,12 +698,16 @@ class LutrisWindow(Gtk.ApplicationWindow,
             self.games_stack.add_named(scrolledwindow, view_type)
             self.views[view_type] = self.current_view
 
-        if view_type == "grid":
-            self.current_view.show_badges = SHOW_BADGES and not bool(
-                self.filters.get("platform") or self.filters.get("runner"))
+        self.update_view_settings()
         self.games_stack.set_visible_child_name(view_type)
         self.update_store()
         self.update_action_state()
+
+    def update_view_settings(self):
+        if self.current_view_type == "grid":
+            show_badges = settings.read_setting("hide_badges_on_icons") != 'True'
+            self.current_view.show_badges = show_badges and not bool(
+                self.filters.get("platform") or self.filters.get("runner"))
 
     def set_viewtype_icon(self, view_type):
         self.viewtype_icon.set_from_icon_name("view-%s-symbolic" % view_type, Gtk.IconSize.BUTTON)
@@ -903,6 +907,12 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
         GLib.idle_add(self.update_revealer, game)
         return False
+
+    def on_settings_changed(self, dialog, settings_key):
+        self.update_view_settings()
+        if self.current_view:
+            self.current_view.queue_draw()
+        return True
 
     def is_game_displayed(self, game):
         """Return whether a game should be displayed on the view"""

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -724,7 +724,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         if self.current_view and self.current_view_type == "grid":
             show_badges = settings.read_setting("hide_badges_on_icons") != 'True'
             self.current_view.show_badges = show_badges and not bool(
-                self.filters.get("platform") or self.filters.get("runner"))
+                self.filters.get("platform"))
 
     def set_viewtype_icon(self, view_type):
         self.viewtype_icon.set_from_icon_name("view-%s-symbolic" % view_type, Gtk.IconSize.BUTTON)

--- a/lutris/gui/views/grid.py
+++ b/lutris/gui/views/grid.py
@@ -19,13 +19,12 @@ class GameGridView(Gtk.IconView, GameView):
         GameView.__init__(self, store.service)
 
         self.set_column_spacing(6)
+        self._show_badges = True
 
         if settings.SHOW_MEDIA:
             self.image_renderer = GridViewCellRendererImage()
             self.pack_start(self.image_renderer, False)
-            self.add_attribute(self.image_renderer, "media_path", COL_MEDIA_PATH)
-            self.add_attribute(self.image_renderer, "platform", COL_PLATFORM)
-            self.add_attribute(self.image_renderer, "is_installed", COL_INSTALLED)
+            self._initialize_image_renderer_attributes()
         else:
             self.image_renderer = None
         self.set_item_padding(1)
@@ -57,6 +56,26 @@ class GameGridView(Gtk.IconView, GameView):
         if self.cell_renderer:
             cell_width = max(size[0], self.min_width)
             self.cell_renderer.set_width(cell_width)
+
+    @property
+    def show_badges(self):
+        return self._show_badges
+
+    @show_badges.setter
+    def show_badges(self, value):
+        if self._show_badges != value:
+            self._show_badges = value
+            self._initialize_image_renderer_attributes()
+
+    def _initialize_image_renderer_attributes(self):
+        if self.image_renderer:
+            self.clear_attributes(self.image_renderer)
+            self.add_attribute(self.image_renderer, "media_path", COL_MEDIA_PATH)
+            if self.show_badges:
+                self.add_attribute(self.image_renderer, "platform", COL_PLATFORM)
+            else:
+                self.image_renderer.platform = None
+            self.add_attribute(self.image_renderer, "is_installed", COL_INSTALLED)
 
     def select(self):
         self.select_path(self.current_path)

--- a/lutris/gui/views/grid.py
+++ b/lutris/gui/views/grid.py
@@ -50,8 +50,8 @@ class GameGridView(Gtk.IconView, GameView):
         size = game_store.service_media.size
 
         if self.image_renderer:
-            self.image_renderer.cell_width = size[0]
-            self.image_renderer.cell_height = size[1]
+            self.image_renderer.media_width = size[0]
+            self.image_renderer.media_height = size[1]
 
         if self.cell_renderer:
             cell_width = max(size[0], self.min_width)
@@ -66,6 +66,7 @@ class GameGridView(Gtk.IconView, GameView):
         if self._show_badges != value:
             self._show_badges = value
             self._initialize_image_renderer_attributes()
+            self.queue_draw()
 
     def _initialize_image_renderer_attributes(self):
         if self.image_renderer:

--- a/lutris/gui/views/grid.py
+++ b/lutris/gui/views/grid.py
@@ -3,7 +3,7 @@
 from gi.repository import Gtk
 
 from lutris import settings
-from lutris.gui.views import COL_MEDIA_PATH, COL_NAME, COL_INSTALLED
+from lutris.gui.views import COL_MEDIA_PATH, COL_NAME, COL_INSTALLED, COL_PLATFORM
 from lutris.gui.views.base import GameView
 from lutris.gui.widgets.cellrenderers import GridViewCellRendererText, GridViewCellRendererImage
 from lutris.util.log import logger
@@ -24,6 +24,7 @@ class GameGridView(Gtk.IconView, GameView):
             self.image_renderer = GridViewCellRendererImage()
             self.pack_start(self.image_renderer, False)
             self.add_attribute(self.image_renderer, "media_path", COL_MEDIA_PATH)
+            self.add_attribute(self.image_renderer, "platform", COL_PLATFORM)
             self.add_attribute(self.image_renderer, "is_installed", COL_INSTALLED)
         else:
             self.image_renderer = None

--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -75,8 +75,8 @@ class GameListView(Gtk.TreeView, GameView):
         size = game_store.service_media.size
 
         if self.image_renderer:
-            self.image_renderer.cell_width = size[0]
-            self.image_renderer.cell_height = size[1]
+            self.image_renderer.media_width = size[0]
+            self.image_renderer.media_height = size[1]
 
         if self.media_column:
             media_width = size[0]

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -101,7 +101,7 @@ class StoreItem:
         if "platform" in self._game_data:
             _platform = self._game_data["platform"]
 
-        if not _platform:
+        if not _platform and "appid" in self._game_data:
             game_data = games.get_game_for_service(self.service, self._game_data["appid"])
 
             if game_data:

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -105,7 +105,7 @@ class StoreItem:
             game_data = games.get_game_for_service(self.service, self._game_data["appid"])
 
             if game_data:
-                _platform = game_data.get("game_data")
+                _platform = game_data.get("platform")
 
         if not _platform and self.service in SERVICES:
             service = SERVICES[self.service]()

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -102,7 +102,7 @@ class StoreItem:
             _platform = self._game_data["platform"]
 
         if not _platform and "appid" in self._game_data:
-            game_data = games.get_game_for_service(self.service, self._game_data["appid"])
+            game_data = self._installed_game_data
 
             if game_data:
                 _platform = game_data.get("platform")

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -97,15 +97,7 @@ class StoreItem:
     @property
     def platform(self):
         """Platform"""
-        _platform = self._game_data.get("platform")
-        if "platform" in self._game_data:
-            _platform = self._game_data["platform"]
-
-        if not _platform and "appid" in self._game_data:
-            game_data = self._installed_game_data
-
-            if game_data:
-                _platform = game_data.get("platform")
+        _platform = self._get_game_attribute("platform")
 
         if not _platform and self.service in SERVICES:
             service = SERVICES[self.service]()

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -1,11 +1,10 @@
 """Game representation for views"""
-import json
 import time
 
 from lutris.database import games
 from lutris.database.games import get_service_games
-from lutris.game import Game
 from lutris.runners import get_runner_human_name
+from lutris.services import SERVICES
 from lutris.util.log import logger
 from lutris.util.strings import get_formatted_playtime, gtk_safe
 
@@ -101,16 +100,17 @@ class StoreItem:
         _platform = self._game_data.get("platform")
         if "platform" in self._game_data:
             _platform = self._game_data["platform"]
-        elif self.service == "lutris":
-            _details = self._game_data.get("details")
-            if _details:
-                _platforms = json.loads(_details).get("platforms")
-                if _platforms and len(_platforms) == 1:
-                    _platform = _platforms[0].get("name")
-        elif not self.service and self.installed:
-            game_inst = Game(self._game_data["id"])
-            if game_inst.platform:
-                _platform = game_inst.platform
+
+        if not _platform:
+            game_data = games.get_game_for_service(self.service, self._game_data["appid"])
+
+            if game_data:
+                _platform = game_data.get("game_data")
+
+        if not _platform and self.service in SERVICES:
+            service = SERVICES[self.service]()
+            _platform = service.get_game_platform(self._game_data)
+
         return gtk_safe(_platform)
 
     @property

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -1,8 +1,10 @@
 """Game representation for views"""
+import json
 import time
 
 from lutris.database import games
 from lutris.database.games import get_service_games
+from lutris.game import Game
 from lutris.runners import get_runner_human_name
 from lutris.util.log import logger
 from lutris.util.strings import get_formatted_playtime, gtk_safe
@@ -96,7 +98,19 @@ class StoreItem:
     @property
     def platform(self):
         """Platform"""
-        _platform = self._get_game_attribute("platform")
+        _platform = self._game_data.get("platform")
+        if "platform" in self._game_data:
+            _platform = self._game_data["platform"]
+        elif self.service == "lutris":
+            _details = self._game_data.get("details")
+            if _details:
+                _platforms = json.loads(_details).get("platforms")
+                if _platforms and len(_platforms) == 1:
+                    _platform = _platforms[0].get("name")
+        elif not self.service and self.installed:
+            game_inst = Game(self._game_data["id"])
+            if game_inst.platform:
+                _platform = game_inst.platform
         return gtk_safe(_platform)
 
     @property

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -109,7 +109,9 @@ class StoreItem:
 
         if not _platform and self.service in SERVICES:
             service = SERVICES[self.service]()
-            _platform = service.get_game_platform(self._game_data)
+            _platforms = service.get_game_platforms(self._game_data)
+            if _platforms:
+                _platform = ", ".join(_platforms)
 
         return gtk_safe(_platform)
 

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -123,6 +123,14 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         y = round(cell_area.y + cell_area.height - height)  # at bottom of cell
         return x, y
 
+    def get_badge_icon_size(self):
+        if self.cell_height < 128:
+            return 16, 16
+        elif self.cell_height < 256:
+            return 24, 24
+        else:
+            return 32, 32
+
     def render_media(self, cr, widget, surface, x, y):
         width, height = get_surface_size(surface)
 
@@ -142,7 +150,8 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
             icon_paths = [get_runtime_icon_path(p + "-symbolic") for p in platforms]
             icon_paths = [path for path in icon_paths if path]
             if icon_paths:
-                self.render_badges(cr, widget, icon_paths, (16, 16), media_right, cell_area)
+                icon_size = self.get_badge_icon_size()
+                self.render_badges(cr, widget, icon_paths, icon_size, media_right, cell_area)
 
     def render_badges(self, cr, widget, icon_paths, icon_size, media_right, cell_area):
         def render_badge(badge_x, badge_y, path):

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -135,13 +135,14 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         return x, y
 
     def get_badge_icon_size(self):
-        """Returns the size of the badge icons to render, or None to hide them."""
-        media_size = max(self.media_height, self.media_width)
-        if media_size < 64:
+        """Returns the size of the badge icons to render, or None to hide them. We check
+        width for the smallest size because Dolphin has very thin banners, but we only hide
+        badges for icons, not banners."""
+        if self.media_width < 64:
             return None
-        if media_size < 128:
+        if self.media_height < 128:
             return 16, 16
-        if media_size < 256:
+        if self.media_height < 256:
             return 24, 24
         return 32, 32
 

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -1,8 +1,9 @@
+# pylint:disable=using-constant-test
 import cairo
 from gi.repository import GLib, Gtk, Pango, GObject
 
 from lutris.gui.widgets.utils import get_default_icon_path, get_scaled_surface_by_path, get_media_generation_number, \
-    get_surface_size, has_stock_icon, get_runtime_icon_path, ICON_SIZE
+    get_surface_size, get_runtime_icon_path
 
 
 class GridViewCellRendererText(Gtk.CellRendererText):
@@ -111,8 +112,8 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
                     icon_path = get_runtime_icon_path(self.platform)
                 if icon_path:
                     icon_size = 16, 16
-                    alpha = 1 if self.is_installed else 100/255
-                    x = min(x + cell_width - icon_size[0] / 2  - 1, cell_area.x + cell_area.width - icon_size[0] -1 )
+                    alpha = 1 if self.is_installed else 100 / 255
+                    x = min(x + cell_width - icon_size[0] / 2 - 1, cell_area.x + cell_area.width - icon_size[0] - 1)
                     y = cell_area.y + cell_area.height - icon_size[1] - 1
 
                     cr.save()
@@ -120,7 +121,7 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
                     cr.set_source_rgba(1, 1, 1, alpha)
                     cr.fill()
 
-                    cr.rectangle(x-.5, y-.5, icon_size[0] + 1, icon_size[0] + 1)
+                    cr.rectangle(x - .5, y - .5, icon_size[0] + 1, icon_size[0] + 1)
                     cr.set_source_rgba(0, 0, 0, alpha)
                     cr.set_line_width(.5)
                     cr.stroke()
@@ -177,6 +178,6 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
     def get_surface_by_path(self, widget, path, size=None, preserve_aspect_ratio=True):
         cell_size = size or (self.cell_width, self.cell_height)
         scale_factor = widget.get_scale_factor() if widget else 1
-        alpha = 1 if self.is_installed else 100 / 255  # pylint:disable=using-constant-test
+        alpha = 1 if self.is_installed else 100 / 255
         return get_scaled_surface_by_path(path, cell_size, scale_factor, alpha,
                                           preserve_aspect_ratio=preserve_aspect_ratio)

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -136,11 +136,12 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
 
     def get_badge_icon_size(self):
         """Returns the size of the badge icons to render, or None to hide them."""
-        if self.media_height < 64:
+        media_size = max(self.media_height, self.media_width)
+        if media_size < 64:
             return None
-        if self.media_height < 128:
+        if media_size < 128:
             return 16, 16
-        if self.media_height < 256:
+        if media_size < 256:
             return 24, 24
         return 32, 32
 

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -91,13 +91,14 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         alpha = 1 if self.is_installed else 100 / 255
 
         if cell_width > 0 and cell_height > 0 and path:  # pylint: disable=comparison-with-callable
-            surface = self.get_cached_surface_by_path(widget, path, alpha)
+            surface = self.get_cached_surface_by_path(widget, path)
             if not surface:
                 # The default icon needs to be scaled to fill the cell space.
                 path = get_default_icon_path((cell_width, cell_height))
-                surface = self.get_cached_surface_by_path(widget, path, alpha,
+                surface = self.get_cached_surface_by_path(widget, path,
                                                           preserve_aspect_ratio=False)
 
+            cr.push_group()
             if surface:
                 width, height = get_surface_size(surface)
 
@@ -118,32 +119,36 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
                 icon_paths = [get_runtime_icon_path(p + "-symbolic") for p in platforms]
                 icon_paths = [path for path in icon_paths if path]
                 if icon_paths:
-                    icon_size = 16, 16
-                    x = min(x + cell_width - icon_size[0] / 2 - 1, cell_area.x + cell_area.width - icon_size[0] - 1)
-                    y = cell_area.y + cell_area.height - icon_size[1] - 1
-                    y_offset = min(icon_size[1] + 3, floor(cell_area.height / len(icon_paths)))
-                    y = y - y_offset * (len(icon_paths) - 1)
+                    icon_size = (8, 8) if cell_height < 64 else (16, 16)
+                    x = min(x + cell_width - icon_size[0] / 2 - 1, cell_area.x + cell_area.width - icon_size[0] - 2)
+                    h = icon_size[1] + 2
+                    spacing = (cell_area.height - h * len(icon_paths)) / max(1, len(icon_paths) - 1)
+                    spacing = min(spacing, 1)
+                    y_offset = h + spacing
+                    y = cell_area.y + cell_area.height - h - y_offset * (len(icon_paths) - 1)
 
                     cr.push_group()
                     for icon_path in icon_paths:
                         if icon_path:
                             cr.save()
-                            cr.rectangle(x, y, icon_size[0], icon_size[0])
+                            cr.rectangle(x + 1, y + 1, icon_size[0], icon_size[0])
                             cr.set_source_rgba(1, 1, 1)
                             cr.fill()
 
-                            cr.rectangle(x - .5, y - .5, icon_size[0] + 1, icon_size[0] + 1)
+                            cr.rectangle(x + 0.5, y + 0.5, icon_size[0] + 1, icon_size[0] + 1)
                             cr.set_source_rgba(0, 0, 0)
-                            cr.set_line_width(.5)
+                            cr.set_line_width(1)
                             cr.stroke()
 
                             icon = self.get_cached_surface_by_path(widget, icon_path, size=icon_size)
-                            cr.set_source_surface(icon, x, y)
+                            cr.set_source_surface(icon, x + 1, y + 1)
                             cr.paint()
                             cr.restore()
                             y = y + y_offset
                     cr.pop_group_to_source()
-                    cr.paint_with_alpha(alpha)
+                    cr.paint()
+            cr.pop_group_to_source()
+            cr.paint_with_alpha(alpha)
 
             # Idle time will wait until the widget has drawn whatever it wants to;
             # we can then discard surfaces we aren't using anymore.
@@ -166,7 +171,7 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         self.cached_surfaces_new = {}
         self.cycle_cache_idle_id = None
 
-    def get_cached_surface_by_path(self, widget, path, alpha=1, size=None, preserve_aspect_ratio=True):
+    def get_cached_surface_by_path(self, widget, path, size=None, preserve_aspect_ratio=True):
         """This obtains the scaled surface to rander for a given media path; this is cached
         in this render, but we'll clear that cache when the media generation number is changed,
         or certain properties are. We also age surfaces from the cache at idle time after
@@ -175,7 +180,7 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
             self.cached_surface_generation = get_media_generation_number()
             self.clear_cache()
 
-        key = widget, path, alpha, size, preserve_aspect_ratio
+        key = widget, path, size, preserve_aspect_ratio
 
         surface = self.cached_surfaces_new.get(key)
         if surface:
@@ -184,13 +189,13 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         surface = self.cached_surfaces_old.get(key)
 
         if not surface:
-            surface = self.get_surface_by_path(widget, path, alpha, size, preserve_aspect_ratio)
+            surface = self.get_surface_by_path(widget, path, size, preserve_aspect_ratio)
 
         self.cached_surfaces_new[key] = surface
         return surface
 
-    def get_surface_by_path(self, widget, path, alpha=1, size=None, preserve_aspect_ratio=True):
+    def get_surface_by_path(self, widget, path, size=None, preserve_aspect_ratio=True):
         cell_size = size or (self.cell_width, self.cell_height)
         scale_factor = widget.get_scale_factor() if widget else 1
-        return get_scaled_surface_by_path(path, cell_size, scale_factor, alpha,
+        return get_scaled_surface_by_path(path, cell_size, scale_factor,
                                           preserve_aspect_ratio=preserve_aspect_ratio)

--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -65,9 +65,8 @@ def get_surface_size(surface):
     return width, height
 
 
-def get_scaled_surface_by_path(path, size, device_scale, alpha=1, preserve_aspect_ratio=True):
-    """Returns a Cairo surface containing the image at the path given. It has the size indicated,
-    and if alpha is less than 1, it will be partially transparent to that degree.
+def get_scaled_surface_by_path(path, size, device_scale, preserve_aspect_ratio=True):
+    """Returns a Cairo surface containing the image at the path given. It has the size indicated.
 
     You specify the device_scale, and the bitmap is generated at an enlarged size accordingly,
     but with the device scale of the surface also set; in this way a high-DPI image can be
@@ -98,7 +97,7 @@ def get_scaled_surface_by_path(path, size, device_scale, alpha=1, preserve_aspec
         cr.scale(scale_x, scale_y)
         Gdk.cairo_set_source_pixbuf(cr, pixbuf, 0, 0)
         cr.get_source().set_extend(cairo.Extend.PAD)  # pylint: disable=no-member
-        cr.paint_with_alpha(alpha)
+        cr.paint()
         surface.set_device_scale(device_scale, device_scale)
         return surface
 

--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -183,7 +183,7 @@ def get_runtime_icon_path(icon_name):
 
 
 def convert_to_background(background_path, target_size=(320, 1080)):
-    """Converts a image to a pane background"""
+    """Converts an image to a pane background"""
     coverart = Image.open(background_path)
     coverart = coverart.convert("RGBA")
 

--- a/lutris/runners/dolphin.py
+++ b/lutris/runners/dolphin.py
@@ -5,11 +5,13 @@ from gettext import gettext as _
 from lutris.runners.runner import Runner
 from lutris.util import system
 
+PLATFORMS = [_("Nintendo GameCube"), _("Nintendo Wii")]
+
 
 class dolphin(Runner):
     description = _("GameCube and Wii emulator")
     human_name = _("Dolphin")
-    platforms = [_("Nintendo GameCube"), _("Nintendo Wii")]
+    platforms = PLATFORMS
     require_libs = ["libOpenGL.so.0", ]
     runnable_alone = True
     runner_executable = "dolphin/dolphin-emu"

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -303,7 +303,7 @@ class BaseService(GObject.Object):
         """Specific services should implement this"""
         return ""
 
-    def get_game_platform(self, db_game):
+    def get_game_platforms(self, db_game):
         """Interprets the database record for this game from this service
         to extract its platform, or returns None if this is not available."""
         return db_game.get("platform")

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -306,7 +306,7 @@ class BaseService(GObject.Object):
     def get_game_platforms(self, db_game):
         """Interprets the database record for this game from this service
         to extract its platform, or returns None if this is not available."""
-        return db_game.get("platform")
+        return None
 
 
 class OnlineService(BaseService):

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -303,6 +303,11 @@ class BaseService(GObject.Object):
         """Specific services should implement this"""
         return ""
 
+    def get_game_platform(self, db_game):
+        """Interprets the database record for this game from this service
+        to extract its platform, or returns None if this is not available."""
+        return db_game.get("platform")
+
 
 class OnlineService(BaseService):
     """Base class for online gaming services"""

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -65,13 +65,14 @@ class DolphinService(BaseService):
         if "details" in db_game:
             details = json.loads(db_game.get("details"))
             if details and details.get("platform"):
-                try:
+                platform_value = details["platform"]
+                if platform_value.isdigit():
                     platform_number = int(details["platform"])
                     if 0 <= platform_number < len(PLATFORMS):
                         platform = PLATFORMS[platform_number]
                         return [platform]
-                except ValueError:
-                    return None
+
+                return [platform_value]
         return None
 
 

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -5,6 +5,7 @@ from gettext import gettext as _
 from PIL import Image
 
 from lutris import settings
+from lutris.runners.dolphin import PLATFORMS
 from lutris.services.base import BaseService
 from lutris.services.service_game import ServiceGame
 from lutris.services.service_media import ServiceMedia
@@ -59,6 +60,19 @@ class DolphinService(BaseService):
     def get_game_directory(self, installer):
         """Pull install location from installer"""
         return os.path.dirname(installer["script"]["game"]["main_file"])
+
+    def get_game_platforms(self, db_game):
+        if "details" in db_game:
+            details = json.loads(db_game.get("details"))
+            if details and details.get("platform"):
+                try:
+                    platform_number = int(details["platform"])
+                    if 0 <= platform_number < len(PLATFORMS):
+                        platform = PLATFORMS[platform_number]
+                        return [platform]
+                except ValueError:
+                    return None
+        return None
 
 
 class DolphinGame(ServiceGame):

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -647,3 +647,12 @@ class GOGService(OnlineService):
             }
             patch_installers.append(installer)
         return patch_installers
+
+    def get_game_platform(self, db_game):
+        details = db_game.get("details")
+        if details:
+            worksOn = json.loads(details).get("worksOn")
+            platforms = [key for key, value in worksOn.items() if value]
+            if platforms and len(platforms) == 1:
+                return platforms[0]
+        return None

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -648,11 +648,10 @@ class GOGService(OnlineService):
             patch_installers.append(installer)
         return patch_installers
 
-    def get_game_platform(self, db_game):
+    def get_game_platforms(self, db_game):
         details = db_game.get("details")
         if details:
             worksOn = json.loads(details).get("worksOn")
-            platforms = [key for key, value in worksOn.items() if value]
-            if platforms and len(platforms) == 1:
-                return platforms[0]
+            if worksOn is not None:
+                return [name for name, works in worksOn.items() if works]
         return None

--- a/lutris/services/lutris.py
+++ b/lutris/services/lutris.py
@@ -124,12 +124,12 @@ class LutrisService(OnlineService):
         application = Gio.Application.get_default()
         application.show_installer_window(installers)
 
-    def get_game_platform(self, db_game):
+    def get_game_platforms(sself, db_game):
         details = db_game.get("details")
         if details:
             platforms = json.loads(details).get("platforms")
-            if platforms and len(platforms) == 1:
-                return platforms[0].get("name")
+            if platforms is not None:
+                return [p.get("name") for p in platforms]
         return None
 
 

--- a/lutris/services/lutris.py
+++ b/lutris/services/lutris.py
@@ -124,6 +124,14 @@ class LutrisService(OnlineService):
         application = Gio.Application.get_default()
         application.show_installer_window(installers)
 
+    def get_game_platform(self, db_game):
+        details = db_game.get("details")
+        if details:
+            platforms = json.loads(details).get("platforms")
+            if platforms and len(platforms) == 1:
+                return platforms[0].get("name")
+        return None
+
 
 def download_lutris_media(slug):
     """Download all media types for a single lutris game"""

--- a/lutris/services/lutris.py
+++ b/lutris/services/lutris.py
@@ -124,7 +124,7 @@ class LutrisService(OnlineService):
         application = Gio.Application.get_default()
         application.show_installer_window(installers)
 
-    def get_game_platforms(sself, db_game):
+    def get_game_platforms(self, db_game):
         details = db_game.get("details")
         if details:
             platforms = json.loads(details).get("platforms")

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -49,7 +49,6 @@ RUNTIME_URL = SITE_URL + "/api/runtimes"
 STEAM_API_KEY = sio.read_setting("steam_api_key") or "34C9698CEB394AB4401D65927C6B3752"
 
 SHOW_MEDIA = os.environ.get("LUTRIS_HIDE_MEDIA") != "1" and sio.read_setting("hide_media") != 'True'
-SHOW_BADGES = os.environ.get("LUTRIS_HIDE_BADGES") != "1" and sio.read_setting("hide_badges_on_icons") != 'True'
 
 DEFAULT_RESOLUTION_WIDTH = 1280
 DEFAULT_RESOLUTION_HEIGHT = 720

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -49,6 +49,7 @@ RUNTIME_URL = SITE_URL + "/api/runtimes"
 STEAM_API_KEY = sio.read_setting("steam_api_key") or "34C9698CEB394AB4401D65927C6B3752"
 
 SHOW_MEDIA = os.environ.get("LUTRIS_HIDE_MEDIA") != "1" and sio.read_setting("hide_media") != 'True'
+SHOW_BADGES = os.environ.get("LUTRIS_HIDE_BADGES") != "1" and sio.read_setting("hide_badges_on_icons") != 'True'
 
 DEFAULT_RESOLUTION_WIDTH = 1280
 DEFAULT_RESOLUTION_HEIGHT = 720


### PR DESCRIPTION
Adds badges to indicate platforms on banners and cover-art:

![Screenshot from 2023-03-28 19-26-15](https://user-images.githubusercontent.com/6507403/228389238-cace0878-be9b-4d50-af69-d26353eb027f.png)

Now, in #220 you asked for consistent, good-looking 32x32 icons. These seem consistent, look pretty crap, and are 16x16. But they are the icons we have in the sidebar, so there's that. 16x16 is still too big to work on the icon view, but 8x8 looks *awful*, so I just omit the badges there.

The badges are omitted from the  platform view, because they are pretty redundant there.

Notice that you can have more than one platform. Installed games should always show  the platform of the installation, but uninstalled games may show multiple if that information is there. I implemented this for Lutris, GOG and the Dolphin service, but it looks like every services has its own 'details' JSON, so each service that knows about platforms will need to handle this separately 

The cover art media get larger badges which look better:
![Screenshot from 2023-03-29 04-21-18](https://user-images.githubusercontent.com/6507403/228483954-8a7bf1d6-75bb-45b7-bfd2-83c44102618b.png)

There are no badges in the list view, but multiple platforms can appear there:
![image](https://user-images.githubusercontent.com/6507403/228389608-79177864-c13e-4048-a723-16f504c57f7e.png)

You can turn the badges off if they offend your sensibilities:
![Screenshot from 2023-04-01 06-31-10](https://user-images.githubusercontent.com/6507403/229282727-02ebd877-a951-4b57-9a28-ebccf4c7c1a5.png)
I've made this update the view as soon as you toggle it, and I threw in the same for 'Hide text under icons', so no settings require restarts anymore.

There may be a slight performance cost here, as this PR no longer caches 'faded' uninstalled media; rather the media is composited with any badges, and that is faded as a whole. I think this should be okay.

Resolves #220