### PR TITLE
Replace watch_errors decorator with method swizzling

### DIFF
--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -67,29 +67,6 @@ class FsyncUnsupportedError(Exception):
     """Raised when FSYNC is enabled, but is not supported by the kernel."""
 
 
-def watch_errors(error_result=None, handler_object=None):
-    """Decorator used to catch exceptions for GUI signal handlers. This
-    catches any exception from the decorated function and calls
-    on_watch_errors(error) on the first argument, which we presume to be self.
-    and then the method will return 'error_result'"""
-    captured_handler_object = handler_object
-
-    def inner_decorator(function):
-        @wraps(function)
-        def wrapper(*args, **kwargs):
-            myself = captured_handler_object or args[0]
-            try:
-                return function(*args, **kwargs)
-            except Exception as ex:
-                logger.exception(str(ex), exc_info=ex)
-                myself.on_watched_error(ex)
-                return error_result
-
-        return wrapper
-
-    return inner_decorator
-
-
 def watch_game_errors(game_stop_result, game=None):
     """Decorator used to catch exceptions and send events instead of propagating them normally.
     If 'game_stop_result' is not None, and the decorated function returns that, this will
@@ -208,7 +185,6 @@ def _error_handling_timeout_add(interval, handler, *args, **kwargs):
 
 
 # TODO: explicit init call is probably safer
-# TODO: GObject.add_emission_hook too
 _original_connect = Gtk.Widget.connect
 GObject.Object.connect = _error_handling_connect
 

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -2,7 +2,7 @@
 from functools import wraps
 from gettext import gettext as _
 
-from gi.repository import GLib, GObject, Gtk
+from gi.repository import Gio, GLib, GObject, Gtk
 
 from lutris.gui.dialogs import ErrorDialog
 from lutris.util.log import logger
@@ -126,6 +126,11 @@ def _handle_callback_error(error_objects, error):
 
         if not first_toplevel:
             first_toplevel = toplevel
+
+    if not first_toplevel:
+        application = Gio.Application.get_default()
+        if application:
+            first_toplevel = application.window
 
     ErrorDialog(error, parent=first_toplevel)
     return

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -157,9 +157,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
     def on_cancel_clicked(self, _widget):
         self.destroy()
 
-    def on_watched_error(self, error):
-        ErrorDialog(error, parent=self)
-
     # Initial Page
 
     def load_initial_page(self):

--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -4,7 +4,6 @@ from gettext import gettext as _
 from gi.repository import Gio, GLib, Gtk
 
 from lutris import api, sysoptions
-from lutris.exceptions import watch_errors
 from lutris.gui.config.add_game_dialog import AddGameDialog
 from lutris.gui.dialogs import ErrorDialog, ModelessDialog
 from lutris.gui.dialogs.game_import import ImportGameDialog
@@ -149,15 +148,12 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
 
         self.load_initial_page()
 
-    @watch_errors()
     def on_back_clicked(self, _widget):
         self.stack.navigate_back()
 
-    @watch_errors()
     def on_navigate_home(self, _accel_group, _window, _keyval, _modifier):
         self.stack.navigate_home()
 
-    @watch_errors()
     def on_cancel_clicked(self, _widget):
         self.destroy()
 
@@ -187,7 +183,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.stack.present_page("initial")
         self.display_cancel_button()
 
-    @watch_errors()
     def on_row_activated(self, listbox, row):
         if row.callback_name:
             callback = getattr(self, row.callback_name)
@@ -245,14 +240,12 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.search_entry.grab_focus()
         self.display_cancel_button()
 
-    @watch_errors()
     def _on_search_updated(self, entry):
         if self.search_timer_id:
             GLib.source_remove(self.search_timer_id)
         self.text_query = entry.get_text().strip()
         self.search_timer_id = GLib.timeout_add(750, self.update_search_results)
 
-    @watch_errors()
     def update_search_results(self):
         # Don't start a search while another is going; defer it instead.
         if self.search_spinner.get_visible():
@@ -266,7 +259,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
             self.search_spinner.start()
             AsyncCall(api.search_games, self.update_search_results_cb, self.text_query)
 
-    @watch_errors()
     def update_search_results_cb(self, api_games, error):
         if error:
             raise error
@@ -297,7 +289,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.search_frame.show()
         self.search_explanation_label.hide()
 
-    @watch_errors()
     def _on_game_selected(self, listbox, row):
         game_slug = row.api_info["slug"]
         installers = get_installers(game_slug=game_slug)
@@ -333,7 +324,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.stack.present_page("scan_folder")
         self.display_continue_button(self.on_continue_scan_folder_clicked)
 
-    @watch_errors()
     def on_continue_scan_folder_clicked(self, _widget):
         path = self.scan_directory_chooser.get_text()
         if not path:
@@ -359,7 +349,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         spinner.start()
         return spinner
 
-    @watch_errors()
     def _on_folder_scanned(self, result, error):
         def present_installed_games_page():
             if installed or missing:
@@ -484,19 +473,16 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.stack.present_page("install_from_setup")
         self.display_continue_button(self._on_install_setup_continue, label=_("_Install"))
 
-    @watch_errors()
     def on_install_from_setup_game_slug_toggled(self, checkbutton):
         self.install_from_setup_game_slug_entry.set_sensitive(checkbutton.get_active())
         self.on_install_from_setup_game_name_changed()
 
-    @watch_errors()
     def on_install_from_setup_game_name_changed(self, *_args):
         if not self.install_from_setup_game_slug_checkbox.get_active():
             name = self.install_from_setup_game_name_entry.get_text()
             proposed_slug = slugify(name) if name else ""
             self.install_from_setup_game_slug_entry.set_text(proposed_slug)
 
-    @watch_errors()
     def _on_install_setup_continue(self, button):
         name = self.install_from_setup_game_name_entry.get_text().strip()
 
@@ -579,7 +565,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.stack.present_page("install_from_script")
         self.display_continue_button(self.on_continue_install_from_script_clicked, label=_("_Install"))
 
-    @watch_errors()
     def on_continue_install_from_script_clicked(self, _widget):
         path = self.install_script_file_chooser.get_text()
         if not path:
@@ -621,7 +606,6 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
         self.stack.present_page("import_rom")
         self.display_continue_button(self.on_continue_import_rom_clicked, label=_("_Install"))
 
-    @watch_errors()
     def on_continue_import_rom_clicked(self, _widget):
         path = self.import_rom_file_chooser.get_text()
         if not path:

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -58,6 +58,7 @@ from lutris.util.savesync import show_save_stats, upload_save, save_check
 from lutris.services import get_enabled_services
 from lutris.database.services import ServiceGameCollection
 from lutris.util.jobs import AsyncCall
+from lutris.exceptions import init_exception_backstops
 
 from .lutriswindow import LutrisWindow
 
@@ -72,6 +73,10 @@ class Application(Gtk.Application):
             flags=Gio.ApplicationFlags.HANDLES_COMMAND_LINE,
             register_session=True,
         )
+
+        # Prepare the backstop logic just before the first emission hook (or connection) is
+        # established; this will apply to all connections from this point forward.
+        init_exception_backstops()
 
         GObject.add_emission_hook(Game, "game-launch", self.on_game_launch)
         GObject.add_emission_hook(Game, "game-start", self.on_game_start)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -875,10 +875,6 @@ class Application(Gtk.Application):
                     return game
         return None
 
-    def on_watched_error(self, error):
-        if self.window:
-            ErrorDialog(error, parent=self.window)
-
     @staticmethod
     def get_lutris_action(url):
         installer_info = {

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -36,7 +36,6 @@ from gi.repository import Gio, GLib, Gtk, GObject
 from lutris.runners import get_runner_names, import_runner, InvalidRunner, RunnerInstallationError
 from lutris import settings
 from lutris.api import parse_installer_url, get_runners
-from lutris.exceptions import watch_errors
 from lutris.command import exec_command
 from lutris.database import games as games_db
 from lutris.game import Game, export_game, import_game
@@ -762,7 +761,6 @@ class Application(Gtk.Application):
             self.quit_on_game_exit = False
         return 0
 
-    @watch_errors()
     def on_settings_changed(self, dialog, state, setting_key):
         if setting_key == "dark_theme":
             self.style_manager.is_config_dark = state
@@ -771,19 +769,16 @@ class Application(Gtk.Application):
                 self.set_tray_icon()
         return True
 
-    @watch_errors(error_result=True)
     def on_game_launch(self, game):
         game.launch(self.launch_ui_delegate)
         return True  # Return True to continue handling the emission hook
 
-    @watch_errors(error_result=True)
     def on_game_start(self, game):
         self.running_games.append(game)
         if settings.read_setting("hide_client_on_game_start") == "True":
             self.window.hide()  # Hide launcher window
         return True
 
-    @watch_errors()
     def on_game_stop(self, game):
         """Callback to remove the game from the running games"""
         ids = self.get_running_game_ids()
@@ -807,7 +802,6 @@ class Application(Gtk.Application):
                     self.quit()
         return True
 
-    @watch_errors(error_result=True)
     def on_game_install(self, game):
         """Request installation of a game"""
         if game.service and game.service != "lutris":
@@ -843,7 +837,6 @@ class Application(Gtk.Application):
         else:
             ErrorDialog(_("No installer available."), parent=self.window)
 
-    @watch_errors(error_result=True)
     def on_game_install_update(self, game):
         service = get_enabled_services()[game.service]()
         db_game = games_db.get_game_by_field(game.id, "id")
@@ -854,7 +847,6 @@ class Application(Gtk.Application):
             ErrorDialog(_("No updates found"), parent=self.window)
         return True
 
-    @watch_errors(error_result=True)
     def on_game_install_dlc(self, game):
         service = get_enabled_services()[game.service]()
         db_game = games_db.get_game_by_field(game.id, "id")

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -8,7 +8,6 @@ from gi.repository import GdkPixbuf, Gtk, Pango
 
 from lutris import runners, settings
 from lutris.config import LutrisConfig, make_game_config_id
-from lutris.exceptions import watch_errors
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.config import DIALOG_HEIGHT, DIALOG_WIDTH
@@ -254,7 +253,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             box.hide()
         return box
 
-    @watch_errors()
     def on_reset_preferred_launch_config_clicked(self, _button, launch_config_box):
         game_config = self.game.config.game_level.get("game", {})
         game_config.pop("preferred_launch_config_name", None)
@@ -374,7 +372,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             runner_liststore.append(("%s (%s)" % (runner.human_name, description), runner.name))
         return runner_liststore
 
-    @watch_errors()
     def on_slug_change_clicked(self, widget):
         if self.slug_entry.get_sensitive() is False:
             widget.set_label(_("Apply"))
@@ -382,7 +379,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         else:
             self.change_game_slug()
 
-    @watch_errors()
     def on_slug_entry_activate(self, _widget):
         self.change_game_slug()
 
@@ -396,7 +392,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         self.slug_entry.set_sensitive(False)
         self.slug_change_button.set_label(_("Change"))
 
-    @watch_errors()
     def on_move_clicked(self, _button):
         new_location = DirectoryDialog("Select new location for the game",
                                        default_path=self.game.directory, parent=self)
@@ -406,7 +401,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         move_dialog.connect("game-moved", self.on_game_moved)
         move_dialog.move()
 
-    @watch_errors()
     def on_game_moved(self, dialog):
         """Show a notification when the game is moved"""
         new_directory = dialog.new_directory
@@ -542,7 +536,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         if self.game_box:
             self.game_box.filter = value
 
-    @watch_errors()
     def on_runner_changed(self, widget):
         """Action called when runner drop down is changed."""
         new_runner_index = widget.get_active()
@@ -643,7 +636,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             return False
         return True
 
-    @watch_errors()
     def on_save(self, _button):
         """Save game info and destroy widget."""
         if not self.is_valid():
@@ -686,7 +678,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         self.saved = True
         return True
 
-    @watch_errors()
     def on_custom_image_select(self, _widget, image_type):
         dialog = Gtk.FileChooserNative.new(
             _("Please choose a custom image"),
@@ -731,7 +722,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
 
         dialog.destroy()
 
-    @watch_errors()
     def on_custom_image_reset_clicked(self, _widget, image_type):
         slug = self.slug or self.game.slug
         service_media = self.service_medias[image_type]

--- a/lutris/gui/config/common.py
+++ b/lutris/gui/config/common.py
@@ -733,9 +733,6 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         invalidate_media_caches()
         self._set_image(image_type, self.image_buttons[image_type])
 
-    def on_watched_error(self, error):
-        dialogs.ErrorDialog(error, parent=self)
-
 
 class RunnerMessageBox(UnderslungMessageBox):
     def __init__(self):

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -6,7 +6,7 @@ from gi.repository import Gtk
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.game import Game
-from lutris.gui.dialogs import ErrorDialog, QuestionDialog, SavableModelessDialog
+from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
 
 
 class EditCategoryGamesDialog(SavableModelessDialog):
@@ -129,6 +129,3 @@ class EditCategoryGamesDialog(SavableModelessDialog):
                 game.add_category(new_name)
 
         self.destroy()
-
-    def on_watched_error(self, error):
-        ErrorDialog(error, parent=self)

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -5,7 +5,6 @@ from gi.repository import Gtk
 
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
-from lutris.exceptions import watch_errors
 from lutris.game import Game
 from lutris.gui.dialogs import ErrorDialog, QuestionDialog, SavableModelessDialog
 
@@ -60,7 +59,6 @@ class EditCategoryGamesDialog(SavableModelessDialog):
         frame.add(sw)
         return frame
 
-    @watch_errors()
     def on_delete_clicked(self, _button):
         dlg = QuestionDialog(
             {
@@ -75,7 +73,6 @@ class EditCategoryGamesDialog(SavableModelessDialog):
                 game.remove_category(self.category)
             self.destroy()
 
-    @watch_errors()
     def on_save(self, _button):
         """Save game info and destroy widget."""
         removed_games = []

--- a/lutris/gui/config/edit_game_categories.py
+++ b/lutris/gui/config/edit_game_categories.py
@@ -5,7 +5,6 @@ from gettext import gettext as _
 from gi.repository import Gtk
 
 from lutris.database import categories as categories_db
-from lutris.gui import dialogs
 from lutris.gui.dialogs import SavableModelessDialog
 
 
@@ -97,6 +96,3 @@ class EditGameCategoriesDialog(SavableModelessDialog):
             self.game.update_game_categories(added_categories, removed_categories)
 
         self.destroy()
-
-    def on_watched_error(self, error):
-        dialogs.ErrorDialog(error, parent=self)

--- a/lutris/gui/config/edit_game_categories.py
+++ b/lutris/gui/config/edit_game_categories.py
@@ -5,7 +5,6 @@ from gettext import gettext as _
 from gi.repository import Gtk
 
 from lutris.database import categories as categories_db
-from lutris.exceptions import watch_errors
 from lutris.gui import dialogs
 from lutris.gui.dialogs import SavableModelessDialog
 
@@ -79,7 +78,6 @@ class EditGameCategoriesDialog(SavableModelessDialog):
 
         return hbox
 
-    @watch_errors()
     def on_save(self, _button):
         """Save game info and destroy widget."""
         removed_categories = set()

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -138,6 +138,3 @@ class RunnerBox(Gtk.Box):
         self.runner_label_box.set_sensitive(False)
         self.action_alignment.get_children()[0].destroy()
         self.action_alignment.add(self.get_action_button())
-
-    def on_watched_error(self, error):
-        ErrorDialog(error, parent=self.get_toplevel())

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -3,7 +3,6 @@ from gettext import gettext as _
 from gi.repository import GObject, Gtk
 
 from lutris import runners
-from lutris.exceptions import watch_errors
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.dialogs import ErrorDialog, QuestionDialog
 from lutris.gui.dialogs.runner_install import RunnerInstallDialog
@@ -84,14 +83,12 @@ class RunnerBox(Gtk.Box):
         _button.show()
         return _button
 
-    @watch_errors()
     def on_versions_clicked(self, widget):
         window = self.get_toplevel()
         application = window.get_application()
         title = _("Manage %s versions") % self.runner.name
         application.show_window(RunnerInstallDialog, title=title, runner=self.runner, parent=window)
 
-    @watch_errors()
     def on_install_clicked(self, widget):
         """Install a runner."""
         logger.debug("Install of %s requested", self.runner)
@@ -110,13 +107,11 @@ class RunnerBox(Gtk.Box):
         else:
             ErrorDialog("Runner failed to install", parent=self.get_toplevel())
 
-    @watch_errors()
     def on_configure_clicked(self, widget):
         window = self.get_toplevel()
         application = window.get_application()
         application.show_window(RunnerConfigDialog, runner=self.runner, parent=window)
 
-    @watch_errors()
     def on_remove_clicked(self, widget):
         dialog = QuestionDialog(
             {
@@ -132,14 +127,12 @@ class RunnerBox(Gtk.Box):
 
             self.runner.uninstall(on_runner_uninstalled)
 
-    @watch_errors()
     def on_runner_installed(self, widget):
         """Called after the runnner is installed"""
         self.runner_label_box.set_sensitive(True)
         self.action_alignment.get_children()[0].destroy()
         self.action_alignment.add(self.get_action_button())
 
-    @watch_errors()
     def on_runner_removed(self, widget):
         """Called after the runner is removed"""
         self.runner_label_box.set_sensitive(False)

--- a/lutris/gui/dialogs/uninstall_game.py
+++ b/lutris/gui/dialogs/uninstall_game.py
@@ -7,7 +7,6 @@ from gi.repository import Gtk
 
 from lutris.database.games import get_games
 from lutris.game import Game
-from lutris.gui import dialogs
 from lutris.gui.dialogs import QuestionDialog
 from lutris.gui.widgets.gi_composites import GtkTemplate
 from lutris.util import datapath
@@ -331,6 +330,3 @@ class UninstallMultipleGamesDialog(Gtk.Dialog):
                     self.game.uninstall(delete_files=self.delete_files)
             elif self.delete_game:
                 self.game.delete()
-
-    def on_watched_error(self, error: Exception) -> None:
-        dialogs.ErrorDialog(error, parent=self)

--- a/lutris/gui/dialogs/uninstall_game.py
+++ b/lutris/gui/dialogs/uninstall_game.py
@@ -6,7 +6,6 @@ from typing import Callable, Dict, List
 from gi.repository import Gtk
 
 from lutris.database.games import get_games
-from lutris.exceptions import watch_errors
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.dialogs import QuestionDialog
@@ -126,6 +125,7 @@ class UninstallMultipleGamesDialog(Gtk.Dialog):
         """Sets the state of the checkboxes at the button that are used to control all
         settings together. While we are actually updating these checkboxes en-meass,
         this method does nothing at all."""
+
         def update(checkbox, is_candidate, is_set):
             set_count = 0
             unset_count = 0
@@ -149,7 +149,6 @@ class UninstallMultipleGamesDialog(Gtk.Dialog):
                    lambda row: row.game.is_installed,
                    lambda row: row.delete_game)
 
-    @watch_errors()
     @GtkTemplate.Callback
     def on_delete_all_files_checkbox_toggled(self, _widget):
         def update_row(row, active):
@@ -158,7 +157,6 @@ class UninstallMultipleGamesDialog(Gtk.Dialog):
 
         self._apply_all_checkbox(self.delete_all_files_checkbox, update_row)
 
-    @watch_errors()
     @GtkTemplate.Callback
     def on_remove_all_games_checkbox_toggled(self, _widget):
         def update_row(row, active):
@@ -182,12 +180,10 @@ class UninstallMultipleGamesDialog(Gtk.Dialog):
             self._setting_all_checkboxes = False
             self.update_all_checkboxes()
 
-    @watch_errors()
     @GtkTemplate.Callback
     def on_cancel_button_clicked(self, _widget) -> None:
         self.destroy()
 
-    @watch_errors()
     @GtkTemplate.Callback
     def on_remove_button_clicked(self, _widget) -> None:
         rows = list(self.uninstall_game_list.get_children())

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -254,7 +254,11 @@ class InstallerWindow(ModelessDialog,
             self
         )
 
-    def on_watched_error(self, error):
+    def on_signal_error(self, error):
+        ErrorDialog(error, parent=self)
+        self.stack.navigation_reset()
+
+    def on_idle_error(self, error):
         ErrorDialog(error, parent=self)
         self.stack.navigation_reset()
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -255,12 +255,17 @@ class InstallerWindow(ModelessDialog,
         )
 
     def on_signal_error(self, error):
-        ErrorDialog(error, parent=self)
-        self.stack.navigation_reset()
+        self._handle_callback_error(error)
 
     def on_idle_error(self, error):
-        ErrorDialog(error, parent=self)
-        self.stack.navigation_reset()
+        self._handle_callback_error(error)
+
+    def _handle_callback_error(self, error):
+        if self.install_in_progress:
+            self.load_error_message_page(str(error))
+        else:
+            ErrorDialog(error, parent=self)
+            self.stack.navigation_reset()
 
     def set_status(self, text):
         """Display a short status text."""

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -475,7 +475,11 @@ class InstallerWindow(ModelessDialog,
             label += " (%s)" % ", ".join(_infos)
         return label
 
-    def on_extras_loaded(self, all_extras, _error):
+    def on_extras_loaded(self, all_extras, error):
+        if error:
+            self._handle_callback_error(error)
+            return
+
         if all_extras:
             self.extras_tree_store.clear()
             for extra_source, extras in all_extras.items():

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -218,9 +218,9 @@ class InstallerWindow(ModelessDialog,
 
             remove_checkbox = Gtk.CheckButton.new_with_label(_("Remove game files"))
             if self.interpreter and self.interpreter.target_path and \
-                self.interpreter.game_dir_created and \
-                self.installation_kind == InstallationKind.INSTALL and \
-                is_removeable(self.interpreter.target_path, LutrisConfig().system_config):
+                    self.interpreter.game_dir_created and \
+                    self.installation_kind == InstallationKind.INSTALL and \
+                    is_removeable(self.interpreter.target_path, LutrisConfig().system_config):
                 remove_checkbox.set_active(self.interpreter.game_dir_created)
                 remove_checkbox.show()
                 widgets.append(remove_checkbox)
@@ -941,7 +941,7 @@ class InstallerWindow(ModelessDialog,
         """Displays the continue button, but labels it 'Install'."""
         self.display_continue_button(handler, continue_button_label=_(
             "_Install"), sensitive=sensitive,
-                                     extra_buttons=[self.source_button])
+            extra_buttons=[self.source_button])
 
     def display_cancel_button(self, extra_buttons=None):
         self.display_buttons(extra_buttons or [])

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -589,7 +589,11 @@ class InstallerWindow(ModelessDialog,
 
         AsyncCall(self.interpreter.installer.prepare_game_files, self.on_files_prepared, patch_version)
 
-    def on_files_prepared(self, _result, _error):
+    def on_files_prepared(self, _result, error):
+        if error:
+            self._handle_callback_error(error)
+            return
+
         if not self.interpreter.installer.files:
             logger.debug("Installer doesn't require files")
             self.launch_installer_commands()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1154,6 +1154,3 @@ class LutrisWindow(Gtk.ApplicationWindow,
                                     completion_function=completion_function,
                                     error_function=error_function,
                                     operation_names=operation_names)
-
-    def on_watched_error(self, error):
-        dialogs.ErrorDialog(error, parent=self)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -13,7 +13,7 @@ from lutris import services, settings
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.database.services import ServiceGameCollection
-from lutris.exceptions import EsyncLimitError, FsyncUnsupportedError, watch_errors
+from lutris.exceptions import EsyncLimitError, FsyncUnsupportedError
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
@@ -258,7 +258,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """Grab the initial focus after the sidebar is initialized - so the view is ready."""
         self.current_view.grab_focus()
 
-    @watch_errors()
     def on_drag_data_received(self, widget, drag_context, x, y, data, info, time):
         """Handler for drop event"""
         file_paths = [unquote(urlparse(uri).path) for uri in data.get_uris()]
@@ -628,7 +627,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.zoom_adjustment.props.value = value
         self.zoom_adjustment.connect("value-changed", self.on_zoom_changed)
 
-    @watch_errors()
     def on_zoom_changed(self, adjustment):
         """Handler for zoom modification"""
         media_index = round(adjustment.props.value)
@@ -799,7 +797,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         settings.write_setting("filter_installed", bool(filter_installed))
         self.filters["installed"] = filter_installed
 
-    @watch_errors()
     def on_service_games_updated(self, service):
         """Request a view update when service games are loaded"""
         if self.service and service.id == self.service.id:
@@ -824,7 +821,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         if self.window_x and self.window_y:
             self.move(int(self.window_x), int(self.window_y))
 
-    @watch_errors()
     def on_service_login(self, service):
         service.start_reload(self._service_reloaded_cb)
         return True
@@ -833,13 +829,11 @@ class LutrisWindow(Gtk.ApplicationWindow,
         if error:
             dialogs.ErrorDialog(error, parent=self)
 
-    @watch_errors()
     def on_service_logout(self, service):
         if self.service and service.id == self.service.id:
             self.emit("view-updated")
         return True
 
-    @watch_errors()
     @GtkTemplate.Callback
     def on_resize(self, widget, *_args):
         """Size-allocate signal.
@@ -878,7 +872,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
             stopper()
 
     @GtkTemplate.Callback
-    @watch_errors()
     def on_hide(self, *_args):
         self.save_window_state()
 
@@ -887,7 +880,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.restore_window_position()
 
     @GtkTemplate.Callback
-    @watch_errors()
     def on_preferences_activate(self, *_args):
         """Callback when preferences is activated."""
         self.application.show_window(PreferencesDialog, parent=self)
@@ -899,7 +891,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.emit("view-updated")
 
     @GtkTemplate.Callback
-    @watch_errors()
     def on_search_entry_changed(self, entry):
         """Callback for the search input keypresses"""
         if self.search_timer_id:
@@ -908,7 +899,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.search_timer_id = GLib.timeout_add(500, self.update_store)
 
     @GtkTemplate.Callback
-    @watch_errors()
     def on_search_entry_key_press(self, widget, event):
         if event.keyval == Gdk.KEY_Down:
             if self.current_view_type == 'grid':
@@ -922,12 +912,10 @@ class LutrisWindow(Gtk.ApplicationWindow,
             self.current_view.grab_focus()
 
     @GtkTemplate.Callback
-    @watch_errors()
     def on_about_clicked(self, *_args):
         """Open the about dialog."""
         dialogs.AboutDialog(parent=self)
 
-    @watch_errors()
     def on_game_unhandled_error(self, game, error):
         """Called when a game has sent the 'game-error' signal"""
 
@@ -940,13 +928,11 @@ class LutrisWindow(Gtk.ApplicationWindow,
         return True
 
     @GtkTemplate.Callback
-    @watch_errors()
     def on_add_game_button_clicked(self, *_args):
         """Add a new game manually with the AddGameDialog."""
         self.application.show_window(AddGamesWindow, parent=self)
         return True
 
-    @watch_errors()
     def on_toggle_viewtype(self, *args):
         view_type = "list" if self.current_view_type == "grid" else "grid"
         logger.debug("View type changed to %s", view_type)
@@ -955,31 +941,26 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.redraw_view()
         self._bind_zoom_adjustment()
 
-    @watch_errors()
     def on_icontype_state_change(self, action, value):
         action.set_state(value)
         self._set_icon_type(value.get_string())
 
-    @watch_errors()
     def on_view_sorting_state_change(self, action, value):
         self.actions["view-sorting"].set_state(value)
         value = str(value).strip("'")
         settings.write_setting("view_sorting", value)
         self.emit("view-updated")
 
-    @watch_errors()
     def on_view_sorting_direction_change(self, action, value):
         self.actions["view-sorting-ascending"].set_state(value)
         settings.write_setting("view_sorting_ascending", bool(value))
         self.emit("view-updated")
 
-    @watch_errors()
     def on_view_sorting_installed_first_change(self, action, value):
         self.actions["view-sorting-installed-first"].set_state(value)
         settings.write_setting("view_sorting_installed_first", bool(value))
         self.emit("view-updated")
 
-    @watch_errors()
     def on_side_panel_state_change(self, action, value):
         """Callback to handle side panel toggle"""
         action.set_state(value)
@@ -987,7 +968,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         settings.write_setting("side_panel_visible", bool(side_panel_visible))
         self.sidebar_revealer.set_reveal_child(side_panel_visible)
 
-    @watch_errors()
     def on_sidebar_changed(self, widget):
         """Handler called when the selected element of the sidebar changes"""
         for filter_type in ("category", "dynamic_category", "service", "runner", "platform"):
@@ -1004,7 +984,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self._bind_zoom_adjustment()
         self.redraw_view()
 
-    @watch_errors()
     def on_game_selection_changed(self, view, selection):
         if not selection:
             GLib.idle_add(self.update_revealer)
@@ -1031,14 +1010,12 @@ class LutrisWindow(Gtk.ApplicationWindow,
         GLib.idle_add(self.update_revealer, games)
         return False
 
-    @watch_errors()
     def on_toggle_badges(self, _widget, _data):
         """Event handler to toggle badge visibility"""
         state = settings.read_setting("hide_badges_on_icons").lower() == "true"
         settings.write_setting("hide_badges_on_icons", not state)
         self.on_settings_changed(None, not state, "hide_badges_on_icons")
 
-    @watch_errors()
     def on_settings_changed(self, dialog, state, setting_key):
         if setting_key == "hide_text_under_icons":
             self.rebuild_view("grid")
@@ -1066,7 +1043,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
         return True
 
-    @watch_errors()
     def on_game_updated(self, game):
         """Updates an individual entry in the view when a game is updated"""
         add_to_path_cache(game)
@@ -1086,7 +1062,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
         return True
 
-    @watch_errors()
     def on_game_stopped(self, game):
         """Updates the game list when a game stops; this keeps the 'running' page updated."""
         selected_row = self.sidebar.get_selected_row()
@@ -1099,7 +1074,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
     def on_game_installed(self, game):
         return True
 
-    @watch_errors()
     def on_game_removed(self, game):
         """Simple method used to refresh the view"""
         remove_from_path_cache(game)
@@ -1107,7 +1081,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.emit("view-updated")
         return True
 
-    @watch_errors()
     def on_game_activated(self, view, game_id):
         """Handles view activations (double click, enter press)"""
         if self.service:

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -5,7 +5,6 @@ from gi.repository import GObject, Gtk, Pango
 
 from lutris import runners, services
 from lutris.database.games import get_game_for_service
-from lutris.exceptions import watch_errors
 from lutris.game import Game
 from lutris.game_actions import get_game_actions
 from lutris.gui.dialogs import ErrorDialog
@@ -262,19 +261,16 @@ class GameBar(Gtk.Box):
                 buttons.append(button)
         return buttons
 
-    @watch_errors()
     def on_link_button_clicked(self, button, callback):
         """Callback for link buttons. Closes the popover then runs the actual action"""
         popover = button.get_parent().get_parent()
         popover.popdown()
         callback(button)
 
-    @watch_errors()
     def on_install_clicked(self, button):
         """Handler for installing service games"""
         self.service.install(self.db_game)
 
-    @watch_errors()
     def on_game_state_changed(self, game):
         """Handler called when the game has changed state"""
         if (

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -7,7 +7,6 @@ from lutris import runners, services
 from lutris.database.games import get_game_for_service
 from lutris.game import Game
 from lutris.game_actions import get_game_actions
-from lutris.gui.dialogs import ErrorDialog
 from lutris.gui.widgets.contextual_menu import update_action_widget_visibility
 from lutris.util.strings import gtk_safe
 
@@ -283,6 +282,3 @@ class GameBar(Gtk.Box):
         self.clear_view()
         self.update_view()
         return True
-
-    def on_watched_error(self, error):
-        ErrorDialog(error, parent=self.get_toplevel())

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -8,7 +8,6 @@ from lutris import runners, services
 from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
-from lutris.exceptions import watch_errors
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
@@ -234,17 +233,14 @@ class RunnerSidebarRow(SidebarRow):
         entries.append(("emblem-system-symbolic", _("Configure"), self.on_configure_runner, "configure"))
         return entries
 
-    @watch_errors()
     def on_run_runner(self, *_args):
         """Runs the runner without no game."""
         self.runner.run(self.get_toplevel())
 
-    @watch_errors()
     def on_configure_runner(self, *_args):
         """Show runner configuration"""
         self.application.show_window(RunnerConfigDialog, runner=self.runner, parent=self.get_toplevel())
 
-    @watch_errors()
     def on_manage_versions(self, *_args):
         """Manage runner versions"""
         dlg_title = _("Manage %s versions") % self.runner.name

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -9,7 +9,6 @@ from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.game import Game
-from lutris.gui import dialogs
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
@@ -246,9 +245,6 @@ class RunnerSidebarRow(SidebarRow):
         dlg_title = _("Manage %s versions") % self.runner.name
         self.application.show_window(RunnerInstallDialog, title=dlg_title,
                                      runner=self.runner, parent=self.get_toplevel())
-
-    def on_watched_error(self, error):
-        dialogs.ErrorDialog(error, parent=self.get_toplevel())
 
 
 class CategorySidebarRow(SidebarRow):

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -13,7 +13,7 @@ from gi.repository import GLib
 from lutris import runtime
 from lutris.cache import get_cache_path
 from lutris.command import MonitoredCommand
-from lutris.exceptions import MissingExecutableError, UnspecifiedVersionError, watch_errors
+from lutris.exceptions import MissingExecutableError, UnspecifiedVersionError
 from lutris.installer.errors import ScriptingError
 from lutris.installer.installer import LutrisInstaller
 from lutris.runners import InvalidRunner, import_runner, import_task
@@ -436,7 +436,6 @@ class CommandsMixin:
             return "STOP"
         return None
 
-    @watch_errors(error_result=False)
     def _monitor_task(self, command):
         if not command.is_running:
             logger.debug("Return code: %s", command.return_code)

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -7,7 +7,7 @@ from gi.repository import GObject
 from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
-from lutris.exceptions import MisconfigurationError, watch_errors
+from lutris.exceptions import MisconfigurationError
 from lutris.installer import AUTO_EXE_PREFIX
 from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependency, ScriptingError
@@ -293,7 +293,6 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
     def on_watched_error(self, error):
         self.interpreter_ui_delegate.report_error(error)
 
-    @watch_errors()
     def _iter_commands(self, result=None, exception=None):
 
         if result == "STOP" or self.cancelled:

--- a/lutris/util/jobs.py
+++ b/lutris/util/jobs.py
@@ -58,4 +58,10 @@ def _make_idle_safe(function):
         function(*args, **kwargs)
         return False  # ignore result from function
 
+    # This is a hack, but if 'function' is a method the
+    # exception handling will want to know what it's __self__ was,
+    # so we'll just paste it right on here.
+
+    if hasattr(function, "__self__"):
+        discarding_result.__self__ = function.__self__
     return discarding_result


### PR DESCRIPTION
Swizzling. Not monkey patching. No monkeys around here.

This PR replaces the repetitive use of the @watch_errors() decorator with automatic error handling provided by replacement methods for connect, add_emission_hook, idle_add and timeout_add. The DBus stuff is not covered; that appears very complicated to swizzle, and we do not use it much.

The cool/scary part is at the end of exceptions.py, where GLib's methods are replaced with our own. We just call the original after wrapping the callback function in an error handler.

The handler logs the exception and pops an ErrorDialog. Most of the ``on_watched_errors()`` methods are gone; the generic handler works in all cases.. but one.

InstallerWindow needs to use an error *page* not a dialog when the installation has begun, which will not let you go 'Back' afterwards. To support this, the handler looks for special methods like ``on_signal_error()`` and defers to them if found. I am a bit disappointed I had to support this, but it's not an enormous amount of code and we might need it again.

But the good news is that this blocks a lot of potential crashes; we have lots of signal handlers and idle-functions and whatnot, and this provides protection for them all.

*Ook ook*