### PR TITLE
Provide a gentler warning if you don't have a system version of Wine installed

### DIFF
--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -519,23 +519,6 @@ class WarningMessageDialog(Gtk.MessageDialog):
         self.destroy()
 
 
-class WineNotInstalledWarning(WarningMessageDialog):
-    """Display a warning if Wine is not detected on the system"""
-
-    def __init__(self, parent=None, cancellable=False):
-        super().__init__(
-            _("Wine is not installed on your system."),
-            secondary_message=_(
-                "Having Wine installed on your system guarantees that "
-                "Wine builds from Lutris will have all required dependencies.\n\nPlease "
-                "follow the instructions given in the <a "
-                "href='https://github.com/lutris/docs/blob/master/WineDependencies.md'>Lutris Wiki</a> to "
-                "install Wine."
-            ),
-            parent=parent
-        )
-
-
 class MoveDialog(ModelessDialog):
     __gsignals__ = {
         "game-moved": (GObject.SIGNAL_RUN_FIRST, None, ()),

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -6,7 +6,6 @@ from lutris.exceptions import UnavailableRunnerError
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.dialogs.download import DownloadDialog
-from lutris.runners import wine
 from lutris.util.downloader import Downloader
 
 
@@ -139,10 +138,6 @@ class DialogLaunchUIDelegate(LaunchUIDelegate):
             installed = game.runner.install_dialog(self)
             if not installed:
                 return False
-
-        if "wine" in game.runner_name and not wine.get_system_wine_version():
-            dialogs.WineNotInstalledWarning(parent=self)
-            return False
 
         return True
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -61,6 +61,12 @@ class Runner:  # pylint: disable=too-many-public-methods
         self.__doc__ = value  # What the shit
 
     @property
+    def runner_warning(self):
+        """Returns a message (as markup) that is displayed in the configuration dialog as
+        a warning."""
+        return None
+
+    @property
     def name(self):
         return self.__class__.__name__
 

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -579,6 +579,18 @@ class wine(Runner):
         ]
 
     @property
+    def runner_warning(self):
+        if not get_system_wine_version():
+            return _(
+                "<b>Warning</b> Wine is not installed on your system\n\n"
+                "Having Wine installed on your system guarantees that "
+                "Wine builds from Lutris will have all required dependencies.\nPlease "
+                "follow the instructions given in the <a "
+                "href='https://github.com/lutris/docs/blob/master/WineDependencies.md'>Lutris Wiki</a> to "
+                "install Wine."
+            )
+
+    @property
     def context_menu_entries(self):
         """Return the contexual menu entries for wine"""
         return [

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -971,6 +971,9 @@ class wine(Runner):
         return None
 
     def prelaunch(self):
+        if not get_system_wine_version():
+            logger.warning("Wine is not installed on your system; required dependencies may be missing.")
+
         prefix_path = self.prefix_path
         if prefix_path:
             if not system.path_exists(os.path.join(prefix_path, "user.reg")):


### PR DESCRIPTION
We presently display an error dialog, and this prevents any Wine game from being started. This used to be a don't-show-again warning dialog, but those are out.

So, here's a version of the warning that appears in configuration, and does not block starting a game. This warning can't be suppressed, though, so it's not just a new don't-show-again thing.

![image](https://github.com/lutris/lutris/assets/6507403/46dcd563-ff46-424a-9a8c-d788d8b5a325)

The downside of this is that you might never look in the configuration, and might never see the warning. To mitigate against this, I've added a logger warning when yous tart a wine game without a system Wine installed.

Resolves #5121