### PR TITLE
ScummVM: don't set LD_LIBRARY_PATH if runtime disabled and custom command used

### DIFF
--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -474,6 +474,10 @@ class scummvm(Runner):
 
     @property
     def libs_dir(self):
+        if ("runner_executable" in self.runner_config
+            and self.runner_config["runner_executable"] == self.get_executable()
+            and not self.use_runtime()):
+            return ""
         path = os.path.join(settings.RUNNER_DIR, "scummvm/lib")
         return path if system.path_exists(path) else ""
 


### PR DESCRIPTION
More often than not, the "custom executable" set for the ScummVM runner will be the system's scummvm binary. If this binary is used, the libraries shipped with Lutris will most probably not match. Therefore, if a custom executable is used and the Lutris runtime is disabled, don't set LD_LIBRARY_PATH.

This avoids the following error on openSUSE Leap 15.5 with the latest ScummVM runner (2.8.0):
```
DEBUG    2023-10-11 00:01:59,594 [grid.on_item_activated:95]:Item activated: 3
INFO     2023-10-11 00:01:59,630 [runner.use_runtime:386]:Runtime disabled by system configuration
lutris-wrapper: The Secret of Monkey Island
Started initial process 32173 from /usr/bin/scummvm --extrapath=/usr/share/scummvm --themepath=/usr/share/scummvm --aspect-ratio --fullscreen --scaler=normal --scale-factor=3 --path=/home/konrad/Games/the-secret-of-monkey-island monkey
Start monitoring process.
/usr/bin/scummvm: error while loading shared libraries: libreadline.so.8: cannot open shared object file: No such file or directory
Monitored process exited.
Initial process has exited (return code: 32512)
```
