### PR TITLE
Use PCSX2 AppImage as a runner

### DIFF
--- a/lutris/runners/pcsx2.py
+++ b/lutris/runners/pcsx2.py
@@ -1,5 +1,7 @@
+# Standard Library
 from gettext import gettext as _
 
+# Lutris Modules
 from lutris.runners.runner import Runner
 from lutris.util import system
 
@@ -9,9 +11,7 @@ class pcsx2(Runner):
     description = _("PlayStation 2 emulator")
     platforms = [_("Sony PlayStation 2")]
     runnable_alone = True
-    runner_executable = "pcsx2/PCSX2"
-    arch = "i386"
-    require_libs = ["libOpenGL.so.0", "libgdk-x11-2.0.so.0", "libEGL.so.1"]
+    runner_executable = "pcsx2/pcsx2"
     game_options = [{
         "option": "main_file",
         "type": "file",
@@ -51,6 +51,10 @@ class pcsx2(Runner):
             "advanced": True,
         },
     ]
+
+
+    # PCSX2 currently uses an AppImage, no need for the runtime.
+    system_options_override = [{"option": "disable_runtime", "default": True}]
 
     def play(self):
         arguments = [self.get_executable()]


### PR DESCRIPTION
Pcsx2 provides AppImage.
To use it with Lutris, we have to change pcsx2 runner code, similar to rcps3 code.