### PR TITLE
Wine dll_manager: Do not hide locally installed versions

### DIFF
--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -36,8 +36,10 @@ class DLLManager:
     def versions(self):
         """Return available versions"""
         self._versions = self.load_versions()
-        if not self._versions and system.path_exists(self.base_dir):
-            self._versions = os.listdir(self.base_dir)
+        if system.path_exists(self.base_dir):
+            for local_version in os.listdir(self.base_dir):
+                if os.path.isdir(os.path.join(self.base_dir, local_version)) and local_version not in self._versions:
+                    self._versions.append(local_version)
         return self._versions
 
     @property


### PR DESCRIPTION
Lutris is able to use locally installed dxvk, vkd3d and others, placed into `~/.local/share/lutris/runtime/dxvk` or `~/.local/share/lutris/runtime/vkd3d`. The locally installed versions are hidden, if remote list is fetched.

This change allow to use locally installed versions. The locally versions are available at the bottom of the selections list.

My use-case is, I set symlinks to versions installed by distribution package manager (Gentoo).

```
ln -s /usr/lib/dxvk ~/.local/share/lutris/runtime/dxvk/system-dxvk
ln -s /usr/lib/vkd3d-proton/ ~/.local/share/lutris/runtime/vkd3d/system-vkd3d-proton
```