### PR TITLE
"Updates" tab for the Preferences Dialog

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -88,6 +88,8 @@ class Application(Gtk.Application):
         self.launch_ui_delegate = LaunchUIDelegate()
         self.install_ui_delegate = InstallUIDelegate()
 
+        self.gpu_info = {}
+
         self.running_games = Gio.ListStore.new(Game)
         self.app_windows = {}
         self.tray = None

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -343,11 +343,11 @@ class Application(Gtk.Application):
             screen = self.window.props.screen  # pylint: disable=no-member
             Gtk.StyleContext.add_provider_for_screen(screen, self.css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
 
-    def start_runtime_updates(self, gpu_info: Dict[str, Any]) -> None:
+    def start_runtime_updates(self) -> None:
         if os.environ.get("LUTRIS_SKIP_INIT"):
             logger.debug("Skipping initialization")
         else:
-            self.window.start_runtime_updates(self.force_updates, gpu_info)
+            self.window.start_runtime_updates(self.force_updates, self.gpu_info)
 
     def get_window_key(self, **kwargs):
         if kwargs.get("appid"):
@@ -475,7 +475,7 @@ class Application(Gtk.Application):
         if argc:
             migrate()
 
-        gpu_info = run_all_checks()
+        self.gpu_info = run_all_checks()
         if options.contains("dest"):
             dest_dir = options.lookup_value("dest").get_string()
         else:
@@ -757,7 +757,7 @@ class Application(Gtk.Application):
             self.launch_ui_delegate = self.window
             self.install_ui_delegate = self.window
             self.window.present()
-            self.start_runtime_updates(gpu_info)
+            self.start_runtime_updates()
             # If the Lutris GUI is started by itself, don't quit it when a game stops
             self.quit_on_game_exit = False
         return 0

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -25,7 +25,6 @@ import tempfile
 
 from datetime import datetime, timedelta
 from gettext import gettext as _
-from typing import Dict, Any
 
 import gi
 

--- a/lutris/gui/config/base_config_box.py
+++ b/lutris/gui/config/base_config_box.py
@@ -40,7 +40,7 @@ class BaseConfigBox(VBox):
         setting_value = settings.read_bool_setting(setting_key, default=default)
 
         if not warning_markup and not extra_widget:
-            box = self._get_inner_settings_box(setting_key, setting_value, label, self.on_setting_change)
+            box = self._get_inner_settings_box(setting_key, setting_value, label)
         else:
             if warning_markup:
                 def update_warning(active):
@@ -65,7 +65,7 @@ class BaseConfigBox(VBox):
         box.set_margin_bottom(12)
         return box
 
-    def _get_inner_settings_box(self, setting_key: str, setting_value: bool, label: bool,
+    def _get_inner_settings_box(self, setting_key: str, setting_value: bool, label: str,
                                 when_setting_changed: Callable[[bool], None] = None):
         box = Gtk.Box(
             orientation=Gtk.Orientation.HORIZONTAL,

--- a/lutris/gui/config/base_config_box.py
+++ b/lutris/gui/config/base_config_box.py
@@ -1,21 +1,23 @@
+from typing import Callable
+
 from gi.repository import Gtk
 
 from lutris import settings
+from lutris.gui.config.boxes import UnderslungMessageBox
 from lutris.gui.widgets.common import VBox
 
 
 class BaseConfigBox(VBox):
-    settings_options = {}
     settings_accelerators = {}
 
-    def get_section_label(self, text):
+    def get_section_label(self, text: str) -> Gtk.Label:
         label = Gtk.Label(visible=True)
         label.set_markup("<b>%s</b>" % text)
         label.set_alignment(0, 0.5)
         label.set_margin_bottom(8)
         return label
 
-    def get_description_label(self, text):
+    def get_description_label(self, text: str) -> Gtk.Label:
         label = Gtk.Label(visible=True)
         label.set_markup("%s" % text)
         label.set_line_wrap(True)
@@ -30,21 +32,47 @@ class BaseConfigBox(VBox):
         self.set_margin_right(80)
         self.set_margin_left(80)
 
-    def get_setting_box(self, setting_key, label):
+    def get_setting_box(self, setting_key: str, label: str,
+                        warning_markup: str = None,
+                        warning_condition: Callable[[bool], bool] = None) -> Gtk.Box:
+
+        setting_value = settings.read_setting(setting_key).casefold() == "true"
+
+        if not warning_markup:
+            box = self._get_inner_settings_box(setting_key, setting_value, label, self.on_setting_change)
+        else:
+            warning = UnderslungMessageBox("dialog-warning")
+
+            def update_warning(state):
+                visible = warning_condition(state) if warning_condition else state
+                warning.show_markup(warning_markup if visible else None)
+
+            def handle_setting_change(widget, state, key):
+                self.on_setting_change(widget, state, key)
+                update_warning(state)
+
+            update_warning(setting_value)
+            inner_box = self._get_inner_settings_box(setting_key, setting_value, label, handle_setting_change)
+            box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6, visible=True)
+            box.pack_start(inner_box, False, False, 0)
+            box.pack_start(warning, False, False, 0)
+
+        box.set_margin_top(12)
+        box.set_margin_bottom(12)
+        return box
+
+    def _get_inner_settings_box(self, setting_key, setting_value, label, change_handler):
         box = Gtk.Box(
+            orientation=Gtk.Orientation.HORIZONTAL,
             spacing=12,
-            margin_top=12,
-            margin_bottom=12,
             visible=True
         )
         label = Gtk.Label(label, visible=True)
         label.set_alignment(0, 0.5)
         box.pack_start(label, True, True, 12)
         checkbox = Gtk.Switch(visible=True)
-
-        if settings.read_setting(setting_key).lower() == "true":
-            checkbox.set_active(True)
-        checkbox.connect("state-set", self.on_setting_change, setting_key)
+        checkbox.set_active(setting_value)
+        checkbox.connect("state-set", change_handler, setting_key)
 
         if setting_key in self.settings_accelerators:
             key, mod = Gtk.accelerator_parse(self.settings_accelerators[setting_key])
@@ -53,7 +81,7 @@ class BaseConfigBox(VBox):
         box.pack_start(checkbox, False, False, 12)
         return box
 
-    def on_setting_change(self, widget, state, setting_key):
+    def on_setting_change(self, _widget, state, setting_key):
         """Save a setting when an option is toggled"""
         settings.write_setting(setting_key, state)
         self.get_toplevel().emit("settings-changed", state, setting_key)

--- a/lutris/gui/config/base_config_box.py
+++ b/lutris/gui/config/base_config_box.py
@@ -33,10 +33,11 @@ class BaseConfigBox(VBox):
         self.set_margin_left(80)
 
     def get_setting_box(self, setting_key: str, label: str,
+                        default: bool = False,
                         warning_markup: str = None,
                         warning_condition: Callable[[bool], bool] = None) -> Gtk.Box:
 
-        setting_value = settings.read_setting(setting_key).casefold() == "true"
+        setting_value = settings.read_bool_setting(setting_key, default=default)
 
         if not warning_markup:
             box = self._get_inner_settings_box(setting_key, setting_value, label, self.on_setting_change)

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -40,7 +40,7 @@ class UpdatePreferencesBox(BaseConfigBox):
         "auto_update_runtime": {
             "label": _("Automatically update the Lutris runtime"),
         },
-        "auto_update_wine": {
+        "auto_update_runners": {
             "label": _("Automatically update Wine"),
             "warning": _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine.")
         }

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -1,9 +1,24 @@
 from gettext import gettext as _
 
 from gi.repository import Gtk, Gio
+
+from lutris.gui.dialogs import ErrorDialog
 from lutris.runtime import RuntimeUpdater
 
 from lutris.gui.config.base_config_box import BaseConfigBox
+
+
+def trigger_runtime_update(parent):
+    application = Gio.Application.get_default()
+    if application:
+        window = application.window
+        if window:
+            if window.download_queue.is_empty:
+                updater = RuntimeUpdater(application.gpu_info)
+                updater.update_runtime = True
+                window.install_runtime_updates(updater)
+            else:
+                ErrorDialog(_("Updates cannot begin while downloads are already underway."), parent=parent)
 
 
 class InterfacePreferencesBox(BaseConfigBox):
@@ -34,16 +49,6 @@ class InterfacePreferencesBox(BaseConfigBox):
             list_box_row.set_activatable(False)
             list_box_row.add(self.get_setting_box(setting_key, label))
             listbox.add(list_box_row)
-
-
-def trigger_runtime_update():
-    application = Gio.Application.get_default()
-    if application:
-        window = application.window
-        if window:
-            updater = RuntimeUpdater(application.gpu_info)
-            updater.update_runtime = True
-            window.install_runtime_updates(updater)
 
 
 class UpdatePreferencesBox(BaseConfigBox):
@@ -79,7 +84,7 @@ class UpdatePreferencesBox(BaseConfigBox):
 
             if update_function:
                 def on_update_now_clicked(_widget, func):
-                    func()
+                    func(self.get_toplevel())
 
                 update_button = Gtk.Button(_("Update Now"), halign=Gtk.Align.END, visible=True)
                 update_button.connect("clicked", on_update_now_clicked, update_function)

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -33,3 +33,33 @@ class InterfacePreferencesBox(BaseConfigBox):
             list_box_row.set_activatable(False)
             list_box_row.add(self.get_setting_box(setting_key, label))
             listbox.add(list_box_row)
+
+
+class UpdatePreferencesBox(BaseConfigBox):
+    settings_options = {
+        "auto_update_runtime": {
+            "label": _("Automatically update the Lutris runtime"),
+        },
+        "auto_update_wine": {
+            "label": _("Automatically update Wine"),
+            "warning": _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine.")
+        }
+    }
+
+    def __init__(self):
+        super().__init__()
+        self.add(self.get_section_label(_("Update options")))
+        frame = Gtk.Frame(visible=True, shadow_type=Gtk.ShadowType.ETCHED_IN)
+        listbox = Gtk.ListBox(visible=True)
+        frame.add(listbox)
+        self.pack_start(frame, False, False, 12)
+        for setting_key, setting_option in self.settings_options.items():
+            label = setting_option["label"]
+            warning_markup = setting_option.get("warning")
+            warning_condition = setting_option.get("warning_condition")
+
+            list_box_row = Gtk.ListBoxRow(visible=True)
+            list_box_row.set_selectable(False)
+            list_box_row.set_activatable(False)
+            list_box_row.add(self.get_setting_box(setting_key, label, warning_markup, warning_condition))
+            listbox.add(list_box_row)

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -1,14 +1,13 @@
 from gettext import gettext as _
 
-from gi.repository import Gtk, Gio
+from gi.repository import Gio, Gtk
 
+from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.gui.dialogs import ErrorDialog
 from lutris.runtime import RuntimeUpdater
 
-from lutris.gui.config.base_config_box import BaseConfigBox
 
-
-def trigger_runtime_update(parent):
+def trigger_runtime_updates(parent):
     application = Gio.Application.get_default()
     if application:
         window = application.window
@@ -16,6 +15,19 @@ def trigger_runtime_update(parent):
             if window.download_queue.is_empty:
                 updater = RuntimeUpdater(application.gpu_info)
                 updater.update_runtime = True
+                window.install_runtime_updates(updater)
+            else:
+                ErrorDialog(_("Updates cannot begin while downloads are already underway."), parent=parent)
+
+
+def trigger_runner_updates(parent):
+    application = Gio.Application.get_default()
+    if application:
+        window = application.window
+        if window:
+            if window.download_queue.is_empty:
+                updater = RuntimeUpdater(application.gpu_info)
+                updater.update_runners = True
                 window.install_runtime_updates(updater)
             else:
                 ErrorDialog(_("Updates cannot begin while downloads are already underway."), parent=parent)
@@ -56,11 +68,12 @@ class UpdatePreferencesBox(BaseConfigBox):
         "auto_update_runtime": {
             "label": _("Automatically update the Lutris runtime"),
             "default": True,
-            "update_function": trigger_runtime_update
+            "update_function": trigger_runtime_updates
         },
         "auto_update_runners": {
             "label": _("Automatically update Wine"),
             "default": True,
+            "update_function": trigger_runner_updates,
             "warning":
                 _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine.\n"
                   "<i>Automatic Wine updates are strongly recommended.</i>"),

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -44,8 +44,10 @@ class UpdatePreferencesBox(BaseConfigBox):
         "auto_update_runners": {
             "label": _("Automatically update Wine"),
             "default": True,
-            "warning": _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine."),
-            "warning_condition": lambda state: not state
+            "warning":
+                _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine.\n"
+                  "<i>Automatic Wine updates are strongly recommended.</i>"),
+            "warning_condition": lambda active: not active
         }
     }
 

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -39,10 +39,13 @@ class UpdatePreferencesBox(BaseConfigBox):
     settings_options = {
         "auto_update_runtime": {
             "label": _("Automatically update the Lutris runtime"),
+            "default": True,
         },
         "auto_update_runners": {
             "label": _("Automatically update Wine"),
-            "warning": _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine.")
+            "default": True,
+            "warning": _("<b>Warning</b> The Lutris Team does not support running games on old version of Wine."),
+            "warning_condition": lambda state: not state
         }
     }
 
@@ -55,11 +58,14 @@ class UpdatePreferencesBox(BaseConfigBox):
         self.pack_start(frame, False, False, 12)
         for setting_key, setting_option in self.settings_options.items():
             label = setting_option["label"]
+            default = setting_option["default"]
             warning_markup = setting_option.get("warning")
             warning_condition = setting_option.get("warning_condition")
 
             list_box_row = Gtk.ListBoxRow(visible=True)
             list_box_row.set_selectable(False)
             list_box_row.set_activatable(False)
-            list_box_row.add(self.get_setting_box(setting_key, label, warning_markup, warning_condition))
+            list_box_row.add(self.get_setting_box(setting_key, label, default=default,
+                                                  warning_markup=warning_markup,
+                                                  warning_condition=warning_condition))
             listbox.add(list_box_row)

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -60,7 +60,7 @@ class UpdatePreferencesBox(BaseConfigBox):
         self.pack_start(frame, False, False, 12)
         for setting_key, setting_option in self.settings_options.items():
             label = setting_option["label"]
-            default = setting_option["default"]
+            default = setting_option.get("default") or False
             warning_markup = setting_option.get("warning")
             warning_condition = setting_option.get("warning_condition")
 

--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -76,12 +76,12 @@ class InterfacePreferencesBox(BaseConfigBox):
 class UpdatePreferencesBox(BaseConfigBox):
     settings_options = {
         "auto_update_runtime": {
-            "label": _("Automatically update the Lutris runtime"),
+            "label": _("Automatically Update the Lutris runtime"),
             "default": True,
             "update_function": trigger_runtime_updates
         },
         "auto_update_runners": {
-            "label": _("Automatically update Wine"),
+            "label": _("Automatically Update Wine"),
             "default": True,
             "update_function": trigger_runner_updates,
             "warning":

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -8,7 +8,7 @@ from lutris.config import LutrisConfig
 from lutris.gui.config.accounts_box import AccountsBox
 from lutris.gui.config.boxes import SystemBox
 from lutris.gui.config.common import GameDialogCommon
-from lutris.gui.config.preferences_box import InterfacePreferencesBox
+from lutris.gui.config.preferences_box import InterfacePreferencesBox, UpdatePreferencesBox
 from lutris.gui.config.runners_box import RunnersBox
 from lutris.gui.config.services_box import ServicesBox
 from lutris.gui.config.sysinfo_box import SysInfoBox
@@ -36,6 +36,7 @@ class PreferencesDialog(GameDialogCommon):
         sidebar.add(self.get_sidebar_button("runners-stack", _("Runners"), "applications-utilities-symbolic"))
         sidebar.add(self.get_sidebar_button("services-stack", _("Sources"), "application-x-addon-symbolic"))
         sidebar.add(self.get_sidebar_button("accounts-stack", _("Accounts"), "system-users-symbolic"))
+        sidebar.add(self.get_sidebar_button("updates-stack", _("Updates"), "system-software-install-symbolic"))
         sidebar.add(self.get_sidebar_button("sysinfo-stack", _("Hardware information"), "computer-symbolic"))
         sidebar.add(self.get_sidebar_button("system-stack", _("Global options"), "emblem-system-symbolic"))
         hbox.pack_start(sidebar, False, False, 0)
@@ -64,6 +65,11 @@ class PreferencesDialog(GameDialogCommon):
         self.stack.add_named(
             self.build_scrolled_window(AccountsBox()),
             "accounts-stack"
+        )
+
+        self.stack.add_named(
+            self.build_scrolled_window(UpdatePreferencesBox()),
+            "updates-stack"
         )
 
         sysinfo_box = SysInfoBox()

--- a/lutris/gui/download_queue.py
+++ b/lutris/gui/download_queue.py
@@ -34,6 +34,11 @@ class DownloadQueue(Gtk.ScrolledWindow):
         except AttributeError:
             pass
 
+    @property
+    def is_empty(self):
+        """True if the queue has no progress boxes in it."""
+        return not bool(self.progress_boxes)
+
     def add_progress_box(self, progress_function: ProgressBox.ProgressFunction) -> ProgressBox:
         """Adds a progress box to the queue; it will display the progress indicated by
         the progress_function, which is called immediately to initialize the box and

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1154,11 +1154,11 @@ class LutrisWindow(Gtk.ApplicationWindow,
             if error:
                 logger.exception("Failed to obtain updates from Lutris.net: %s", error)
             elif runtime_updater.has_updates:
-                self._install_runtime_updates(runtime_updater)
+                self.install_runtime_updates(runtime_updater)
 
         AsyncCall(create_runtime_updater, create_runtime_updater_cb)
 
-    def _install_runtime_updates(self, runtime_updater: RuntimeUpdater) -> None:
+    def install_runtime_updates(self, runtime_updater: RuntimeUpdater) -> None:
         """Installs runtime updates, once we know there are any. This displays progress bars
         in the sidebar as it installs updates, one at a time."""
 

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -161,6 +161,9 @@ class RuntimeUpdater:
         elif force:
             self.update_runtime = True
             self.update_runners = True
+        elif not check_stale_runtime_versions():
+            self.update_runtime = False
+            self.update_runners = False
         else:
             self.update_runtime = settings.read_bool_setting("auto_update_runtime", default=True)
             self.update_runners = settings.read_bool_setting("auto_update_runners", default=True)

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -162,8 +162,8 @@ class RuntimeUpdater:
             self.update_runtime = True
             self.update_runners = True
         else:
-            self.update_runtime = settings.read_bool_setting("auto_update_runtime")
-            self.update_runners = settings.read_bool_setting("auto_update_runners")
+            self.update_runtime = settings.read_bool_setting("auto_update_runtime", default=True)
+            self.update_runners = settings.read_bool_setting("auto_update_runners", default=True)
 
     @property
     def has_updates(self):

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -168,6 +168,11 @@ class RuntimeUpdater:
             self.update_runtime = settings.read_bool_setting("auto_update_runtime", default=True)
             self.update_runners = settings.read_bool_setting("auto_update_runners", default=True)
 
+            if not self.update_runtime:
+                logger.warning("Lutris runtime updates have been disabled by the configuration.")
+            if not self.update_runners:
+                logger.warning("Runner updates have been disabled by the configuration.")
+
     @property
     def has_updates(self):
         return self.update_runtime or self.update_runners

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -65,6 +65,7 @@ DEFAULT_RESOLUTION_WIDTH = sio.read_setting("default_resolution_width", default=
 DEFAULT_RESOLUTION_HEIGHT = sio.read_setting("default_resolution_height", default="720")
 
 read_setting = sio.read_setting
+read_bool_setting = sio.read_bool_setting
 write_setting = sio.write_setting
 
 

--- a/lutris/util/settings.py
+++ b/lutris/util/settings.py
@@ -5,7 +5,6 @@ from lutris.util.log import logger
 
 
 class SettingsIO:
-
     """ConfigParser abstraction."""
 
     def __init__(self, config_file):
@@ -31,6 +30,15 @@ class SettingsIO:
             return self.config.get(section, key)
         except (configparser.NoOptionError, configparser.NoSectionError):
             return default
+
+    def read_bool_setting(self, key: str, default: bool = False, section="lutris") -> bool:
+        text = self.read_setting(key, "", section=section).casefold()
+        if text == "true":
+            return True
+        if text == "false":
+            return False
+
+        return default
 
     def write_setting(self, key, value, section="lutris"):
         if not self.config.has_section(section):


### PR DESCRIPTION
We'll probably mean to add more stuff here, but here's basic control over automatic updates:

![image](https://github.com/lutris/lutris/assets/6507403/5ee92085-ab2e-45e8-96d2-410ac08e887d)

Not very fine grained; "Automatically update the Lutris runtime" determines if anything in the ~/.local/share/lutris/runtime gets auto-upgrades. "Automatically update Wine" actually controls if we update ~/.local/share/lutris/runners, but we only update Wine in there at present.

A warning appears if you turn off Wine updates, but not for runtime updates. The '--force' command line arg overrides these settings and causes everything to get updated anyway.

The 'Update Now' buttons trigger the normal update procedure for one or the other directory; progress is displayed in the Lutris window as per normal. An error dialog appears if no updates can be queued either because there just are none to make, or because the download queue is busy.

The behavior here- no updates while the download queue has anything in it- is meant to block users from queuing up the same updates over and over, and is easy to implement. Something more fine grained would be nicer though.