### PR TITLE
Improved 'Live' Missing Game Checks

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1122,7 +1122,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
     def on_game_removed(self, game):
         """Simple method used to refresh the view"""
         remove_from_path_cache(game)
-        MISSING_GAMES.update_missing([game.id])
+        MISSING_GAMES.update_missing(game.id)
         self.update_missing_games_sidebar_row()
         self.emit("view-updated")
         return True

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -14,7 +14,7 @@ from lutris.exceptions import MissingMediaError
 from lutris.gui.widgets.utils import (
     MEDIA_CACHE_INVALIDATED, get_default_icon_path, get_runtime_icon_path, get_scaled_surface_by_path, get_surface_size
 )
-from lutris.scanners.lutris import is_game_missing
+from lutris.scanners.lutris import MISSING_GAMES
 
 
 class GridViewCellRendererText(Gtk.CellRendererText):
@@ -248,8 +248,9 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
                     if self.show_badges:
                         self.render_platforms(cr, widget, surface, 0, cell_area)
 
-                        if self.game_id and is_game_missing(self.game_id):
+                        if self.game_id and self.game_id in MISSING_GAMES.missing_game_ids:
                             self.render_text_badge(cr, widget, _("Missing"), 0, cell_area.y + cell_area.height)
+                            MISSING_GAMES.update_missing([self.game_id])
                 else:
                     cr.push_group()
                     self.render_media(cr, widget, surface, 0, 0)

--- a/lutris/gui/widgets/cellrenderers.py
+++ b/lutris/gui/widgets/cellrenderers.py
@@ -246,16 +246,12 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
                 if alpha >= 1:
                     self.render_media(cr, widget, surface, 0, 0)
                     if self.show_badges:
-                        self.render_platforms(cr, widget, surface, 0, cell_area)
-
-                        if self.game_id and self.game_id in MISSING_GAMES.missing_game_ids:
-                            self.render_text_badge(cr, widget, _("Missing"), 0, cell_area.y + cell_area.height)
-                            MISSING_GAMES.update_missing([self.game_id])
+                        self._render_badges(cr, widget, surface, cell_area)
                 else:
                     cr.push_group()
                     self.render_media(cr, widget, surface, 0, 0)
                     if self.show_badges:
-                        self.render_platforms(cr, widget, surface, 0, cell_area)
+                        self._render_badges(cr, widget, surface, cell_area)
                     cr.pop_group_to_source()
                     cr.paint_with_alpha(alpha)
                 cr.restore()
@@ -351,9 +347,16 @@ class GridViewCellRendererImage(Gtk.CellRenderer):
         cr.rectangle(x, y, width, height)
         cr.fill()
 
+    def _render_badges(self, cr, widget, surface, cell_area):
+        self.render_platforms(cr, widget, surface, 0, cell_area)
+
+        if self.game_id:
+            if self.game_id in MISSING_GAMES.missing_game_ids:
+                self.render_text_badge(cr, widget, _("Missing"), 0, cell_area.y + cell_area.height)
+            MISSING_GAMES.update_missing(self.game_id)
+
     def render_platforms(self, cr, widget, surface, surface_x, cell_area):
-        """Renders the stack of platform icons. They appear lined up vertically to the
-        right of 'media_right', if that will fit in 'cell_area'."""
+        """Renders the stack of platform icons."""
         platform = self.platform
         if platform and self.badge_size:
             icon_paths = self.get_platform_icon_paths(platform)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -434,6 +434,7 @@ class LutrisSidebar(Gtk.ListBox):
         # I wanted this to be on top but it really messes with the headers when showing/hiding the row.
         self.add(self.running_row)
         self.show_all()
+        self.missing_row.hide()
         self.running_row.hide()
 
         # Create the dynamic rows that are initially needed

--- a/lutris/scanners/lutris.py
+++ b/lutris/scanners/lutris.py
@@ -1,7 +1,8 @@
 import json
 import os
 import time
-from typing import Iterable
+
+from gi.repository import GLib
 
 from lutris import settings
 from lutris.api import get_api_games, get_game_installers
@@ -208,98 +209,82 @@ class MissingGames:
     """This class is a singleton that holds a set of game-ids for games whose directories
     are missing. It is updated on a background thread, but there's a NotificationSource ('updated')
     that fires when that thread has made changes and exited, so that the UI cab update then."""
-    CHECK_STALL = 3
 
     def __init__(self):
         self.updated = NotificationSource()
         self.missing_game_ids = set()
-        self._check_game_ids = None
-        self._check_game_queue = []
-        self._check_all_games = False
-        self._changed = False
+        self._update_scheduled = False
+        self._pending_game_ids = set()
 
-    def update_all_missing(self):
+    def update_all_missing(self) -> None:
         """This starts the check for all games; the actual list of game-ids will be obtained
         on the worker thread, and this method will start it."""
-        self._check_all_games = True
-        self.update_missing()
+        self._pending_game_ids = None  # indicate 'update all games'
+        self._schedule_update(delay=0)
 
-    def update_missing(self, game_ids: Iterable[str] = None):
-        """Starts checking the missing status on a list of games. This starts the worker
-        thread, but if it is running already, it queues the games. The worker will pause
-        briefly before processing extra games just to limit the rate of filesystem accesses."""
+    def update_missing(self, game_id: str) -> None:
+        """Starts checking the missing status on a games. This starts the worker thread
+        as required, though only after a brief delay. This is a way to reduce the pounding on
+        the filesystem, and also to accumulate multiple games before doing the update.
 
-        # The presence of this set indicates that the worker is running
-        start_fetch = self._check_game_ids is None
+        Even if the delay is 0, the update won't be immediate - you always need to handle the
+        'updated' notification."""
 
-        if not self._check_game_ids:
-            self._check_game_ids = set()
+        if self._pending_game_ids is not None:
+            self._pending_game_ids.add(game_id)
+        self._schedule_update(delay=3)
 
-        if game_ids:
-            self._check_game_ids |= set(game_ids)
+    def _schedule_update(self, delay: float) -> None:
+        """Sets up a timeout to run the _update_missing_games method after a delay,
+        unless it is already scheduled, in which case this method does nothing."""
+        def start():
+            game_ids = self._pending_game_ids
+            self._pending_game_ids = set()
+            AsyncCall(self._update_missing_games, self._update_missing_games_cb, game_ids)
+            return False  # do not run again
 
-        if start_fetch:
-            initial_delay = self.CHECK_STALL if game_ids else 0
-            AsyncCall(self._fetch, None, initial_delay)
+        if not self._update_scheduled and self._has_more_updates():
+            self._update_scheduled = True
+            GLib.timeout_add(delay * 1000, start)  # delay is in seconds, not milliseconds
 
-    def _fetch(self, initial_delay=0):
-        """This is the method that runs on the worker thread; it continues until all
-        games are processed, even extras added while it is running."""
-        time.sleep(initial_delay)
+    def _has_more_updates(self):
+        """True if there are more updates to do; note that None here means
+        'update all games', but an empty set is 'nothing to do'."""
+        return self._pending_game_ids is None or len(self._pending_game_ids) > 0
+
+    def _update_missing_games(self, game_ids):
+        """This is the method that runs on the worker thread; it checks each game given
+        and returns True if any changes to missing_game_ids was made.."""
         logger.debug("Checking for missing games")
-        try:
-            while True:
-                game_id = self._next_game_id()
-                if not game_id:
-                    break
 
-                path = get_path_cache().get(game_id)
+        changed = False
+        path_cache = get_path_cache()
+        if game_ids is None:
+            game_ids = path_cache
 
-                if path:
-                    if os.path.exists(path):
-                        if game_id in self.missing_game_ids:
-                            self.missing_game_ids.discard(game_id)
-                            self._changed = True
-                    elif game_id not in self.missing_game_ids:
-                        self.missing_game_ids.add(game_id)
-                        self._changed = True
-        except Exception as ex:
-            logger.exception("Unable to detect missing games: %s", ex)
-        finally:
-            # Clearing out _check_game_ids is how we know the worker is no longer running
-            self._check_game_ids = None
-            self._notify_changed()
+        for game_id in game_ids:
+            path = path_cache.get(game_id)
 
-    def _notify_changed(self):
-        """Fires the 'updated' notification if changes have been made since the last time
-        this method was called."""
-        if self._changed:
-            self._changed = False
+            if path:
+                if os.path.exists(path):
+                    if game_id in self.missing_game_ids:
+                        self.missing_game_ids.discard(game_id)
+                        changed = True
+                elif game_id not in self.missing_game_ids:
+                    self.missing_game_ids.add(game_id)
+                    changed = True
+        return changed
+
+    def _update_missing_games_cb(self, changed, error):
+        self._update_scheduled = False
+
+        if error:
+            logger.exception("Unable to detect missing games: %s", error)
+        elif changed:
             self.updated.fire()
 
-    def _next_game_id(self):
-        """Returns the next game-id to check, or None if we're done. This will detect
-        additional games once the queue empties, and moves hem to the queue, but fires
-        the notification then too."""
-        if self._check_all_games:
-            self._check_all_games = False
-            path_cache = get_path_cache()
-            self._check_game_queue = list(path_cache)
-            self._check_game_ids.clear()
-
-        if not self._check_game_queue and self._check_game_ids:
-            # If more ids have arrived while fetching the old ones, we do not
-            # just check them too. We notify immediate and wait a little,
-            # then continue checking. This will
-            self._notify_changed()
-            time.sleep(self.CHECK_STALL)
-            self._check_game_queue = list(self._check_game_ids)
-            self._check_game_ids.clear()
-
-        if self._check_game_queue:
-            return self._check_game_queue.pop()
-
-        return None
+        # In case more games are pending already, we'll update again soon.
+        self._schedule_update(.5)
 
 
 MISSING_GAMES = MissingGames()


### PR DESCRIPTION
This PR improves Lutris' detection of missing games so it does a better job of updating if games are moved around while Lutris is running.

All the missing-games data are now tracked in a singleton class, and everybody uses that. This is always updated in a background thread (not just sometimes) for better GTK/Wayland survivabilty. When updates occur a notification is used to update the UI.

This means that if you fix missing games, Lutris can notice and remove the 'missing' badge, and also hide the Missing tab. It can also notice when a game goes missing in the same way.

To avoid pounding the filesystem too hard, it triggers the 'live' checks when banners are drawn, so only games you can see are checked. Even then there is a delay of up to 3 seconds to rate limit it, so we do not hit the filesystem on every view redraw, and now we do it on a background thread anyway.