### PR TITLE
Added StartupWMClass to .desktop file

### DIFF
--- a/share/applications/net.lutris.Lutris.desktop
+++ b/share/applications/net.lutris.Lutris.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=Lutris
+StartupWMClass=Lutris
 Comment=Video Game Preservation Platform
 Categories=Game;
 Keywords=gaming;wine;emulator;


### PR DESCRIPTION
Having `StartupWMClass=` in `*.desktop` file helps locate the proper desktop icon on the task bar in desktop environments like Budgie 10.5.2 and others.
