### PR TITLE
Runner updates and added Rosalie's Mupen GUI as runner

### DIFF
--- a/lutris/runners/mupen64plus.py
+++ b/lutris/runners/mupen64plus.py
@@ -13,7 +13,6 @@ class mupen64plus(Runner):
     description = _("Nintendo 64 emulator")
     platforms = [_("Nintendo 64")]
     runner_executable = "mupen64plus/mupen64plus"
-    flatpak_id = "com.github.Rosalie241.RMG"
     game_options = [
         {
             "option": "main_file",

--- a/share/lutris/json/mgba.json
+++ b/share/lutris/json/mgba.json
@@ -14,7 +14,7 @@
             "option": "main_file",
             "type": "file",
             "label": "ROM file",
-            "help": "A GBA ROM",
+            "help": "A GBA or GB(C) ROM",
             "default_path": "game_path"
         }
     ]

--- a/share/lutris/json/mgba.json
+++ b/share/lutris/json/mgba.json
@@ -1,0 +1,21 @@
+{
+    "human_name": "mGBA",
+    "description": "Multi-system emulator: GBA & GB(C)",
+    "platforms": [
+        "Nintendo Game Boy Advance",
+        "Nintendo Game Boy (Color)"
+    ],
+    "runner_executable": "mgba/mGBA-0.10.2-appimage-x64.appimage",
+    "flatpak_id": "io.mgba.mGBA",
+    "runnable_alone": true,
+    "download_url": "https://github.com/mgba-emu/mgba/releases/download/0.10.2/mGBA-0.10.2-appimage-x64.appimage",
+    "game_options": [
+        {
+            "option": "main_file",
+            "type": "file",
+            "label": "ROM file",
+            "help": "A GBA ROM",
+            "default_path": "game_path"
+        }
+    ]
+}

--- a/share/lutris/json/microm8.json
+++ b/share/lutris/json/microm8.json
@@ -3,7 +3,7 @@
     "description": "microM8 is an Apple II emulator",
     "platforms": ["Apple IIe"],
     "runner_executable": "microm8/microm8",
-    "download_url": "http://paleotronic.com/download/microm8-linux.zip",
+    "download_url": "https://paleotronic.com/download/microm8-linux.zip",
     "game_options": [
         {
             "option": "main_file",

--- a/share/lutris/json/pcem.json
+++ b/share/lutris/json/pcem.json
@@ -4,7 +4,7 @@
     "platforms": ["MS-DOS"],
     "runnable_alone": "True",
     "runner_executable": "pcem/pcem",
-    "download_url": "http://pcem-emulator.co.uk/files/PCemV17Linux.tar.gz",
+    "download_url": "https://pcem-emulator.co.uk/files/PCemV17Linux.tar.gz",
     "game_options": [
         {
             "option": "main_file",

--- a/share/lutris/json/rosaliesmupengui.json
+++ b/share/lutris/json/rosaliesmupengui.json
@@ -1,0 +1,18 @@
+{
+    "human_name": "Rosalie's Mupen GUI",
+    "description": "Nintendo 64 emulator",
+    "platforms": [ "Nintendo 64" ],
+    "runner_executable": "rosaliesmupengui/RMG-Portable-Linux64-v0.5.2.AppImage",
+    "flatpak_id": "com.github.Rosalie241.RMG",
+    "runnable_alone": true,
+    "download_url": "https://github.com/Rosalie241/RMG/releases/download/v0.5.2/RMG-Portable-Linux64-v0.5.2.AppImage",
+    "game_options": [
+        {
+            "option": "main_file",
+            "type": "file",
+            "label": "ROM file",
+            "help": "A N64 ROM",
+            "default_path": "game_path"
+        }
+    ]
+}

--- a/share/lutris/json/ruffle.json
+++ b/share/lutris/json/ruffle.json
@@ -3,7 +3,7 @@
     "description": "Emulates Flash games",
     "platforms": ["Flash"],
     "runner_executable": "ruffle/ruffle",
-    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/nightly-2023-06-04/ruffle-nightly-2023_06_04-linux-x86_64.tar.gz",
+    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/nightly-2023-10-14/ruffle-nightly-2023_10_14-linux-x86_64.tar.gz",
     "game_options": [
         {
             "option": "main_file",


### PR DESCRIPTION
I went through and updated some of the runners.

Added Rosalie's Mupen GUI as a standalone runner. I also removed its flatpak ID from the mupen64plus runner to avoid confusion or conflicts.

Updated the ruffle link to the current nightly since it was a few months out-of-date.

Updated the mGBA runner to include GB(C) ROMs as a possible option in its help.

Changed http links to https links to avoid the, albeit very minor, concern of possible MITM attacks. I checked each of the links to make sure https is viable.