### PR TITLE
Replace various Optional[T] examples with exceptions and stuff

### DIFF
--- a/lutris/api.py
+++ b/lutris/api.py
@@ -124,15 +124,26 @@ def download_runner_versions(runner_name: str) -> list:
     return versions
 
 
+def format_runner_version(version_info: Dict[str, str]) -> str:
+    version = version_info.get("version")
+    if not version:
+        return ""
+    arch = version_info.get("architecture")
+    if arch:
+        return "{}-{}".format(version, arch)
+
+    return version
+
+
 @functools.lru_cache()
-def get_default_runner_version(runner_name: str, version: str = None) -> Dict[str, str]:
+def get_default_runner_version_info(runner_name: str, version: str = None) -> Dict[str, str]:
     """Get the appropriate version for a runner
 
     Params:
         version: Optional version to lookup, will return this one if found
 
     Returns:
-        Dict containing version, architecture and url for the runner, None
+        Dict containing version, architecture and url for the runner, an empty dict
         if the data can't be retrieved. If a pseudo-version is accepted, may be
         a dict containing only the version itself.
     """

--- a/lutris/command.py
+++ b/lutris/command.py
@@ -97,7 +97,7 @@ class MonitoredCommand:
         if not self.terminal:
             return wrapper_command + self.command
 
-        terminal_path = system.find_required_executable(self.terminal)
+        terminal_path = system.find_executable(self.terminal)
         script_path = get_terminal_script(self.command, self.cwd, self.env)
         return wrapper_command + [terminal_path, "-e", script_path]
 

--- a/lutris/config.py
+++ b/lutris/config.py
@@ -234,7 +234,14 @@ class LutrisConfig:
         defaults = {}
         for option, params in options_dict.items():
             if "default" in params:
-                defaults[option] = params["default"]
+                default = params["default"]
+                if callable(default):
+                    try:
+                        default = default()
+                    except Exception as ex:
+                        logger.exception("Unable to generate a default for '%s': %s", option, ex)
+                        continue
+                defaults[option] = default
         return defaults
 
     def options_as_dict(self, options_type):

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -8,19 +8,31 @@ from lutris.util.log import logger
 class LutrisError(Exception):
     """Base exception for Lutris related errors"""
 
-    def __init__(self, message):
-        super().__init__(message)
+    def __init__(self, message, *args, **kwarg):
+        super().__init__(message, *args, **kwarg)
         self.message = message
 
 
-class GameConfigError(LutrisError):
+class MisconfigurationError(LutrisError):
+    """Raised for incorrect configuration or installation, like incorrect
+    or missing settings, missing components, that sort of thing. This has subclasses
+    that are less vague."""
+
+
+class GameConfigError(MisconfigurationError):
     """Throw this error when the game configuration prevents the game from
-    running properly.
-    """
+    running properly."""
 
 
-class UnavailableLibrariesError(RuntimeError):
+class AuthenticationError(LutrisError):
+    """Raised when authentication to a service fails"""
 
+
+class UnavailableGameError(LutrisError):
+    """Raised when a game is unavailable from a service"""
+
+
+class UnavailableLibrariesError(MisconfigurationError):
     def __init__(self, libraries, arch=None):
         message = _(
             "The following {arch} libraries are required but are not installed on your system:\n{libs}"
@@ -32,23 +44,15 @@ class UnavailableLibrariesError(RuntimeError):
         self.libraries = libraries
 
 
-class AuthenticationError(Exception):
-    """Raised when authentication to a service fails"""
-
-
-class UnavailableGameError(Exception):
-    """Raised when a game is unavailable from a service"""
-
-
-class UnavailableRunnerError(Exception):
+class UnavailableRunnerError(MisconfigurationError):
     """Raised when a runner is not installed or not installed fully."""
 
 
-class UnspecifiedVersionError(ValueError):
+class UnspecifiedVersionError(MisconfigurationError):
     """Raised when a version number must be specified, but was not."""
 
 
-class MissingExecutableError(RuntimeError):
+class MissingExecutableError(MisconfigurationError):
     """Raised when a program can't be located."""
 
 

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -48,6 +48,10 @@ class UnspecifiedVersionError(ValueError):
     """Raised when a version number must be specified, but was not."""
 
 
+class MissingExecutableError(RuntimeError):
+    """Raised when a program can't be located."""
+
+
 class EsyncLimitError(Exception):
     """Raised when the ESYNC limit is not set correctly."""
 

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -44,6 +44,10 @@ class UnavailableRunnerError(Exception):
     """Raised when a runner is not installed or not installed fully."""
 
 
+class UnspecifiedVersionError(ValueError):
+    """Raised when a version number must be specified, but was not."""
+
+
 class EsyncLimitError(Exception):
     """Raised when the ESYNC limit is not set correctly."""
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -528,7 +528,7 @@ class Game(GObject.Object):
     def start_antimicrox(self, antimicro_config):
         """Start Antimicrox with a given config path"""
         try:
-            antimicro_path = system.find_required_executable("antimicrox")
+            antimicro_path = system.find_executable("antimicrox")
         except MissingExecutableError as ex:
             raise GameConfigError(_("Unable to find Antimicrox, install it or disable the Antimicrox option")) from ex
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -868,7 +868,7 @@ class Game(GObject.Object):
         logger.info("Stopping %s", self)
 
         if self.game_thread:
-            def stop_cb(result, error):
+            def stop_cb(_result, error):
                 if error:
                     self.signal_error(error)
 
@@ -942,14 +942,14 @@ class Game(GObject.Object):
         if self.game_thread.return_code == 127:
             # Error missing shared lib
             error = "error while loading shared lib"
-            error_line = strings.lookup_string_in_text(error, self.game_thread.stdout)
-            if error_line:
-                raise RuntimeError(_("<b>Error: Missing shared library.</b>\n\n%s") % error_line)
+            error_lines = strings.lookup_strings_in_text(error, self.game_thread.stdout)
+            if error_lines:
+                raise RuntimeError(_("<b>Error: Missing shared library.</b>\n\n%s") % error_lines[0])
 
         if self.game_thread.return_code == 1:
             # Error Wine version conflict
             error = "maybe the wrong wineserver"
-            if strings.lookup_string_in_text(error, self.game_thread.stdout):
+            if strings.lookup_strings_in_text(error, self.game_thread.stdout):
                 raise RuntimeError(_("<b>Error: A different Wine version is already using the same Wine prefix.</b>"))
 
     def write_script(self, script_path, launch_ui_delegate):

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -18,7 +18,7 @@ from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.database import sql
-from lutris.exceptions import GameConfigError, watch_game_errors
+from lutris.exceptions import GameConfigError, MissingExecutableError, watch_game_errors
 from lutris.runner_interpreter import export_bash_script, get_launch_parameters
 from lutris.runners import InvalidRunner, import_runner
 from lutris.util import audio, discord, extract, jobs, linux, strings, system, xdgshortcuts
@@ -527,10 +527,11 @@ class Game(GObject.Object):
 
     def start_antimicrox(self, antimicro_config):
         """Start Antimicrox with a given config path"""
-        antimicro_path = system.find_executable("antimicrox")
-        if not antimicro_path:
-            logger.warning("Antimicrox is not installed.")
-            return
+        try:
+            antimicro_path = system.find_required_executable("antimicrox")
+        except MissingExecutableError as ex:
+            raise GameConfigError(_("Unable to find Antimicrox, install it or disable the Antimicrox option")) from ex
+
         logger.info("Starting Antic")
         antimicro_command = [antimicro_path, "--hidden", "--tray", "--profile", antimicro_config]
         self.antimicro_thread = MonitoredCommand(antimicro_command)

--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -167,6 +167,8 @@ class ConfigBox(VBox):
 
                 # Set tooltip's "Default" part
                 default = option.get("default")
+                if callable(default):
+                    default = default()
                 self.tooltip_default = default if isinstance(default, str) else None
 
                 # Generate option widget
@@ -674,12 +676,17 @@ class ConfigBox(VBox):
         if current_value == reset_value:
             return
 
+        default = option.get("default")
+        if callable(default):
+            default = default()
+
         # Destroy and recreate option widget
         self.wrapper = wrapper
         children = wrapper.get_children()
         for child in children:
             child.destroy()
-        self.call_widget_generator(option, option_key, reset_value, option.get("default"))
+
+        self.call_widget_generator(option, option_key, reset_value, default)
         self.wrapper.show_all()
         self.update_warnings()
 

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -30,7 +30,7 @@ class LaunchUIDelegate:
         actual checks.
         """
         if not game.runner.is_installed():
-            raise UnavailableRunnerError("The required runner '%s' is not installed." % game.runner.name)
+            raise UnavailableRunnerError(_("The required runner '%s' is not installed.") % game.runner.name)
         return True
 
     def select_game_launch_config(self, game):

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -9,6 +9,7 @@ from gettext import gettext as _
 from gi.repository import GLib, Gtk
 
 from lutris import api, settings
+from lutris.api import format_runner_version
 from lutris.database.games import get_games_by_runner
 from lutris.game import Game
 from lutris.gui.dialogs import ErrorDialog, ModelessDialog
@@ -275,7 +276,8 @@ class RunnerInstallDialog(ModelessDialog):
 
     def get_runner_path(self, version, arch):
         """Return the local path where the runner is/will be installed"""
-        return os.path.join(self.runner_directory, "{}-{}".format(version, arch))
+        info = {"version": version, "architecture": arch}
+        return os.path.join(self.runner_directory, format_runner_version(info))
 
     def get_dest_path(self, row):
         """Return temporary path where the runners should be downloaded to"""

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -13,7 +13,7 @@ from gi.repository import GLib
 from lutris import runtime
 from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
-from lutris.exceptions import UnspecifiedVersionError, watch_errors
+from lutris.exceptions import MissingExecutableError, UnspecifiedVersionError, watch_errors
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer import LutrisInstaller
 from lutris.runners import InvalidRunner, import_runner, import_task
@@ -151,9 +151,11 @@ class CommandsMixin:
         if system.path_exists(exec_path) and not system.is_executable(exec_path):
             logger.warning("Making %s executable", exec_path)
             system.make_executable(exec_path)
-        exec_abs_path = system.find_executable(exec_path)
-        if not exec_abs_path:
-            raise ScriptingError(_("Unable to find executable %s") % exec_path)
+
+        try:
+            exec_abs_path = system.find_required_executable(exec_path)
+        except MissingExecutableError as ex:
+            raise ScriptingError(_("Unable to find executable %s") % exec_path) from ex
 
         if terminal:
             terminal = linux.get_default_terminal()

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -16,7 +16,7 @@ from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import UnavailableRunnerError, watch_errors
+from lutris.exceptions import UnavailableRunnerError, UnspecifiedVersionError, watch_errors
 from lutris.game import Game
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer import LutrisInstaller
@@ -83,7 +83,7 @@ class CommandsMixin:
             if not version:
                 version = get_default_wine_version()
             return get_wine_path_for_version(version)
-        except UnavailableRunnerError:
+        except (UnavailableRunnerError, UnspecifiedVersionError):
             return None
 
     @staticmethod

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -14,13 +14,11 @@ from gi.repository import GLib
 from lutris import runtime
 from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
-from lutris.config import LutrisConfig
-from lutris.database.games import get_game_by_field
-from lutris.exceptions import MisconfigurationError, watch_errors
-from lutris.game import Game
+from lutris.exceptions import MisconfigurationError, UnspecifiedVersionError, watch_errors
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer import LutrisInstaller
-from lutris.runners import import_task
+from lutris.runners import InvalidRunner, import_runner, import_task
+from lutris.runners.wine import wine
 from lutris.util import extract, linux, selective_merge, system
 from lutris.util.fileio import EvilConfigParser, MultiOrderedDict
 from lutris.util.log import logger
@@ -33,58 +31,32 @@ class CommandsMixin:
     # pylint: disable=no-member
     installer: LutrisInstaller = NotImplemented
 
-    def get_runner_version(self) -> Optional[str]:
-        """Return the version of the runner used for the installer"""
-        version = self._get_installer_runner_version()
-        if not version and self.installer.runner == "wine":
-            # Look up the runner config setting, but only if it is explicitly set;
-            # install scripts do not get the usual default if it is not!
-            runner_config = LutrisConfig(runner_slug="wine")
-            if "wine" in runner_config.runner_level:
-                config_version = runner_config.runner_level["wine"].get("version")
-                if config_version:
-                    return config_version
-        return version
-
-    def _get_installer_runner_version(self) -> Optional[str]:
-        """Return the version of the runner, as specified by the installer; the
-         runner configuration is ignored."""
-        if self.installer.runner == "wine":
-            # If a version is specified in the script choose this one
-            if self.installer.script.get(self.installer.runner):
-                return self.installer.script[self.installer.runner].get("version")
-            # If the installer is an extension, use the wine version from the base game
-            if self.installer.requires:
-                db_game = get_game_by_field(self.installer.requires, field="installer_slug")
-                if not db_game:
-                    db_game = get_game_by_field(self.installer.requires, field="slug")
-                if not db_game:
-                    logger.warning("Can't find game %s", self.installer.requires)
-                    return None
-                game = Game(db_game["id"])
-                return game.config.runner_config["version"]
-        if self.installer.runner == "libretro":
-            return self.installer.script["game"]["core"]
-        return None
-
     def get_wine_path(self) -> Optional[str]:
         """Return absolute path of wine version used during the installation, but
         None if the wine exe can't be located."""
+        runner = self.get_runner_class(self.installer.runner)()
         try:
-            version = self._get_installer_runner_version()
-            if not version and self.installer.runner == "wine":
-                # Look up the runner config setting, but only if it is explicitly set;
-                # install scripts do not get the usual default if it is not!
-                runner_config = LutrisConfig(runner_slug="wine")
-                if "wine" in runner_config.runner_level:
-                    config_version = runner_config.runner_level["wine"].get("version")
-                    if config_version:
-                        return get_wine_path_for_version(config_version, config=runner_config.runner_level)
-            if not version:
+            try:
+                version = runner.get_installer_runner_version(self.installer, use_runner_config=False)
+            except UnspecifiedVersionError:
+                # Special case that lets the Wine configuration explicit specify the path
+                # to the Wine executable, not just a version number.
+                if self.installer.runner == "wine":
+                    config_version, runner_config = wine.get_runner_version_and_config()
+                    return get_wine_path_for_version(config_version, config=runner_config.runner_level)
+
                 version = get_default_wine_version()
             return get_wine_path_for_version(version)
         except MisconfigurationError:
             return None
+
+    def get_runner_class(self, runner_name):
+        """Runner the runner class from its name"""
+        try:
+            runner = import_runner(runner_name)
+        except InvalidRunner as err:
+            raise ScriptingError(_("Invalid runner provided %s") % runner_name) from err
+        return runner
 
     @staticmethod
     def _check_required_params(params, command_data, command_name):

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -7,14 +7,13 @@ import shlex
 import shutil
 from gettext import gettext as _
 from pathlib import Path
-from typing import Optional
 
 from gi.repository import GLib
 
 from lutris import runtime
 from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
-from lutris.exceptions import MisconfigurationError, UnspecifiedVersionError, watch_errors
+from lutris.exceptions import UnspecifiedVersionError, watch_errors
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer import LutrisInstaller
 from lutris.runners import InvalidRunner, import_runner, import_task

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -153,7 +153,7 @@ class CommandsMixin:
             system.make_executable(exec_path)
 
         try:
-            exec_abs_path = system.find_required_executable(exec_path)
+            exec_abs_path = system.find_executable(exec_path)
         except MissingExecutableError as ex:
             raise ScriptingError(_("Unable to find executable %s") % exec_path) from ex
 

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -31,24 +31,21 @@ class CommandsMixin:
     # pylint: disable=no-member
     installer: LutrisInstaller = NotImplemented
 
-    def get_wine_path(self) -> Optional[str]:
+    def get_wine_path(self) -> str:
         """Return absolute path of wine version used during the installation, but
         None if the wine exe can't be located."""
         runner = self.get_runner_class(self.installer.runner)()
         try:
-            try:
-                version = runner.get_installer_runner_version(self.installer, use_runner_config=False)
-            except UnspecifiedVersionError:
-                # Special case that lets the Wine configuration explicit specify the path
-                # to the Wine executable, not just a version number.
-                if self.installer.runner == "wine":
-                    config_version, runner_config = wine.get_runner_version_and_config()
-                    return get_wine_path_for_version(config_version, config=runner_config.runner_level)
+            version = runner.get_installer_runner_version(self.installer, use_runner_config=False)
+        except UnspecifiedVersionError:
+            # Special case that lets the Wine configuration explicit specify the path
+            # to the Wine executable, not just a version number.
+            if self.installer.runner == "wine":
+                config_version, runner_config = wine.get_runner_version_and_config()
+                return get_wine_path_for_version(config_version, config=runner_config.runner_level)
 
-                version = get_default_wine_version()
-            return get_wine_path_for_version(version)
-        except MisconfigurationError:
-            return None
+            version = get_default_wine_version()
+        return get_wine_path_for_version(version)
 
     def get_runner_class(self, runner_name):
         """Runner the runner class from its name"""
@@ -402,9 +399,7 @@ class CommandsMixin:
             return_code = "0"
 
         if runner_name.startswith("wine"):
-            wine_path = self.get_wine_path()
-            if wine_path:
-                data["wine_path"] = wine_path
+            data["wine_path"] = self.get_wine_path()
             data["prefix"] = data.get("prefix") \
                 or self.installer.script.get("game", {}).get("prefix") \
                 or "$GAMEDIR"

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -33,7 +33,7 @@ class CommandsMixin:
     # pylint: disable=no-member
     installer: LutrisInstaller = NotImplemented
 
-    def _get_runner_version(self) -> Optional[str]:
+    def get_runner_version(self) -> Optional[str]:
         """Return the version of the runner used for the installer"""
         version = self._get_installer_runner_version()
         if not version and self.installer.runner == "wine":

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -16,7 +16,7 @@ from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import UnavailableRunnerError, UnspecifiedVersionError, watch_errors
+from lutris.exceptions import MisconfigurationError, watch_errors
 from lutris.game import Game
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer import LutrisInstaller
@@ -83,7 +83,7 @@ class CommandsMixin:
             if not version:
                 version = get_default_wine_version()
             return get_wine_path_for_version(version)
-        except (UnavailableRunnerError, UnspecifiedVersionError):
+        except MisconfigurationError:
             return None
 
     @staticmethod

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -149,13 +149,13 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         for dependency in binary_dependencies:
             if isinstance(dependency, tuple):
                 installed_binaries = {
-                    dependency_option: bool(system.find_executable(dependency_option))
+                    dependency_option: system.can_find_executable(dependency_option)
                     for dependency_option in dependency
                 }
                 if not any(installed_binaries.values()):
                     raise ScriptingError(_("This installer requires %s on your system") % _(" or ").join(dependency))
             else:
-                if not system.find_executable(dependency):
+                if system.can_find_executable(dependency):
                     raise ScriptingError(_("This installer requires %s on your system") % dependency)
 
     def _check_dependency(self):

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -5,6 +5,7 @@ from gettext import gettext as _
 from gi.repository import GObject
 
 from lutris import settings
+from lutris.api import format_runner_version
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
 from lutris.exceptions import watch_errors
@@ -252,17 +253,12 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
                     params["version"] = version
                 else:
                     # Looking up default wine version
-                    default_wine = runner.get_runner_version() or {}
-                    if "version" in default_wine:
-                        logger.debug("Default wine version is %s", default_wine["version"])
-                        if "architecture" in default_wine:
-                            version = "{}-{}".format(default_wine["version"],
-                                                     default_wine["architecture"])
-                        else:
-                            version = default_wine["version"]
-                        params["version"] = version
+                    default_wine_info = runner.get_runner_version()
+                    if "version" in default_wine_info:
+                        logger.debug("Default wine version is %s", default_wine_info["version"])
+                        params["version"] = format_runner_version(default_wine_info)
                     else:
-                        logger.error("Failed to get default wine version (got %s)", default_wine)
+                        logger.error("Failed to get default wine version (got %s)", default_wine_info)
 
             if not runner.is_installed(**params):
                 logger.info("Runner %s needs to be installed", runner)

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -7,7 +7,7 @@ from gi.repository import GObject
 from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import watch_errors, MisconfigurationError
+from lutris.exceptions import MisconfigurationError, watch_errors
 from lutris.installer import AUTO_EXE_PREFIX
 from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependency, ScriptingError

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -426,7 +426,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         try:
             replacements["RESOLUTION_WIDTH_HEX"] = hex(int(current_res[0]))
             replacements["RESOLUTION_HEIGHT_HEX"] = hex(int(current_res[1]))
-        except MisconfigurationError:
+        except (ValueError, TypeError):
             pass  # If we can't generate hex, just omit the vars
 
         try:

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -13,7 +13,7 @@ from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependency, ScriptingError
 from lutris.installer.installer import LutrisInstaller
 from lutris.installer.legacy import get_game_launcher
-from lutris.runners import InvalidRunner, NonInstallableRunnerError, RunnerInstallationError, import_runner, steam, wine
+from lutris.runners import NonInstallableRunnerError, RunnerInstallationError, steam, wine
 from lutris.services.lutris import download_lutris_media
 from lutris.util import system
 from lutris.util.display import DISPLAY_MANAGER
@@ -265,20 +265,12 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         try:
             runner.install(
                 ui_delegate,
-                version=self.get_runner_version(),
+                version=runner.get_installer_runner_version(self) if runner.has_runner_version else None,
                 callback=install_more_runners,
             )
         except (NonInstallableRunnerError, RunnerInstallationError) as ex:
             logger.error(ex.message)
             raise ScriptingError(ex.message) from ex
-
-    def get_runner_class(self, runner_name):
-        """Runner the runner class from its name"""
-        try:
-            runner = import_runner(runner_name)
-        except InvalidRunner as err:
-            raise ScriptingError(_("Invalid runner provided %s") % runner_name) from err
-        return runner
 
     def launch_installer_commands(self):
         """Run the pre-installation steps and launch install."""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -7,7 +7,7 @@ from gi.repository import GObject
 from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import watch_errors
+from lutris.exceptions import watch_errors, MisconfigurationError
 from lutris.installer import AUTO_EXE_PREFIX
 from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependency, ScriptingError
@@ -203,10 +203,10 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
     def create_game_folder(self):
         """Create the game folder if needed and store if is was created"""
         if (
-                self.installer.files
-                and self.target_path
-                and not system.path_exists(self.target_path)
-                and self.installer.creates_game_folder
+            self.installer.files
+            and self.target_path
+            and not system.path_exists(self.target_path)
+            and self.installer.creates_game_folder
         ):
             try:
                 logger.debug("Creating destination path %s", self.target_path)
@@ -370,10 +370,10 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
                 path = system.fix_path_case(os.path.join(self.target_path, path))
 
         if (
-                path
-                and AUTO_EXE_PREFIX not in path
-                and not os.path.isfile(path)
-                and self.installer.runner not in ("web", "browser")
+            path
+            and AUTO_EXE_PREFIX not in path
+            and not os.path.isfile(path)
+            and self.installer.runner not in ("web", "browser")
         ):
             status = _(
                 "The executable at path %s can't be found, please check the destination folder.\n"
@@ -407,12 +407,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
     def _get_string_replacements(self):
         """Return a mapping of variables to their actual value"""
 
-        def int_hex(text):
-            try:
-                return hex(int(text)) if text else None
-            except (ValueError, TypeError) as ex:
-                logger.exception("Unable to convert '%s' to hex: %s", text, ex)
-                return None
+        current_res = self.current_resolution()
 
         replacements = {
             "GAMEDIR": self.target_path,
@@ -423,13 +418,21 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             "USER": os.getenv("USER"),
             "INPUT": self.user_inputs[-1]["value"] if self.user_inputs else "",
             "VERSION": self.installer.version,
-            "RESOLUTION": "x".join(self.current_resolution),
-            "RESOLUTION_WIDTH": self.current_resolution[0],
-            "RESOLUTION_HEIGHT": self.current_resolution[1],
-            "RESOLUTION_WIDTH_HEX": int_hex(self.current_resolution[0]),
-            "RESOLUTION_HEIGHT_HEX": int_hex(self.current_resolution[1]),
-            "WINEBIN": self.get_wine_path(),
+            "RESOLUTION": "x".join(current_res),
+            "RESOLUTION_WIDTH": current_res[0],
+            "RESOLUTION_HEIGHT": current_res[1],
         }
+
+        try:
+            replacements["RESOLUTION_WIDTH_HEX"] = hex(int(current_res[0]))
+            replacements["RESOLUTION_HEIGHT_HEX"] = hex(int(current_res[1]))
+        except MisconfigurationError:
+            pass  # If we can't generate hex, just omit the vars
+
+        try:
+            replacements["WINEBIN"] = self.get_wine_path()
+        except MisconfigurationError:
+            pass  # If we can't get the path, just omit it
 
         # None values stringify as 'None', which is not what you want, so we'll
         # remove then pre-emptively. This happens for game install scripts that have

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -432,6 +432,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
 
     def _get_string_replacements(self):
         """Return a mapping of variables to their actual value"""
+
         def int_hex(text):
             try:
                 return hex(int(text)) if text else None

--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -4,6 +4,7 @@ import shlex
 import stat
 from functools import lru_cache
 
+from lutris.exceptions import MissingExecutableError
 from lutris.util import system
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
@@ -54,10 +55,10 @@ def get_launch_parameters(runner, gameplay_info):
     # Libstrangle
     fps_limit = system_config.get("fps_limit") or ""
     if fps_limit:
-        strangle_cmd = system.find_executable("strangle")
-        if strangle_cmd:
+        try:
+            strangle_cmd = system.find_required_executable("strangle")
             launch_arguments = [strangle_cmd, fps_limit] + launch_arguments
-        else:
+        except MissingExecutableError:
             logger.warning("libstrangle is not available on this system, FPS limiter disabled")
 
     prefix_command = system_config.get("prefix_command") or ""

--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -56,7 +56,7 @@ def get_launch_parameters(runner, gameplay_info):
     fps_limit = system_config.get("fps_limit") or ""
     if fps_limit:
         try:
-            strangle_cmd = system.find_required_executable("strangle")
+            strangle_cmd = system.find_executable("strangle")
             launch_arguments = [strangle_cmd, fps_limit] + launch_arguments
         except MissingExecutableError:
             logger.warning("libstrangle is not available on this system, FPS limiter disabled")

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -14,8 +14,8 @@ from lutris.util.strings import split_arguments
 from lutris.util.wine.cabinstall import CabInstaller
 from lutris.util.wine.prefix import WinePrefixManager
 from lutris.util.wine.wine import (
-    WINE_DEFAULT_ARCH, WINE_DIR, detect_arch, detect_prefix_arch, get_overrides_env, get_real_executable,
-    is_installed_systemwide
+    WINE_DEFAULT_ARCH, WINE_DIR, detect_arch, get_overrides_env, get_real_executable, is_installed_systemwide,
+    is_prefix_directory
 )
 
 
@@ -273,7 +273,7 @@ def wineexec(  # noqa: C901
     # Create prefix if necessary
     if arch not in ("win32", "win64"):
         arch = detect_arch(prefix, wine_path)
-    if not detect_prefix_arch(prefix):
+    if not is_prefix_directory(prefix):
         wine_bin = winetricks_wine if winetricks_wine else wine_path
         create_prefix(prefix, wine_path=wine_bin, arch=arch, runner=runner)
 

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -338,7 +338,7 @@ def find_winetricks(env=None, system_winetricks=False):
     """Find winetricks path."""
     winetricks_path = os.path.join(settings.RUNTIME_DIR, "winetricks/winetricks")
     if system_winetricks or not system.path_exists(winetricks_path):
-        winetricks_path = system.find_required_executable("winetricks")
+        winetricks_path = system.find_executable("winetricks")
         working_dir = None
     else:
         # We will use our own zenity if available, which is here, and it

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -93,7 +93,7 @@ class flatpak(Runner):
     def get_executable(self) -> str:
         exe = _flatpak.get_executable()
         if not exe:
-            raise MissingExecutableError("The Flatpak executable could not be found.")
+            raise MissingExecutableError(_("The Flatpak executable could not be found."))
         return exe
 
     def install(self, install_ui_delegate, version=None, callback=None):

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -4,6 +4,7 @@ from gettext import gettext as _
 from pathlib import Path
 
 from lutris.command import MonitoredCommand
+from lutris.exceptions import MissingExecutableError
 from lutris.runners import NonInstallableRunnerError
 from lutris.runners.runner import Runner
 from lutris.util import flatpak as _flatpak
@@ -92,7 +93,7 @@ class flatpak(Runner):
     def get_executable(self) -> str:
         exe = _flatpak.get_executable()
         if not exe:
-            raise ValueError("The Flatpak executable could not be found.")
+            raise MissingExecutableError("The Flatpak executable could not be found.")
         return exe
 
     def install(self, install_ui_delegate, version=None, callback=None):

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -142,6 +142,10 @@ class libretro(Runner):
         is_core_installed = system.path_exists(self.get_core_path(core))
         return super().is_installed() and is_core_installed
 
+    def is_installed_for(self, interpreter):
+        core = interpreter.installer.script["game"].get("core")
+        return self.is_installed(core=core)
+
     def install(self, install_ui_delegate, version=None, callback=None):
         captured_super = super()  # super() does not work inside install_core()
 

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -151,7 +151,7 @@ class libretro(Runner):
     def get_installer_runner_version(self, installer, use_runner_config: bool = True) -> str:
         version = installer.script["game"].get("core")
         if not version:
-            raise UnspecifiedVersionError("The installer does not specify the libretro 'core' version.")
+            raise UnspecifiedVersionError(_("The installer does not specify the libretro 'core' version."))
         return version
 
     def install(self, install_ui_delegate, version=None, callback=None):

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -7,6 +7,7 @@ from zipfile import ZipFile
 import requests
 
 from lutris import settings
+from lutris.exceptions import UnspecifiedVersionError
 from lutris.runners.runner import Runner
 from lutris.util import system
 from lutris.util.libretro import RetroConfig
@@ -70,6 +71,7 @@ class libretro(Runner):
     runnable_alone = True
     runner_executable = "retroarch/retroarch"
     flatpak_id = "org.libretro.RetroArch"
+    has_runner_versions = True
 
     game_options = [
         {
@@ -145,6 +147,12 @@ class libretro(Runner):
     def is_installed_for(self, interpreter):
         core = interpreter.installer.script["game"].get("core")
         return self.is_installed(core=core)
+
+    def get_installer_runner_version(self, installer, use_runner_config: bool = True) -> str:
+        version = installer.script["game"].get("core")
+        if not version:
+            raise UnspecifiedVersionError("The installer does not specify the libretro 'core' version.")
+        return version
 
     def install(self, install_ui_delegate, version=None, callback=None):
         captured_super = super()  # super() does not work inside install_core()

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -5,7 +5,7 @@ import stat
 from gettext import gettext as _
 
 # Lutris Modules
-from lutris.exceptions import GameConfigError
+from lutris.exceptions import GameConfigError, MissingExecutableError
 from lutris.runners.runner import Runner
 from lutris.util import system
 from lutris.util.strings import split_arguments
@@ -85,7 +85,10 @@ class linux(Runner):
             return exe
         if self.game_path:
             return os.path.join(self.game_path, exe)
-        return system.find_executable(exe)
+        try:
+            return system.find_required_executable(exe)
+        except MissingExecutableError:
+            return None
 
     def resolve_game_path(self):
         return super().resolve_game_path() or os.path.dirname(self.game_exe or "")

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -86,7 +86,7 @@ class linux(Runner):
         if self.game_path:
             return os.path.join(self.game_path, exe)
         try:
-            return system.find_required_executable(exe)
+            return system.find_executable(exe)
         except MissingExecutableError:
             return None
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -9,7 +9,7 @@ from lutris.api import format_runner_version, get_default_runner_version_info
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import GameConfigError, UnavailableLibrariesError, MissingExecutableError
+from lutris.exceptions import GameConfigError, MissingExecutableError, UnavailableLibrariesError
 from lutris.runners import RunnerInstallationError
 from lutris.util import flatpak, strings, system
 from lutris.util.extract import ExtractFailure, extract_archive

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -9,7 +9,7 @@ from lutris.api import format_runner_version, get_default_runner_version_info
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import GameConfigError, MissingExecutableError, UnavailableLibrariesError
+from lutris.exceptions import GameConfigError, MisconfigurationError, MissingExecutableError, UnavailableLibrariesError
 from lutris.runners import RunnerInstallationError
 from lutris.util import flatpak, strings, system
 from lutris.util.extract import ExtractFailure, extract_archive
@@ -168,7 +168,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             if os.path.isfile(runner_executable):
                 return runner_executable
         if not self.runner_executable:
-            raise ValueError("runner_executable not set for {}".format(self.name))
+            raise MisconfigurationError("runner_executable not set for {}".format(self.name))
 
         exe = os.path.join(settings.RUNNER_DIR, self.runner_executable)
         if not os.path.isfile(exe):
@@ -424,7 +424,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             # Don't care where the exe is, only if we can find it.
             self.get_executable()
             return True
-        except (MissingExecutableError, ValueError):
+        except MisconfigurationError:
             pass  # We can still try flatpak even if 'which' fails us!
 
         return self.flatpak_id and flatpak.is_app_installed(self.flatpak_id)

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -5,7 +5,7 @@ from gettext import gettext as _
 from typing import Dict
 
 from lutris import runtime, settings
-from lutris.api import get_default_runner_version
+from lutris.api import format_runner_version, get_default_runner_version_info
 from lutris.command import MonitoredCommand
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
@@ -429,7 +429,7 @@ class Runner:  # pylint: disable=too-many-public-methods
     def get_runner_version(self, version: str = None) -> Dict[str, str]:
         """Get the appropriate version for a runner, as with get_default_runner_version(),
         but this method allows the runner to apply its configuration."""
-        return get_default_runner_version(self.name, version)
+        return get_default_runner_version_info(self.name, version)
 
     def install(self, install_ui_delegate, version=None, callback=None):
         """Install runner using package management systems."""
@@ -443,20 +443,20 @@ class Runner:  # pylint: disable=too-many-public-methods
         if self.download_url:
             opts["dest"] = self.directory
             return self.download_and_extract(self.download_url, **opts)
-        runner_version = self.get_runner_version(version)
-        if not runner_version:
+        runner_version_info = self.get_runner_version(version)
+        if not runner_version_info:
             raise RunnerInstallationError(_("Failed to retrieve {} ({}) information").format(self.name, version))
 
         if "wine" in self.name:
             opts["merge_single"] = True
             opts["dest"] = os.path.join(
-                self.directory, "{}-{}".format(runner_version["version"], runner_version["architecture"])
+                self.directory, format_runner_version(runner_version_info)
             )
 
         if self.name == "libretro" and version:
             opts["merge_single"] = False
             opts["dest"] = os.path.join(settings.RUNNER_DIR, "retroarch/cores")
-        self.download_and_extract(runner_version["url"], **opts)
+        self.download_and_extract(runner_version_info["url"], **opts)
 
     def download_and_extract(self, url, dest=None, **opts):
         install_ui_delegate = opts["install_ui_delegate"]

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -34,6 +34,7 @@ class Runner:  # pylint: disable=too-many-public-methods
     download_url = None
     arch = None  # If the runner is only available for an architecture that isn't x86_64
     flatpak_id = None
+    has_runner_versions = False
 
     def __init__(self, config=None):
         """Initialize runner."""
@@ -433,6 +434,9 @@ class Runner:  # pylint: disable=too-many-public-methods
         """Returns whether the runner is installed. Specific runners can extract additional
         script settings, to determine more precisely what must be installed."""
         return self.is_installed()
+
+    def get_installer_runner_version(self, installer, use_runner_config: bool = True) -> str:
+        raise RuntimeError("The '%s' runner does not support versions" % self.name)
 
     def get_runner_version(self, version: str = None) -> Dict[str, str]:
         """Get the appropriate version for a runner, as with get_default_runner_version(),

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -146,13 +146,13 @@ class steam(Runner):
     def get_executable(self) -> str:
         if linux.LINUX_SYSTEM.is_flatpak:
             # Fallback to xgd-open for Steam URIs in Flatpak
-            return system.find_required_executable("xdg-open")
+            return system.find_executable("xdg-open")
         if self.runner_config.get("lsi_steam") and system.can_find_executable("lsi-steam"):
-            return system.find_required_executable("lsi-steam")
+            return system.find_executable("lsi-steam")
         runner_executable = self.runner_config.get("runner_executable")
         if runner_executable and os.path.isfile(runner_executable):
             return runner_executable
-        return system.find_required_executable(self.runner_executable)
+        return system.find_executable(self.runner_executable)
 
     @property
     def working_dir(self):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1109,7 +1109,7 @@ class wine(Runner):
         else:
             exe = self.get_executable()
         if not exe.startswith("/"):
-            exe = system.find_executable(exe)
+            exe = system.find_required_executable(exe)
         pids = system.get_pids_using_file(exe)
         if self.wine_arch == "win64" and os.path.basename(exe) == "wine":
             pids = pids | system.get_pids_using_file(exe + "64")

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -7,7 +7,9 @@ from typing import Dict
 
 from lutris import runtime, settings
 from lutris.api import format_runner_version, get_default_runner_version_info
-from lutris.exceptions import EsyncLimitError, FsyncUnsupportedError, MissingExecutableError, UnavailableRunnerError
+from lutris.exceptions import (
+    EsyncLimitError, FsyncUnsupportedError, MisconfigurationError, MissingExecutableError
+)
 from lutris.gui.dialogs import FileDialog
 from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-import
     create_prefix, delete_registry_key, eject_disc, install_cab_component, open_wine_terminal, set_regedit,
@@ -736,7 +738,7 @@ class wine(Runner):
                 # We don't care where Wine is, but only if it was found at all.
                 self.get_executable(version, fallback)
                 return True
-            except (UnavailableRunnerError, MissingExecutableError):
+            except MisconfigurationError:
                 return False
 
         return bool(get_installed_wine_versions())

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1109,7 +1109,7 @@ class wine(Runner):
         else:
             exe = self.get_executable()
         if not exe.startswith("/"):
-            exe = system.find_required_executable(exe)
+            exe = system.find_executable(exe)
         pids = system.get_pids_using_file(exe)
         if self.wine_arch == "win64" and os.path.basename(exe) == "wine":
             pids = pids | system.get_pids_using_file(exe + "64")

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -784,7 +784,7 @@ class wine(Runner):
                 version = format_runner_version(default_version_info)
 
         if not version:
-            raise UnspecifiedVersionError("The installer does not specify a Wine version.")
+            raise UnspecifiedVersionError(_("The installer does not specify a Wine version."))
 
         return version
 
@@ -796,7 +796,7 @@ class wine(Runner):
             if config_version:
                 return config_version, runner_config
 
-        raise UnspecifiedVersionError("The runner configuration does not specify a Wine version.")
+        raise UnspecifiedVersionError(_("The runner configuration does not specify a Wine version."))
 
     @classmethod
     def msi_exec(

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -8,7 +8,7 @@ from typing import Any, Callable, Dict, List, Tuple
 from gi.repository import GLib
 
 from lutris import settings
-from lutris.api import download_runtime_versions, get_time_from_api_date
+from lutris.api import download_runtime_versions, format_runner_version, get_time_from_api_date
 from lutris.util import http, jobs, system, update_cache
 from lutris.util.downloader import Downloader
 from lutris.util.extract import extract_archive
@@ -274,7 +274,7 @@ class RuntimeUpdater:
             if not system.path_exists(runner_base_path) or not os.listdir(runner_base_path):
                 continue
 
-            runner_version = "-".join([upstream_runner["version"], upstream_runner["architecture"]])
+            runner_version = format_runner_version(upstream_runner)
 
             archive_download_path = os.path.join(settings.TMP_DIR, os.path.basename(upstream_runner["url"]))
             version_path = os.path.join(settings.RUNNER_DIR, name, runner_version)

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -9,6 +9,7 @@ import requests
 from gi.repository import Gio
 
 from lutris import settings
+from lutris.exceptions import MissingExecutableError
 from lutris.services.base import BaseService
 from lutris.services.service_game import ServiceGame
 from lutris.services.service_media import ServiceMedia
@@ -88,7 +89,7 @@ class FlathubService(BaseService):
         flatpak_spawn_abspath = shutil.which("flatpak-spawn")
         if flatpak_spawn_abspath:
             return [flatpak_spawn_abspath, "--host", "flatpak"]
-        raise RuntimeError("No flatpak or flatpak-spawn found")
+        raise MissingExecutableError("No flatpak or flatpak-spawn found")
 
     def load(self):
         """Load the available games from Flathub"""

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -89,7 +89,7 @@ class FlathubService(BaseService):
         flatpak_spawn_abspath = shutil.which("flatpak-spawn")
         if flatpak_spawn_abspath:
             return [flatpak_spawn_abspath, "--host", "flatpak"]
-        raise MissingExecutableError("No flatpak or flatpak-spawn found")
+        raise MissingExecutableError(_("No flatpak or flatpak-spawn found"))
 
     def load(self):
         """Load the available games from Flathub"""

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -169,7 +169,7 @@ class XDGGame(ServiceGame):
         args = list(map(lambda arg: re.sub("%[^%]", "", arg).replace("%%", "%"), command[1:]))
         exe = command[0]
         if not exe.startswith("/"):
-            exe = system.find_required_executable(exe)
+            exe = system.find_executable(exe)
         return exe, subprocess.list2cmdline(args)
 
     @staticmethod

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -169,7 +169,7 @@ class XDGGame(ServiceGame):
         args = list(map(lambda arg: re.sub("%[^%]", "", arg).replace("%%", "%"), command[1:]))
         exe = command[0]
         if not exe.startswith("/"):
-            exe = system.find_executable(exe)
+            exe = system.find_required_executable(exe)
         return exe, subprocess.list2cmdline(args)
 
     @staticmethod

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -51,7 +51,7 @@ def get_default_dpi():
 
 def restore_gamma():
     """Restores gamma to a normal level."""
-    xgamma_path = system.find_required_executable("xgamma")
+    xgamma_path = system.find_executable("xgamma")
     try:
         subprocess.Popen([xgamma_path, "-gamma", "1.0"])  # pylint: disable=consider-using-with
     except (FileNotFoundError, TypeError):
@@ -89,7 +89,7 @@ def _get_graphics_adapters():
         list: list of tuples containing PCI ID and description of the display controller
     """
     try:
-        lspci_path = system.find_required_executable("lspci")
+        lspci_path = system.find_executable("lspci")
     except MissingExecutableError:
         logger.warning("lspci is not available. List of graphics cards not available")
         return []

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -5,10 +5,10 @@ import os
 import subprocess
 import gi
 
-
 try:
     gi.require_version("GnomeDesktop", "3.0")
     from gi.repository import GnomeDesktop
+
     LIB_GNOME_DESKTOP_AVAILABLE = True
 except ValueError:
     LIB_GNOME_DESKTOP_AVAILABLE = False
@@ -16,6 +16,7 @@ except ValueError:
 
 try:
     from dbus.exceptions import DBusException
+
     DBUS_AVAILABLE = True
 except ImportError:
     DBUS_AVAILABLE = False
@@ -28,6 +29,7 @@ from lutris.util.graphics import drivers
 from lutris.util.graphics.displayconfig import MutterDisplayManager
 from lutris.util.graphics.xrandr import LegacyDisplayManager, change_resolution, get_outputs
 from lutris.util.log import logger
+from lutris.exceptions import MissingExecutableError
 
 
 class NoScreenDetected(Exception):
@@ -86,11 +88,13 @@ def _get_graphics_adapters():
     Returns:
         list: list of tuples containing PCI ID and description of the display controller
     """
-    lspci_path = system.find_executable("lspci")
-    dev_subclasses = ["VGA", "XGA", "3D controller", "Display controller"]
-    if not lspci_path:
+    try:
+        lspci_path = system.find_required_executable("lspci")
+    except MissingExecutableError:
         logger.warning("lspci is not available. List of graphics cards not available")
         return []
+
+    dev_subclasses = ["VGA", "XGA", "3D controller", "Display controller"]
     return [
         (pci_id, device_desc.split(": ")[1]) for pci_id, device_desc in [
             line.split(maxsplit=1) for line in system.execute(lspci_path, timeout=3).split("\n")
@@ -185,7 +189,6 @@ USE_DRI_PRIME = len(list(drivers.get_gpus())) > 1
 
 
 class DesktopEnvironment(enum.Enum):
-
     """Enum of desktop environments."""
 
     PLASMA = 0
@@ -324,7 +327,6 @@ def enable_compositing():
 
 
 class DBusScreenSaverInhibitor:
-
     """Inhibit and uninhibit the screen saver using DBus.
 
     It will use the Gtk.Application's inhibit and uninhibit methods to inhibit

--- a/lutris/util/extract.py
+++ b/lutris/util/extract.py
@@ -208,9 +208,7 @@ def extract_exe(path: str, dest: str) -> None:
         # use 7za to check if exe is an archive
         _7zip_path = os.path.join(settings.RUNTIME_DIR, "p7zip/7za")
         if not system.path_exists(_7zip_path):
-            _7zip_path = system.find_executable("7za")
-        if not system.path_exists(_7zip_path):
-            raise OSError("7zip is not found in the lutris runtime or on the system")
+            _7zip_path = system.find_required_executable("7za")
         command = [_7zip_path, "t", path]
         return_code = subprocess.call(command)
         if return_code == 0:
@@ -312,9 +310,7 @@ def decompress_gz(file_path: str, dest_path: str):
 def extract_7zip(path: str, dest: str, archive_type: str = None) -> None:
     _7zip_path = os.path.join(settings.RUNTIME_DIR, "p7zip/7z")
     if not system.path_exists(_7zip_path):
-        _7zip_path = system.find_executable("7z")
-    if not system.path_exists(_7zip_path):
-        raise OSError("7zip is not found in the lutris runtime or on the system")
+        _7zip_path = system.find_required_executable("7z")
     command = [_7zip_path, "x", path, "-o{}".format(dest), "-aoa"]
     if archive_type and archive_type != "auto":
         command.append("-t{}".format(archive_type))

--- a/lutris/util/extract.py
+++ b/lutris/util/extract.py
@@ -208,7 +208,7 @@ def extract_exe(path: str, dest: str) -> None:
         # use 7za to check if exe is an archive
         _7zip_path = os.path.join(settings.RUNTIME_DIR, "p7zip/7za")
         if not system.path_exists(_7zip_path):
-            _7zip_path = system.find_required_executable("7za")
+            _7zip_path = system.find_executable("7za")
         command = [_7zip_path, "t", path]
         return_code = subprocess.call(command)
         if return_code == 0:
@@ -261,7 +261,7 @@ def get_innoextract_path() -> str:
         if not system.path_exists(inno_path):
             return inno_path
 
-    inno_path = system.find_required_executable("innoextract")
+    inno_path = system.find_executable("innoextract")
     logger.warning("innoextract not available in the runtime folder, using some random version")
     return inno_path
 
@@ -310,7 +310,7 @@ def decompress_gz(file_path: str, dest_path: str):
 def extract_7zip(path: str, dest: str, archive_type: str = None) -> None:
     _7zip_path = os.path.join(settings.RUNTIME_DIR, "p7zip/7z")
     if not system.path_exists(_7zip_path):
-        _7zip_path = system.find_required_executable("7z")
+        _7zip_path = system.find_executable("7z")
     command = [_7zip_path, "x", path, "-o{}".format(dest), "-aoa"]
     if archive_type and archive_type != "auto":
         command.append("-t{}".format(archive_type))

--- a/lutris/util/strings.py
+++ b/lutris/util/strings.py
@@ -5,7 +5,7 @@ import shlex
 import unicodedata
 import uuid
 from gettext import gettext as _
-from typing import List, Optional, Tuple, Union
+from typing import List, Tuple, Union
 
 from gi.repository import GLib
 
@@ -41,13 +41,10 @@ def slugify(value: str) -> str:
     return slug
 
 
-def lookup_string_in_text(string: str, text: str) -> Optional[str]:
-    """Return full line if string found in the multi-line text."""
-    output_lines = text.split("\n")
-    for line in output_lines:
-        if string in line:
-            return line
-    return None
+def lookup_strings_in_text(string: str, text: str) -> List[str]:
+    """Return each full line where a string was found in the multi-line text."""
+    input_lines = text.split("\n")
+    return [line for line in input_lines if string in line]
 
 
 def parse_version(version: str) -> Tuple[List[int], str, str]:

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -13,7 +13,6 @@ from collections import defaultdict
 from functools import lru_cache
 from gettext import gettext as _
 from pathlib import Path
-from typing import Optional
 
 from gi.repository import Gio, GLib
 
@@ -226,22 +225,15 @@ def make_executable(exec_path):
     os.chmod(exec_path, file_stats.st_mode | stat.S_IEXEC)
 
 
-def find_executable(exec_name: str) -> Optional[str]:
-    """Return the absolute path of an executable"""
-    if not exec_name:
-        return None
-    return bool(shutil.which(exec_name))
-
-
 def can_find_executable(exec_name: str) -> bool:
     """Checks if an executable can be located; if false,
-    find_required_executable will raise an exception."""
-    return exec_name and bool(shutil.which(exec_name))
+    find_executable will raise an exception."""
+    return bool(exec_name) and bool(shutil.which(exec_name))
 
 
-def find_required_executable(exec_name: str) -> str:
-    """Return the absolute path of an executable, but raises an
-    exception if it could not be found."""
+def find_executable(exec_name: str) -> str:
+    """Return the absolute path of an executable, but raises a
+    MissingExecutableError if it could not be found."""
     if exec_name:
         exe = shutil.which(exec_name)
         if exe:
@@ -439,7 +431,7 @@ def get_pids_using_file(path):
         logger.error("Can't return PIDs using non existing file: %s", path)
         return set()
     try:
-        fuser_path = find_required_executable("fuser")
+        fuser_path = find_executable("fuser")
     except MissingExecutableError:
         logger.warning("fuser not available, please install psmisc")
         return set([])

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -243,7 +243,7 @@ def find_required_executable(exec_name: str) -> str:
     exception if it could not be found."""
     exe = find_executable(exec_name)
     if not exe:
-        raise RuntimeError(f"The executable '{exec_name}' could not be found.")
+        raise ValueError(_("The executable '%s' could not be found.") % exec_name)
     return exe
 
 

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -18,6 +18,7 @@ from typing import Optional
 from gi.repository import Gio, GLib
 
 from lutris import settings
+from lutris.exceptions import MissingExecutableError
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 
@@ -243,7 +244,7 @@ def find_required_executable(exec_name: str) -> str:
     exception if it could not be found."""
     exe = find_executable(exec_name)
     if not exe:
-        raise ValueError(_("The executable '%s' could not be found.") % exec_name)
+        raise MissingExecutableError(_("The executable '%s' could not be found.") % exec_name)
     return exe
 
 

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -3,7 +3,7 @@ import os
 from collections import OrderedDict
 from functools import lru_cache
 from gettext import gettext as _
-from typing import Dict, Generator, List, Optional, Tuple
+from typing import Dict, Generator, List, Tuple
 
 from lutris import settings
 from lutris.api import get_default_runner_version_info
@@ -177,7 +177,7 @@ def get_installed_wine_versions() -> List[str]:
     return list_system_wine_versions() + list_lutris_wine_versions() + list_proton_versions()
 
 
-def get_wine_path_for_version(version: Optional[str], config: dict = None) -> str:
+def get_wine_path_for_version(version: str, config: dict = None) -> str:
     """Return the absolute path of a wine executable for a given version,
     or the configured version if you don't ask for a version."""
     if not version and config:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -184,7 +184,7 @@ def get_wine_path_for_version(version: str, config: dict = None) -> str:
         version = config["version"]
 
     if not version:
-        raise UnspecifiedVersionError("The Wine version must be specified.")
+        raise UnspecifiedVersionError(_("The Wine version must be specified."))
 
     if version in WINE_PATHS:
         return system.find_executable(WINE_PATHS[version])

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -187,7 +187,7 @@ def get_wine_path_for_version(version: Optional[str], config: dict = None) -> st
         raise UnspecifiedVersionError("The Wine version must be specified.")
 
     if version in WINE_PATHS:
-        return system.find_required_executable(WINE_PATHS[version])
+        return system.find_executable(WINE_PATHS[version])
     if "Proton" in version:
         for proton_path in get_proton_paths():
             if os.path.isfile(os.path.join(proton_path, version, "dist/bin/wine")):

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 from typing import Dict, Generator, List, Optional, Tuple
 
 from lutris import settings
-from lutris.api import get_default_runner_version
+from lutris.api import get_default_runner_version_info
 from lutris.exceptions import UnavailableRunnerError
 from lutris.gui.dialogs import ErrorDialog
 from lutris.util import linux, system
@@ -230,13 +230,13 @@ def get_default_wine_version() -> str:
     """Return the default version of wine."""
     installed_versions = get_installed_wine_versions()
     if installed_versions:
-        default_version = get_default_runner_version("wine")
-        if default_version:
+        default_version = get_default_runner_version_info("wine")
+        if "version" in default_version and "architecture" in default_version:
             version = default_version["version"] + '-' + default_version["architecture"]
             if version in installed_versions:
                 return version
         return installed_versions[0]
-    raise UnavailableRunnerError("No versions of Wine are installed.")
+    raise UnavailableRunnerError(_("No versions of Wine are installed."))
 
 
 def get_system_wine_version(wine_path: str = "wine") -> str:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -7,7 +7,7 @@ from typing import Dict, Generator, List, Optional, Tuple
 
 from lutris import settings
 from lutris.api import get_default_runner_version_info
-from lutris.exceptions import UnavailableRunnerError, UnspecifiedVersionError
+from lutris.exceptions import MisconfigurationError, UnavailableRunnerError, UnspecifiedVersionError
 from lutris.gui.dialogs import ErrorDialog
 from lutris.util import linux, system
 from lutris.util.log import logger
@@ -145,7 +145,7 @@ def list_lutris_wine_versions() -> List[str]:
             wine_path = get_wine_path_for_version(version=dirname)
             if wine_path and os.path.isfile(wine_path):
                 versions.append(dirname)
-        except UnavailableRunnerError:
+        except MisconfigurationError:
             pass  # if it's not properly installed, skip it
     return versions
 

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -226,7 +226,7 @@ def is_fsync_supported() -> bool:
     return fsync.get_fsync_support()
 
 
-def get_default_wine_version() -> Optional[str]:
+def get_default_wine_version() -> str:
     """Return the default version of wine."""
     installed_versions = get_installed_wine_versions()
     if installed_versions:
@@ -236,7 +236,7 @@ def get_default_wine_version() -> Optional[str]:
             if version in installed_versions:
                 return version
         return installed_versions[0]
-    return None
+    raise UnavailableRunnerError("No versions of Wine are installed.")
 
 
 def get_system_wine_version(wine_path: str = "wine") -> str:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -262,8 +262,8 @@ def get_system_wine_version(wine_path: str = "wine") -> str:
     return version
 
 
-def get_real_executable(windows_executable: str, working_dir: str = None) -> Tuple[
-        str, List[str], Optional[str]]:
+def get_real_executable(windows_executable: str, working_dir: str) -> Tuple[
+        str, List[str], str]:
     """Given a Windows executable, return the real program
     capable of launching it along with necessary arguments."""
 

--- a/tests/runners/test_pcsx2.py
+++ b/tests/runners/test_pcsx2.py
@@ -9,10 +9,10 @@ class TestPCSX2Runner(unittest.TestCase):
     def setUp(self):
         self.runner = pcsx2()
 
-    @patch('lutris.util.system.path_exists')
-    def test_play_iso_does_not_exist(self, mock_path_exists):
+    @patch('os.path.isfile')
+    def test_play_iso_does_not_exist(self,  mock_isfile):
         main_file = '/invalid/path/to/iso'
-        mock_path_exists.return_value = False
+        mock_isfile.return_value = True
         mock_config = MagicMock()
         mock_config.game_config = {'main_file': main_file}
         mock_config.runner_config = MagicMock()
@@ -21,9 +21,11 @@ class TestPCSX2Runner(unittest.TestCase):
         self.assertEqual(self.runner.play(), expected)
 
     @patch('lutris.util.system.path_exists')
-    def test_play_fullscreen(self, mock_path_exists):
+    @patch('os.path.isfile')
+    def test_play_fullscreen(self, mock_path_exists, mock_isfile):
         main_file = '/valid/path/to/iso'
         mock_path_exists.return_value = True
+        mock_isfile.return_value = True
         mock_config = MagicMock()
         mock_config.game_config = {'main_file': main_file}
         mock_config.runner_config = {'fullscreen': True}
@@ -32,9 +34,11 @@ class TestPCSX2Runner(unittest.TestCase):
         self.assertEqual(self.runner.play(), expected)
 
     @patch('lutris.util.system.path_exists')
-    def test_play_full_boot(self, mock_path_exists):
+    @patch('os.path.isfile')
+    def test_play_full_boot(self, mock_path_exists, mock_isfile):
         main_file = '/valid/path/to/iso'
         mock_path_exists.return_value = True
+        mock_isfile.return_value = True
         mock_config = MagicMock()
         mock_config.game_config = {'main_file': main_file}
         mock_config.runner_config = {'full_boot': True}
@@ -43,9 +47,11 @@ class TestPCSX2Runner(unittest.TestCase):
         self.assertEqual(self.runner.play(), expected)
 
     @patch('lutris.util.system.path_exists')
-    def test_play_nogui(self, mock_path_exists):
+    @patch('os.path.isfile')
+    def test_play_nogui(self, mock_path_exists, mock_isfile):
         main_file = '/valid/path/to/iso'
         mock_path_exists.return_value = True
+        mock_isfile.return_value = True
         mock_config = MagicMock()
         mock_config.game_config = {'main_file': main_file}
         mock_config.runner_config = {'nogui': True}
@@ -54,9 +60,11 @@ class TestPCSX2Runner(unittest.TestCase):
         self.assertEqual(self.runner.play(), expected)
 
     @patch('lutris.util.system.path_exists')
-    def test_play(self, mock_path_exists):
+    @patch('os.path.isfile')
+    def test_play(self, mock_path_exists, mock_isfile):
         main_file = '/valid/path/to/iso'
         mock_path_exists.return_value = True
+        mock_isfile.return_value = True
         mock_config = MagicMock()
         mock_config.game_config = {'main_file': main_file}
         mock_config.runner_config = {

--- a/tests/runners/test_pcsx2.py
+++ b/tests/runners/test_pcsx2.py
@@ -10,7 +10,7 @@ class TestPCSX2Runner(unittest.TestCase):
         self.runner = pcsx2()
 
     @patch('os.path.isfile')
-    def test_play_iso_does_not_exist(self,  mock_isfile):
+    def test_play_iso_does_not_exist(self, mock_isfile):
         main_file = '/invalid/path/to/iso'
         mock_isfile.return_value = True
         mock_config = MagicMock()


### PR DESCRIPTION
The word of @strycore is that we don't want methods or functions returning Optional[T], and that means they should return a consistent type and not None, and when they can't they should raise an exception. This PR reworking all the Optional[T] we had like that.

This represents some churn, and likely introduces bugs. It certainly makes validation tighter; I had to tweak the PCSX2 unit test to pass even if PCSX2 is not installed. Most of the change is around selecting versions (especially Wine versions) and paths to executables.

Consider if this PR should wait until after 0.5.15. The only user value it delivers is improved error messages.

In many places we raise exceptions only to catch them a few frames up; mostly this is kept off the happy path, and does represent a failure even if we can log and continue. Sometimes, not so much. I do feel a bit dirty.

To minimize exceptions on the happy path, I've reworked the version selection for runners to use virtual methods on the runner, which have flag parameters. The method then still uses None, but only internally- it raises if it still has None for the version at the end.

We are raising more exceptions, so to tolerate this better I've modified the "default" key for configuration options so that it can be a callable. If so, it is called with exception handling so that if the default can't be generated, Lutris does not crash (though the option will be unavailable in the UI).

The exceptions themselves are a different too, with more of a hierarchy. Many exceptions now derive from LutrisError, and I've introduced a base class ``MisconfigurationError`` so I can catch a bunch of things at once, where once we checked for None. I also some additional specific exceptions.