### PR TITLE
Add a warning when the 'Virtual Desktop' feature is enabled on a 'GE'…

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -117,6 +117,14 @@ def _get_fsync_warning(config, _option_key):
         return ""
 
 
+def _get_virtual_desktop_warning(config, _option_key):
+    if config.get("Desktop"):
+        version = config.get("version")
+        if "-ge-" in version.casefold():
+            return _("The virtual desktop feature is not supported on 'GE' Wine versions.")
+    return ""
+
+
 class wine(Runner):
     description = _("Runs Windows games")
     human_name = _("Wine")
@@ -417,6 +425,7 @@ class wine(Runner):
                 "section": _("Virtual Desktop"),
                 "label": _("Windowed (virtual desktop)"),
                 "type": "bool",
+                "warning": _get_virtual_desktop_warning,
                 "default": False,
                 "help": _(
                     "Run the whole Windows desktop in a window.\n"


### PR DESCRIPTION
This PR adds an "underslung" warning if you enable the "Virtual Desktop" feature on a Glorious Eggroll (GE) Wine version, thus:

![Screenshot from 2023-12-20 18-55-40](https://github.com/lutris/lutris/assets/6507403/c21f0d46-01e8-431b-8ac4-65c7d0a480c4)

Just kidding. Wouldn't want to point fingers. How about this:

![Screenshot from 2023-12-20 18-57-01](https://github.com/lutris/lutris/assets/6507403/5dc41eaf-2a64-42d1-a411-54b786b77ee2)

We can just let General Electric take the blame.

The check is simple- it's looking for '-ge-' in the version string, case-insensitively. I think that'll do it.

Resolves #5196