### PR TITLE
Add 'Recommended' dependencies on app-indicators for DEB and RPM.

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -46,6 +46,7 @@ Recommends: python3-evdev,
             fluidsynth,
             gamescope,
             gamemode,
+            gir1.2-appindicator3-0.1,
             xdg-desktop-portal,
             xdg-desktop-portal-gtk | xdg-desktop-portal-kde,
 Description: video game preservation platform

--- a/lutris.spec
+++ b/lutris.spec
@@ -31,6 +31,7 @@ Requires:       cabextract
 Requires:       mesa-vulkan-drivers
 Requires:       vulkan-loader
 Recommends:     wine-core
+Recommends:     libappindicator-gtk3
 
 %ifarch x86_64
 Requires:       mesa-vulkan-drivers(x86-32)


### PR DESCRIPTION
I am not too confident about packaging, so I'll pop this as a PR and won't just merge it.

The thing is, we offer status icons via AppIndicators or Gtk.StatusIcon. AppIndicators are often not installed, and Gtk.StatusIcon does nothing on Wayland, except to log a strange error. Wayland users are finding the the status icon just doesn't work because they do not happen to have the AppIndicators package installed.

I've already committed code to not even try to use Gtk.StatusIcon except on X11, and to hide the option in Preferences if it won't be possible to implement it. But that reduces the status icon to a magic hidden feature on Wayland- you have to know what package to install. Not discoverable.

This PR should prompt DEB and RPM package managers to install the AppIndicators package we need, if it is available. If not, we should be installable anyway - without the status-icon option, on Wayland.

Resolves #5249