### PR TITLE
Add two new sizes for itch.io banners

### DIFF
--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -42,6 +42,16 @@ class ItchIoCover(ServiceMedia):
         return
 
 
+class ItchIoCoverMedium(ItchIoCover):
+    """itch.io game cover, at 60% size"""
+    size = (189, 150)
+
+
+class ItchIoCoverSmall(ItchIoCover):
+    """itch.io game cover, at 30% size"""
+    size = (95, 75)
+
+
 class ItchIoGame(ServiceGame):
     """itch.io Game"""
     service = "itchio"
@@ -82,6 +92,8 @@ class ItchIoService(OnlineService):
     drm_free = True
     has_extras = True
     medias = {
+        "banner_small": ItchIoCoverSmall,
+        "banner_med": ItchIoCoverMedium,
         "banner": ItchIoCover,
     }
     default_format = "banner"


### PR DESCRIPTION
Now that I have an itch.io account and and a whole game, I see some room for improvement. The itch.io banners are quite large (315, 250). Okay if you have one game, but if you have two?

We do medium cover-art by scaling with Cairo, and it's quite simple to use that here. So:

Medium size is 60% size (189, 150)
![image](https://github.com/lutris/lutris/assets/6507403/15f66715-897e-412a-b5a7-2800a7e356e1)

Small is 30% size (95, 75)
![image](https://github.com/lutris/lutris/assets/6507403/312d77f6-4d8f-4e63-a1c8-9bb637222a9d)

The small size makes the list view more usable, I think:
![image](https://github.com/lutris/lutris/assets/6507403/b3885458-8ac2-4f84-aa79-5f3d7ca0b4a3)
Still a bit much, but we don't have actual icons from itch.io, so itty bitty banners will have to do.

This should resolve #4951. But I totally thought of this on my own, honest!