### PR TITLE
Background download for new Wine updates

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -320,7 +320,7 @@ class Application(Gtk.Application):
         else:
             pci_ids = [" ".join([gpu["PCI_ID"], gpu["PCI_SUBSYS_ID"]]) for gpu in gpu_info["gpus"].values()]
             runtime_updater = RuntimeUpdater(pci_ids=pci_ids, force=self.force_updates)
-            if runtime_updater.has_updates:
+            if runtime_updater.has_updates():
                 init_dialog = LutrisInitDialog(runtime_updater)
                 init_dialog.run()
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -331,7 +331,7 @@ class LutrisInitDialog(Gtk.Dialog):
         self.show_all()
 
         self.connect("destroy", self.on_destroy)
-        AsyncCall(self.runtime_updater.update_runtimes, self.init_cb)
+        AsyncCall(self.runtime_updater.update_runtimes_at_startup, self.init_cb)
 
     def show_progress(self):
         self.progress.set_fraction(self.runtime_updater.percentage_completed())
@@ -348,7 +348,7 @@ class LutrisInitDialog(Gtk.Dialog):
         GLib.source_remove(self.progress_timeout)
         if self.runtime_updater.deferred_updates > 0:
             self.runtime_updater.startup = False
-            AsyncCall(self.runtime_updater.update_runtimes, None)
+            AsyncCall(self.runtime_updater.update_runtime_in_background, None)
         return True
 
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -346,6 +346,9 @@ class LutrisInitDialog(Gtk.Dialog):
 
     def on_destroy(self, window):
         GLib.source_remove(self.progress_timeout)
+        if self.runtime_updater.deferred_updates > 0:
+            self.runtime_updater.startup = False
+            AsyncCall(self.runtime_updater.update_runtimes, None)
         return True
 
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -346,7 +346,7 @@ class LutrisInitDialog(Gtk.Dialog):
 
     def on_destroy(self, window):
         GLib.source_remove(self.progress_timeout)
-        if self.runtime_updater.deferred_updates > 0:
+        if self.runtime_updater.has_updates(startup=False):
             AsyncCall(self.runtime_updater.update_runtime_in_background, None)
         return True
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -4,6 +4,8 @@ from gettext import gettext as _
 
 import gi
 
+from lutris.gui.widgets.notifications import send_notification
+
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
 
@@ -348,8 +350,14 @@ class LutrisInitDialog(Gtk.Dialog):
         GLib.source_remove(self.progress_timeout)
         if self.runtime_updater.deferred_updates > 0:
             self.runtime_updater.startup = False
-            AsyncCall(self.runtime_updater.update_runtime_in_background, None)
+            AsyncCall(self.runtime_updater.update_runtime_in_background, self.update_runtime_in_background_cb)
         return True
+
+    def update_runtime_in_background_cb(self, result, error):
+        completed = self.runtime_updater.completed_updates
+        if not error and completed:
+            text = _("Lutris has downloaded updates to %s. Restart Lutris to apply them.") % ", ".join(completed)
+            send_notification("Lutris updates ready", text)
 
 
 class InstallOrPlayDialog(ModalDialog):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -11,7 +11,6 @@ from gi.repository import Gdk, GLib, GObject, Gtk
 
 from lutris import api, settings
 from lutris.gui.widgets.log_text_view import LogTextView
-from lutris.gui.widgets.notifications import send_notification
 from lutris.util import datapath
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
@@ -348,15 +347,8 @@ class LutrisInitDialog(Gtk.Dialog):
     def on_destroy(self, window):
         GLib.source_remove(self.progress_timeout)
         if self.runtime_updater.deferred_updates > 0:
-            self.runtime_updater.startup = False
-            AsyncCall(self.runtime_updater.update_runtime_in_background, self.update_runtime_in_background_cb)
+            AsyncCall(self.runtime_updater.update_runtime_in_background, None)
         return True
-
-    def update_runtime_in_background_cb(self, result, error):
-        completed = self.runtime_updater.completed_updates
-        if not error and completed:
-            text = _("Lutris has downloaded updates to %s. Restart Lutris to apply them.") % ", ".join(completed)
-            send_notification("Lutris updates ready", text)
 
 
 class InstallOrPlayDialog(ModalDialog):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -4,8 +4,6 @@ from gettext import gettext as _
 
 import gi
 
-from lutris.gui.widgets.notifications import send_notification
-
 gi.require_version('Gdk', '3.0')
 gi.require_version('Gtk', '3.0')
 
@@ -13,6 +11,7 @@ from gi.repository import Gdk, GLib, GObject, Gtk
 
 from lutris import api, settings
 from lutris.gui.widgets.log_text_view import LogTextView
+from lutris.gui.widgets.notifications import send_notification
 from lutris.util import datapath
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -1,6 +1,7 @@
 """Runtime handling module"""
 import concurrent.futures
 import os
+import shutil
 import time
 from gettext import gettext as _
 from typing import Any, Callable, Dict, List, Tuple
@@ -301,7 +302,7 @@ class RuntimeUpdater:
                 continue
 
             if system.path_exists(staged_path):
-                os.rename(staged_path, version_path)
+                shutil.move(staged_path, version_path)
                 get_installed_wine_versions.cache_clear()
                 continue
 

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -212,6 +212,7 @@ class RuntimeUpdater:
         self.downloaders: Dict[Runtime, Downloader] = {}
         self.status_text = ""
         self.deferred_updates = 0
+        self.completed_updates: List[str] = []
 
         if RUNTIME_DISABLED:
             logger.warning("Runtime disabled. Safety not guaranteed.")
@@ -257,6 +258,7 @@ class RuntimeUpdater:
     def _perform_updates(self, startup: bool) -> None:
         self.startup = startup
         self.deferred_updates = 0
+        self.completed_updates = []
 
         # This can be called twice, once at startup, and once for deferred updates
         # while you play. No need to re-download runtime versions though.
@@ -317,6 +319,7 @@ class RuntimeUpdater:
             self.status_text = _("Extracting %s") % name
             extract_archive(archive_download_path, staged_path)
             os.remove(archive_download_path)
+            self.completed_updates.append(f"{name} ({runner_version})")
 
             get_installed_wine_versions.cache_clear()
 
@@ -347,6 +350,7 @@ class RuntimeUpdater:
                         downloader.join()
                     else:
                         runtime.download_components()
+                    self.completed_updates.append(name)
             except Exception as ex:
                 logger.exception("Unable to download %s: %s", name, ex)
 

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -27,6 +27,8 @@ sio = SettingsIO(CONFIG_FILE)
 RUNNER_DIR = sio.read_setting("runner_dir") or os.path.join(DATA_DIR, "runners")
 RUNTIME_DIR = sio.read_setting("runtime_dir") or os.path.join(DATA_DIR, "runtime")
 CACHE_DIR = sio.read_setting("cache_dir") or os.path.join(GLib.get_user_cache_dir(), "lutris")
+TMP_DIR = os.path.join(CACHE_DIR, "tmp")
+STAGING_DIR = os.path.join(CACHE_DIR, "staging")
 GAME_CONFIG_DIR = os.path.join(CONFIG_DIR, "games")
 RUNNERS_CONFIG_DIR = os.path.join(CONFIG_DIR, "runners")
 

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -28,7 +28,6 @@ RUNNER_DIR = sio.read_setting("runner_dir") or os.path.join(DATA_DIR, "runners")
 RUNTIME_DIR = sio.read_setting("runtime_dir") or os.path.join(DATA_DIR, "runtime")
 CACHE_DIR = sio.read_setting("cache_dir") or os.path.join(GLib.get_user_cache_dir(), "lutris")
 TMP_DIR = os.path.join(CACHE_DIR, "tmp")
-STAGING_DIR = os.path.join(CACHE_DIR, "staging")
 GAME_CONFIG_DIR = os.path.join(CONFIG_DIR, "games")
 RUNNERS_CONFIG_DIR = os.path.join(CONFIG_DIR, "runners")
 

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -1,5 +1,4 @@
 """Check to run at program start"""
-import os
 import sqlite3
 from gettext import gettext as _
 

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -40,7 +40,6 @@ def init_dirs():
         settings.SHADER_CACHE_DIR,
         settings.INSTALLER_CACHE_DIR,
         settings.TMP_DIR,
-        settings.STAGING_DIR
     ]
     for directory in directories:
         create_folder(directory)

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -40,7 +40,8 @@ def init_dirs():
         settings.CACHE_DIR,
         settings.SHADER_CACHE_DIR,
         settings.INSTALLER_CACHE_DIR,
-        os.path.join(settings.CACHE_DIR, "tmp"),
+        settings.TMP_DIR,
+        settings.STAGING_DIR
     ]
     for directory in directories:
         create_folder(directory)


### PR DESCRIPTION
This is minimal, but may quell the demands to stop updates to the runtime. I think the big issue is that the downloads block Lutris startup.

With this PR, Wine version updates (only!) do not. The Wine updates are big and frequent, and represent the biggest pain point, so I focused on them.

The download is deferred and runs in the background while you play.

1. The archive downloads to ~/.cache/lutris/tmp/whatever in the background, while you blast aliens.
2. The archive extracts to ~/.local/share/lutris/runners/wine/whatever in the background, while you stealth past mooks.
3. We clear the wine version cache, and your new Wine becomes available.

I'm relying on the extraction function to not leave a half-extracted Wine where it can be used; it appears to do this.

There is no UI *at all*. I'm working on that.