### PR TITLE
Enable download of DLC extras from GOG.

### DIFF
--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -70,7 +70,7 @@ class InstallerWindow(ModelessDialog,
         self.set_default_size(740, 460)
         self.installers = installers
         self.config = {}
-        self.selected_extra_ids = []
+        self.selected_extras = []
         self.install_in_progress = False
         self.install_complete = False
         self.interpreter = None
@@ -137,7 +137,7 @@ class InstallerWindow(ModelessDialog,
         self.extras_tree_store = Gtk.TreeStore(
             bool,  # is selected?
             bool,  # is inconsistent?
-            str,  # id
+            object,  # extras dict
             str,  # label
         )
 
@@ -499,7 +499,7 @@ class InstallerWindow(ModelessDialog,
             for extra_source, extras in all_extras.items():
                 parent = self.extras_tree_store.append(None, (None, None, None, extra_source))
                 for extra in extras:
-                    self.extras_tree_store.append(parent, (False, False, extra["id"], self.get_extra_label(extra)))
+                    self.extras_tree_store.append(parent, (False, False, extra, self.get_extra_label(extra)))
 
             self.stack.navigate_to_page(self.present_extras_page)
         else:
@@ -577,13 +577,13 @@ class InstallerWindow(ModelessDialog,
         selected_extras = []
 
         def save_extra(store, path, iter_):
-            selected, _inconsistent, id_, _label = store[iter_]
-            if selected and id_:
-                selected_extras.append(id_)
+            selected, _inconsistent, extra, _label = store[iter_]
+            if selected and extra:
+                selected_extras.append(extra)
 
         extra_store.foreach(save_extra)
 
-        self.selected_extra_ids = selected_extras
+        self.selected_extras = selected_extras
         GLib.idle_add(self.on_extras_ready)
 
     def on_extras_ready(self, *args):
@@ -602,7 +602,7 @@ class InstallerWindow(ModelessDialog,
             patch_version = None
 
         AsyncCall(self.interpreter.installer.prepare_game_files,
-                  self.on_files_prepared, self.selected_extra_ids, patch_version)
+                  self.on_files_prepared, self.selected_extras, patch_version)
 
     def on_files_prepared(self, _result, error):
         if error:

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -148,7 +148,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
             errors.append("Scripts can't have both extends and requires")
         return errors
 
-    def prepare_game_files(self, extra_ids, patch_version=None):
+    def prepare_game_files(self, extras, patch_version=None):
         """Gathers necessary files before iterating through them."""
         if not self.script_files:
             return
@@ -177,7 +177,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
                     # If a patch version is given download the patch files instead of the installer
                     installer_files = self.service.get_patch_files(self, installer_file_id)
                 else:
-                    content_files, extra_files = self.service.get_installer_files(self, installer_file_id, extra_ids)
+                    content_files, extra_files = self.service.get_installer_files(self, installer_file_id, extras)
                     self.extra_file_paths = [path for f in extra_files for path in f.get_dest_files_by_id().values()]
                     installer_files = content_files + extra_files
             except UnavailableGameError as ex:

--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -529,6 +529,7 @@ class ItchIoService(OnlineService):
         extra_files = []
         link = None
         filename = "setup.zip"
+        selected_extras_ids = set(x["id"] for x in selected_extras or [])
 
         file = next(_file.copy() for _file in installer.script_files if _file.id == installer_file_id)
         if not file.url.startswith("N/A"):
@@ -542,9 +543,9 @@ class ItchIoService(OnlineService):
             "date": int(datetime.datetime.now().timestamp())
         }
 
-        if not link or len(selected_extras) > 0:
+        if not link or len(selected_extras_ids) > 0:
             for upload in uploads["uploads"]:
-                if selected_extras and (upload["type"] in self.extra_types):
+                if selected_extras_ids and (upload["type"] in self.extra_types):
                     extras.append(upload)
                     continue
                 # default =  games/tools ("executables")
@@ -594,7 +595,7 @@ class ItchIoService(OnlineService):
             )
 
         for extra in extras:
-            if str(extra["id"]) not in selected_extras:
+            if str(extra["id"]) not in selected_extras_ids:
                 continue
             link = self.get_download_link(extra["id"], key)
             extra_files.append(


### PR DESCRIPTION
I figured out how to get the DLC extras from GOG, but the change is maybe too much just before release.

But this should finally Resolve #4974 fully.

The downlink stuff we need is there when we get the list of  extras in the first place; we need to keep it. I stash it in the extra's dict that we provide the InstallerWindow, but it must not throw that dict away. I have changed it to keep that dict in the ListStore it uses, then pass it back rather than just an id.

With that, the GOG service can download the file in the normal way.

But there are minimal changes for itch.io, the only other service with extras. The new code here just strips the IDs out and proceeds as before. But I have no itch.io game with extras to test with (I have only the one!)