### PR TITLE
battle.net service: add Diablo 4

### DIFF
--- a/lutris/services/battlenet.py
+++ b/lutris/services/battlenet.py
@@ -34,6 +34,7 @@ GAME_IDS = {
     'hero': ('hero', 'Heroes of the Storm', 'Hero', 'heroes-of-the-storm'),
     'd3cn': ('d3cn', '暗黑破壞神III', 'D3CN', 'diablo-iii'),
     'd3': ('d3', 'Diablo III', 'D3', 'diablo-iii'),
+    'fenris': ('fenris', 'Diablo IV', 'Fen', 'diablo-iv'),
     'viper': ('viper', 'Call of Duty: Black Ops 4', 'VIPR', 'call-of-duty-black-ops-4'),
     'odin': ('odin', 'Call of Duty: Modern Warfare', 'ODIN', 'call-of-duty-modern-warfare'),
     'lazarus': ('lazarus', 'Call of Duty: MW2 Campaign Remastered', 'LAZR',

--- a/lutris/util/battlenet/definitions.py
+++ b/lutris/util/battlenet/definitions.py
@@ -77,6 +77,7 @@ class _Blizzard(object, metaclass=Singleton):
         1465140039: RegionalGameInfo('hs_beta', True),
         1214607983: RegionalGameInfo('heroes', True),
         17459: RegionalGameInfo('diablo3', True),
+        4613486: RegionalGameInfo('fenris', True),
         1447645266: RegionalGameInfo('viper', False),
         1329875278: RegionalGameInfo('odin', True),
         1279351378: RegionalGameInfo('lazarus', False),
@@ -101,6 +102,7 @@ class _Blizzard(object, metaclass=Singleton):
         BlizzardGame('heroes', 'Heroes of the Storm', 'Hero'),
         BlizzardGame('d3cn', '暗黑破壞神III', 'D3CN'),
         BlizzardGame('diablo3', 'Diablo III', 'D3'),
+        BlizzardGame('fenris', 'Diablo IV', 'FEN'),
         BlizzardGame('viper', 'Call of Duty: Black Ops 4', 'VIPR'),
         BlizzardGame('odin', 'Call of Duty: Modern Warfare', 'ODIN'),
         BlizzardGame('lazarus', 'Call of Duty: MW2 Campaign Remastered', 'LAZR'),
@@ -121,7 +123,7 @@ class _Blizzard(object, metaclass=Singleton):
     ]
 
     def __init__(self):
-        self._games = {game.uid: game for game in self.BATTLENET_GAMES + self.CLASSIC_GAMES}
+        self._games: dict[str, ClassicGame | BlizzardGame] = {game.uid: game for game in self.BATTLENET_GAMES + self.CLASSIC_GAMES}
 
     def __getitem__(self, key: str) -> BlizzardGame:
         """


### PR DESCRIPTION
Seems like this is all that's needed, the game shows up and is detected as installed on my build now.


Relevant Battle.NET launcher logs:

```
"cxpProduct":
    {
        "cxpProductId": "blt795c314400d7ded9",
        "titleId": 4613486,
        "title": "Diablo IV",
        "productCode": "Fen",
        "segment": "diablo-4",
        "logo":
            {
                "imageUrl": "https://blz-contentstack-images.akamaized.net/v3/assets/blt286175c11a6b3f4c/blt95aebf4d119210f5/5e543f7e8dc1e51c53168b7a/games-d4-colored.svg",
                "imageFileType": "image/svg+xml",
                "imageAltText": "Diablo IV",
                "url": "https://blz-contentstack-images.akamaized.net/v3/assets/blt286175c11a6b3f4c/blt95aebf4d119210f5/5e543f7e8dc1e51c53168b7a/games-d4-colored.svg",
                "fileType": "image/svg+xml",
                "altText": "Diablo IV",
            },
        "context": { "locale": "en-us" },
    },
```

```
D 2023-06-06 22:50:18.111258 [Agent] {Agent} GameResource created for uid: fenris
```