### PR TITLE
Vary the colors of platform badges to blend in better with the media

### DIFF
--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -144,6 +144,11 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         if surface_format != cairo.FORMAT_ARGB32:  # pylint:disable=no-member
             return False
 
+        # Scale the corner according to the surface's scale factor -
+        # normally the same as our UI scale factor.
+        device_scale_x, device_scale_y = surface.get_device_scale()
+        corner_pixel_width = int(corner_size[0] * device_scale_x)
+        corner_pixel_height = int(corner_size[1] * device_scale_y)
         pixel_width = surface.get_width()
         pixel_height = surface.get_height()
 
@@ -166,9 +171,9 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
 
         return (
             is_bright_pixel(pixel_width - 1, pixel_height - 1)
-            and is_bright_pixel(pixel_width - corner_size[0], pixel_height - 1)
-            and is_bright_pixel(pixel_width - 1, pixel_height - corner_size[1])
-            and is_bright_pixel(pixel_width - corner_size[0], pixel_height - corner_size[1])
+            and is_bright_pixel(pixel_width - corner_pixel_width, pixel_height - 1)
+            and is_bright_pixel(pixel_width - 1, pixel_height - corner_pixel_height)
+            and is_bright_pixel(pixel_width - corner_pixel_width, pixel_height - corner_pixel_height)
         )
 
     def get_media_position(self, surface, cell_area):


### PR DESCRIPTION
Now, this may offend against your sense of grim-dark dark grimness.

That is, this detects bright cover art or banners and swaps the fore and back colors of the badges. It looks like this:
![Screenshot from 2023-04-14 16-33-13](https://user-images.githubusercontent.com/6507403/232149899-4ff78234-5234-437f-aa89-4ed9c4ac2be1.png)

Look at the game "Prey" and compare with "Prey". Blends in better this way.

The code is checking the four pixels at the corners of the bottom badge; if all color channels in all those pixels are >50%, we swap the colors. This favors dark badges quite a bit - notice "Rime" - but goes to white in extreme cases.