### PR TITLE
Added new cli options to list service games

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,25 +85,27 @@ Command line options
 
 The following command line arguments are available::
 
--v, --version              Print the version of Lutris and exit
--d, --debug                Show debug messages
--i, --install              Install a game from a yml file
--b, --output-script        Generate a bash script to run a game without the client
--e, --exec                 Execute a program with the lutris runtime
--l, --list-games           List all games in database
--o, --installed            Only list installed games
--s, --list-steam-games     List available Steam games
---list-steam-folders       List all known Steam library folders
---list-runners             List all known runners
---list-wine-runners        List all known Wine runners
--r, --install-runner       Install a Runner
--u, --uninstall-runner     Uninstall a Runner
--j, --json                 Display the list of games in JSON format
---reinstall                Reinstall game
---display=DISPLAY          X display to use
---export <game>            Exports specified game (requires --dest)
---import <game.7z)         Import games from exportfile (requires --dest)
---dest <folder>            Specifies Export/Import destination folder
+-v, --version                    Print the version of Lutris and exit
+-d, --debug                      Show debug messages
+-i, --install                    Install a game from a yml file
+-b, --output-script              Generate a bash script to run a game without the client
+-e, --exec                       Execute a program with the lutris runtime
+-l, --list-games                 List all games in database
+-o, --installed                  Only list installed games
+-s, --list-steam-games           List available Steam games
+--list-steam-folders             List all known Steam library folders
+--list-runners                   List all known runners
+--list-wine-runners              List all known Wine runners
+-a, --list-all-service-games     List all games for all services in database
+--list-service-games             List all games for provided service in database
+-r, --install-runner             Install a Runner
+-u, --uninstall-runner           Uninstall a Runner
+-j, --json                       Display the list of games in JSON format
+--reinstall                      Reinstall game
+--display=DISPLAY                X display to use
+--export <game>                  Exports specified game (requires --dest)
+--import <game.7z)               Import games from exportfile (requires --dest)
+--dest <folder>                  Specifies Export/Import destination folder
 
 Additionally, you can pass a ``lutris:`` protocol link followed by a game
 identifier on the command line such as::

--- a/lutris/database/services.py
+++ b/lutris/database/services.py
@@ -6,6 +6,23 @@ from lutris.util.log import logger
 class ServiceGameCollection:
 
     @classmethod
+    def get_service_games(
+    cls,
+    searches=None,
+    filters=None,
+    excludes=None,
+    sorts=None
+    ):
+        return sql.filtered_query(
+            settings.PGA_DB,
+            "service_games",
+            searches=searches,
+            filters=filters,
+            excludes=excludes,
+            sorts=sorts
+        )
+
+    @classmethod
     def get_for_service(cls, service):
         if not service:
             raise ValueError("No service provided")


### PR DESCRIPTION
Resolves https://github.com/lutris/lutris/issues/4985

- Updated readme to detail new options
- Created two new CLI options `-a, --list-all-service-games` and `--list-service-games`
- One lists all games associated with a provided service
- The second lists all service games
- Both options work with the existing `-o` and `-j` options to return just those marked as installed, or as a json
- Added generic query to service_games table

I know you said not to list all service games, but it seemed best if this didn't cater to my niche use case and was more generic. Games from the steam source are already filtered on the Boilr side, which is likely where I'll move on to next to achieve my dream, but this way it isn't misleading for others and provides everything somebody might want.

Happy to discuss this further, or add additional options to take a list of services, rather than just one.

Looking forward to your comments.

