### PR TITLE
ScummVM: fix of last-minute-before-commit bug

### DIFF
--- a/lutris/services/scummvm.py
+++ b/lutris/services/scummvm.py
@@ -67,7 +67,6 @@ class ScummvmService(BaseService):
                 "game": {
                     "game_id": game["appid"],
                     "path": details["path"],
-                    "platform": "scummvm"
                 }
             }
         }

--- a/lutris/services/scummvm.py
+++ b/lutris/services/scummvm.py
@@ -48,7 +48,6 @@ class ScummvmService(BaseService):
             game.name = config[section]["description"]
             game.slug = slugify(re.split(r" \(.*\)$", game.name)[0])
             game.appid = section
-            game.game_id = section
             game.runner = "scummvm"
             game.lutris_slug = game.slug
             game.details = json.dumps({
@@ -66,7 +65,7 @@ class ScummvmService(BaseService):
             "runner": "scummvm",
             "script": {
                 "game": {
-                    "game_id": game["game_id"],
+                    "game_id": game["appid"],
                     "path": details["path"],
                     "platform": "scummvm"
                 }


### PR DESCRIPTION
"game_id" is available in the scummvm runner only, but not in database. My last fix at this place was garbage. Now switch back to "appid" and remove unused game_id assignment.