### PR TITLE
Citra - appimage compatibility and runnable alone

### DIFF
--- a/lutris/runners/json.py
+++ b/lutris/runners/json.py
@@ -31,7 +31,8 @@ class JsonRunner(Runner):
         self.system_options_override = self._json_data.get("system_options_override", [])
         self.entry_point_option = self._json_data.get("entry_point_option", "main_file")
         self.download_url = self._json_data.get("download_url")
-
+        self.runnable_alone = self._json_data.get("runnable_alone")
+        
     def play(self):
         """Return a launchable command constructed from the options"""
         arguments = [self.get_executable()]

--- a/share/lutris/json/citra.json
+++ b/share/lutris/json/citra.json
@@ -2,8 +2,8 @@
     "human_name": "Citra",
     "description": "Nintendo 3DS emulator",
     "platforms": ["Nintendo 3DS"],
-    "require_libs": ["libQt5OpenGL.so.5", "libQt5Widgets.so.5", "libQt5Multimedia.so.5"],
-    "runner_executable": "citra/citra-qt",
+    "require_libs": [],
+    "runner_executable": "citra/citra",
     "runnable_alone": true,
     "game_options": [
         {


### PR DESCRIPTION
Citra dev team now provide AppImage
--> change citra.json for AppImage compatibility
--> modify json.py to enable Citra and others JSON runners to be directly launch from left panel.