### PR TITLE
Make Locale dropdown searchable (fixes #4933)

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -495,10 +495,10 @@ system_options = [  # pylint: disable=invalid-name
     {
         "section": "Game execution",
         "option": "locale",
-        "type": "choice",
+        "type": "choice_with_search",
         "label": _("Locale"),
         "choices": (
-            get_locale_choices()
+            get_locale_choices
         ),
         "default": "",
         "advanced": False,


### PR DESCRIPTION
This should make it easier for users on openSUSE and Fedora to select locales for a game.