### PR TITLE
Header-bar search of configuration and preferences

### DIFF
--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -56,11 +56,17 @@ class ConfigBox(VBox):
 
     @filter.setter
     def filter(self, value):
+        """Sets the visibility of the options that have some text in the label or
+        help-text."""
         self._filter = value
         self.update_option_visibility()
 
     def update_option_visibility(self):
+        """Recursively searches out all the options and shows or hides them according to
+        the filter and advanced-visibility settings."""
         def update_widgets(widgets):
+            filter_text = self.filter.lower()
+
             visible_count = 0
             for widget in widgets:
                 if isinstance(widget, ConfigBox.SectionFrame):
@@ -70,9 +76,10 @@ class ConfigBox(VBox):
                     widget.set_frame_visible(frame_visible_count > 1)
                 else:
                     widget_visible = self.advanced_visibility or not widget.get_style_context().has_class("advanced")
-                    if widget_visible and self.filter and hasattr(widget, "lutris_option_label"):
-                        label = widget.lutris_option_label
-                        if self.filter.lower() not in label.lower():
+                    if widget_visible and filter_text and hasattr(widget, "lutris_option_label"):
+                        label = widget.lutris_option_label.lower()
+                        helptext = widget.lutris_option_helptext.lower()
+                        if filter_text not in label and filter_text not in helptext:
                             widget_visible = False
                     widget.set_visible(widget_visible)
                     widget.set_no_show_all(not widget_visible)
@@ -237,6 +244,7 @@ class ConfigBox(VBox):
 
                 option_container.lutris_option_key = option_key
                 option_container.lutris_option_label = option["label"]
+                option_container.lutris_option_helptext = option.get("help") or ""
                 current_vbox.pack_start(option_container, False, False, 0)
             except Exception as ex:
                 logger.exception("Failed to generate option widget for '%s': %s", option.get("option"), ex)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -112,10 +112,11 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             show_search = current_page_index in self.option_page_indices
             self.set_search_entry_visibility(show_search)
 
-    def set_search_entry_visibility(self, show_search):
+    def set_search_entry_visibility(self, show_search, placeholder_text=_("Search options")):
         header_bar = self.get_header_bar()
         if show_search and self.search_entry:
             header_bar.set_custom_title(self.search_entry)
+            self.search_entry.set_placeholder_text(placeholder_text)
             self.search_entry.show_all()
         else:
             header_bar.set_custom_title(None)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -108,16 +108,17 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
                 widget.set_visible(show_switch)
 
     def update_search_entry_visibility(self, current_page_index):
+        """Shows or hides the search entry according to what page is currently displayed."""
         if self.notebook:
             show_search = current_page_index in self.option_page_indices
             self.set_search_entry_visibility(show_search)
 
     def set_search_entry_visibility(self, show_search, placeholder_text=_("Search options")):
+        """Explicitly shows or hides the search entry; can also update the placeholder text."""
         header_bar = self.get_header_bar()
         if show_search and self.search_entry:
             header_bar.set_custom_title(self.search_entry)
             self.search_entry.set_placeholder_text(placeholder_text)
-            self.search_entry.show_all()
         else:
             header_bar.set_custom_title(None)
 
@@ -423,6 +424,7 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
     def build_header_bar(self):
         self.search_entry = Gtk.SearchEntry(width_chars=30, placeholder_text=_("Search options"))
         self.search_entry.connect("search-changed", self.on_search_entry_changed)
+        self.search_entry.show_all()
 
         # Advanced settings toggle
         switch_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL,
@@ -454,7 +456,7 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
     def on_search_entry_changed(self, entry):
         """Callback for the search input keypresses"""
         text = entry.get_text().lower().strip()
-        self._set_options_filter(text)
+        self._set_filter(text)
 
     def on_show_advanced_options_toggled(self, is_active):
         settings.write_setting("show_advanced_options", is_active)
@@ -469,7 +471,7 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         if self.game_box:
             self.game_box.set_advanced_visibility(value)
 
-    def _set_options_filter(self, value):
+    def _set_filter(self, value):
         self.system_box.filter = value
         if self.runner_name:
             self.runner_box.filter = value

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -84,6 +84,7 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             del self.notebook_page_generators[index]
 
         self.update_advanced_switch_visibility(index)
+        self.update_search_entry_visibility(index)
 
     def build_tabs(self, config_level):
         """Build tabs (for game and runner levels)"""

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -453,8 +453,8 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
 
     def on_search_entry_changed(self, entry):
         """Callback for the search input keypresses"""
-        filter = entry.get_text().lower().strip()
-        self._set_options_filter(filter)
+        text = entry.get_text().lower().strip()
+        self._set_options_filter(text)
 
     def on_show_advanced_options_toggled(self, is_active):
         settings.write_setting("show_advanced_options", is_active)

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -109,13 +109,16 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
 
     def update_search_entry_visibility(self, current_page_index):
         if self.notebook:
-            show_switch = current_page_index in self.option_page_indices
-            header_bar = self.get_header_bar()
-            if show_switch and self.search_entry:
-                header_bar.set_custom_title(self.search_entry)
-                self.search_entry.show_all()
-            else:
-                header_bar.set_custom_title(None)
+            show_search = current_page_index in self.option_page_indices
+            self.set_search_entry_visibility(show_search)
+
+    def set_search_entry_visibility(self, show_search):
+        header_bar = self.get_header_bar()
+        if show_search and self.search_entry:
+            header_bar.set_custom_title(self.search_entry)
+            self.search_entry.show_all()
+        else:
+            header_bar.set_custom_title(None)
 
     def _build_info_tab(self):
         info_box = Gtk.VBox()

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -114,14 +114,20 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             show_search = current_page_index in self.searchable_page_indices
             self.set_search_entry_visibility(show_search)
 
-    def set_search_entry_visibility(self, show_search, placeholder_text=_("Search options")):
+    def set_search_entry_visibility(self, show_search, placeholder_text=None):
         """Explicitly shows or hides the search entry; can also update the placeholder text."""
         header_bar = self.get_header_bar()
         if show_search and self.search_entry:
             header_bar.set_custom_title(self.search_entry)
-            self.search_entry.set_placeholder_text(placeholder_text)
+            self.search_entry.set_placeholder_text(placeholder_text or self.get_search_entry_placeholder())
         else:
             header_bar.set_custom_title(None)
+
+    def get_search_entry_placeholder(self):
+        if self.game and self.game.name:
+            return _("Search %s options") % self.game.name
+
+        return _("Search options")
 
     def _build_info_tab(self):
         info_box = Gtk.VBox()

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -48,10 +48,10 @@ class PreferencesDialog(GameDialogCommon):
             "prefs-stack"
         )
 
-        runners_box = RunnersBox()
-        self.page_generators["runners-stack"] = runners_box.populate_runners
+        self.runners_box = RunnersBox()
+        self.page_generators["runners-stack"] = self.runners_box.populate_runners
         self.stack.add_named(
-            self.build_scrolled_window(runners_box),
+            self.build_scrolled_window(self.runners_box),
             "runners-stack"
         )
         self.stack.add_named(
@@ -84,7 +84,14 @@ class PreferencesDialog(GameDialogCommon):
 
         show_actions = stack_id == "system-stack"
         self.set_header_bar_widgets_visibility(show_actions)
-        self.set_search_entry_visibility(show_actions)
+
+        if stack_id == "system-stack":
+            self.set_search_entry_visibility(True)
+        elif stack_id == "runners-stack":
+            self.set_search_entry_visibility(True, self.runners_box.search_entry_placeholder_text)
+        else:
+            self.set_search_entry_visibility(False)
+
         self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 
@@ -107,3 +114,6 @@ class PreferencesDialog(GameDialogCommon):
     def on_save(self, _widget):
         self.lutris_config.save()
         self.destroy()
+
+    def _set_options_filter(self, value):
+        self.runners_box.filter = value

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -83,7 +83,7 @@ class PreferencesDialog(GameDialogCommon):
             generator()
 
         show_actions = stack_id == "system-stack"
-        self.set_header_bar_widgets_visbility(show_actions)
+        self.set_header_bar_widgets_visibility(show_actions)
         self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -116,4 +116,5 @@ class PreferencesDialog(GameDialogCommon):
         self.destroy()
 
     def _set_filter(self, value):
+        super()._set_filter(value)
         self.runners_box.filter = value

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -84,6 +84,7 @@ class PreferencesDialog(GameDialogCommon):
 
         show_actions = stack_id == "system-stack"
         self.set_header_bar_widgets_visibility(show_actions)
+        self.set_search_entry_visibility(show_actions)
         self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -95,6 +95,9 @@ class PreferencesDialog(GameDialogCommon):
         self.get_header_bar().set_show_close_button(not show_actions)
         self.stack.set_visible_child_name(row.get_children()[0].stack_id)
 
+    def get_search_entry_placeholder(self):
+        return _("Search global options")
+
     def get_sidebar_button(self, stack_id, text, icon_name):
         hbox = Gtk.HBox(visible=True)
         hbox.stack_id = stack_id

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -115,5 +115,5 @@ class PreferencesDialog(GameDialogCommon):
         self.lutris_config.save()
         self.destroy()
 
-    def _set_options_filter(self, value):
+    def _set_filter(self, value):
         self.runners_box.filter = value

--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -2,6 +2,7 @@ from gettext import gettext as _
 
 from lutris.config import LutrisConfig
 from lutris.gui.config.common import GameDialogCommon
+from lutris.runners import get_runner_human_name
 
 
 class RunnerConfigDialog(GameDialogCommon):
@@ -15,6 +16,9 @@ class RunnerConfigDialog(GameDialogCommon):
         self.build_notebook()
         self.build_tabs("runner")
         self.show_all()
+
+    def get_search_entry_placeholder(self):
+        return _("Search %s options") % get_runner_human_name(self.runner_name)
 
     def on_save(self, wigdet, data=None):
         self.lutris_config.save()

--- a/lutris/gui/config/runners_box.py
+++ b/lutris/gui/config/runners_box.py
@@ -14,14 +14,14 @@ class RunnersBox(BaseConfigBox):
 
     def __init__(self):
         super().__init__()
+        self._filter = ""
+        self.search_entry_placeholder_text = ""
+
         self.add(self.get_section_label(_("Add, remove or configure runners")))
         self.add(self.get_description_label(
             _("Runners are programs such as emulators, engines or "
               "translation layers capable of running games.")
         ))
-        self.search_entry = Gtk.SearchEntry(visible=True, margin_top=12)
-        self.search_entry.connect("changed", self.on_search_changed)
-        self.add(self.search_entry)
         self.search_failed_label = Gtk.Label(_("No runners matched the search"))
         self.pack_start(self.search_failed_label, False, False, 6)
         self.runner_list_frame = Gtk.Frame(visible=True, shadow_type=Gtk.ShadowType.ETCHED_IN)
@@ -39,15 +39,25 @@ class RunnersBox(BaseConfigBox):
             self.runner_listbox.add(list_box_row)
             runner_count += 1
 
+        self._update_row_visibility()
         # pretty sure there will always be many runners, so assume plural
-        self.search_entry.set_placeholder_text(_("Search %s runners") % runner_count)
+        self.search_entry_placeholder_text = _("Search %s runners") % runner_count
 
     @staticmethod
     def on_folder_clicked(_widget):
         open_uri("file://" + settings.RUNNER_DIR)
 
-    def on_search_changed(self, entry):
-        text = entry.get_text().lower()
+    @property
+    def filter(self):
+        return self._filter
+
+    @filter.setter
+    def filter(self, value):
+        self._filter = value
+        self._update_row_visibility()
+
+    def _update_row_visibility(self):
+        text = self.filter.lower()
 
         any_matches = False
         for row in self.runner_listbox.get_children():


### PR DESCRIPTION
This PR provides a search function for the runner and system configurations, which can be pretty long. It takes the form of a search entry in the header bar. Like so:
![Screenshot from 2023-07-22 10-18-15](https://github.com/lutris/lutris/assets/6507403/a627654b-212a-4cd6-bb96-8d5d5f02859d)
The search appears when you switch to a tab which supports it, and replaces the title in the header bar.

It filters as you might expect:
![Screenshot from 2023-07-20 19-08-30](https://github.com/lutris/lutris/assets/6507403/09fcf0f2-0b27-4ebc-9be1-3a47c6f615d0)
The search checks the label and the help text, as you can see.

This works in the preferences dialog also:
![Screenshot from 2023-07-20 19-10-10](https://github.com/lutris/lutris/assets/6507403/8c76ad2b-2722-4afb-9789-dbc7da17f000)

Also, this PR replaces the runner search with this same entry:
![Screenshot from 2023-07-20 19-10-56](https://github.com/lutris/lutris/assets/6507403/6c00a83a-80b8-4147-b0c9-31eca74ce6ad)
The advantage here is that the search entry does not scroll with the runner list. That was always a bit annoying, since it would put the search entry off-screen very quickly.

A downside here is that the game name is less visible when you get the search entry. The title is present as normal when you are on a tab that does not have search, and the game or runner name appears in the placeholder text. The runner dialog always has a search, so you just get this:
![Screenshot from 2023-07-22 10-19-09](https://github.com/lutris/lutris/assets/6507403/3e196b43-cc5e-4d34-b997-ace0d73273da)
This works a bit less well for games with longer names. Compare:
![Screenshot from 2023-07-22 10-24-48](https://github.com/lutris/lutris/assets/6507403/820a7bb8-76de-4181-81d1-e78946d8a168)
Is is 'Batman: Arkham Asylum Game of Thrones Edition'?
![Screenshot from 2023-07-22 10-24-38](https://github.com/lutris/lutris/assets/6507403/e96f0577-2da8-4bb6-acd5-2b069a714c50)
Ohhh, it's the game of the year edition!
