### PR TITLE
Game Starting Animation

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -706,7 +706,7 @@ class Game(GObject.Object):
         return True
 
     def start_game(self):
-        """Run a background command to lauch the game"""
+        """Run a background command to launch the game"""
         self.game_thread = MonitoredCommand(
             self.game_runtime_config["args"],
             title=self.name,

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -132,9 +132,13 @@ class GameView:
             if fraction > limit:
                 fraction = limit
                 delta = -0.0125
-            elif fraction <= 0:
-                self.image_renderer.inset_game(game.id, 0.0)
-                return False
+            elif fraction <= 0.0:
+                if game.state == game.STATE_LAUNCHING:
+                    fraction = 0.0
+                    delta = 0.0125
+                else:
+                    self.image_renderer.inset_game(game.id, 0.0)
+                    return False
 
             self.image_renderer.inset_game(game.id, fraction)
             return True  # Return True to call again after another timeout

--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -32,7 +32,8 @@ class GameListView(Gtk.TreeView, GameView):
             self.image_renderer = GridViewCellRendererImage()
             self.media_column = Gtk.TreeViewColumn("", self.image_renderer,
                                                    media_path=COL_MEDIA_PATH,
-                                                   is_installed=COL_INSTALLED)
+                                                   is_installed=COL_INSTALLED,
+                                                   game_id=COL_ID)
             self.media_column.set_reorderable(True)
             self.media_column.set_sort_indicator(False)
             self.media_column.set_sizing(Gtk.TreeViewColumnSizing.FIXED)

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -115,6 +115,14 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         self._inset_fractions = {}
 
     def inset_game(self, game_id, fraction):
+        """This function indicates that a particular game should be displayed inset by a certain fraction of
+        its total size; 0 is full size, 0.1 would show it at 90% size, but centered.
+
+        This is not bound as an attribute; it's used for an ephemeral animation, and we wouldn't want
+        to mess with the GameStore to do it. Instead, the cell renderer tracks these per game ID, and
+        the caller uses queue_draw() to trigger a redraw.
+
+        Set the fraction to 0 for a game to remove the effect when done."""
         if fraction > 0.0:
             self._inset_fractions[game_id] = fraction
         else:

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -115,7 +115,7 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         self._inset_fractions = {}
 
     def inset_game(self, game_id, fraction):
-        if fraction > 0:
+        if fraction > 0.0:
             self._inset_fractions[game_id] = fraction
         else:
             del self._inset_fractions[game_id]


### PR DESCRIPTION
Just a little UI nicety- an animation to indicate that a game is starting. It looks like this:

[Screencast from 2023-12-13 18-59-15.webm](https://github.com/lutris/lutris/assets/6507403/71fa16c4-8976-4a01-9e0f-14f5e3987bd3)

This is an exaggeration though, since the pulse animation is usually much shorter- just one cycle. It will continue as long as the game is in the Launching state, but since that often goes by very fast, it will do a minimum of one cycle

I'd like to keep it going longer, until the game is really up and runner, but I can see no way to know when that is. As it is, the Launching state lasts while the game is running the prelaunch stuff, but once the game proper gets launched, it ends.

I think the in-and-out animation looks nice, but part of it is that I can draw the banner *smaller* easily, but growing it out of its cell is harder.

This is really kinda redundant with the text on the "Play" button, which updates to show the same state. But users may not understand that, and this may be more obvious for them.

Resolves #5081