### PR TITLE
Untranslate Ubisoft connect

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -6246,7 +6246,7 @@ msgstr "Steam pour Windows"
 
 #: lutris/services/ubisoft.py:82
 msgid "Ubisoft Connect"
-msgstr "Connexion Ubisoft"
+msgstr "Ubisoft Connect"
 
 #: lutris/services/xdg.py:44
 msgid "Local"


### PR DESCRIPTION
It's a brand, it should not be translated