### PR TITLE
File Collection fix Gog 'Select File' and remove it for Amazon

### DIFF
--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -126,7 +126,8 @@ class InstallerFileBox(Gtk.VBox):
             model.append(["pga", _("Use Cache")])
         if "steam" in self.installer_file.providers:
             model.append(["steam", _("Steam")])
-        model.append(["user", _("Select File")])
+        if not (isinstance(self.installer_file, InstallerFileCollection) and self.installer_file.service == "amazon"):
+            model.append(["user", _("Select File")])
         return model
 
     def get_combobox(self):

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -1,11 +1,14 @@
 """Manipulates installer files"""
 import os
 from gettext import gettext as _
+from urllib.parse import urlparse
 
 from lutris import cache, settings
 from lutris.util import system
 from lutris.util.log import logger
 from lutris.util.strings import add_url_tags, gtk_safe
+
+AMAZON_DOMAIN = "a2z.com"
 
 
 class InstallerFileCollection:
@@ -18,6 +21,17 @@ class InstallerFileCollection:
         self.num_files = len(files_list)
         self.files_list = files_list
         self._dest_folder = dest_folder  # Used to override the destination
+        self._get_service()
+
+    def _get_service(self):
+        """Try to get the service using the url of an InstallerFile"""
+        self.service = None
+        if self.num_files < 1:
+            return
+        url = self.files_list[0].url
+        url_parts = urlparse(url)
+        if url_parts.netloc.endswith(AMAZON_DOMAIN):
+            self.service = "amazon"
 
     def copy(self):
         """Copy InstallerFileCollection"""

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -39,7 +39,7 @@ class InstallerFileCollection:
         self._dest_folder = value
         # try to set main gog file to dest_file
         for installer_file in self.files_list:
-            if installer_file.id == "gogintaller":
+            if installer_file.id == "goginstaller":
                 installer_file.dest_file = value
 
     def __str__(self):


### PR DESCRIPTION
Possible to install Gog games independent of the location. Removed 'Select File' option for Amazon games.