### PR TITLE
Fixed typo in lutris.spec

### DIFF
--- a/lutris.spec
+++ b/lutris.spec
@@ -15,7 +15,7 @@ BuildRequires:  desktop-file-utils
 BuildRequires:  python3-devel
 BuildRequires:  python3-gobject
 BuildRequires:  python-wheel
-BuildRequires   python-setuptools
+BuildRequires:  python-setuptools
 BuildRequires:  fdupes
 BuildRequires:  libappstream-glib
 BuildRequires:  meson


### PR DESCRIPTION
Typo in the BuildRequires, needs a semicolon