### PR TITLE
Reduce the locale drop down in configuration to a fixed list

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -480,7 +480,7 @@ system_options = [  # pylint: disable=invalid-name
     {
         "section": "Game execution",
         "option": "locale",
-        "type": "choice_with_search",
+        "type": "choice_with_entry",
         "label": _("Locale"),
         "choices": (
             get_locale_choices

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -30,13 +30,12 @@ def get_locale_choices():
         ("es_ES.utf8", "es_ES.utf8"),
         ("hr_HR.utf8", "hr_HR.utf8"),
         ("it_IT.utf8", "it_IT.utf8"),
+        ("ja_JP.utf8", "ja_JP.utf8"),
         ("ka_GE.utf8", "ka_GE.utf8"),
-        ("ko_KR.utf8", "ko_KR.utf8"),
         ("ko_KR.utf8", "ko_KR.utf8"),
         ("nl_NL.utf8", "nl_NL.utf8"),
         ("pt_BR.utf8", "pt_BR.utf8"),
         ("ru_RU.utf8", "ru_RU.utf8"),
-        ("tr_TR.utf8", "tr_TR.utf8"),
         ("tr_TR.utf8", "tr_TR.utf8"),
         ("zh_CN.utf8", "zh_CN.utf8")
     ]

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -25,20 +25,20 @@ def get_locale_choices():
     """
     return [
         (_("System"), ""),
-        ("en_US.utf8", "en_US.utf8"),
-        ("fi_FI.utf8", "fi_FI.utf8"),
-        ("de_DE.utf8", "de_DE.utf8"),
-        ("es_ES.utf8", "es_ES.utf8"),
-        ("hr_HR.utf8", "hr_HR.utf8"),
-        ("it_IT.utf8", "it_IT.utf8"),
-        ("ja_JP.utf8", "ja_JP.utf8"),
-        ("ka_GE.utf8", "ka_GE.utf8"),
-        ("ko_KR.utf8", "ko_KR.utf8"),
-        ("nl_NL.utf8", "nl_NL.utf8"),
-        ("pt_BR.utf8", "pt_BR.utf8"),
-        ("ru_RU.utf8", "ru_RU.utf8"),
-        ("tr_TR.utf8", "tr_TR.utf8"),
-        ("zh_CN.utf8", "zh_CN.utf8")
+        (_("Chinese"), "zh_CN.utf8"),
+        (_("Croatian"), "hr_HR.utf8"),
+        (_("Dutch"), "nl_NL.utf8"),
+        (_("English"), "en_US.utf8"),
+        (_("Finnish"), "fi_FI.utf8"),
+        (_("Georgian"), "ka_GE.utf8"),
+        (_("German"), "de_DE.utf8"),
+        (_("Italian"), "it_IT.utf8"),
+        (_("Japanese"), "ja_JP.utf8"),
+        (_("Korean"), "ko_KR.utf8"),
+        (_("Portuguese (Brazilian)"), "pt_BR.utf8"),
+        (_("Russian"), "ru_RU.utf8"),
+        (_("Spanish"), "es_ES.utf8"),
+        (_("Turkish"), "tr_TR.utf8"),
     ]
 
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -23,15 +23,33 @@ def get_locale_choices():
     """Return list of available locales as label, value tuples
     suitable for inclusion in drop-downs.
     """
+    return [
+        ("en_US.utf8", "en_US.utf8"),
+        ("fi_FI.utf8", "fi_FI.utf8"),
+        ("de_DE.utf8", "de_DE.utf8"),
+        ("es_ES.utf8", "es_ES.utf8"),
+        ("hr_HR.utf8", "hr_HR.utf8"),
+        ("it_IT.utf8", "it_IT.utf8"),
+        ("ka_GE.utf8", "ka_GE.utf8"),
+        ("ko_KR.utf8", "ko_KR.utf8"),
+        ("ko_KR.utf8", "ko_KR.utf8"),
+        ("nl_NL.utf8", "nl_NL.utf8"),
+        ("pt_BR.utf8", "pt_BR.utf8"),
+        ("ru_RU.utf8", "ru_RU.utf8"),
+        ("tr_TR.utf8", "tr_TR.utf8"),
+        ("tr_TR.utf8", "tr_TR.utf8"),
+        ("zh_CN.utf8", "zh_CN.utf8")
+    ]
     locales = system.get_locale_list()
 
-    # adds "(recommended)" string to utf8 locales
-    locales_humanized = locales.copy()
-    for index, locale in enumerate(locales_humanized):
-        if "utf8" in locale:
-            locales_humanized[index] += " " + _("(recommended)")
+    # To keep the list down to a reasonable length, we'll
+    # offer only UTF-8 locales if any are present.
+    selected = [l for l in locales if "utf8" in l.casefold()]
 
-    locale_choices = list(zip(locales_humanized, locales))
+    if not selected:
+        selected = locales
+
+    locale_choices = list(zip(selected, selected))
     locale_choices.insert(0, (_("System"), ""))
 
     return locale_choices

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -24,6 +24,7 @@ def get_locale_choices():
     suitable for inclusion in drop-downs.
     """
     return [
+        (_("System"), ""),
         ("en_US.utf8", "en_US.utf8"),
         ("fi_FI.utf8", "fi_FI.utf8"),
         ("de_DE.utf8", "de_DE.utf8"),
@@ -39,19 +40,6 @@ def get_locale_choices():
         ("tr_TR.utf8", "tr_TR.utf8"),
         ("zh_CN.utf8", "zh_CN.utf8")
     ]
-    locales = system.get_locale_list()
-
-    # To keep the list down to a reasonable length, we'll
-    # offer only UTF-8 locales if any are present.
-    selected = [l for l in locales if "utf8" in l.casefold()]
-
-    if not selected:
-        selected = locales
-
-    locale_choices = list(zip(selected, selected))
-    locale_choices.insert(0, (_("System"), ""))
-
-    return locale_choices
 
 
 def get_output_choices():


### PR DESCRIPTION
This replaces the drop down of locales with a much shorter, fixed list:
![image](https://github.com/lutris/lutris/assets/6507403/7ae04c44-c877-46a1-abb8-e331e2d20347)

The old locale list was enormous, and not very user-friendly. This is a fixed list, including the languages we have translations for in Lutris itself, except Arabic; I don't know what language code to use for that.

Also, the PR throws in Japanese. You know why.

We have been seeing crashes on KDE Plasma that seems to be caused by the big locale list somehow- I hope this will eliminate that crash.

Resolves #5092