### PR TITLE
Make the "System Information" line up neatly with Gtk.Grid

### DIFF
--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -62,32 +62,31 @@ class SystemBox(BaseConfigBox):
 
     def __init__(self):
         super().__init__()
-
         self.add(self.get_section_label(_("System features")))
-        features_grid = self.get_features_grid()
-        features_frame = Gtk.Frame(visible=True)
-        features_frame.get_style_context().add_class("info-frame")
-        features_frame.add(features_grid)
-        self.add(features_frame)
+        self.features_frame = Gtk.Frame(visible=True)
+        self.features_frame.get_style_context().add_class("info-frame")
+        self.pack_start(self.features_frame, False, False, 0)
 
-        sysinfo_label = Gtk.Label(halign=Gtk.Align.START, visible=True)
-        sysinfo_label.set_markup(_("<b>System information</b>"))
-        self.pack_start(sysinfo_label, False, False, 0)
+        self.pack_start(self.get_section_label(_("System information")), False, False, 0)
 
+        self.scrolled_window = Gtk.ScrolledWindow(visible=True)
+        self.scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
         sysinfo_frame = Gtk.Frame(visible=True)
         sysinfo_frame.get_style_context().add_class("info-frame")
-
-        scrolled_window = Gtk.ScrolledWindow(visible=True)
-        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
-        sysinfo_grid = self.get_system_info_grid()
-        scrolled_window.add(sysinfo_grid)
-        sysinfo_frame.add(scrolled_window)
+        sysinfo_frame.add(self.scrolled_window)
         self.pack_start(sysinfo_frame, True, True, 0)
 
         button_copy = Gtk.Button(_("Copy to Clipboard"), halign=Gtk.Align.START, visible=True)
         button_copy.connect("clicked", self._copy_text)
 
         self.pack_start(button_copy, False, False, 0)
+
+    def populate(self):
+        features_grid = self.get_features_grid()
+        self.features_frame.add(features_grid)
+
+        sysinfo_grid = self.get_system_info_grid()
+        self.scrolled_window.add(sysinfo_grid)
 
     def get_features_grid(self):
         features = self.get_features()
@@ -139,11 +138,6 @@ class SystemBox(BaseConfigBox):
             return result
 
         return [eval_feature(f) for f in self.features_definitions]
-
-    def populate(self):
-        # text_buffer = self.sysinfo_view.get_buffer()
-        # text_buffer.set_text(gather_system_info_str())
-        pass
 
     def _copy_text(self, _widget):
         features = self.get_features()

--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -1,4 +1,5 @@
 from gettext import gettext as _
+from typing import Dict, Iterable, List
 
 from gi.repository import Gdk, Gtk
 
@@ -71,20 +72,24 @@ class SystemBox(BaseConfigBox):
         items = self.get_items()
         self.scrolled_window.add(self.get_grid(items))
 
-    def get_items(self):
+    def get_items(self) -> list:
+        """Assembles a list of items to display; most items are name-value tuples
+        giving various bits of information, section headers appear also, as plain strings."""
         features = self.get_features()
         items = [(f["name"], f["available_text"]) for f in features]
 
         system_info_readable = gather_system_info_dict()
         for section, dictionary in system_info_readable.items():
             items.append(section)
-            for key, value in dictionary.items():
-                items.append((gtk_safe(key), gtk_safe(value)))
+            items.extend(dictionary.items())
 
         return items
 
     @staticmethod
-    def get_grid(items):
+    def get_grid(items: Iterable) -> Gtk.Grid:
+        """Constructs a Gtk.Grid containing labels for each item given; each item
+        may be a name-value tuple, producing two labels, or just a string, giving one
+        that covers two columns; this later is used for section headers."""
         grid = Gtk.Grid(visible=True, row_spacing=6, margin=16)
         row = 0
         for item in items:
@@ -108,7 +113,8 @@ class SystemBox(BaseConfigBox):
         return grid
 
     @staticmethod
-    def get_text(items):
+    def get_text(items: Iterable) -> str:
+        """Constructs text for the clipboard, given the same items as get_grid() takess"""
         lines = []
         for item in items:
             if isinstance(item, str):
@@ -118,7 +124,9 @@ class SystemBox(BaseConfigBox):
                 lines.append(f"{name}: {text}")
         return "\n".join(lines)
 
-    def get_features(self):
+    def get_features(self) -> List[Dict[str, str]]:
+        """Provides a list of features that may be present in your system; each
+        is given as a dict, which hase 'name' and 'available_text' keys."""
         yes = _("YES")
         no = _("NO")
 
@@ -132,7 +140,7 @@ class SystemBox(BaseConfigBox):
 
         return [eval_feature(f) for f in self.features_definitions]
 
-    def on_copy_clicked(self, _widget):
+    def on_copy_clicked(self, _widget) -> None:
         items = self.get_items()
         text = self.get_text(items)
 

--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -4,7 +4,7 @@ from gi.repository import Gdk, Gtk
 
 from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.util import linux, system
-from lutris.util.linux import gather_system_info_dict, gather_system_info_str
+from lutris.util.linux import gather_system_info_dict
 from lutris.util.strings import gtk_safe
 from lutris.util.wine.wine import is_esync_limit_set, is_fsync_supported, is_installed_systemwide
 
@@ -13,60 +13,46 @@ class SystemBox(BaseConfigBox):
     features_definitions = [
         {
             "name": _("Vulkan support"),
-            "label_markup": _("Vulkan support:\t<b>%s</b>"),
             "callable": linux.LINUX_SYSTEM.is_vulkan_supported,
         },
         {
             "name": _("Esync support"),
-            "label_markup": _("Esync support:\t<b>%s</b>"),
             "callable": is_esync_limit_set,
         },
         {
             "name": _("Fsync support"),
-            "label_markup": _("Fsync support:\t<b>%s</b>"),
             "callable": is_fsync_supported,
         },
         {
             "name": _("Wine installed"),
-            "label_markup": _("Wine installed:\t<b>%s</b>"),
             "callable": is_installed_systemwide,
         },
         {
             "name": _("Gamescope"),
-            "label_markup": _("Gamescope:\t\t<b>%s</b>"),
             "callable": system.can_find_executable,
             "args": ("gamescope",)
         },
         {
             "name": _("Mangohud"),
-            "label_markup": _("Mangohud:\t\t<b>%s</b>"),
             "callable": system.can_find_executable,
             "args": ("mangohud",)
         },
         {
             "name": _("Gamemode"),
-            "label_markup": _("Gamemode:\t\t<b>%s</b>"),
             "callable": linux.LINUX_SYSTEM.gamemode_available
         },
         {
             "name": _("Steam"),
-            "label_markup": _("Steam:\t\t\t<b>%s</b>"),
             "callable": linux.LINUX_SYSTEM.has_steam
         },
         {
             "name": _("In Flatpak"),
-            "label_markup": _("In Flatpak:\t\t<b>%s</b>"),
             "callable": linux.LINUX_SYSTEM.is_flatpak
         },
     ]
 
     def __init__(self):
         super().__init__()
-        self.add(self.get_section_label(_("System features")))
-        self.features_frame = Gtk.Frame(visible=True)
-        self.features_frame.get_style_context().add_class("info-frame")
-        self.pack_start(self.features_frame, False, False, 0)
-
         self.pack_start(self.get_section_label(_("System information")), False, False, 0)
 
         self.scrolled_window = Gtk.ScrolledWindow(visible=True)
@@ -77,30 +63,25 @@ class SystemBox(BaseConfigBox):
         self.pack_start(sysinfo_frame, True, True, 0)
 
         button_copy = Gtk.Button(_("Copy to Clipboard"), halign=Gtk.Align.START, visible=True)
-        button_copy.connect("clicked", self._copy_text)
+        button_copy.connect("clicked", self.on_copy_clicked)
 
         self.pack_start(button_copy, False, False, 0)
 
     def populate(self):
-        features_grid = self.get_features_grid()
-        self.features_frame.add(features_grid)
+        items = self.get_items()
+        self.scrolled_window.add(self.get_grid(items))
 
-        sysinfo_grid = self.get_system_info_grid()
-        self.scrolled_window.add(sysinfo_grid)
-
-    def get_features_grid(self):
+    def get_items(self):
         features = self.get_features()
-        items = ((f["name"], f["available_text"]) for f in features)
-        return self.get_grid(items)
+        items = [(f["name"], f["available_text"]) for f in features]
 
-    def get_system_info_grid(self):
         system_info_readable = gather_system_info_dict()
-        items = []
         for section, dictionary in system_info_readable.items():
-            items.append("<b>[%s]</b>" % section)
+            items.append(section)
             for key, value in dictionary.items():
                 items.append((gtk_safe(key), gtk_safe(value)))
-        return self.get_grid(items)
+
+        return items
 
     @staticmethod
     def get_grid(items):
@@ -109,21 +90,33 @@ class SystemBox(BaseConfigBox):
         for item in items:
             if isinstance(item, str):
                 header_label = Gtk.Label(visible=True, xalign=0, yalign=0, margin_top=16)
-                header_label.set_markup(str(item))
-                grid.set_margin_top(0)
+                header_label.set_markup("<b>[%s]</b>" % gtk_safe(item))
+                if row == 0:
+                    grid.set_margin_top(0)
                 grid.attach(header_label, 0, row, 2, 1)
             else:
-                name, markup = item
+                name, text = item
                 name_label = Gtk.Label(name + ":",
                                        visible=True, xalign=0, yalign=0,
                                        margin_right=30)
                 grid.attach(name_label, 0, row, 1, 1)
 
                 markup_label = Gtk.Label(visible=True, xalign=0, selectable=True)
-                markup_label.set_markup("<b>%s</b>" % markup)
+                markup_label.set_markup("<b>%s</b>" % gtk_safe(text))
                 grid.attach(markup_label, 1, row, 1, 1)
             row += 1
         return grid
+
+    @staticmethod
+    def get_text(items):
+        lines = []
+        for item in items:
+            if isinstance(item, str):
+                lines.append(f"[{item}]")
+            else:
+                name, text = item
+                lines.append(f"{name}: {text}")
+        return "\n".join(lines)
 
     def get_features(self):
         yes = _("YES")
@@ -139,14 +132,9 @@ class SystemBox(BaseConfigBox):
 
         return [eval_feature(f) for f in self.features_definitions]
 
-    def _copy_text(self, _widget):
-        features = self.get_features()
-        _clipboard_buffer = "[Features]\n"
+    def on_copy_clicked(self, _widget):
+        items = self.get_items()
+        text = self.get_text(items)
 
-        for f in features:
-            _clipboard_buffer += "%s: %s\n" % (f["name"], f["available_text"])
-
-        _clipboard_buffer += "\n"
-        _clipboard_buffer += gather_system_info_str()
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
-        clipboard.set_text(_clipboard_buffer.strip(), -1)
+        clipboard.set_text(text.strip(), -1)

--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -64,8 +64,8 @@ class SystemBox(BaseConfigBox):
         super().__init__()
 
         self.add(self.get_section_label(_("System features")))
-        feature_widgets = self.get_feature_widgets()
-        self.add(self._get_framed_options_list_box(feature_widgets))
+        features_grid = self.get_features_grid()
+        self.add(self._get_framed_options_list_box([features_grid]))
 
         sysinfo_label = Gtk.Label(halign=Gtk.Align.START, visible=True)
         sysinfo_label.set_markup(_("<b>System information</b>"))
@@ -86,18 +86,22 @@ class SystemBox(BaseConfigBox):
 
         self.pack_start(button_copy, False, False, 0)
 
-    def get_feature_widgets(self):
+    def get_features_grid(self):
         """Return a list of labels related to this system's features"""
-        labels = []
+        grid = Gtk.Grid(visible=True, row_spacing=6, margin=16)
+        row = 0
         features = self.get_features()
         for feature in features:
-            label = Gtk.Label(visible=True, xalign=0)
-            label.set_margin_top(3)
-            label.set_margin_bottom(3)
-            label.set_margin_start(16)
-            label.set_markup(feature["label_markup"] % feature["available_text"])
-            labels.append(label)
-        return labels
+            label = Gtk.Label(feature["name"] + ":",
+                              visible=True, xalign=0, yalign=0,
+                              margin_right=30)
+            grid.attach(label, 0, row, 1, 1)
+
+            status = Gtk.Label(visible=True, xalign=0)
+            status.set_markup("<b>%s</b>" % feature["available_text"])
+            grid.attach(status, 1, row, 1, 1)
+            row += 1
+        return grid
 
     def get_features(self):
         yes = _("YES")

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -527,18 +527,6 @@ def gather_system_info_dict():
     return system_info_readable
 
 
-def gather_system_info_str():
-    system_info_readable = gather_system_info_dict()
-    output = ''
-    for section, dictionary in system_info_readable.items():
-        output += '[%s]\n' % section
-        for key, value in dictionary.items():
-            tabs = " " * (16 - len(key))
-            output += '%s:%s%s\n' % (key, tabs, value)
-        output += '\n'
-    return output
-
-
 def get_terminal_apps():
     """Return the list of installed terminal emulators"""
     return LINUX_SYSTEM.get_terminals()

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -476,7 +476,7 @@ def gather_system_info():
     return system_info
 
 
-def gather_system_info_str():
+def gather_system_info_dict():
     """Get all relevant system information already formatted as a string"""
     system_info = gather_system_info()
     system_info_readable = {}
@@ -524,7 +524,11 @@ def gather_system_info_str():
     else:
         graphics_dict["Vulkan"] = "Not Supported"
     system_info_readable["Graphics"] = graphics_dict
+    return system_info_readable
 
+
+def gather_system_info_str():
+    system_info_readable = gather_system_info_dict()
     output = ''
     for section, dictionary in system_info_readable.items():
         output += '[%s]\n' % section

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -34,3 +34,13 @@
 .section-frame > box {
 	margin-bottom: 6px;
 }
+
+.info-frame {
+  color: rgb(255, 199, 116);
+  background-color: rgb(47, 47, 47);
+}
+
+.info-frame label selection {
+  color: rgb(47, 47, 47);
+  background-color: rgb(255, 199, 116);
+}

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -36,11 +36,6 @@
 }
 
 .info-frame {
-  color: rgb(255, 199, 116);
-  background-color: rgb(47, 47, 47);
-}
-
-.info-frame label selection {
-  color: rgb(47, 47, 47);
-  background-color: rgb(255, 199, 116);
+  color: @theme_text_color;
+  background-color: @theme_base_color;
 }


### PR DESCRIPTION
This PR replaces the labels with tabs and such with a single big grid, in a scrolled-window, so everything lines up neatly, thus:

![image](https://github.com/lutris/lutris/assets/6507403/43c3ea89-f73a-4f99-b7cd-93679f27c0b5)

I've combined the two frames into one, because the second frame was getting very cramped; I think this way is more usable. I've changed the colors (via a little CSS) to look like a list-box, instead using the log-view colors that I hate.

Fear not thought, it does respect dark-mode:

![image](https://github.com/lutris/lutris/assets/6507403/7066453f-e158-4c54-a2ef-b65877be06e0)


One downside is that you can only copy one label's worth at a time normally; however "Copy to Clipboard" will give you all that content in as text, so that is perhaps not such a bit problem.