### PR TITLE
Remove one progress bar from file collection downloads

### DIFF
--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -214,6 +214,12 @@ class InstallerFile:
             raise ScriptingError(hash_type.capitalize() + _(" checksum mismatch "), self.checksum)
 
     @property
+    def size(self):
+        if isinstance(self._file_meta, dict) and "size" in self._file_meta and isinstance(self._file_meta["size"], int):
+            return self._file_meta["size"]
+        return 0
+
+    @property
     def is_cached(self):
         """Is the file available in the local PGA cache?"""
         return self.uses_pga_cache() and system.path_exists(self.dest_file)

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -1,5 +1,6 @@
 """Manipulates installer files"""
 import os
+from functools import reduce
 from urllib.parse import urlparse
 
 from lutris import cache, settings
@@ -20,7 +21,13 @@ class InstallerFileCollection:
         self.num_files = len(files_list)
         self.files_list = files_list
         self._dest_folder = dest_folder  # Used to override the destination
+        self.full_size = 0
+        self._get_files_size()
         self._get_service()
+
+    def _get_files_size(self):
+        if self.num_files > 0:
+            self.full_size = reduce(lambda x, y: x + y, map(lambda a: a.size, self.files_list))
 
     def _get_service(self):
         """Try to get the service using the url of an InstallerFile"""

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -633,6 +633,7 @@ class AmazonService(OnlineService):
             files.append(InstallerFile(installer.game_slug, file_hash, {
                 "url": file["url"],
                 "filename": file_name,
+                "size": file["size"]
             }))
         # return should be a list of files, so we return a list containing a InstallerFileCollection
         return [InstallerFileCollection(installer.game_slug, "amazongame", files)]

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -468,7 +468,8 @@ class GOGService(OnlineService):
             files.append(InstallerFile(installer.game_slug, file_id, {
                 "url": installer_file["url"],
                 "filename": installer_file["filename"],
-                "checksum_url": installer_file.get("checksum_url")
+                "checksum_url": installer_file.get("checksum_url"),
+                "size": installer_file["total_size"]
             }))
         if not file_id_provided:
             raise UnavailableGameError(_("Unable to determine correct file to launch installer"))

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -481,13 +481,14 @@ class GOGService(OnlineService):
             raise UnavailableGameError(_("Couldn't load the downloads for this game")) from err
         links = self._get_installer_links(installer, downloads)
         if links:
-            files = self._format_links(installer, installer_file_id, links)
+            files = [InstallerFileCollection(installer.game_slug, installer_file_id,
+                        self._format_links(installer, installer_file_id, links))]
         else:
             files = []
         if selected_extras:
             for extra_file in self.get_extra_files(downloads, installer, selected_extras):
                 files.append(extra_file)
-        return [InstallerFileCollection(installer.game_slug, installer_file_id, files)]
+        return files
 
     def read_file_checksum(self, file_path):
         """Return the MD5 checksum for a GOG file


### PR DESCRIPTION
Add InstallerFile size support and InstallerFileCollection full download size support.
Removed one progress bar from the widget.

Separate Gog extra files from FileCollection.

Amazon and Gog using new file size system.

Please, check the UI if it is correct. I do not have a lot of games on Gog and Amazon, I tested downloading almost all my games, but it is best to test with more games, if possible.