### PR TITLE
File Collection allow user to select main installer exe for Gog files

### DIFF
--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -89,14 +89,11 @@ class InstallerFileBox(Gtk.VBox):
             url_label = InstallerLabel("In cache: %s" % self.installer_file.get_label(), wrap=False)
             box.pack_start(url_label, False, False, 6)
             return box
-        # InstallerFileCollection should not have user or steam providers
         if self.provider == "user":
-            if isinstance(self.installer_file, InstallerFileCollection):
-                raise UnsupportedProvider(
-                    "Installer file is type InstallerFileCollection and do not support 'user' provider")
             user_label = InstallerLabel(gtk_safe(self.installer_file.human_url))
             box.pack_start(user_label, False, False, 0)
             return box
+        # InstallerFileCollection should not have steam provider
         if self.provider == "steam":
             if isinstance(self.installer_file, InstallerFileCollection):
                 raise UnsupportedProvider(
@@ -177,10 +174,6 @@ class InstallerFileBox(Gtk.VBox):
     def get_file_provider_label(self):
         """Return the label displayed before the download starts"""
         if self.provider == "user":
-            # installer_file should not be instance of InstallerFileCollection if provider is user
-            if isinstance(self.installer_file, InstallerFileCollection):
-                raise UnsupportedProvider(
-                    "Installer file is type InstallerFileCollection and do not support 'user' provider")
             box = Gtk.VBox(spacing=6)
             label = InstallerLabel(self.installer_file.get_label())
             label.props.can_focus = True
@@ -213,12 +206,11 @@ class InstallerFileBox(Gtk.VBox):
         source_box = Gtk.HBox()
         source_box.props.valign = Gtk.Align.START
         box.pack_start(source_box, False, False, 0)
-        if isinstance(self.installer_file, InstallerFile):
-            source_box.pack_start(InstallerLabel(_("Source:")), False, False, 0)
-            combobox = self.get_combobox()
-            source_box.pack_start(combobox, False, False, 0)
-            return box
-        source_box.pack_start(InstallerLabel(str(self.installer_file.num_files) + " " + _("Files")), False, False, 0)
+        if isinstance(self.installer_file, InstallerFileCollection):
+            source_box.pack_start(InstallerLabel(f"{self.installer_file.num_files} {_('Files')}"), False, False, 0)
+        source_box.pack_start(InstallerLabel(_("Source:")), False, False, 0)
+        combobox = self.get_combobox()
+        source_box.pack_start(combobox, False, False, 0)
         return box
 
     def on_location_changed(self, widget):

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -37,6 +37,10 @@ class InstallerFileCollection:
     @dest_file.setter
     def dest_file(self, value):
         self._dest_folder = value
+        # trys to set main gog file to dest_file
+        for installer_file in self.files_list:
+            if installer_file.id == "gogintaller":
+                installer_file.dest_file = value
 
     def __str__(self):
         return "%s/%s" % (self.game_slug, self.id)

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -32,12 +32,12 @@ class InstallerFileCollection:
         """dest_file represents destination folder to all file collection"""
         if self._dest_folder:
             return self._dest_folder
-        return os.path.join(self.cache_path, self.id)
+        return self.cache_path
 
     @dest_file.setter
     def dest_file(self, value):
         self._dest_folder = value
-        # trys to set main gog file to dest_file
+        # try to set main gog file to dest_file
         for installer_file in self.files_list:
             if installer_file.id == "gogintaller":
                 installer_file.dest_file = value
@@ -86,7 +86,9 @@ class InstallerFileCollection:
         if create:
             try:
                 logger.debug("Creating cache path %s", self.cache_path)
-                os.makedirs(self.cache_path)
+                # make dirs to all files
+                for installer_file in self.files_list:
+                    os.makedirs(installer_file.cache_path)
             except (OSError, PermissionError) as ex:
                 logger.error("Failed to created cache path: %s", ex)
                 return False
@@ -100,7 +102,7 @@ class InstallerFileCollection:
         _cache_path = cache.get_cache_path()
         if not _cache_path:
             _cache_path = os.path.join(settings.CACHE_DIR, "installer")
-        return os.path.join(_cache_path, self.game_slug, self.id)
+        return os.path.join(_cache_path, self.game_slug)
 
     def prepare(self):
         """Prepare all files for download"""
@@ -110,5 +112,11 @@ class InstallerFileCollection:
 
     @property
     def is_cached(self):
-        """Is the file available in the local PGA cache?"""
-        return self.uses_pga_cache() and system.path_exists(self.dest_file)
+        """Are the files available in the local PGA cache?"""
+        if self.uses_pga_cache():
+            # check if every file is on cache
+            for installer_file in self.files_list:
+                if not system.path_exists(installer_file.dest_file):
+                    return False
+            return True
+        return False


### PR DESCRIPTION
Allow the user to select main installer file for Gog games. Amazon games will fail to install if user try to select a file, there is no way of knowing the service in file_box, so I was not able to filter only Gog.