### PR TITLE
Fix installer.schema.yml

### DIFF
--- a/schema/installer.schema.yml
+++ b/schema/installer.schema.yml
@@ -371,7 +371,7 @@ properties:
                   type: boolean
                   description: Suppress threading
                 description:
-                  type: boolean
+                  type: string
                   description: A message be shown to the user during the execution of the task
                 working_dir:
                   type: string
@@ -440,7 +440,7 @@ properties:
             - required: [ write_file ]
             - required: [ write_config ]
             - required: [ write_json ]
-            - required: [ write_task ]
+            - required: [ task ]
             - required: [ input_menu ]
       system:
         type: object


### PR DESCRIPTION
I was happy to see that lutris provides a yaml-schema for installer scripts. However I noticed two errors in the schema:

---

1.
`/script/installer/task/description` is marked as `boolean` but should probably be `string`.

> `description` (a message be shown to the user during the execution of the task)

https://github.com/lutris/lutris/blob/master/docs/installers.rst#running-a-task-provided-by-a-runner

I also verified, the current behaviour of Lutris matches this documentation.

---

2.
`/script/installer/items/properties` defines multiple possible keys, and then ensures via `/script/installer/items/oneOf` that at least one of them is used.

All entries are fine, except for one. `properties` defines `task`, but `oneOf` has no entry for `task`, but `write_task` instead.

```yaml
items: 
  properties:
    insert-disc:
    # [...]
    task:
    # [...]
  oneOf:
    - required: [ insert-disk ]
    # - [...]
    - required: [ write_task ]
```
It's probably a typo since the three entries before it all had a `write_` prefix.

---

I hope these small fixes are good to go.