### PR TITLE
Hidden Runner Switches

### DIFF
--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -368,7 +368,7 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         """Build a ListStore with available runners."""
         runner_liststore = Gtk.ListStore(str, str)
         runner_liststore.append((_("Select a runner from the list"), ""))
-        for runner in runners.get_installed():
+        for runner in runners.get_installed_runners():
             description = runner.description
             runner_liststore.append(("%s (%s)" % (runner.human_name, description), runner.name))
         return runner_liststore

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -75,7 +75,7 @@ class RunnerBox(Gtk.Box):
         self.visible_switch.set_visible(is_installed)
 
     def on_visible_checkbox_changed(self, _widget, state, runner_name):
-        """Save a setting when an option is toggled"""
+        """Save the visibility when it is toggled."""
         settings.write_setting(runner_name, state, section="runners")
         self.emit("runners-changed")
 
@@ -121,7 +121,10 @@ class RunnerBox(Gtk.Box):
             ErrorDialog(ex.message, parent=self.get_toplevel())
             return
         if self.runner.is_installed():
-            self.emit("runners-changed")
+            if not self.visible_switch.get_active():
+                self.visible_switch.set_active(True)
+            else:
+                self.emit("runners-changed")
         else:
             ErrorDialog("Runner failed to install", parent=self.get_toplevel())
 

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -53,10 +53,12 @@ class RunnerBox(Gtk.Box):
         if settings.read_bool_setting(runner_name, default=True, section="runners"):
             self.visible_switch.set_active(True)
         self.visible_switch.connect("state-set", self.on_visible_checkbox_changed, runner_name)
+        self.visible_switch.set_tooltip_text(_("Visibility in the sidebar"))
 
         self.pack_start(self.visible_switch, False, False, 12)
 
         self.configure_button = Gtk.Button.new_from_icon_name("preferences-system-symbolic", Gtk.IconSize.BUTTON)
+        self.configure_button.set_tooltip_text(_("Runner configuration"))
         self.configure_button.set_valign(Gtk.Align.CENTER)
         self.configure_button.set_margin_right(12)
         self.configure_button.connect("clicked", self.on_configure_clicked)
@@ -80,19 +82,22 @@ class RunnerBox(Gtk.Box):
         self.emit("runners-changed")
 
     def get_action_button(self):
-        """Return a install or remove button"""
+        """Return an install or remove button"""
         if self.runner.multiple_versions:
             _button = Gtk.Button.new_from_icon_name("system-software-install-symbolic", Gtk.IconSize.BUTTON)
+            _button.set_tooltip_text(_("Manage runner versions"))
             _button.get_style_context().add_class("circular")
             _button.connect("clicked", self.on_versions_clicked)
         else:
             if self.runner.can_uninstall():
                 _button = Gtk.Button.new_from_icon_name("edit-delete-symbolic", Gtk.IconSize.BUTTON)
+                _button.set_tooltip_text(_("Remove runner"))
                 _button.get_style_context().add_class("circular")
                 _button.connect("clicked", self.on_remove_clicked)
                 _button.set_sensitive(self.runner.can_uninstall())
             else:
                 _button = Gtk.Button.new_from_icon_name("system-software-install-symbolic", Gtk.IconSize.BUTTON)
+                _button.set_tooltip_text(_("Remove runner"))
                 _button.get_style_context().add_class("circular")
                 _button.connect("clicked", self.on_install_clicked)
                 _button.set_sensitive(not self.runner.is_installed(flatpak_allowed=False))
@@ -122,7 +127,7 @@ class RunnerBox(Gtk.Box):
             return
         if self.runner.is_installed():
             if not self.visible_switch.get_active():
-                self.visible_switch.set_active(True)
+                self.visible_switch.set_active(True)  # raises runners-changed
             else:
                 self.emit("runners-changed")
         else:

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -523,7 +523,7 @@ class LutrisSidebar(Gtk.ListBox):
 
         self.used_categories = {c["name"] for c in categories}
         self.active_services = services.get_enabled_services()
-        self.installed_runners = [runner.name for runner in runners.get_installed()]
+        self.installed_runners = [runner.name for runner in runners.get_visible_runners()]
         self.active_platforms = games_db.get_used_platforms()
 
         for service_name, service_class in self.active_services.items():

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -353,8 +353,7 @@ class LutrisSidebar(Gtk.ListBox):
             "runner": SidebarHeader(_("Runners"), header_index=3),
             "platform": SidebarHeader(_("Platforms"), header_index=4),
         }
-        GObject.add_emission_hook(RunnerBox, "runner-installed", self.update_rows)
-        GObject.add_emission_hook(RunnerBox, "runner-removed", self.update_rows)
+        GObject.add_emission_hook(RunnerBox, "runners-changed", self.update_rows)
         GObject.add_emission_hook(ScriptInterpreter, "runners-installed", self.update_rows)
         GObject.add_emission_hook(ServicesBox, "services-changed", self.update_rows)
         GObject.add_emission_hook(Game, "game-start", self.on_game_start)
@@ -483,7 +482,7 @@ class LutrisSidebar(Gtk.ListBox):
         else:
             header = None
 
-        if row.get_header() != header:
+        if header and row.get_header() != header:
             # GTK is messy here; a header can't belong to two rows at once,
             # so we must remove it from the one that owns it, if any, and
             # also from the sidebar itself. Then we can reuse it.

--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -44,6 +44,8 @@ __all__ = [
     "zdoom",
 ]
 
+from lutris import settings
+
 ADDON_RUNNERS = {}
 _cached_runner_human_names = {}
 
@@ -100,7 +102,9 @@ def get_installed(sort=True):
     for runner_name in __all__:
         runner = import_runner(runner_name)()
         if runner.is_installed():
-            installed.append(runner)
+            visible = settings.read_bool_setting(runner_name, default=True, section="runners")
+            if visible:
+                installed.append(runner)
     return sorted(installed) if sort else installed
 
 

--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -96,16 +96,26 @@ def import_task(runner, task):
     return getattr(runner_module, task)
 
 
-def get_installed(sort=True):
+def get_installed_runners(sort=True):
     """Return a list of installed runners (class instances)."""
     installed = []
     for runner_name in __all__:
         runner = import_runner(runner_name)()
         if runner.is_installed():
-            visible = settings.read_bool_setting(runner_name, default=True, section="runners")
-            if visible:
-                installed.append(runner)
+            installed.append(runner)
     return sorted(installed) if sort else installed
+
+
+def get_visible_runners(sort=True):
+    """Return a list of installed runners that are not hidden."""
+    runners = []
+    for runner_name in __all__:
+        visible = settings.read_bool_setting(runner_name, default=True, section="runners")
+        if visible:
+            runner = import_runner(runner_name)()
+            if runner.is_installed():
+                runners.append(runner)
+    return sorted(runners) if sort else runners
 
 
 def inject_runners(runners):

--- a/tests/test_dialogs.py
+++ b/tests/test_dialogs.py
@@ -16,9 +16,9 @@ class TestGameDialogCommon(TestCase):
         dlg = GameDialogCommon("test")
         list_store = dlg._get_runner_liststore()
         self.assertTrue(
-            list_store[1][0].startswith(runners.get_installed()[0].human_name)
+            list_store[1][0].startswith(runners.get_installed_runners()[0].human_name)
         )
-        self.assertEqual(list_store[1][1], runners.get_installed()[0].name)
+        self.assertEqual(list_store[1][1], runners.get_installed_runners()[0].name)
 
 
 class TestGameDialog(TestCase):


### PR DESCRIPTION
This is a simple feature, but I've wanted this for a while. It's an option to hide runners from the sidebar using switches, similar to what you get in 'Sources'. Like this:

![image](https://github.com/lutris/lutris/assets/6507403/d1e909fd-752c-40f2-8b81-74dd291c3d0a)

You only get switches on installed runners, but that includes the Linux and Flatpak runners and those runners that are found though flatpak. The main reason I want this is because I can't really uninstall these guys, but I don't want them to clutter up my sidebar.

This affects only the sidebar; games can still use hidden runners.

These settings are kept in ~/.config/lutris/lutris.conf; it's meant to be very like the sources switches.

I'm not wholly sold on this UI, since these switches aren't labelled. I did put tool-tips on the switches and buttons. But it resembles the 'Sources' tab, and it does not interfere with the install/remove button.

I also considered presenting this as a 'remove' option on flatpak, linux, and so on, and that would actually just hide the things. But while I want to hide the flatpak provided runners, there is also an option to install the native version instead, and I would not wish to displace that. So, separate switches.