### PR TITLE
Provide explicit compatibility checking for components

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -16,7 +16,7 @@ from lutris.util.display import DISPLAY_MANAGER, get_default_dpi
 from lutris.util.graphics import vkquery
 from lutris.util.log import logger
 from lutris.util.steam.config import get_steam_dir
-from lutris.util.strings import parse_version, split_arguments
+from lutris.util.strings import split_arguments
 from lutris.util.wine.d3d_extras import D3DExtrasManager
 from lutris.util.wine.dgvoodoo2 import dgvoodoo2Manager
 from lutris.util.wine.dxvk import REQUIRED_VULKAN_API_VERSION, DXVKManager
@@ -28,7 +28,7 @@ from lutris.util.wine.wine import (
     POL_PATH, WINE_DIR, WINE_PATHS, detect_arch, display_vulkan_error, esync_display_limit_warning,
     esync_display_version_warning, fsync_display_support_warning, fsync_display_version_warning, get_default_version,
     get_overrides_env, get_proton_paths, get_real_executable, get_wine_version, get_wine_versions, is_esync_limit_set,
-    is_fsync_supported, is_gstreamer_build, is_version_esync, is_version_fsync
+    is_fsync_supported, is_gstreamer_build, is_version_esync, is_version_fsync, parse_wine_version
 )
 
 DEFAULT_WINE_PREFIX = "~/.wine"
@@ -729,9 +729,9 @@ class wine(Runner):
 
         wine_versions = get_wine_versions()
         if min_version:
-            min_version_list, _, _ = parse_version(min_version)
+            min_version_list, _, _ = parse_wine_version(min_version)
             for wine_version in wine_versions:
-                version_list, _, _ = parse_version(wine_version)
+                version_list, _, _ = parse_wine_version(wine_version)
                 if version_list > min_version_list:
                     return True
             logger.warning("Wine %s or higher not found", min_version)

--- a/lutris/util/strings.py
+++ b/lutris/util/strings.py
@@ -69,8 +69,6 @@ def parse_version(version):
     Returns:
         tuple: (version number as list, prefix, suffix)
     """
-    version = version.replace("Proton7-", "Proton-7.")
-    version = version.replace("Proton8-", "Proton-8.")
     version_match = re.search(r"(\d[\d\.]+\d)", version)
     if not version_match:
         return [], "", ""
@@ -78,19 +76,6 @@ def parse_version(version):
     prefix = version[0:version_match.span()[0]]
     suffix = version[version_match.span()[1]:]
     return [int(p) for p in version_number.split(".")], suffix, prefix
-
-
-def version_sort(versions, reverse=False):
-
-    def version_key(version):
-        version_list, prefix, suffix = parse_version(version)
-        # Normalize the length of sub-versions
-        sort_key = version_list + [0] * (10 - len(version_list))
-        sort_key.append(prefix)
-        sort_key.append(suffix)
-        return sort_key
-
-    return sorted(versions, key=version_key, reverse=reverse)
 
 
 def unpack_dependencies(string):

--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -67,15 +67,15 @@ class DLLManager:
         """True if the version of the component is compatible with this Lutris. We can tell only
         once it is downloaded; if not this is always True.
 
-        This checks the file '.lutris_compatibility.json', which contains the lowest version of Lutris
+        This checks the file 'lutris.json', which contains the lowest version of Lutris
         the component version will work with. If this is absent, it is assumed compatible."""
-        path = os.path.join(self.base_dir, version, ".lutris_compatibility.json")
+        path = os.path.join(self.base_dir, version, "lutris.json")
         if os.path.isfile(path):
             with open(path, "r", encoding='utf-8') as json_file:
                 try:
                     js = json.load(json_file)
                 except JSONDecodeError as ex:
-                    logger.exception("Invalid .lutris_compatibility.json: %s", ex)
+                    logger.exception("Invalid lutris.json: %s", ex)
                     return False
 
                 try:
@@ -85,7 +85,7 @@ class DLLManager:
                         if current_lutris_version < min_lutris_version:
                             return False
                 except TypeError as ex:
-                    logger.exception("Invalid .lutris_compatibility.json: %s", ex)
+                    logger.exception("Invalid lutris.json: %s", ex)
                     return False
 
         return True

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -10,7 +10,7 @@ from lutris.gui.dialogs import DontShowAgainDialog, ErrorDialog
 from lutris.runners.steam import steam
 from lutris.util import linux, system
 from lutris.util.log import logger
-from lutris.util.strings import version_sort
+from lutris.util.strings import parse_version
 from lutris.util.wine import fsync
 
 WINE_DIR = os.path.join(settings.RUNNER_DIR, "wine")
@@ -234,6 +234,27 @@ def get_wine_version_exe(version):
     if version in WINE_PATHS:
         return WINE_PATHS[version]
     return os.path.join(WINE_DIR, "{}/bin/wine".format(version))
+
+
+def parse_wine_version(version):
+    """This is a specialized parse_version() that adjusts some odd
+    Wine versions for correct parsing."""
+    version = version.replace("Proton7-", "Proton-7.")
+    version = version.replace("Proton8-", "Proton-8.")
+    return parse_version(version)
+
+
+def version_sort(versions, reverse=False):
+
+    def version_key(version):
+        version_list, prefix, suffix = parse_wine_version(version)
+        # Normalize the length of sub-versions
+        sort_key = version_list + [0] * (10 - len(version_list))
+        sort_key.append(prefix)
+        sort_key.append(suffix)
+        return sort_key
+
+    return sorted(versions, key=version_key, reverse=reverse)
 
 
 def is_version_installed(version):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import os
 from collections import OrderedDict
 from unittest import TestCase
 
+from lutris.util.wine import wine
 from lutris.util import fileio, strings, system
 from lutris.util.steam import vdfutils
 
@@ -96,11 +97,11 @@ class TestStringUtils(TestCase):
 
 class TestVersionSort(TestCase):
     def test_parse_version(self):
-        self.assertEqual(strings.parse_version("3.6-staging"), ([3, 6], '-staging', ''))
+        self.assertEqual(wine.parse_wine_version("3.6-staging"), ([3, 6], '-staging', ''))
 
     def test_versions_are_correctly_sorted(self):
         versions = ['1.8', '1.7.4', '1.9.1', '1.9.10', '1.9.4']
-        versions = strings.version_sort(versions)
+        versions = wine.version_sort(versions)
         self.assertEqual(versions[0], '1.7.4')
         self.assertEqual(versions[1], '1.8')
         self.assertEqual(versions[2], '1.9.1')
@@ -114,7 +115,7 @@ class TestVersionSort(TestCase):
             '1.9.10-staging', '1.9.10',
             '1.9.4', 'staging-1.9.4'
         ]
-        versions = strings.version_sort(versions)
+        versions = wine.version_sort(versions)
         self.assertEqual(versions[0], '1.7.4')
         self.assertEqual(versions[1], '1.8')
         self.assertEqual(versions[2], '1.8-staging')
@@ -126,7 +127,7 @@ class TestVersionSort(TestCase):
 
     def test_versions_can_be_reversed(self):
         versions = ['1.9', '1.6', '1.7', '1.8']
-        versions = strings.version_sort(versions, reverse=True)
+        versions = wine.version_sort(versions, reverse=True)
         self.assertEqual(versions[0], '1.9')
         self.assertEqual(versions[3], '1.6')
 


### PR DESCRIPTION
The recent addition of a DLL to VKD3D caused problems for older versions of Lutris as soon as it was downloadable. These older Lutris versions tried to use the new VKD3D, but did not know about the new DLL, so it did not work.

It's a bit hard to expect everyone to upgrade to latest instantly; we should have some better behavior here.

So, this PR adds a check to the version selection and download process for components. If a component has a JSON file named '.lutris_compatibility.json'. It looks like this:
```
{"min_lutris_version": "0.5.14"}
```

It's JSON in case we want to get fancier about this.

What this PR does is check for this, and if the version downloaded is found to be incompatible with your Lutris, we'll go on to download the next version (and so on until we find a compatible one). The incompatible versions remain and can be selected, but won't be the default if any compatible version is found.