### PR TITLE
Hidden Runner Option

### DIFF
--- a/lutris/gui/config/runner.py
+++ b/lutris/gui/config/runner.py
@@ -1,5 +1,7 @@
 from gettext import gettext as _
 
+from gi.repository import GObject
+
 from lutris.config import LutrisConfig
 from lutris.gui.config.common import GameDialogCommon
 from lutris.runners import get_runner_human_name
@@ -7,6 +9,10 @@ from lutris.runners import get_runner_human_name
 
 class RunnerConfigDialog(GameDialogCommon):
     """Runner config edit dialog."""
+
+    __gsignals__ = {
+        "runner-updated": (GObject.SIGNAL_RUN_FIRST, None, (str,)),
+    }
 
     def __init__(self, runner, parent=None):
         super().__init__(_("Configure %s") % runner.human_name, config_level="runner", parent=parent)
@@ -20,6 +26,7 @@ class RunnerConfigDialog(GameDialogCommon):
     def get_search_entry_placeholder(self):
         return _("Search %s options") % get_runner_human_name(self.runner_name)
 
-    def on_save(self, wigdet, data=None):
+    def on_save(self, _wigdet, data=None):
         self.lutris_config.save()
+        self.emit("runner-updated", self.runner_name)
         self.destroy()

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -5,6 +5,7 @@ from gettext import gettext as _
 from gi.repository import GLib, GObject, Gtk, Pango
 
 from lutris import runners, services
+from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.exceptions import watch_errors
@@ -466,7 +467,11 @@ class LutrisSidebar(Gtk.ListBox):
         if row.type == "runner":
             if row.id is None:
                 return True  # 'All'
-            return row.id in self.installed_runners
+            if row.id in self.installed_runners:
+                runner_config = LutrisConfig(runner_slug=row.id)
+                return runner_config.system_config.get("visible_in_side_panel", True)
+            else:
+                return False
         return row.id in self.active_platforms
 
     def _header_func(self, row, before):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -498,7 +498,7 @@ class LutrisSidebar(Gtk.ListBox):
         else:
             header = None
 
-        if row.get_header() != header:
+        if header and row.get_header() != header:
             # GTK is messy here; a header can't belong to two rows at once,
             # so we must remove it from the one that owns it, if any, and
             # also from the sidebar itself. Then we can reuse it.

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -463,7 +463,7 @@ class LutrisSidebar(Gtk.ListBox):
         def is_runner_visible(runner_name):
             if runner_name not in self.runner_visibility_cache:
                 runner_config = LutrisConfig(runner_slug=row.id)
-                self.runner_visibility_cache[runner_name] = runner_config.system_config.get(
+                self.runner_visibility_cache[runner_name] = runner_config.runner_config.get(
                     "visible_in_side_panel", True)
             return self.runner_visibility_cache[runner_name]
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -167,6 +167,19 @@ class Runner:  # pylint: disable=too-many-public-methods
                     "advanced": True,
                 }
             )
+
+        runner_options.append(
+            {
+                "section": _("Side Panel"),
+                "option": "visible_in_side_panel",
+                "type": "bool",
+                "label": _("Visible in Side Panel"),
+                "default": True,
+                "advanced": True,
+                "scope": ["runner"],
+                "help": _("Show this runner in the side panel if it is installed or available through Flatpak.")
+            }
+        )
         return runner_options
 
     def get_executable(self) -> str:

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -608,17 +608,6 @@ system_options = [  # pylint: disable=invalid-name
         "advanced": True,
         "help": _("Open Xephyr in fullscreen (at the desktop resolution)"),
     },
-
-    {
-        "section": _("Side Panel"),
-        "option": "visible_in_side_panel",
-        "type": "bool",
-        "label": _("Visible in Side Panel"),
-        "default": True,
-        "advanced": True,
-        "scope": ["runner"],
-        "help": _("Show this runner in the side panel if it is installed or available through Flatpak.")
-    },
 ]
 
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -608,6 +608,17 @@ system_options = [  # pylint: disable=invalid-name
         "advanced": True,
         "help": _("Open Xephyr in fullscreen (at the desktop resolution)"),
     },
+
+    {
+        "section": _("Side Panel"),
+        "option": "visible_in_side_panel",
+        "type": "bool",
+        "label": _("Visible in Side Panel"),
+        "default": True,
+        "advanced": True,
+        "scope": ["runner"],
+        "help": _("Show this runner in the side panel if it is installed or available through Flatpak.")
+    },
 ]
 
 


### PR DESCRIPTION
At @strycore request, a new version of the hidden runners... a hidden version of it. Hidden hidden runners. It's meta! Let's look at it:
![image](https://github.com/lutris/lutris/assets/6507403/808ca9a9-7310-4ffc-980f-7432b7d8b763)
Wait, where is it? Oh, it's way down here:
![image](https://github.com/lutris/lutris/assets/6507403/1f394c19-02ba-4883-ae77-4c62aade49d7)
At the very bottom of the "Runner Options", only in the runner config dialog, an only if advanced options are turned on.

When this is turned off, the runner disappears from the side panel even if it is installed or available from flatpak. It's still in the runners drop down in the game configuration though- this is just about the side panel.

Replaces #5177