### PR TITLE
Reduce the use of signals in Lutris

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -344,7 +344,7 @@ max-branches=12
 max-locals=15
 
 # Maximum number of parents for a class (see R0901).
-max-parents=7
+max-parents=15
 
 # Maximum number of public methods for a class (see R0904).
 max-public-methods=20

--- a/lutris/exception_backstops.py
+++ b/lutris/exception_backstops.py
@@ -30,14 +30,12 @@ def watch_game_errors(game_stop_result, game=None):
             try:
                 result = function(*args, **kwargs)
                 if game_stop_result is not None and result == game_stop_result and game.state != game.STATE_STOPPED:
-                    game.state = game.STATE_STOPPED
-                    game.emit("game-stop")
+                    game.stop_game()
                 return result
             except Exception as ex:
                 logger.exception("%s has encountered an error: %s", game, ex, exc_info=ex)
                 if game.state != game.STATE_STOPPED:
-                    game.state = game.STATE_STOPPED
-                    game.emit("game-stop")
+                    game.stop_game()
                 game.signal_error(ex)
                 return game_stop_result
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -21,6 +21,7 @@ from lutris.database import games as games_db
 from lutris.database import sql
 from lutris.exception_backstops import watch_game_errors
 from lutris.exceptions import GameConfigError, InvalidGameMoveError, MissingExecutableError
+from lutris.installer import InstallationKind
 from lutris.runner_interpreter import export_bash_script, get_launch_parameters
 from lutris.runners import import_runner
 from lutris.runners.runner import Runner
@@ -61,8 +62,6 @@ class Game(GObject.Object):
         "game-stopped": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-removed": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-updated": (GObject.SIGNAL_RUN_FIRST, None, ()),
-        "game-install-update": (GObject.SIGNAL_RUN_FIRST, None, ()),
-        "game-install-dlc": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-installed": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
@@ -334,6 +333,7 @@ class Game(GObject.Object):
                 self.compositor_disabled = True
 
     def install(self, launch_ui_delegate=None):
+        """Request installation of a game"""
         application = Gio.Application.get_default()
         if not launch_ui_delegate:
             launch_ui_delegate = application.launch_ui_delegate
@@ -341,7 +341,6 @@ class Game(GObject.Object):
         if not self.slug:
             raise ValueError("Invalid game passed: %s" % self)
 
-        """Request installation of a game"""
         if not self.service or self.service == "lutris":
             application.show_lutris_installer_window(game_slug=self.slug)
             return
@@ -366,6 +365,46 @@ class Game(GObject.Object):
             game = Game(game_id)
             game.connect("game-error", on_error)
             game.launch(launch_ui_delegate)
+
+    def install_updates(self, launch_ui_delegate=None):
+        application = Gio.Application.get_default()
+        if not launch_ui_delegate:
+            launch_ui_delegate = application.launch_ui_delegate
+
+        service = launch_ui_delegate.get_service(self.service)
+        db_game = games_db.get_game_by_field(self.id, "id")
+
+        def on_installers_ready(installers, error):
+            if error:
+                raise error  # bounce errors off the backstop
+
+            if not installers:
+                raise RuntimeError(_("No updates found"))
+            application.show_installer_window(installers, service, self.appid,
+                                              installation_kind=InstallationKind.UPDATE)
+
+        jobs.AsyncCall(service.get_update_installers, on_installers_ready, db_game)
+        return True
+
+    def install_dlc(self, launch_ui_delegate=None):
+        application = Gio.Application.get_default()
+        if not launch_ui_delegate:
+            launch_ui_delegate = application.launch_ui_delegate
+
+        service = launch_ui_delegate.get_service(self.service)
+        db_game = games_db.get_game_by_field(self.id, "id")
+
+        def on_installers_ready(installers, error):
+            if error:
+                raise error  # bounce errors off the backstop
+
+            if not installers:
+                raise RuntimeError(_("No DLC found"))
+
+            application.show_installer_window(installers, service, self.appid, installation_kind=InstallationKind.DLC)
+
+        jobs.AsyncCall(service.get_dlc_installers_runner, on_installers_ready, db_game, db_game["runner"])
+        return True
 
     def remove(self, delete_files: bool = False, no_signal: bool = False) -> None:
         """Uninstall a game, and removes it from the library if this it has no playtime.

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -11,7 +11,7 @@ import time
 from gettext import gettext as _
 from typing import cast
 
-from gi.repository import GLib, GObject, Gtk
+from gi.repository import GLib, GObject, Gtk, Gio
 
 from lutris import settings
 from lutris.command import MonitoredCommand
@@ -56,7 +56,6 @@ class Game(GObject.Object):
         # fix merged Dec 2020, but we support older GNOME!
         "game-error": (GObject.SIGNAL_RUN_LAST, bool, (object,)),
         "game-unhandled-error": (GObject.SIGNAL_RUN_FIRST, None, (object,)),
-        "game-launch": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-stop": (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -643,7 +642,10 @@ class Game(GObject.Object):
         return True
 
     @watch_game_errors(game_stop_result=False)
-    def launch(self, launch_ui_delegate):
+    def launch(self, launch_ui_delegate=None):
+        if not launch_ui_delegate:
+            launch_ui_delegate = Gio.Application.get_default().launch_ui_delegate
+
         """Request launching a game. The game may not be installed yet."""
         if not self.check_launchable():
             logger.error("Game is not launchable")

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -713,11 +713,8 @@ class Game(GObject.Object):
         return True
 
     @watch_game_errors(game_stop_result=False)
-    def launch(self, launch_ui_delegate=None):
+    def launch(self, launch_ui_delegate):
         """Request launching a game. The game may not be installed yet."""
-        if not launch_ui_delegate:
-            launch_ui_delegate = Gio.Application.get_default().launch_ui_delegate
-
         if not self.check_launchable():
             logger.error("Game is not launchable")
             return False

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -11,7 +11,7 @@ import time
 from gettext import gettext as _
 from typing import cast
 
-from gi.repository import GLib, GObject, Gtk, Gio
+from gi.repository import Gio, GLib, GObject, Gtk
 
 from lutris import settings
 from lutris.command import MonitoredCommand
@@ -58,7 +58,6 @@ class Game(GObject.Object):
         "game-unhandled-error": (GObject.SIGNAL_RUN_FIRST, None, (object,)),
         "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
-        "game-stop": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-stopped": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-removed": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-updated": (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -643,10 +642,10 @@ class Game(GObject.Object):
 
     @watch_game_errors(game_stop_result=False)
     def launch(self, launch_ui_delegate=None):
+        """Request launching a game. The game may not be installed yet."""
         if not launch_ui_delegate:
             launch_ui_delegate = Gio.Application.get_default().launch_ui_delegate
 
-        """Request launching a game. The game may not be installed yet."""
         if not self.check_launchable():
             logger.error("Game is not launchable")
             return False
@@ -810,7 +809,7 @@ class Game(GObject.Object):
             # Inspect why it could have crashed
 
         self.state = self.STATE_STOPPED
-        self.emit("game-stop")
+        self.emit("game-stopped")
         if os.path.exists(self.now_playing_path):
             os.unlink(self.now_playing_path)
         if not self.timer.finished:

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -366,12 +366,8 @@ class Game(GObject.Object):
             game.connect("game-error", on_error)
             game.launch(launch_ui_delegate)
 
-    def install_updates(self, launch_ui_delegate=None):
-        application = Gio.Application.get_default()
-        if not launch_ui_delegate:
-            launch_ui_delegate = application.launch_ui_delegate
-
-        service = launch_ui_delegate.get_service(self.service)
+    def install_updates(self, install_ui_delegate):
+        service = install_ui_delegate.get_service(self.service)
         db_game = games_db.get_game_by_field(self.id, "id")
 
         def on_installers_ready(installers, error):
@@ -380,18 +376,16 @@ class Game(GObject.Object):
 
             if not installers:
                 raise RuntimeError(_("No updates found"))
+
+            application = Gio.Application.get_default()
             application.show_installer_window(installers, service, self.appid,
                                               installation_kind=InstallationKind.UPDATE)
 
         jobs.AsyncCall(service.get_update_installers, on_installers_ready, db_game)
         return True
 
-    def install_dlc(self, launch_ui_delegate=None):
-        application = Gio.Application.get_default()
-        if not launch_ui_delegate:
-            launch_ui_delegate = application.launch_ui_delegate
-
-        service = launch_ui_delegate.get_service(self.service)
+    def install_dlc(self, install_ui_delegate):
+        service = install_ui_delegate.get_service(self.service)
         db_game = games_db.get_game_by_field(self.id, "id")
 
         def on_installers_ready(installers, error):
@@ -401,6 +395,7 @@ class Game(GObject.Object):
             if not installers:
                 raise RuntimeError(_("No DLC found"))
 
+            application = Gio.Application.get_default()
             application.show_installer_window(installers, service, self.appid, installation_kind=InstallationKind.DLC)
 
         jobs.AsyncCall(service.get_dlc_installers_runner, on_installers_ready, db_game, db_game["runner"])

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -151,19 +151,6 @@ class Game(GObject.Object):
             self.emit("game-state-changed")
 
     @property
-    def is_cache_managed(self):
-        """Is the DXVK cache receiving updates from lutris?"""
-        try:
-            if not self.has_runner:
-                return False
-
-            env = self.runner.system_config.get("env", {})
-            return "DXVK_STATE_CACHE_PATH" in env
-        except InvalidRunnerError as ex:
-            logger.exception("Unable to query runner configuration: %s", ex)
-            return False
-
-    @property
     def id(self) -> str:
         if not self._id:
             logger.error("The game '%s' has no ID, it is not stored in the database.", self.name)

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -332,16 +332,13 @@ class Game(GObject.Object):
                 disable_compositing()
                 self.compositor_disabled = True
 
-    def install(self, launch_ui_delegate=None):
+    def install(self, launch_ui_delegate):
         """Request installation of a game"""
-        application = Gio.Application.get_default()
-        if not launch_ui_delegate:
-            launch_ui_delegate = application.launch_ui_delegate
-
         if not self.slug:
             raise ValueError("Invalid game passed: %s" % self)
 
         if not self.service or self.service == "lutris":
+            application = Gio.Application.get_default()
             application.show_lutris_installer_window(game_slug=self.slug)
             return
 

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -73,7 +73,7 @@ class BaseGameActions:
                 if not game.slug:
                     game_id = game.id if game.is_db_stored else game.name
                     raise RuntimeError("No game to install: %s" % game_id)
-                game.emit("game-install")
+                game.install(launch_ui_delegate=self.window)
 
     def on_locate_installed_game(self, *_args):
         """Show the user a dialog to import an existing install to a DRM free service

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -32,7 +32,7 @@ from lutris.util.system import path_exists
 class BaseGameActions:
     def __init__(self, games, window, application=None):
         self.application = application or Gio.Application.get_default()
-        self.window = window  # also used as a LaunchUIDelegate
+        self.window = window  # also used as a LaunchUIDelegate and InstallUIDelegate
         self.games = games
 
     def get_game_actions(self):
@@ -278,11 +278,11 @@ class GameActions(BaseGameActions):
 
     def on_update_clicked(self, _widget):
         for game in self.games:
-            game.install_updates(launch_ui_delegate=self.window)
+            game.install_updates(install_ui_delegate=self.window)
 
     def on_install_dlc_clicked(self, _widget):
         for game in self.games:
-            game.install_dlc(launch_ui_delegate=self.window)
+            game.install_dlc(install_ui_delegate=self.window)
 
     def on_game_duplicate(self, _widget):
         for game in self.games:

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -278,11 +278,11 @@ class GameActions(BaseGameActions):
 
     def on_update_clicked(self, _widget):
         for game in self.games:
-            game.emit("game-install-update")
+            game.install_updates(launch_ui_delegate=self.window)
 
     def on_install_dlc_clicked(self, _widget):
         for game in self.games:
-            game.emit("game-install-dlc")
+            game.install_dlc(launch_ui_delegate=self.window)
 
     def on_game_duplicate(self, _widget):
         for game in self.games:

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -246,7 +246,7 @@ class GameActions(BaseGameActions):
         for game in self.games:
             if game.is_installed and game.is_db_stored:
                 if not self.application.is_game_running_by_id(game.id):
-                    game.launch(self.window)
+                    game.launch(launch_ui_delegate=self.window)
 
     def get_running_games(self):
         running_games = []

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -79,7 +79,6 @@ class Application(Gtk.Application):
         # established; this will apply to all connections from this point forward.
         init_exception_backstops()
 
-        GObject.add_emission_hook(Game, "game-launch", self.on_game_launch)
         GObject.add_emission_hook(Game, "game-start", self.on_game_start)
         GObject.add_emission_hook(Game, "game-stop", self.on_game_stop)
         GObject.add_emission_hook(Game, "game-install", self.on_game_install)
@@ -783,10 +782,6 @@ class Application(Gtk.Application):
             if self.window.get_visible():
                 self.set_tray_icon()
         return True
-
-    def on_game_launch(self, game):
-        game.launch(self.launch_ui_delegate)
-        return True  # Return True to continue handling the emission hook
 
     def on_game_start(self, game):
         self.running_games.append(game)

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -813,7 +813,7 @@ class Application(Gtk.Application):
     def get_launch_ui_delegate(self):
         return self.launch_ui_delegate
 
-    def get_running_games(self) -> List[str]:
+    def get_running_games(self) -> List[Game]:
         # This method reflects games that have stopped even if the 'game-stopped' signal
         # has not been handled yet; that handler will still clean up the list though.
         return [g for g in self._running_games if g.state != g.STATE_STOPPED]
@@ -828,7 +828,7 @@ class Application(Gtk.Application):
 
     def is_game_running_by_id(self, game_id: str) -> bool:
         """True if the ID is the ID of a game that is running."""
-        return game_id and str(game_id) in self.get_running_game_ids()
+        return bool(game_id and str(game_id) in self.get_running_game_ids())
 
     def get_game_by_id(self, game_id: str) -> Game:
         """Returns the game with the ID given; if it's running this is the running

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -81,8 +81,6 @@ class Application(Gtk.Application):
 
         GObject.add_emission_hook(Game, "game-start", self.on_game_start)
         GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
-        GObject.add_emission_hook(Game, "game-install-update", self.on_game_install_update)
-        GObject.add_emission_hook(Game, "game-install-dlc", self.on_game_install_dlc)
         GObject.add_emission_hook(PreferencesDialog, "settings-changed", self.on_settings_changed)
 
         GLib.set_application_name(_("Lutris"))
@@ -810,36 +808,6 @@ class Application(Gtk.Application):
             if not self.has_running_games:
                 if self.quit_on_game_exit or not self.has_tray_icon():
                     self.quit()
-        return True
-
-    def on_game_install_update(self, game):
-        service = get_enabled_services()[game.service]()
-        db_game = games_db.get_game_by_field(game.id, "id")
-
-        def on_installers_ready(installers, error):
-            if error:
-                ErrorDialog(error, parent=self.window)
-            elif installers:
-                self.show_installer_window(installers, service, game.appid, installation_kind=InstallationKind.UPDATE)
-            else:
-                ErrorDialog(_("No updates found"), parent=self.window)
-
-        AsyncCall(service.get_update_installers, on_installers_ready, db_game)
-        return True
-
-    def on_game_install_dlc(self, game):
-        service = get_enabled_services()[game.service]()
-        db_game = games_db.get_game_by_field(game.id, "id")
-
-        def on_installers_ready(installers, error):
-            if error:
-                ErrorDialog(error, parent=self.window)
-            elif installers:
-                self.show_installer_window(installers, service, game.appid, installation_kind=InstallationKind.DLC)
-            else:
-                ErrorDialog(_("No DLC found"), parent=self.window)
-
-        AsyncCall(service.get_dlc_installers_runner, on_installers_ready, db_game, db_game["runner"])
         return True
 
     def get_launch_ui_delegate(self):

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -6,6 +6,7 @@ from lutris.exceptions import UnavailableRunnerError
 from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.dialogs.download import DownloadDialog
+from lutris.services import get_enabled_services
 from lutris.util.downloader import Downloader
 
 
@@ -40,6 +41,11 @@ class LaunchUIDelegate:
         The default is the select the primary game.
         """
         return {}  # primary game
+
+    def get_service(self, service_id):
+        """Returns a new service object by its id. This seems dumb, but it is a work-around
+        for Python's circular import limitations."""
+        return get_enabled_services()[service_id]()
 
 
 class InstallUIDelegate:

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -10,7 +10,14 @@ from lutris.services import get_enabled_services
 from lutris.util.downloader import Downloader
 
 
-class LaunchUIDelegate:
+class Delegate:
+    def get_service(self, service_id):
+        """Returns a new service object by its id. This seems dumb, but it is a work-around
+        for Python's circular import limitations."""
+        return get_enabled_services()[service_id]()
+
+
+class LaunchUIDelegate(Delegate):
     """These objects provide UI for the game while it is being launched;
     one provided to the launch() method.
 
@@ -42,13 +49,8 @@ class LaunchUIDelegate:
         """
         return {}  # primary game
 
-    def get_service(self, service_id):
-        """Returns a new service object by its id. This seems dumb, but it is a work-around
-        for Python's circular import limitations."""
-        return get_enabled_services()[service_id]()
 
-
-class InstallUIDelegate:
+class InstallUIDelegate(Delegate):
     """These objects provide UI for a runner as it is installing itself.
     One of these must be provided to the install() method.
 

--- a/lutris/gui/dialogs/game_import.py
+++ b/lutris/gui/dialogs/game_import.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from copy import deepcopy
 from gettext import gettext as _
 
-from gi.repository import GLib, Gtk
+from gi.repository import Gio, GLib, Gtk
 
 from lutris.config import write_game_config
 from lutris.database.games import add_game
@@ -216,7 +216,10 @@ class ImportGameDialog(ModelessDialog):
         launch_button.connect("clicked", self.on_launch_clicked, game)
 
     def on_launch_clicked(self, _button, game):
-        game.launch()
+        # We can't use this window as the delegate because we
+        # are destroying it.
+        application = Gio.Application.get_default()
+        game.launch(application.launch_ui_delegate)
         self.destroy()
 
     def display_existing_game_info(self, filename, game):

--- a/lutris/gui/dialogs/game_import.py
+++ b/lutris/gui/dialogs/game_import.py
@@ -216,7 +216,7 @@ class ImportGameDialog(ModelessDialog):
         launch_button.connect("clicked", self.on_launch_clicked, game)
 
     def on_launch_clicked(self, _button, game):
-        game.emit("game-launch")
+        game.launch()
         self.destroy()
 
     def display_existing_game_info(self, filename, game):

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -909,7 +909,7 @@ class InstallerWindow(ModelessDialog,
         self.on_cancel_clicked(button)
         game = Game(self.interpreter.installer.game_id)
         if game.is_db_stored:
-            game.emit("game-launch")
+            game.launch()
         else:
             logger.error("Game has no ID, launch button should not be drawn")
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -906,12 +906,15 @@ class InstallerWindow(ModelessDialog,
     def on_launch_clicked(self, button):
         """Launch a game after it's been installed."""
         button.set_sensitive(False)
-        self.on_cancel_clicked(button)
         game = Game(self.interpreter.installer.game_id)
         if game.is_db_stored:
-            game.launch()
+            # Since we're closing this window, we can't use
+            # it as the delegate.
+            application = Gio.Application.get_default()
+            game.launch(application.launch_ui_delegate)
         else:
             logger.error("Game has no ID, launch button should not be drawn")
+        self.on_cancel_clicked(button)
 
     def on_window_focus(self, _widget, *_args):
         """Remove urgency hint (flashing indicator) when window receives focus"""

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -140,7 +140,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.update_action_state()
 
         self.connect("view-updated", self.update_store)
-        GObject.add_emission_hook(BaseService, "service-login", self.on_service_login)
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
         GObject.add_emission_hook(BaseService, "service-games-loaded", self.on_service_games_updated)
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
@@ -843,14 +842,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.window_y = settings.read_setting("window_y")
         if self.window_x and self.window_y:
             self.move(int(self.window_x), int(self.window_y))
-
-    def on_service_login(self, service):
-        service.start_reload(self._service_reloaded_cb)
-        return True
-
-    def _service_reloaded_cb(self, error):
-        if error:
-            dialogs.ErrorDialog(error, parent=self)
 
     def on_service_logout(self, service):
         if self.service and service.id == self.service.id:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1115,7 +1115,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
             if game.is_installed:
                 game.launch(launch_ui_delegate=self)
             else:
-                game.emit("game-install")
+                game.install(launch_ui_delegate=self)
 
     @property
     def download_queue(self) -> DownloadQueue:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -872,7 +872,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
     def on_window_delete(self, *_args):
         app = self.application
-        if app.running_games:
+        if app.has_running_games:
             self.hide()
             return True
         if app.has_tray_icon():

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -139,7 +139,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
         GObject.add_emission_hook(BaseService, "service-games-loaded", self.on_service_games_updated)
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
-        GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
+        GObject.add_emission_hook(Game, "game-state-changed", self.on_game_state_changed)
         GObject.add_emission_hook(Game, "game-installed", self.on_game_installed)
         GObject.add_emission_hook(Game, "game-removed", self.on_game_removed)
         GObject.add_emission_hook(Game, "game-unhandled-error", self.on_game_unhandled_error)
@@ -1067,13 +1067,14 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
         return True
 
-    def on_game_stopped(self, game):
+    def on_game_state_changed(self, game):
         """Updates the game list when a game stops; this keeps the 'running' page updated."""
-        selected_row = self.sidebar.get_selected_row()
-        # Only update the running page- we lose the selected row when we do this,
-        # but on the running page this is okay.
-        if selected_row is not None and selected_row.id == "running":
-            self.game_store.remove_game(game.id)
+        if game.state == game.STATE_STOPPED:
+            selected_row = self.sidebar.get_selected_row()
+            # Only update the running page - we lose the selected row when we do this,
+            # but on the running page this is okay.
+            if selected_row is not None and selected_row.id == "running":
+                self.game_store.remove_game(game.id)
         return True
 
     def on_game_installed(self, game):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -52,9 +52,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
     default_height = 600
 
     __gtype_name__ = "LutrisWindow"
-    __gsignals__ = {
-        "view-updated": (GObject.SIGNAL_RUN_FIRST, None, ()),
-    }
     games_stack = GtkTemplate.Child()
     sidebar_revealer = GtkTemplate.Child()
     sidebar_scrolled = GtkTemplate.Child()
@@ -139,7 +136,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
         self.update_action_state()
 
-        self.connect("view-updated", self.update_store)
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
         GObject.add_emission_hook(BaseService, "service-games-loaded", self.on_service_games_updated)
         GObject.add_emission_hook(Game, "game-updated", self.on_game_updated)
@@ -285,7 +281,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         action.set_state(value)
         settings.write_setting("show_hidden_games", str(value).lower(), section="lutris")
         self.filters["hidden"] = bool(value)
-        self.emit("view-updated")
+        self.update_store()
 
     @property
     def current_view_type(self):
@@ -788,7 +784,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.update_view_settings()
         self.games_stack.set_visible_child_name(view_type)
         self.update_action_state()
-        self.emit("view-updated")
+        self.update_store()
 
     def rebuild_view(self, view_type):
         """Discards the view named by 'view_type' and if it is the current view,
@@ -822,7 +818,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
     def on_service_games_updated(self, service):
         """Request a view update when service games are loaded"""
         if self.service and service.id == self.service.id:
-            self.emit("view-updated")
+            self.update_store()
         return True
 
     def save_window_state(self):
@@ -845,7 +841,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
     def on_service_logout(self, service):
         if self.service and service.id == self.service.id:
-            self.emit("view-updated")
+            self.update_store()
         return True
 
     @GtkTemplate.Callback
@@ -902,7 +898,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """Callback to handle uninstalled game filter switch"""
         action.set_state(value)
         self.set_show_installed_state(value.get_boolean())
-        self.emit("view-updated")
+        self.update_store()
 
     @GtkTemplate.Callback
     def on_search_entry_changed(self, entry):
@@ -959,17 +955,17 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self.actions["view-sorting"].set_state(value)
         value = str(value).strip("'")
         settings.write_setting("view_sorting", value)
-        self.emit("view-updated")
+        self.update_store()
 
     def on_view_sorting_direction_change(self, action, value):
         self.actions["view-reverse-order"].set_state(value)
         settings.write_setting("view_reverse_order", bool(value))
-        self.emit("view-updated")
+        self.update_store()
 
     def on_view_sorting_installed_first_change(self, action, value):
         self.actions["view-sorting-installed-first"].set_state(value)
         settings.write_setting("view_sorting_installed_first", bool(value))
-        self.emit("view-updated")
+        self.update_store()
 
     def on_side_panel_state_change(self, action, value):
         """Callback to handle side panel toggle"""
@@ -1087,7 +1083,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """Simple method used to refresh the view"""
         remove_from_path_cache(game)
         self.update_missing_games_sidebar_row()
-        self.emit("view-updated")
+        self.update_store()
         return True
 
     def on_game_activated(self, _view, game_id):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1113,7 +1113,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
         if game_id:
             game = Game(game_id)
             if game.is_installed:
-                game.emit("game-launch")
+                game.launch(launch_ui_delegate=self)
             else:
                 game.emit("game-install")
 

--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -55,10 +55,6 @@ def sort_func(model, row1, row2, sort_col):
 
 
 class GameStore(GObject.Object):
-    __gsignals__ = {
-        "icons-changed": (GObject.SIGNAL_RUN_FIRST, None, ()),
-    }
-
     def __init__(self, service, service_media):
         super().__init__()
         self.service = service

--- a/lutris/gui/widgets/game_bar.py
+++ b/lutris/gui/widgets/game_bar.py
@@ -24,9 +24,8 @@ class GameBar(Gtk.Box):
         self.application = application
         self.window = window
 
-        self.game_start_hook_id = GObject.add_emission_hook(Game, "game-start", self.on_game_state_changed)
-        self.game_started_hook_id = GObject.add_emission_hook(Game, "game-started", self.on_game_state_changed)
-        self.game_stopped_hook_id = GObject.add_emission_hook(Game, "game-stopped", self.on_game_state_changed)
+        self.game_state_changed_hook_id = GObject.add_emission_hook(
+            Game, "game-state-changed", self.on_game_state_changed)
         self.game_updated_hook_id = GObject.add_emission_hook(Game, "game-updated", self.on_game_state_changed)
         self.game_removed_hook_id = GObject.add_emission_hook(Game, "game-removed", self.on_game_state_changed)
         self.game_installed_hook_id = GObject.add_emission_hook(Game, "game-installed", self.on_game_state_changed)
@@ -57,9 +56,7 @@ class GameBar(Gtk.Box):
         self.update_view()
 
     def on_destroy(self, widget):
-        GObject.remove_emission_hook(Game, "game-start", self.game_start_hook_id)
-        GObject.remove_emission_hook(Game, "game-started", self.game_started_hook_id)
-        GObject.remove_emission_hook(Game, "game-stopped", self.game_stopped_hook_id)
+        GObject.remove_emission_hook(Game, "game-state-changed", self.game_state_changed_hook_id)
         GObject.remove_emission_hook(Game, "game-updated", self.game_updated_hook_id)
         GObject.remove_emission_hook(Game, "game-removed", self.game_removed_hook_id)
         GObject.remove_emission_hook(Game, "game-installed", self.game_installed_hook_id)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -152,7 +152,7 @@ class ServiceSidebarRow(SidebarRow):
 
     def on_service_run(self, button):
         """Run a launcher associated with a service"""
-        self.service.run()
+        self.service.run(self.get_toplevel())
 
     def on_refresh_clicked(self, button):
         """Reload the service games"""

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -163,8 +163,8 @@ class ServiceSidebarRow(SidebarRow):
         self.start_reload()
 
     def start_reload(self):
-        self.set_is_updating(True)
         self.service.start_reload(self._service_reloaded_cb)
+        self.set_is_updating(True)
 
     def set_is_updating(self, is_updating):
         self.is_updating = is_updating
@@ -609,17 +609,13 @@ class LutrisSidebar(Gtk.ListBox):
         return True  # continue to handle this emission hook
 
     def on_service_login(self, service):
-        self.on_service_auth_changed(service)
         row = self.service_rows.get(service.id)
         if row:
+            row.create_button_box()
             row.start_reload()
         return True
 
     def on_service_logout(self, service):
-        self.on_service_auth_changed(service)
-        return True
-
-    def on_service_auth_changed(self, service):
         row = self.service_rows.get(service.id)
         if row:
             row.create_button_box()

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -358,7 +358,7 @@ class LutrisSidebar(Gtk.ListBox):
         GObject.add_emission_hook(ScriptInterpreter, "runners-installed", self.update_rows)
         GObject.add_emission_hook(ServicesBox, "services-changed", self.update_rows)
         GObject.add_emission_hook(Game, "game-start", self.on_game_start)
-        GObject.add_emission_hook(Game, "game-stop", self.on_game_stop)
+        GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
         GObject.add_emission_hook(Game, "game-updated", self.update_rows)
         GObject.add_emission_hook(Game, "game-removed", self.update_rows)
         GObject.add_emission_hook(BaseService, "service-login", self.on_service_auth_changed)
@@ -594,9 +594,9 @@ class LutrisSidebar(Gtk.ListBox):
         self.running_row.show()
         return True
 
-    def on_game_stop(self, _game):
+    def on_game_stopped(self, _game):
         """Hide the "running" section when no games are running"""
-        if not self.application.running_games:
+        if not self.application.has_running_games:
             self.running_row.hide()
 
             if self.get_selected_row() == self.running_row:

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -8,6 +8,7 @@ from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database.games import get_game_by_field
 from lutris.exceptions import MisconfigurationError
+from lutris.gui.dialogs.delegates import Delegate
 from lutris.installer import AUTO_EXE_PREFIX
 from lutris.installer.commands import CommandsMixin
 from lutris.installer.errors import MissingGameDependencyError, ScriptingError
@@ -29,7 +30,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         "runners-installed": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
-    class InterpreterUIDelegate:
+    class InterpreterUIDelegate(Delegate):
         """This is a base class for objects that provide UI services
         for running scripts. The InstallerWindow inherits from this."""
 

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -90,7 +90,6 @@ class BaseService(GObject.Object):
     is_loading = False
 
     __gsignals__ = {
-        "service-games-load": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "service-games-loaded": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "service-login": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "service-logout": (GObject.SIGNAL_RUN_FIRST, None, ()),
@@ -150,7 +149,6 @@ class BaseService(GObject.Object):
             self.emit("service-games-loaded")
             reloaded_callback(error)
 
-        self.emit("service-games-load")
         AsyncCall(do_reload, reload_cb)
 
     def load(self):

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -101,20 +101,20 @@ class BaseService(GObject.Object):
             return self._matcher
         return self.id
 
-    def run(self):
+    def run(self, launch_ui_delegate):
         """Launch the game client"""
         launcher = self.get_launcher()
         if launcher:
-            launcher.launch()
+            launcher.launch(launch_ui_delegate)
 
     def is_launchable(self):
         if self.client_installer:
-            return get_game_by_field(self.client_installer, "slug")
+            return bool(get_game_by_field(self.client_installer, "slug"))
         return False
 
     def get_launcher(self):
         if not self.client_installer:
-            return
+            return None
         db_launcher = get_game_by_field(self.client_installer, "slug")
         if db_launcher:
             return Game(db_launcher["id"])

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -106,7 +106,7 @@ class BaseService(GObject.Object):
         """Launch the game client"""
         launcher = self.get_launcher()
         if launcher:
-            launcher.emit("game-launch")
+            launcher.launch()
 
     def is_launchable(self):
         if self.client_installer:

--- a/lutris/services/ea_app.py
+++ b/lutris/services/ea_app.py
@@ -173,7 +173,7 @@ class EAAppService(OnlineService):
     def run(self):
         db_game = get_game_by_field(self.client_installer, "slug")
         game = Game(db_game["id"])
-        game.emit("game-launch")
+        game.launch()
 
     def is_launchable(self):
         return get_game_by_field(self.client_installer, "slug")

--- a/lutris/services/ea_app.py
+++ b/lutris/services/ea_app.py
@@ -170,14 +170,6 @@ class EAAppService(OnlineService):
     def api_url(self):
         return "https://api%s.origin.com" % random.randint(1, 4)
 
-    def run(self):
-        db_game = get_game_by_field(self.client_installer, "slug")
-        game = Game(db_game["id"])
-        game.launch()
-
-    def is_launchable(self):
-        return get_game_by_field(self.client_installer, "slug")
-
     def is_connected(self):
         return bool(self.access_token)
 

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -191,14 +191,6 @@ class EpicGamesStoreService(OnlineService):
             'daafbccc737745039dffe53d94fc76cf'
         )
 
-    def run(self):
-        egs = get_game_by_field(self.client_installer, "slug")
-        egs_game = Game(egs["id"])
-        egs_game.launch()
-
-    def is_launchable(self):
-        return get_game_by_field(self.client_installer, "slug")
-
     def is_connected(self):
         return self.is_authenticated()
 

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -194,7 +194,7 @@ class EpicGamesStoreService(OnlineService):
     def run(self):
         egs = get_game_by_field(self.client_installer, "slug")
         egs_game = Game(egs["id"])
-        egs_game.emit("game-launch")
+        egs_game.launch()
 
     def is_launchable(self):
         return get_game_by_field(self.client_installer, "slug")

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -164,7 +164,7 @@ class OriginService(OnlineService):
     def run(self):
         db_game = get_game_by_field(self.client_installer, "slug")
         game = Game(db_game["id"])
-        game.emit("game-launch")
+        game.launch()
 
     def is_launchable(self):
         return get_game_by_field(self.client_installer, "slug")

--- a/lutris/services/origin.py
+++ b/lutris/services/origin.py
@@ -161,14 +161,6 @@ class OriginService(OnlineService):
     def api_url(self):
         return "https://api%s.origin.com" % random.randint(1, 4)
 
-    def run(self):
-        db_game = get_game_by_field(self.client_installer, "slug")
-        game = Game(db_game["id"])
-        game.launch()
-
-    def is_launchable(self):
-        return get_game_by_field(self.client_installer, "slug")
-
     def is_connected(self):
         return bool(self.access_token)
 


### PR DESCRIPTION
Been sitting on this for the release, but I think Lutris uses too many signals. Many are used to essentially call a method, and maybe capture the default application object on the way there.

This PR removes many signals!

- icons-changed

This one is just unused altogether.

- game-launch
- game-install
- game-install-update
- game-install-dlc

These are all used to just run some method on Application; they can be methods on Game itself and we can just call them.

- view-updated

This is just a call to self.update_store(), so we can just call that.

- game-stop

Is a dupe of game-stopped, but fired a little earlier so the running-games list can be updated before use. I've dropped it, and use a method to get the running games that filters out the stopped ones instead.

- service-games-load

This is used to update the UI of the sidebar, which it can do itself. It means the sidebar has to handle service-login instead of LutrisWindow.

- game-start
- game-started
- game-stopped

These are handled via a replacement 'game-state-changed' event, which is raised by a property setter. The handlers wind up with if statements in them, but I think it's okay- the branches are closely related stuff like hiding and showing a sidebar row. Pulling that together seems okay.
