### PR TITLE
Fixed empty context menu error

### DIFF
--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -117,7 +117,10 @@ class GameListView(Gtk.TreeView, GameView):
         self.model.set_sort_func(col, sort_func, sort_col)
 
     def get_path_at(self, x, y):
-        path, _col, _cx, _cy = self.get_path_at_pos(x, y)
+        path_at = self.get_path_at_pos(x, y)
+        if path_at is None:
+            return None
+        path, _col, _cx, _cy = path_at
         return path
 
     def set_selected(self, path):


### PR DESCRIPTION
Right-clicking on empty space in list mode caused a
`cannot unpack non-iterable NoneType object` popup.

This was simply fixed by adding a basic `if .. is None` in `lutris/gui/views/list.py`.

This is actually expected behaviour because it is already checked for None at 
`lutris/gui/views/base.py:63`.