### PR TITLE
Add more options to get service_game and return appid

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -112,6 +112,10 @@ identifier on the command line such as::
 
     lutris lutris:quake
 
+or if you want to specify the game's service too::
+
+    lutris lutris:gog:quake
+
 This will install the game if it is not already installed, otherwise it will
 launch the game. The game will always be installed if the ``--reinstall`` flag is passed.
 

--- a/lutris/api.py
+++ b/lutris/api.py
@@ -257,7 +257,7 @@ def get_game_installers(game_slug, revision=None):
     request = http.Request(installer_url)
     request.get()
     response = request.json
-    if response is None:
+    if response["count"] == 0:
         raise RuntimeError("Couldn't get installer at %s" % installer_url)
 
     # Revision requests return a single installer

--- a/lutris/database/services.py
+++ b/lutris/database/services.py
@@ -29,6 +29,22 @@ class ServiceGameCollection:
         return sql.filtered_query(settings.PGA_DB, "service_games", filters={"service": service})
 
     @classmethod
+    def get_game_by_field(cls, appid, service, field):
+        """Query a service game based on a database field"""
+        if not appid:
+            raise ValueError("No game_slug provided")
+        if not service:
+            raise ValueError("No service provided")
+        if field not in ("slug", "lutris_slug", "appid", "name"):
+            raise ValueError("Can't query by field '%s'" % field)
+        results = sql.filtered_query(settings.PGA_DB, "service_games", filters={field: appid, "service": service})
+        if not results:
+            return
+        if len(results) > 1:
+            logger.warning("More than one game found for %s on %s", appid, service)
+        return results[0]
+
+    @classmethod
     def get_game(cls, service, appid):
         """Return a single game referred by its appid"""
         logger.debug("Getting service game %s for %s", appid, service)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -657,7 +657,12 @@ class Application(Gtk.Application):
                 action = "install"
 
         if service:
-            service_game = ServiceGameCollection.get_game(service, appid)
+            service_game = (
+                ServiceGameCollection.get_game_by_field(appid, service, "appid")
+                or ServiceGameCollection.get_game_by_field(appid, service, "slug")
+                or ServiceGameCollection.get_game_by_field(appid, service, "lutris_slug")
+                or ServiceGameCollection.get_game_by_field(appid, service, "name")
+            )
             if service_game:
                 service = get_enabled_services()[service]()
                 service.install(service_game)
@@ -897,6 +902,7 @@ class Application(Gtk.Application):
         games = [
             {
                 "id": game["id"],
+                "appid": game["appid"],
                 "slug": game["slug"],
                 "name": game["name"],
                 "service": game["service"],


### PR DESCRIPTION
Resolves #5116.

- Adds more options to grab `service_game` so it isn't just relying on the `appid`, now accepts `slug`, `lutris_slug` or `name` as well as `appid`
- Adds `get_game_by_field` function to `services`
- Returns `appid` as part of the json response for list all games for all services CLI command so there is a consistent way to obtain it
- Adds an example of how to specify games with their service for the `lutris` protocol link to the `README`
- Potentially fixes error handling for when an installer isn't returned

Let me know what you think. These changes shouldn't impact the existing functionality.

Apologies for submitting this without prior approval.