### PR TITLE
scummvm: handle runner not being available in get_command, add/fix test

### DIFF
--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -482,6 +482,8 @@ class scummvm(Runner):
 
     def get_command(self):
         command = super().get_command()
+        if not command:
+            return []
         if "flatpak" in command[0]:
             return command
         return command + [

--- a/tests/test_scummvm.py
+++ b/tests/test_scummvm.py
@@ -1,6 +1,8 @@
 from unittest import TestCase
+from unittest.mock import patch
 
 from lutris.config import LutrisConfig
+from lutris.runners.runner import Runner
 from lutris.runners.scummvm import scummvm
 
 
@@ -10,5 +12,10 @@ class TestScummvm(TestCase):
         scummvm_runner.config = LutrisConfig()
         scummvm_runner.config.runner_config["datadir"] = "~/custom/scummvm"
 
-        self.assertEqual(scummvm_runner.get_scummvm_data_dir(), "~/custom/scummvm")
-        self.assertEqual(scummvm_runner.get_command()[1], "--extrapath=~/custom/scummvm")
+        with patch.object(Runner, "get_command", return_value=["scummvm"]):
+            self.assertEqual(scummvm_runner.get_scummvm_data_dir(), "~/custom/scummvm")
+            self.assertEqual(scummvm_runner.get_command()[1], "--extrapath=~/custom/scummvm")
+
+    def test_no_executable(self):
+        with patch.object(Runner, "get_command", return_value=[]):
+            self.assertEqual(scummvm().get_command(), [])


### PR DESCRIPTION
Before this change, the scummvm tests would fail on a system where scummvm is not available, because https://github.com/K900/lutris/blob/7efc304f595a9547bb4f01a823250d95b7722506/lutris/runners/scummvm.py#L487 attempted to access an element from an empty list. Fix that by propagating the empty list, and use mocks to ensure we test both cases.