### PR TITLE
Update pcsx2.py to command line of PCSX2 1.7+

### DIFF
--- a/lutris/runners/pcsx2.py
+++ b/lutris/runners/pcsx2.py
@@ -11,7 +11,7 @@ class pcsx2(Runner):
     description = _("PlayStation 2 emulator")
     platforms = [_("Sony PlayStation 2")]
     runnable_alone = True
-    runner_executable = "pcsx2/pcsx2-qt"
+    runner_executable = "pcsx2/PCSX2"
     game_options = [{
         "option": "main_file",
         "type": "file",

--- a/lutris/runners/pcsx2.py
+++ b/lutris/runners/pcsx2.py
@@ -11,7 +11,7 @@ class pcsx2(Runner):
     description = _("PlayStation 2 emulator")
     platforms = [_("Sony PlayStation 2")]
     runnable_alone = True
-    runner_executable = "pcsx2/PCSX2"
+    runner_executable = "pcsx2/pcsx2-qt"
     game_options = [{
         "option": "main_file",
         "type": "file",
@@ -37,19 +37,7 @@ class pcsx2(Runner):
             "type": "bool",
             "label": _("No GUI"),
             "default": False
-        },
-        {
-            "option": "config_file",
-            "type": "file",
-            "label": _("Custom config file"),
-            "advanced": True,
-        },
-        {
-            "option": "config_path",
-            "type": "directory_chooser",
-            "label": _("Custom config path"),
-            "advanced": True,
-        },
+        }
     ]
 
     # PCSX2 currently uses an AppImage, no need for the runtime.
@@ -59,15 +47,11 @@ class pcsx2(Runner):
         arguments = [self.get_executable()]
 
         if self.runner_config.get("fullscreen"):
-            arguments.append("--fullscreen")
+            arguments.append("-fullscreen")
         if self.runner_config.get("full_boot"):
-            arguments.append("--fullboot")
+            arguments.append("-slowboot")
         if self.runner_config.get("nogui"):
-            arguments.append("--nogui")
-        if self.runner_config.get("config_file"):
-            arguments.append("--cfg={}".format(self.runner_config["config_file"]))
-        if self.runner_config.get("config_path"):
-            arguments.append("--cfgpath={}".format(self.runner_config["config_path"]))
+            arguments.append("-nogui")
 
         iso = self.game_config.get("main_file") or ""
         if not system.path_exists(iso):


### PR DESCRIPTION
- Corrected command line switches from double dashes to single dashes (e.g. -nogui instead of --nogui)
- Removed --configpath and --configfile as they've been removed and replaced by per game configuration files created through the game properties in the PCSX2 GUI

Rebased my code base to latest code as suggested by legluondunet in the initial PR https://github.com/lutris/lutris/pull/4828#issuecomment-1524778484

Tested with a local install of PCSX2 1.7.3753 and updated nightly 1.7.4433