### PR TITLE
Retire all use of @lru_cache in favor of a simpler substitute

### DIFF
--- a/lutris/api.py
+++ b/lutris/api.py
@@ -1,5 +1,4 @@
 """Functions to interact with the Lutris REST API"""
-import functools
 import json
 import os
 import re
@@ -174,7 +173,6 @@ def format_runner_version(version_info: Dict[str, str]) -> str:
     return version
 
 
-@functools.lru_cache()
 def get_default_runner_version_info(runner_name: str, version: str = None) -> Dict[str, str]:
     """Get the appropriate version for a runner
 

--- a/lutris/gui/config/updates_box.py
+++ b/lutris/gui/config/updates_box.py
@@ -5,7 +5,7 @@ from typing import Callable
 from gi.repository import Gio, Gtk
 
 from lutris import settings
-from lutris.api import get_default_runner_version_info, get_runtime_versions_date
+from lutris.api import get_runtime_versions_date
 from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.gui.dialogs import NoticeDialog
 from lutris.runtime import RuntimeUpdater
@@ -15,6 +15,7 @@ from lutris.util import system
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 from lutris.util.strings import gtk_safe, time_ago
+from lutris.util.wine.wine import get_default_wine_runner_version_info
 
 
 class UpdatesBox(BaseConfigBox):
@@ -81,7 +82,7 @@ class UpdatesBox(BaseConfigBox):
         return (stable_channel_radio_button, unsupported_channel_radio_button)
 
     def get_wine_update_texts(self):
-        wine_version_info = get_default_runner_version_info("wine")
+        wine_version_info = get_default_wine_runner_version_info()
         wine_version = f"{wine_version_info['version']}-{wine_version_info['architecture']}"
         if system.path_exists(os.path.join(settings.RUNNER_DIR, "wine", wine_version)):
             update_label_text = _(

--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -2,10 +2,9 @@
 import os
 import shlex
 import stat
-from functools import lru_cache
 
 from lutris.exceptions import MissingExecutableError
-from lutris.util import system
+from lutris.util import cache_single, system
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 
@@ -146,7 +145,7 @@ def get_gamescope_args(launch_arguments, system_config):
     return launch_arguments
 
 
-@lru_cache()
+@cache_single
 def _get_gamescope_fsr_option():
     """Returns a list containing the arguments to insert to trigger FSR in gamescope;
     this changes in later versions, so we have to check the help output. There seems to be

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 from typing import Dict, Tuple
 
 from lutris import runtime, settings
-from lutris.api import format_runner_version, get_default_runner_version_info
+from lutris.api import format_runner_version
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
 from lutris.exceptions import (
@@ -35,9 +35,9 @@ from lutris.util.wine.extract_icon import PEFILE_AVAILABLE, ExtractIcon
 from lutris.util.wine.prefix import DEFAULT_DLL_OVERRIDES, WinePrefixManager, find_prefix
 from lutris.util.wine.vkd3d import VKD3DManager
 from lutris.util.wine.wine import (
-    WINE_DEFAULT_ARCH, WINE_DIR, WINE_PATHS, detect_arch, get_default_wine_version, get_installed_wine_versions,
-    get_overrides_env, get_proton_paths, get_real_executable, get_system_wine_version, get_wine_path_for_version,
-    is_esync_limit_set, is_fsync_supported, is_gstreamer_build
+    WINE_DEFAULT_ARCH, WINE_DIR, WINE_PATHS, detect_arch, get_default_wine_runner_version_info,
+    get_default_wine_version, get_installed_wine_versions, get_overrides_env, get_proton_paths, get_real_executable,
+    get_system_wine_version, get_wine_path_for_version, is_esync_limit_set, is_fsync_supported, is_gstreamer_build
 )
 
 
@@ -649,7 +649,7 @@ class wine(Runner):
 
     def get_runner_version(self, version: str = None) -> Dict[str, str]:
         if not version:
-            default_version_info = get_default_runner_version_info(self.name)
+            default_version_info = get_default_wine_runner_version_info()
             default_version = format_runner_version(default_version_info) if default_version_info else None
             version = self.read_version_from_config(default=default_version)
 

--- a/lutris/scanners/lutris.py
+++ b/lutris/scanners/lutris.py
@@ -10,6 +10,7 @@ from lutris.game import Game
 from lutris.installer.errors import MissingGameDependency
 from lutris.installer.interpreter import ScriptInterpreter
 from lutris.services.lutris import download_lutris_media
+from lutris.util import cache_single
 from lutris.util.log import logger
 from lutris.util.strings import slugify
 
@@ -185,7 +186,7 @@ def remove_from_path_cache(game):
     get_path_cache.cache_clear()
 
 
-@lru_cache()
+@cache_single
 def get_path_cache():
     """Return the contents of the path cache file; this
     dict is cached, so do not modify it."""

--- a/lutris/scanners/lutris.py
+++ b/lutris/scanners/lutris.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-from functools import lru_cache
 
 from lutris import settings
 from lutris.api import get_api_games, get_game_installers

--- a/lutris/util/__init__.py
+++ b/lutris/util/__init__.py
@@ -1,4 +1,5 @@
 """ Misc common functions """
+from functools import wraps
 
 
 def selective_merge(base_obj, delta_obj):
@@ -12,3 +13,32 @@ def selective_merge(base_obj, delta_obj):
     for k in new_keys:
         base_obj[k] = delta_obj[k]
     return base_obj
+
+
+def cache_single(function):
+    """A simple replacement for lru_cache, with no LRU behavior. This caches
+    a single result from a function that has no arguments at all. Exceptions
+    are not cached; there's a 'clear_cache()' function on the wrapper like with
+    lru_cache to explicitly clear the cache."""
+    is_cached = False
+    cached_item = None
+
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        nonlocal is_cached, cached_item
+        if args or kwargs:
+            return function(*args, **kwargs)
+
+        if not is_cached:
+            cached_item = function()
+            is_cached = True
+
+        return cached_item
+
+    def cache_clear():
+        nonlocal is_cached, cached_item
+        is_cached = False
+        cached_item = None
+
+    wrapper.cache_clear = cache_clear
+    return wrapper

--- a/lutris/util/flatpak.py
+++ b/lutris/util/flatpak.py
@@ -1,4 +1,3 @@
-import functools
 import shutil
 from gettext import gettext as _
 

--- a/lutris/util/flatpak.py
+++ b/lutris/util/flatpak.py
@@ -3,11 +3,12 @@ import shutil
 from gettext import gettext as _
 
 from lutris.exceptions import UnavailableRunnerError
+from lutris.util import cache_single
 from lutris.util.log import logger
 from lutris.util.system import read_process_output
 
 
-@functools.lru_cache(maxsize=None)
+@cache_single
 def get_executable():
     """Return the executable used to access Flatpak. None if Flatpak is not installed.
 
@@ -31,7 +32,7 @@ def get_command():
     return [exe]
 
 
-@functools.lru_cache(maxsize=None)
+@cache_single
 def get_installed_apps():
     if not is_installed():
         return []

--- a/lutris/util/graphics/vkquery.py
+++ b/lutris/util/graphics/vkquery.py
@@ -8,7 +8,6 @@ from ctypes import (
     CDLL, POINTER, Structure, byref, c_char, c_char_p, c_float, c_int32, c_size_t, c_uint8, c_uint32, c_uint64,
     c_void_p, pointer
 )
-from functools import lru_cache
 
 from lutris.util import cache_single
 
@@ -266,7 +265,7 @@ def is_vulkan_supported() -> bool:
     return result == VK_SUCCESS and dev_count.value > 0
 
 
-@lru_cache(maxsize=None)
+@cache_single
 def get_vulkan_api_version():
     """
     Queries libvulkan to get the API version; if this library is missing
@@ -329,7 +328,7 @@ def get_device_info():
     return sorted(device_info, key=lambda t: t.api_version, reverse=True)
 
 
-@lru_cache(maxsize=None)
+@cache_single
 def get_expected_api_version():
     """Returns the version tuple of the API version we expect
     to have; it is the least of the Vulkan library API version, and

--- a/lutris/util/graphics/vkquery.py
+++ b/lutris/util/graphics/vkquery.py
@@ -10,6 +10,8 @@ from ctypes import (
 )
 from functools import lru_cache
 
+from lutris.util import cache_single
+
 VkResult = c_int32  # enum (size == 4)
 VK_SUCCESS = 0
 VK_ERROR_INITIALIZATION_FAILED = -3
@@ -242,7 +244,7 @@ class VkPhysicalDeviceProperties(Structure):
     ]
 
 
-@lru_cache(maxsize=None)
+@cache_single
 def is_vulkan_supported() -> bool:
     """
     Returns True iff vulkan library can be loaded, initialized,

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -709,8 +709,8 @@ def _load_vulkan_gpu_name(icd_files, use_dri_prime):
 
             return gpu or "Not Found"
         except Exception as ex:
-            # Must not raise an exception as @lru_cache does not cache them, and
-            # this function must be preloaded or it can slow down
+            # Must not raise an exception as we do not cache them, and
+            # this function must be preloaded, or it can slow down the UI.
             logger.exception("Fail to load Vulkan GPU names: %s", ex)
             return _("Unknown GPU")
 

--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -51,7 +51,6 @@ This module's code is based on https://gist.github.com/openglfreak/715d5ab590249
 """
 import ctypes
 import errno
-import functools
 import os
 import subprocess
 

--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -57,6 +57,8 @@ import subprocess
 
 __all__ = ("get_fsync_support",)
 
+from lutris.util import cache_single
+
 
 # pylint: disable=invalid-name,too-few-public-methods
 class timespec(ctypes.Structure):
@@ -253,7 +255,7 @@ def _get_futex_wait_multiple_op(futex_syscall):
     return None
 
 
-@functools.lru_cache(None)
+@cache_single
 def is_futex_wait_multiple_supported():
     """Checks whether the Linux futex FUTEX_WAIT_MULTIPLE operation is
     supported on this kernel.
@@ -267,7 +269,7 @@ def is_futex_wait_multiple_supported():
         return False
 
 
-@functools.lru_cache(None)
+@cache_single
 def is_futex2_supported():
     """Checks whether the Linux futex2 syscall is supported on this
     kernel.
@@ -386,7 +388,7 @@ def _get_futex_waitv_syscall():
     return _futex_waitv_syscall
 
 
-@functools.lru_cache(None)
+@cache_single
 def is_futex_waitv_supported():
     """Checks whether the Linux 5.16 futex_waitv syscall is supported on
     this kernel.
@@ -401,7 +403,7 @@ def is_futex_waitv_supported():
         return False
 
 
-@functools.lru_cache(None)
+@cache_single
 def get_fsync_support():
     """Checks whether the FUTEX_WAIT_MULTIPLE operation, the futex2
     syscalls, or the futex_waitv syscall is supported on this kernel.

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -1,7 +1,6 @@
 """Utilities for manipulating Wine"""
 import os
 from collections import OrderedDict
-from functools import lru_cache
 from gettext import gettext as _
 from typing import Dict, Generator, List, Tuple
 
@@ -238,13 +237,20 @@ def get_default_wine_version() -> str:
     """Return the default version of wine."""
     installed_versions = get_installed_wine_versions()
     if installed_versions:
-        default_version = get_default_runner_version_info("wine")
+        default_version = get_default_wine_runner_version_info()
         if "version" in default_version and "architecture" in default_version:
             version = default_version["version"] + '-' + default_version["architecture"]
             if version in installed_versions:
                 return version
         return installed_versions[0]
     raise UnavailableRunnerError(_("No versions of Wine are installed."))
+
+
+@cache_single
+def get_default_wine_runner_version_info():
+    """Just returns the runner info for the default Wine, but with
+    caching."""
+    return get_default_runner_version_info("wine")
 
 
 def get_system_wine_version(wine_path: str = "wine") -> str:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -9,7 +9,7 @@ from lutris import settings
 from lutris.api import get_default_runner_version_info
 from lutris.exceptions import MisconfigurationError, UnavailableRunnerError, UnspecifiedVersionError
 from lutris.gui.dialogs import ErrorDialog
-from lutris.util import linux, system
+from lutris.util import cache_single, linux, system
 from lutris.util.log import logger
 from lutris.util.steam.config import get_steamapps_dirs
 from lutris.util.strings import parse_version
@@ -171,7 +171,7 @@ def list_proton_versions() -> List[str]:
     return versions
 
 
-@lru_cache(maxsize=8)
+@cache_single
 def get_installed_wine_versions() -> List[str]:
     """Return the list of Wine versions installed"""
     return list_system_wine_versions() + list_lutris_wine_versions() + list_proton_versions()


### PR DESCRIPTION
I don't know that this PR really has a lot of value, but it seemed like an interesting exercise. If you hate having ``lru`` pasted all over everything even when it's not meaningful, well, this PR fixes that.

We've been using ``@lru_cache`` for our simple caching needs, and it is a lot more than we need. We are only caching single values from no-arg functions (almost!).

So, this PR adds ``@cache_single``, a minimal caching decorator that only works on no-arg functions. It has a ``cache_clear()`` attached-function like ``@lru_cache``, but that's the only frill. No ``dict``, no stats, nothing fancy.

It's a drop in replacement for ``@lru_cache`` in every case we have... but one. That one case is ``get_default_runner_version_info``, which takes args. But I believe I've found a workaround- we almost always call it with the same args, ("wine", None) and I've added a no-args function to do that- with``@cache_single``. The one exception is in a place where the lack of caching should not be noticed.