### PR TITLE
Gentler configuration warnings

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -50,7 +50,7 @@ def _get_dxvk_version_warning(config):
             required_api_version = REQUIRED_VULKAN_API_VERSION
             library_api_version = vkquery.get_vulkan_api_version()
             if library_api_version and library_api_version < required_api_version:
-                return _("Lutris has detected that Vulkan API version %s is installed, "
+                return _("<b>Warning</b> Lutris has detected that Vulkan API version %s is installed, "
                          "but to use the latest DXVK version, %s is required."
                          ) % (
                     vkquery.format_version(library_api_version),
@@ -60,7 +60,7 @@ def _get_dxvk_version_warning(config):
             devices = vkquery.get_device_info()
 
             if devices and devices[0].api_version < required_api_version:
-                return _("Lutris has detected that the best device available ('%s') supports Vulkan API %s, "
+                return _("<b>Warning</b> Lutris has detected that the best device available ('%s') supports Vulkan API %s, "
                          "but to use the latest DXVK version, %s is required."
                          ) % (
                     devices[0].name,
@@ -74,7 +74,7 @@ def _get_dxvk_version_warning(config):
 def _get_vkd3d_warning(config):
     if config.get("vkd3d"):
         if not vkquery.is_vulkan_supported():
-            return _("Vulkan is not installed or is not supported by your system")
+            return _("<b>Warning</b> Vulkan is not installed or is not supported by your system")
 
     return None
 

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -48,24 +48,24 @@ def _get_dxvk_version_warning(config):
         version = config.get("dxvk_version")
         if version and not version.startswith("v1."):
             required_api_version = REQUIRED_VULKAN_API_VERSION
-            library_api_version = vkquery.get_vulkan_api_version_tuple()
+            library_api_version = vkquery.get_vulkan_api_version()
             if library_api_version and library_api_version < required_api_version:
                 return _("Lutris has detected that Vulkan API version %s is installed, "
                          "but to use the latest DXVK version, %s is required."
                          ) % (
-                    vkquery.format_version_tuple(library_api_version),
-                    vkquery.format_version_tuple(required_api_version)
+                    vkquery.format_version(library_api_version),
+                    vkquery.format_version(required_api_version)
                 )
 
-            max_dev_name, max_dev_api_version = vkquery.get_best_device_info()
+            devices = vkquery.get_device_info()
 
-            if max_dev_api_version and max_dev_api_version < required_api_version:
+            if devices and devices[0].api_version < required_api_version:
                 return _("Lutris has detected that the best device available ('%s') supports Vulkan API %s, "
                          "but to use the latest DXVK version, %s is required."
                          ) % (
-                    max_dev_name,
-                    vkquery.format_version_tuple(max_dev_api_version),
-                    vkquery.format_version_tuple(required_api_version)
+                    devices[0].name,
+                    vkquery.format_version(devices[0].api_version),
+                    vkquery.format_version(required_api_version)
                 )
 
     return None

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -129,21 +129,6 @@ class wine(Runner):
                 version_choices.append((label, version))
             return version_choices
 
-        def fsync_support_callback(widget, option, config):
-            fsync_supported = is_fsync_supported()
-            wine_path = self.get_path_for_version(config["version"])
-            wine_ver = is_version_fsync(wine_path)
-            response = True
-
-            if not wine_ver:
-                response = thread_safe_call(fsync_display_version_warning)
-
-            if not fsync_supported:
-                thread_safe_call(fsync_display_support_warning)
-                response = False
-
-            return widget, option, response
-
         self.runner_options = [
             {
                 "option": "version",
@@ -297,10 +282,9 @@ class wine(Runner):
             {
                 "option": "fsync",
                 "label": _("Enable Fsync"),
-                "type": "extended_bool",
+                "type": "bool",
                 "default": is_fsync_supported(),
-                "callback": fsync_support_callback,
-                "callback_on": True,
+                "warning": self._get_fsync_warning,
                 "active": True,
                 "help": _(
                     "Enable futex-based synchronization (fsync). "
@@ -1107,6 +1091,13 @@ class wine(Runner):
 
         return None
 
+    def _get_vkd3d_warning(self, config):
+        if config.get("vkd3d"):
+            if not vkquery.is_vulkan_supported():
+                return _("Vulkan is not installed or is not supported by your system")
+
+        return None
+
     def _get_esync_warning(self, config):
         if config.get("esync"):
             limits_set = is_esync_limit_set()
@@ -1123,9 +1114,16 @@ class wine(Runner):
 
         return None
 
-    def _get_vkd3d_warning(self, config):
-        if config.get("vkd3d"):
-            if not vkquery.is_vulkan_supported():
-                return _("Vulkan is not installed or is not supported by your system")
+    def _get_fsync_warning(self, config):
+        if config.get("fsync"):
+            fsync_supported = is_fsync_supported()
+            wine_path = self.get_path_for_version(config["version"])
+            wine_ver = is_version_fsync(wine_path)
 
-        return None
+            if not wine_ver:
+                return _("<b>Warning</b> The Wine build you have selected does not support Fsync.")
+
+            if not fsync_supported:
+                return _("<b>Warning</b> Your kernel is not patched for fsync.")
+
+            return None

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -15,7 +15,6 @@ from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-
 from lutris.runners.runner import Runner
 from lutris.util import system
 from lutris.util.display import DISPLAY_MANAGER, get_default_dpi
-from lutris.util.jobs import thread_safe_call
 from lutris.util.log import logger
 from lutris.util.steam.config import get_steam_dir
 from lutris.util.strings import parse_version, split_arguments

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -148,22 +148,7 @@ def check_vulkan():
             logger.warning("Vulkan reports an API version of %s. "
                            "%s is required for the latest DXVK.",
                            vkquery.format_version(library_api_version),
-                           vkquery.format_version(library_api_version))
-            setting = "dismiss-obsolete-vulkan-api-warning"
-            if settings.read_setting(setting) != "True":
-                DontShowAgainDialog(
-                    setting,
-                    _("Obsolete Vulkan libraries"),
-                    secondary_message=_(
-                        "Lutris has detected that Vulkan API version %s is installed, "
-                        "but to use the latest DXVK version, %s is required.\n\n"
-                        "DXVK 1.x will be used instead."
-                    ) % (
-                        vkquery.format_version(library_api_version),
-                        vkquery.format_version(required_api_version)
-                    )
-                )
-                return
+                           vkquery.format_version(required_api_version))
 
         devices = vkquery.get_device_info()
 
@@ -173,21 +158,6 @@ def check_vulkan():
                            devices[0].name,
                            vkquery.format_version(devices[0].api_version),
                            vkquery.format_version(required_api_version))
-            setting = "dismiss-obsolete-vulkan-api-warning"
-            if settings.read_setting(setting) != "True":
-                DontShowAgainDialog(
-                    setting,
-                    _("Obsolete Vulkan driver support"),
-                    secondary_message=_(
-                        "Lutris has detected that the best device available ('%s') supports Vulkan API %s, "
-                        "but to use the latest DXVK version, %s is required.\n\n"
-                        "DXVK 1.x will be used instead."
-                    ) % (
-                        devices[0].name,
-                        vkquery.format_version(devices[0].api_version),
-                        vkquery.format_version(required_api_version)
-                    )
-                )
 
 
 def check_gnome():


### PR DESCRIPTION
So, we've got these dialogs we pop up for configuration issues, most recently for 'Your Vulkan is too old'. But we have even more annoying dialogs that pop up when you toggle particular options on, like FSYNC and ESYNC.

These are not great. They are irritating and they pop when you turn on something like FSYNC, but you have to do it at the right time. Turn on FSYNC, then choose a WINE version that does not support it, and you see nothing until you run your game.

For a ScummVM fix, I added a warning into the config dialog itself, which appears below an offending setting. Thus:

![Screenshot from 2023-04-22 06-46-59](https://user-images.githubusercontent.com/6507403/233788016-f7d7f5b5-e692-41be-acd5-c6c72bf61375.png)

But we might use this technique for these other validations. This PR does that- it provides such warnings for ESYNC, FSYNC, DXVK and VKD3D. Here's selecting a >1.x DXVK when your Vulkan isn't new enough:

![Screenshot from 2023-04-22 08-51-58](https://user-images.githubusercontent.com/6507403/233788113-2d99caf7-20f7-4b6a-a1ac-d941bba9ab0a.png)

Here's ESYNC when your limits are too low:
![Screenshot from 2023-04-22 09-23-47](https://user-images.githubusercontent.com/6507403/233788154-e5c88e90-9dbd-45a8-ba24-a462589bd8ce.png)
With a working hyperlink and everything!

There are dialogs that pop when you start a game, and for now I've left them in place. I'm not sure I like them; but you can miss these new warnings if they are scrolled off screen, so maybe the startup dialogs still have value.

We're still logging if your Vulkan is old, but there isn't a dialog on startup. Instead, we just default to DXVK 1.x, and if you change that you see the warning.