### PR TITLE
Fix launching games from tray icon

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -805,6 +805,9 @@ class Application(Gtk.Application):
             ErrorDialog(_("No DLC found"), parent=self.window)
         return True
 
+    def get_launch_ui_delegate(self):
+        return self.launch_ui_delegate
+
     def get_running_game_ids(self):
         ids = []
         for i in range(self.running_games.get_n_items()):


### PR DESCRIPTION
The tray icon class calls Application.get_launch_ui_delegate, which is not defined in Application.
I wasn't sure if it was better to make the icon class use directly Application.launch_ui_delegate or add the getter method.
I opted for the getter method so that the field can be treated as an implementation detail.

EDIT: Sorry for the messy PR, making the change directly via github might have been a bad idea.