### PR TITLE
Update es.po

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -242,7 +242,7 @@ msgstr "Ejecutar un guion"
 
 #: lutris/game_actions.py:61
 msgid "Update shader cache"
-msgstr "Actualizar la caché de sombreadores"
+msgstr "Actualizar la caché de los shaders"
 
 #: lutris/game_actions.py:62
 msgid "Browse files"


### PR DESCRIPTION
The word shaders is not necessary to translate since shaders are a standard English word to refer to them in Spanish, the translated word is not used.