### PR TITLE
Platformapalooza!

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -860,9 +860,9 @@ class Application(Gtk.Application):
                 self._print(command_line, path)
 
     def print_runners(self):
-        runnersName = get_runner_names()
-        sortednames = sorted(runnersName.keys(), key=lambda x: x.lower())
-        for name in sortednames:
+        runner_names = get_runner_names()
+        sorted_names = sorted(runner_names, key=lambda x: x.lower())
+        for name in sorted_names:
             print(name)
 
     def print_wine_runners(self):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -240,6 +240,7 @@ class SidebarHeader(Gtk.Box):
     def __init__(self, name, header_index):
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.header_index = header_index
+        self.first_row = None
         self.get_style_context().add_class("sidebar-header")
         label = Gtk.Label(
             halign=Gtk.Align.START,
@@ -419,6 +420,14 @@ class LutrisSidebar(Gtk.ListBox):
             header = None
 
         if row.get_header() != header:
+            # GTK is messy here; a header can't belong to two rows at once,
+            # so we must remove it from the one that owns it, if any, and
+            # also from the sidebar itself. Then we can reuse it.
+            if header.first_row:
+                header.first_row.set_header(None)
+                if header.get_parent() == self:
+                    self.remove(header)
+            header.first_row = row
             row.set_header(header)
 
     def update_rows(self, *_args):

--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -1,5 +1,4 @@
 """Runner loaders"""
-from collections import defaultdict
 
 __all__ = [
     # Native
@@ -43,9 +42,9 @@ __all__ = [
     "o2em",
     "zdoom",
 ]
+
 ADDON_RUNNERS = {}
-RUNNER_NAMES = {}  # This needs to be initialized at startup with get_runner_names
-RUNNER_PLATFORMS = {}  # This also must be initialized at the right moment
+_cached_runner_human_names = {}
 
 
 class InvalidRunner(Exception):
@@ -108,23 +107,20 @@ def inject_runners(runners):
     for runner_name in runners:
         ADDON_RUNNERS[runner_name] = runners[runner_name]
         __all__.append(runner_name)
+    _cached_runner_human_names.clear()
 
 
 def get_runner_names():
-    return {
-        runner: import_runner(runner)().human_name for runner in __all__
-    }
-
-
-def get_platforms():
-    """Return a dictionary of all supported platforms with their runners"""
-    platforms = defaultdict(list)
-    for runner_name in __all__:
-        runner = import_runner(runner_name)()
-        for platform in runner.platforms:
-            platforms[platform].append(runner_name)
-    return platforms
+    return __all__
 
 
 def get_runner_human_name(runner_name):
-    return RUNNER_NAMES.get(runner_name)
+    """Returns a human-readable name for a runner; as a convenience, if the name
+    is falsy (None or blank) this returns an empty string. Provides caching for the
+    names."""
+    if runner_name:
+        if runner_name not in _cached_runner_human_names:
+            _cached_runner_human_names[runner_name] = import_runner(runner_name)().human_name
+        return _cached_runner_human_names[runner_name]
+
+    return ""

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -238,7 +238,6 @@ def init_lutris():
     runners.inject_runners(load_json_runners())
     # Load runner names and platforms
     runners.RUNNER_NAMES = runners.get_runner_names()
-    runners.RUNNER_PLATFORMS = runners.get_platforms()
     init_dirs()
     try:
         syncdb()

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -236,7 +236,7 @@ def init_lutris():
     """Run full initialization of Lutris"""
     logger.info("Starting Lutris %s", settings.VERSION)
     runners.inject_runners(load_json_runners())
-    # Load runner names and platforms
+    # Load runner names
     runners.RUNNER_NAMES = runners.get_runner_names()
     init_dirs()
     try:

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -236,8 +236,6 @@ def init_lutris():
     """Run full initialization of Lutris"""
     logger.info("Starting Lutris %s", settings.VERSION)
     runners.inject_runners(load_json_runners())
-    # Load runner names
-    runners.RUNNER_NAMES = runners.get_runner_names()
     init_dirs()
     try:
         syncdb()


### PR DESCRIPTION
We have a lot more platforms than you may think- 2277. We create sidebar rows for them all, and hide the ones we do not use. That's enough that GTK struggles just a bit.

You can see this switching between windows- there's a slight delay and the animation in the default GNOME window rendering stutters. It's not a huge deal, but we may as well do better.

This PR generates sidebar rows for runners, platforms and services when they are needed, reducing the number a lot. They are created as needed and inserted in sorted order when you add sources or runners.

We never *remove* a row- GTK seems to have trouble coping with that somehow. The filter func remains to handle rows we want to hide, and also handles hiding services now. The result should look just like before but fractionally faster.

I've also silenced the widget-already-has-a-parent warning by transferring headers to new owning rows more carefully.

This PR is an improvement and at another time I might just commit it- but it is but minor enough that it is perhaps not worthwhile to merge near a release (which I imagine must be imminent), so I'll leave the call to @strycore.