### PR TITLE
Against the Waggle of Death

### DIFF
--- a/lutris/gui/addgameswindow.py
+++ b/lutris/gui/addgameswindow.py
@@ -288,9 +288,8 @@ class AddGamesWindow(ModelessDialog):  # pylint: disable=too-many-public-methods
 
     def _on_game_selected(self, listbox, row):
         game_slug = row.api_info["slug"]
-        installers = get_installers(game_slug=game_slug)
         application = Gio.Application.get_default()
-        application.show_installer_window(installers)
+        application.show_lutris_installer_window(game_slug=game_slug)
         self.destroy()
 
     # Scan Folder Page

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -402,6 +402,15 @@ class Application(Gtk.Application):
             installation_kind=installation_kind
         )
 
+    def show_lutris_installer_window(self, game_slug):
+        def on_installers_ready(installers, error):
+            if error:
+                ErrorDialog(error, parent=self.window)
+            else:
+                self.show_installer_window(installers)
+
+        AsyncCall(get_installers, on_installers_ready, game_slug=game_slug)
+
     def on_app_window_destroyed(self, app_window, window_key):
         """Remove the reference to the window when it has been destroyed"""
         window_key = str(app_window.__class__.__name__) + window_key

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -16,7 +16,7 @@ from lutris.gui.installer.script_picker import InstallerPicker
 from lutris.gui.widgets.common import FileChooserEntry
 from lutris.gui.widgets.log_text_view import LogTextView
 from lutris.gui.widgets.navigation_stack import NavigationStack
-from lutris.installer import InstallationKind, get_installers, interpreter
+from lutris.installer import InstallationKind, interpreter
 from lutris.installer.errors import MissingGameDependencyError, ScriptingError
 from lutris.installer.interpreter import ScriptInterpreter
 from lutris.util import xdgshortcuts
@@ -363,9 +363,8 @@ class InstallerWindow(ModelessDialog,
                 }
             )
             if dlg.result == Gtk.ResponseType.YES:
-                installers = get_installers(game_slug=ex.slug)
                 application = Gio.Application.get_default()
-                application.show_installer_window(installers)
+                application.show_lutris_installer_window(game_slug=ex.slug)
             return
 
         self.set_title(_("Installing {}").format(self.interpreter.installer.game_name))

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -17,7 +17,6 @@ from lutris.gui.dialogs import NoticeDialog
 from lutris.gui.dialogs.webconnect_dialog import DEFAULT_USER_AGENT, WebConnectDialog
 from lutris.gui.views.media_loader import download_media
 from lutris.gui.widgets.utils import BANNER_SIZE, ICON_SIZE
-from lutris.installer import get_installers
 from lutris.services.service_media import ServiceMedia
 from lutris.util import system
 from lutris.util.cookies import WebkitCookieJar
@@ -420,8 +419,7 @@ class OnlineService(BaseService):
                 _("This service requires a game launcher. The following steps will install it.\n"
                   "Once the client is installed, you can login to %s.") % self.name)
             application = Gio.Application.get_default()
-            installers = get_installers(game_slug=self.client_installer)
-            application.show_installer_window(installers)
+            application.show_lutris_installer_window(game_slug=self.client_installer)
             return
         logger.debug("Connecting to %s", self.name)
         dialog = WebConnectDialog(self, parent)

--- a/lutris/services/ea_app.py
+++ b/lutris/services/ea_app.py
@@ -15,7 +15,6 @@ from lutris.config import LutrisConfig, write_game_config
 from lutris.database.games import add_game, get_game_by_field
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
-from lutris.installer import get_installers
 from lutris.services.base import OnlineService
 from lutris.services.lutris import sync_media
 from lutris.services.service_game import ServiceGame
@@ -389,8 +388,7 @@ class EAAppService(OnlineService):
         application = Gio.Application.get_default()
         if not ea_app_game or not ea_app_game["installed"]:
             logger.warning("Installing the EA App client")
-            installers = get_installers(game_slug=self.client_installer)
-            application.show_installer_window(installers)
+            application.show_lutris_installer_window(game_slug=self.client_installer)
         else:
             application.show_installer_window(
                 [self.generate_installer(db_game, ea_app_game)],

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -12,7 +12,6 @@ from lutris.database.games import add_game, get_game_by_field
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
 from lutris.gui.widgets.utils import Image, paste_overlay, thumbnail_image
-from lutris.installer import get_installers
 from lutris.services.base import AuthTokenExpiredError, OnlineService
 from lutris.services.lutris import sync_media
 from lutris.services.service_game import ServiceGame
@@ -413,10 +412,7 @@ class EpicGamesStoreService(OnlineService):
         application = Gio.Application.get_default()
         if not egs_game or not egs_game["installed"]:
             logger.warning("EGS (%s) not installed", self.client_installer)
-            installers = get_installers(
-                game_slug=self.client_installer,
-            )
-            application.show_installer_window(installers)
+            application.show_lutris_installer_window(game_slug=self.client_installer)
         else:
             application.show_installer_window(
                 [self.generate_installer(db_game, egs_game)],

--- a/lutris/services/flathub.py
+++ b/lutris/services/flathub.py
@@ -6,7 +6,6 @@ from gettext import gettext as _
 from pathlib import Path
 
 import requests
-from gi.repository import Gio
 
 from lutris import settings
 from lutris.exceptions import MissingExecutableError
@@ -108,14 +107,10 @@ class FlathubService(BaseService):
         logger.debug("Installing %s from service %s", app_id, self.id)
         # Check if Flathub repo is active on the system
         if not self.is_flathub_remote_active():
-            logger.error("Flathub is not configured on the system. Visit https://flatpak.org/setup/ for instructions.")
-            return
+            raise RuntimeError(
+                _("Flathub is not configured on the system. Visit https://flatpak.org/setup/ for instructions."))
         # Install the game
-        service_installers = self.get_installers_from_api(app_id)
-        if not service_installers:
-            service_installers = [self.generate_installer(db_game)]
-        application = Gio.Application.get_default()
-        application.show_installer_window(service_installers, service=self, appid=app_id)
+        self.install_from_api(db_game, app_id)
 
     def get_installed_apps(self):
         """Get list of installed Flathub apps"""

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -16,7 +16,6 @@ from lutris.config import LutrisConfig, write_game_config
 from lutris.database.games import add_game, get_game_by_field
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
-from lutris.installer import get_installers
 from lutris.services.base import OnlineService
 from lutris.services.lutris import sync_media
 from lutris.services.service_game import ServiceGame
@@ -382,8 +381,7 @@ class OriginService(OnlineService):
         application = Gio.Application.get_default()
         if not origin_game or not origin_game["installed"]:
             logger.warning("Installing the Origin client")
-            installers = get_installers(game_slug=self.client_installer)
-            application.show_installer_window(installers)
+            application.show_lutris_installer_window(game_slug=self.client_installer)
         else:
             application.show_installer_window(
                 [self.generate_installer(db_game, origin_game)],

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -4,8 +4,6 @@ import os
 from collections import defaultdict
 from gettext import gettext as _
 
-from gi.repository import Gio
-
 from lutris import settings
 from lutris.config import LutrisConfig, write_game_config
 from lutris.database import sql
@@ -242,8 +240,4 @@ class SteamService(BaseService):
             game = Game(existing_game.id)
             game.save()
             return
-        service_installers = self.get_installers_from_api(appid)
-        if not service_installers:
-            service_installers = [self.generate_installer(db_game)]
-        application = Gio.Application.get_default()
-        application.show_installer_window(service_installers, service=self, appid=appid)
+        self.install_from_api(db_game, appid)

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -12,7 +12,6 @@ from lutris.config import LutrisConfig, write_game_config
 from lutris.database.games import add_game, get_game_by_field, update_existing
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
-from lutris.installer import get_installers
 from lutris.services.base import OnlineService
 from lutris.services.lutris import sync_media
 from lutris.services.service_game import ServiceGame
@@ -282,8 +281,7 @@ class UbisoftConnectService(OnlineService):
         application = Gio.Application.get_default()
         if not ubisoft_connect or not ubisoft_connect["installed"]:
             logger.warning("Ubisoft Connect (%s) not installed", self.client_installer)
-            installers = get_installers(game_slug=self.client_installer)
-            application.show_installer_window(installers)
+            application.show_lutris_installer_window(game_slug=self.client_installer)
         else:
             application.show_installer_window(
                 [self.generate_installer(db_game, ubisoft_connect)],


### PR DESCRIPTION
This is a set of changes that try to put the API calls to fetch installers from the Lutris website onto threads.

Mostly these happen before showing an installer window, and that's non-blocking anyway, so it's a fire-and-forget thing.

The advantage of doing this is to keep GTK processing input, so the nasty Wayland/GTK broken pipe crash is less likely, even if the Lutris API does not respond promptly.

This can cause the installer window to appear after another window (like the add games window) has closed instead of before that. Beats crashing.

Also, I surely didn't manage to exercise every code-path I touched here.