### PR TITLE
A 'Sort Installed First' menu item

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ lutris (0.5.13) jammy; urgency=medium
   * Re-style the configuration, preferences, installer and add-games windows
   * Group configuration options into sections
   * Added checkbox to stop asking for the launch config for a game
+  * Added checkbox to sort installed games first
   * Support for launch-configs in shortcuts and the command line
   * The add-games window can now create 32-bit WINE prefixes
   * Add filter field to runner list

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -326,9 +326,12 @@
           </packing>
         </child>
         <child>
-          <object class="GtkSeparator">
+          <object class="GtkModelButton">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="action-name">win.view-sorting-installed-first</property>
+            <property name="text" translatable="yes">Sort Installed First</property>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -351,6 +354,17 @@
           </packing>
         </child>
         <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkModelButton">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
@@ -362,7 +376,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">3</property>
+            <property name="position">4</property>
           </packing>
         </child>
         <child>
@@ -377,7 +391,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -392,7 +406,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">5</property>
+            <property name="position">6</property>
           </packing>
         </child>
         <child>
@@ -407,7 +421,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -422,7 +436,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">7</property>
+            <property name="position">8</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
Lutris does not strictly sort by what the user selects; it sorts first by installation status- installed games first. So this PR gives you a checkbox to turn that off:

![image](https://user-images.githubusercontent.com/6507403/230690268-48d85c15-8e19-470a-bd0f-51f004964ef0.png)

This came up in #2104; it was not obvious why the games were not in the specified order. Adding this checkbox isn't just to turn this off, but also to give the user some clue about what Lutris is doing.

The default is 'on' here, so we continue to sort by installation status until overridden.

This isn't really the GNOMEy thing to do- I should really just strip the feature right out, because you don't need it and I know best. But maybe I'm not achieved true personal GNOMEyness.