### PR TITLE
Update melonDS to 0.9.5

### DIFF
--- a/share/lutris/json/melonds.json
+++ b/share/lutris/json/melonds.json
@@ -4,7 +4,7 @@
     "platforms": ["Nintendo DS"],
     "runner_executable": "melonds/melonDS",
     "flatpak_id": "net.kuribo64.melonDS",
-    "download_url": "http://melonds.kuribo64.net/downloads/melonDS_0.9.3_linux_x64.7z",
+    "download_url": "https://melonds.kuribo64.net/downloads/melonDS_0.9.5_linux_x64.zip",
     "game_options": [
         {
             "option": "main_file",


### PR DESCRIPTION
There's been some big updates to melonDS since 0.9.3. One of them being it now includes DraStic's open-source DS BIOS, so now users won't be required to dump their own BIOS.