### PR TITLE
Update es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -1107,8 +1107,8 @@ msgstr "Usar tema oscuro (requiere la variante oscura del tema para Gtk)"
 #: lutris/gui/config/preferences_box.py:16
 msgid "Enable Discord Rich Presence for Available Games"
 msgstr ""
-"Activar presencia enriquecida de Discord en los juegos que la tienen "
-"disponible"
+"Activar rich presence de Discord en los juegos que la tienen "
+"disponible (requiere instalar pypresence)"
 
 #: lutris/gui/config/preferences_box.py:36
 msgid "Interface options"


### PR DESCRIPTION
The "enable discord rich presence for avalible games" line is modified, since "rich presence" was being translated, which is a proper English word "it would be like translating software name like "facebook" which should not be done, it is also I add in parentheses information about what requires installing pypresence for it to work