### PR TITLE
Added condition for downloader progress cleanup

### DIFF
--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -72,6 +72,7 @@ class InstallerFileBox(Gtk.VBox):
         if (
                 not self.installer_file.uses_pga_cache()
                 and system.path_exists(self.installer_file.dest_file)
+                and os.path.isfile(self.installer_file.dest_file)
         ):
             os.remove(self.installer_file.dest_file)
         return download_progress


### PR DESCRIPTION
This fixes the error `[Errno 21] Is a directory: '/home/dusty/.cache/lutris/installer/name-of-the-game'` that is triggered for Amazon games with multiple files.