### PR TITLE
New InstallerFileCollection to handle big numbers of downloads

### DIFF
--- a/lutris/gui/installer/__init__.py
+++ b/lutris/gui/installer/__init__.py
@@ -1,0 +1,5 @@
+class NotInstallerFile(Exception):
+    """Error that represents a installer file type that is not supported"""
+
+class UnsupportedProvider(Exception):
+    """Error that represents a unsupported provider"""

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -2,6 +2,7 @@ from gi.repository import GObject, Gtk
 
 from lutris.gui.installer.file_box import InstallerFileBox
 from lutris.util.log import logger
+from lutris.installer.installer_file_collection import InstallerFileCollection
 
 
 class InstallerFilesBox(Gtk.ListBox):
@@ -116,7 +117,11 @@ class InstallerFilesBox(Gtk.ListBox):
 
     def get_game_files(self):
         """Return a mapping of the local files usable by the interpreter"""
-        return {
-            installer_file.id: installer_file.dest_file
-            for installer_file in self.installer.files
-        }
+        out = {}
+        for installer_file in self.installer.files:
+            if isinstance(installer_file, InstallerFileCollection):
+                for file in installer_file.files_list:
+                    out.update({file.id: file.dest_file})
+            else:
+                out.update({installer_file.id: installer_file.dest_file})
+        return out

--- a/lutris/gui/widgets/download_collection_progress_box.py
+++ b/lutris/gui/widgets/download_collection_progress_box.py
@@ -1,0 +1,198 @@
+from gettext import gettext as _
+from urllib.parse import urlparse
+
+from gi.repository import GLib, GObject, Gtk, Pango
+
+from lutris.util.downloader import Downloader
+from lutris.util.log import logger
+from lutris.util.strings import gtk_safe
+
+class DownloadCollectionProgressBox(Gtk.Box):
+    """Progress bar used to monitor a collection of files download."""
+
+    max_retries = 3
+
+    __gsignals__ = {
+        "complete": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_PYOBJECT, )),
+        "cancel": (GObject.SignalFlags.RUN_LAST, None, ()),
+        "error": (GObject.SignalFlags.RUN_LAST, None, (GObject.TYPE_PYOBJECT, )),
+    }
+
+    def __init__(self, mult_files, cancelable=True, downloader=None):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL)
+
+        self.downloader = downloader
+        self.is_complete = False
+        self._file_queue = mult_files.files_list.copy()
+        self._file_downlaod = None  # file being downloaded
+        self.title = mult_files.human_url
+        self.num_files_downloaded = 0
+        self.num_files_to_download = mult_files.num_files
+        self.num_retries = 0
+
+        top_box = Gtk.Box()
+        self.main_label = Gtk.Label(self.title)
+        self.main_label.set_alignment(0, 0)
+        self.main_label.set_property("wrap", True)
+        self.main_label.set_margin_bottom(10)
+        self.main_label.set_selectable(True)
+        self.main_label.set_property("ellipsize", Pango.EllipsizeMode.MIDDLE)
+        top_box.pack_start(self.main_label, False, False, 0)
+
+        self.cancel_button = Gtk.Button.new_with_mnemonic(_("_Cancel"))
+        self.cancel_cb_id = self.cancel_button.connect("clicked", self.on_cancel_clicked)
+        if not cancelable:
+            self.cancel_button.set_sensitive(False)
+        top_box.pack_end(self.cancel_button, False, False, 0)
+
+        self.pack_start(top_box, True, True, 0)
+
+        full_progress_box = Gtk.Box()
+        self.full_progressbar = Gtk.ProgressBar(show_text=True)
+        self.full_progressbar.set_margin_top(5)
+        self.full_progressbar.set_margin_bottom(5)
+        self.full_progressbar.set_margin_right(10)
+        full_progress_box.pack_start(self.full_progressbar, True, True, 0)
+
+        self.pack_start(full_progress_box, False, False, 0)
+        self.update_full_progress()
+
+        self.file_name_label = Gtk.Label()
+        self.file_name_label.set_alignment(0, 0)
+        self.file_name_label.set_property("wrap", True)
+        self.file_name_label.set_margin_bottom(10)
+        self.file_name_label.set_selectable(True)
+        self.file_name_label.set_property("ellipsize", Pango.EllipsizeMode.MIDDLE)
+        self.pack_start(self.file_name_label, True, True, 0)
+
+        progress_box = Gtk.Box()
+        self.progressbar = Gtk.ProgressBar()
+        self.progressbar.set_margin_top(5)
+        self.progressbar.set_margin_bottom(5)
+        self.progressbar.set_margin_right(10)
+        progress_box.pack_start(self.progressbar, True, True, 0)
+
+        self.pack_start(progress_box, False, False, 0)
+
+        self.progress_label = Gtk.Label()
+        self.progress_label.set_alignment(0, 0)
+        self.pack_start(self.progress_label, True, True, 0)
+
+        self.show_all()
+        self.cancel_button.hide()
+
+    def update_full_progress(self):
+        """Update Full download progress bar"""
+        if self.num_files_to_download <= 0:
+            self.full_progressbar.pulse()
+        else:
+            self.full_progressbar.set_fraction(self.num_files_downloaded/self.num_files_to_download)
+        self.full_progressbar.set_text(f"{self.num_files_downloaded} / {self.num_files_to_download} {_('Files')}")
+
+    def update_downlaod_file_label(self, file_name):
+        """Update file label to file being downloaded"""
+        self.file_name_label.set_text(file_name)
+
+    def get_new_file_from_queue(self):
+        """Set downloaded file to new file from queue or None if empty"""
+        if self._file_queue:
+            self._file_downlaod = self._file_queue.pop()
+            return
+        self._file_downlaod = None
+
+    def start(self):
+        """Start downloading a file."""
+        if not self._file_queue:
+            self.cancel_button.set_sensitive(False)
+            self.is_complete = True
+            self.emit("complete", {})
+            return None
+        if not self._file_downlaod:
+            self.get_new_file_from_queue()
+            self.num_retries = 0
+        file = self._file_downlaod
+        self.update_downlaod_file_label(file.filename)
+        if not self.downloader:
+            try:
+                self.downloader = Downloader(file.url, file.dest_file, referer=file.referer, overwrite=True)
+            except RuntimeError as ex:
+                from lutris.gui.dialogs import ErrorDialog
+
+                ErrorDialog(ex.args[0])
+                self.emit("cancel")
+                return None
+
+        timer_id = GLib.timeout_add(500, self._progress)
+        self.cancel_button.show()
+        self.cancel_button.set_sensitive(True)
+        if not self.downloader.state == self.downloader.DOWNLOADING:
+            self.downloader.start()
+        return timer_id
+
+    def set_retry_button(self):
+        """Transform the cancel button into a retry button"""
+        self.cancel_button.set_label(_("Retry"))
+        self.cancel_button.disconnect(self.cancel_cb_id)
+        self.cancel_cb_id = self.cancel_button.connect("clicked", self.on_retry_clicked)
+        self.cancel_button.set_sensitive(True)
+
+    def on_retry_clicked(self, button):
+        """Retry current download."""
+        logger.debug("Retrying download")
+        button.set_label(_("Cancel"))
+        button.disconnect(self.cancel_cb_id)
+        self.cancel_cb_id = button.connect("clicked", self.on_cancel_clicked)
+        self.downloader.reset()
+        self.start()
+
+    def on_cancel_clicked(self, _widget=None):
+        """Cancel the current download."""
+        logger.debug("Download cancel requested")
+        if self.downloader:
+            self.downloader.cancel()
+        self.cancel_button.set_sensitive(False)
+        self.emit("cancel")
+
+    def _progress(self):
+        """Show download progress of current file."""
+        progress = min(self.downloader.check_progress(), 1)
+        if self.downloader.state in [self.downloader.CANCELLED, self.downloader.ERROR]:
+            self.progressbar.set_fraction(0)
+            if self.downloader.state == self.downloader.CANCELLED:
+                self._set_text(_("Download interrupted"))
+                self.emit("cancel")
+            else:
+                if self.num_retries > self.max_retries:
+                    self._set_text(str(self.downloader.error)[:80])
+                    self.emit("error")
+                    return False
+                self.num_retries += 1
+                if self.downloader:
+                    self.downloader.reset()
+                    self.start()
+            return False
+        self.progressbar.set_fraction(progress)
+        megabytes = 1024 * 1024
+        progress_text = _(
+            "{downloaded:0.2f} / {size:0.2f}MB ({speed:0.2f}MB/s), {time} remaining"
+        ).format(
+            downloaded=float(self.downloader.downloaded_size) / megabytes,
+            size=float(self.downloader.full_size) / megabytes,
+            speed=float(self.downloader.average_speed) / megabytes,
+            time=self.downloader.time_left,
+        )
+        self._set_text(progress_text)
+        if self.downloader.state == self.downloader.COMPLETED:
+            self.num_files_downloaded += 1
+            self.update_full_progress()
+            # set file to None to get next one
+            self._file_downlaod = None
+            self.downloader = None
+            # start the downloader to a new file or finish
+            self.start()
+            return False
+        return True
+
+    def _set_text(self, text):
+        markup = "<span size='10000'>{}</span>".format(gtk_safe(text))
+        self.progress_label.set_markup(markup)

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -23,6 +23,7 @@ from lutris.util import extract, linux, selective_merge, system
 from lutris.util.fileio import EvilConfigParser, MultiOrderedDict
 from lutris.util.log import logger
 from lutris.util.wine.wine import WINE_DEFAULT_ARCH, get_wine_version_exe
+from lutris.installer.installer_file_collection import InstallerFileCollection
 
 
 class CommandsMixin:
@@ -652,6 +653,19 @@ class CommandsMixin:
                 "executable": file_id,
                 "args": args
             })
+
+    def autosetup_amazon(self, file_and_dir_dict):
+        files = file_and_dir_dict["files"]
+        directories = file_and_dir_dict["directories"]
+
+        # create directories
+        for directory in directories:
+            self.mkdir(f"$GAMEDIR/drive_c/game/{directory}")
+
+        # move installed files from CACHE to game folder
+        for file_hash, file in self.game_files.items():
+            file_dir = os.path.dirname(files[file_hash]['path'])
+            self.move({"src": file, "dst": f"$GAMEDIR/drive_c/game/{file_dir}"})
 
     def install_or_extract(self, file_id):
         """Runs if file is executable or extracts if file is archive"""

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -1,0 +1,110 @@
+"""Manipulates installer files"""
+import os
+from gettext import gettext as _
+
+from lutris import cache, settings
+from lutris.util import system
+from lutris.util.log import logger
+from lutris.util.strings import add_url_tags, gtk_safe
+
+
+class InstallerFileCollection:
+    """Representation of a collection of files in the `files` sections of an installer.
+       Store files in a folder"""
+
+    def __init__(self, game_slug, file_id, files_list, dest_folder=None):
+        self.game_slug = game_slug
+        self.id = file_id.replace("-", "_")  # pylint: disable=invalid-name
+        self.num_files = len(files_list)
+        self.files_list = files_list
+        self._dest_folder = dest_folder  # Used to override the destination
+
+    def copy(self):
+        """Copy InstallerFileCollection"""
+        # copy all InstallerFile inside file list
+        new_file_list = []
+        for file in self.files_list:
+            new_file_list.append(file.copy())
+        return InstallerFileCollection(self.game_slug, self.id, new_file_list, self.dest_file)
+
+    @property
+    def dest_file(self):
+        """dest_file represents destination folder to all file collection"""
+        if self._dest_folder:
+            return self._dest_folder
+        return os.path.join(self.cache_path, self.id)
+
+    @dest_file.setter
+    def dest_file(self, value):
+        self._dest_folder = value
+
+    def __str__(self):
+        return "%s/%s" % (self.game_slug, self.id)
+
+    @property
+    def human_url(self):
+        """Return game_slug"""
+        return self.game_slug
+
+    def get_label(self):
+        """Return a human readable label for installer files"""
+        return add_url_tags(gtk_safe(self.game_slug))
+
+    @property
+    def provider(self):
+        """Return file provider used. File Collection only supports 'pga' and 'download'"""
+        if self.is_cached:
+            return "pga"
+        return "download"
+
+    @property
+    def providers(self):
+        """Return all supported providers. File Collection only supports 'pga' and 'download'"""
+        _providers = set()
+        if self.is_cached:
+            _providers.add("pga")
+        _providers.add("download")
+        return _providers
+
+    def uses_pga_cache(self, create=False):
+        """Determines whether the installer files are stored in a PGA cache
+
+        Params:
+            create (bool): If a cache is active, auto create directories if needed
+        Returns:
+            bool
+        """
+        cache_path = cache.get_cache_path()
+        if not cache_path:
+            return False
+        if system.path_exists(cache_path):
+            return True
+        if create:
+            try:
+                logger.debug("Creating cache path %s", self.cache_path)
+                os.makedirs(self.cache_path)
+            except (OSError, PermissionError) as ex:
+                logger.error("Failed to created cache path: %s", ex)
+                return False
+            return True
+        logger.warning("Cache path %s does not exist", cache_path)
+        return False
+
+    @property
+    def cache_path(self):
+        """Return the directory used as a cache for the duration of the installation"""
+        _cache_path = cache.get_cache_path()
+        if not _cache_path:
+            _cache_path = os.path.join(settings.CACHE_DIR, "installer")
+        return os.path.join(_cache_path, self.game_slug, self.id)
+
+    def prepare(self):
+        """Prepare all files for download"""
+        # File Collection do not need to prepare, only the files_list
+        for file in self.files_list:
+            file.prepare()
+
+    @property
+    def is_cached(self):
+        """Is the file available in the local PGA cache?"""
+        return self.uses_pga_cache() and system.path_exists(self.dest_file)

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -12,6 +12,7 @@ from lutris import settings
 from lutris.exceptions import AuthenticationError, UnavailableGameError
 from lutris.installer import AUTO_ELF_EXE, AUTO_WIN32_EXE
 from lutris.installer.installer_file import InstallerFile
+from lutris.installer.installer_file_collection import InstallerFileCollection
 from lutris.services.base import OnlineService
 from lutris.services.service_game import ServiceGame
 from lutris.services.service_media import ServiceMedia
@@ -486,7 +487,7 @@ class GOGService(OnlineService):
         if selected_extras:
             for extra_file in self.get_extra_files(downloads, installer, selected_extras):
                 files.append(extra_file)
-        return files
+        return [InstallerFileCollection(installer.game_slug, installer_file_id, files)]
 
     def read_file_checksum(self, file_path):
         """Return the MD5 checksum for a GOG file


### PR DESCRIPTION
(Closes #4917)

Add new InstallerFileCollection to allow the download of big amount of files.
Updated Gog and Amazon services to use the new File Collection.

This pull request do not solve all amazon games installation issues, so it is expected to still fail, but the UI can handle it better.