### PR TITLE
Add in Gentoo's multiple system-wide Wine installs to WINE_PATHs.

### DIFF
--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -23,6 +23,19 @@ WINE_PATHS = {
     "system": "wine",
 }
 
+# Insert additional system-wide Wine installations, such as are found
+# on Gentoo.
+try:
+    for _candidate in os.listdir('/usr/lib/'):
+        if _candidate.startswith("wine-"):
+            _wine_path = os.path.join("/usr/lib/", _candidate, "bin/wine")
+            if os.path.isfile(_wine_path):
+                WINE_PATHS["System " + _candidate] = _wine_path
+    _candidate = None
+    _wine_path = None
+except Exception as ex:
+    logger.exception("Unable to enumerate system Wine versions: %s", ex)
+
 
 def _iter_proton_locations():
     """Iterate through all existing Proton locations"""


### PR DESCRIPTION
What is says on the tin. Wine installs found at  /usr/lib/wine-*/ are recognized and added to the list of system-level Wine installs you can select from.

Credit to @bell07 for the code; I just touched it up a little.

Resolves #4995