### PR TITLE
Allow user to set cache directory in settings and also delete existing cache files

### DIFF
--- a/lutris/config.py
+++ b/lutris/config.py
@@ -9,6 +9,7 @@ from lutris.runners import InvalidRunner, import_runner
 from lutris.util.log import logger
 from lutris.util.system import path_exists
 from lutris.util.yaml import read_yaml_from_file, write_yaml_to_file
+from lutris.cache import save_cache_path
 
 
 def make_game_config_id(game_slug: str) -> str:
@@ -138,6 +139,12 @@ class LutrisConfig:
         self.game_level.update(read_yaml_from_file(self.game_config_path))
         self.runner_level.update(read_yaml_from_file(self.runner_config_path))
         self.system_level.update(read_yaml_from_file(self.system_config_path))
+
+        self.default_cache_directory = read_yaml_from_file(self.system_config_path).get("system").get("default_cache_directory")
+        if self.default_cache_directory:
+            save_cache_path(self.default_cache_directory)
+        else:
+            save_cache_path("")
 
         self.update_cascaded_config()
         self.update_raw_config()

--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -333,6 +333,8 @@ class ConfigBox(VBox):
     #Purge Cache Function
     def purge_cache(self, widget):
         self.cache_path = get_cache_path()
+        if not self.cache_path:
+            self.cache_path = os.path.join(GLib.get_user_cache_dir(), "lutris", "installer")
         if self.cache_path:
             for filename in os.listdir(self.cache_path):
                 file_path = os.path.join(self.cache_path, filename)
@@ -341,17 +343,6 @@ class ConfigBox(VBox):
                     os.remove(file_path)
                 elif os.path.isdir(file_path):
                     shutil.rmtree(file_path)
-        else:
-            self.cache_path = os.path.join(GLib.get_user_cache_dir(), "lutris", "installer")
-            if self.cache_path:
-                for filename in os.listdir(self.cache_path):
-                    file_path = os.path.join(self.cache_path, filename)
-
-                    if os.path.isfile(file_path):
-                        os.remove(file_path)
-                    elif os.path.isdir(file_path):
-                        shutil.rmtree(file_path)
-
 
     # Label
     def generate_label(self, text):

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -143,7 +143,21 @@ system_options = [  # pylint: disable=invalid-name
         "help": _("When the runtime is enabled, prioritize the system libraries"
                   " over the provided ones."),
     },
-
+    {
+        "section": "Lutris",
+        "option": "default_cache_directory",
+        "type": "directory_chooser",
+        "label": _("Installer Save Location (If left empty, installer files are discarded after install completion.)"),
+        "default": "",
+        "help": _("Set where by default downloaded installer files will be saved. If left empty, installer files are discarded after install completion.")
+    },
+    {
+        "section": "Lutris",
+        "option": "installer_cache",
+        "type": "cache_button",
+        "label": _("Delete Cached Installer Files"),
+        "help": _("Delete all files from download cache")
+    },
     {
         "section": "Gamescope",
         "option": "gamescope",


### PR DESCRIPTION
Adds the ability to set cache folder, i.e. installer download location globally in global settings.

Also added a button that on click will delete all the cached installer files.

Closes #3695 