### PR TITLE
A Sluggish Duplicate Game Dialog

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -16,7 +16,7 @@ from lutris.gui import dialogs
 from lutris.gui.config.add_game_dialog import AddGameDialog
 from lutris.gui.config.edit_game import EditGameConfigDialog
 from lutris.gui.config.edit_game_categories import EditGameCategoriesDialog
-from lutris.gui.dialogs import InputDialog
+from lutris.gui.dialogs import DuplicateGameDialog
 from lutris.gui.dialogs.log import LogWindow
 from lutris.gui.dialogs.uninstall_game import UninstallMultipleGamesDialog
 from lutris.gui.widgets.utils import open_uri
@@ -25,7 +25,7 @@ from lutris.util import xdgshortcuts
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 from lutris.util.steam import shortcut as steam_shortcut
-from lutris.util.strings import gtk_safe, slugify
+from lutris.util.strings import slugify
 from lutris.util.system import path_exists
 
 
@@ -286,23 +286,12 @@ class GameActions(BaseGameActions):
 
     def on_game_duplicate(self, _widget):
         for game in self.games:
-            duplicate_game_dialog = InputDialog(
-                {
-                    "parent": self.window,
-                    "question": _(
-                        "Do you wish to duplicate %s?\nThe configuration will be duplicated, "
-                        "but the games files will <b>not be duplicated</b>.\n"
-                        "Please enter the new name for the copy:"
-                    ) % gtk_safe(game.name),
-                    "title": _("Duplicate game?"),
-                    "initial_value": game.name
-                }
-            )
+            duplicate_game_dialog = DuplicateGameDialog(game, parent=self.window)
             result = duplicate_game_dialog.run()
             if result != Gtk.ResponseType.OK:
                 duplicate_game_dialog.destroy()
                 return
-            new_name = duplicate_game_dialog.user_value
+            new_name = duplicate_game_dialog.new_name
 
             old_config_id = game.game_config_id
             if old_config_id:

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -25,7 +25,6 @@ from lutris.util import xdgshortcuts
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 from lutris.util.steam import shortcut as steam_shortcut
-from lutris.util.strings import slugify
 from lutris.util.system import path_exists
 
 

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -292,6 +292,7 @@ class GameActions(BaseGameActions):
                 duplicate_game_dialog.destroy()
                 return
             new_name = duplicate_game_dialog.new_name
+            new_slug = duplicate_game_dialog.new_slug
 
             old_config_id = game.game_config_id
             if old_config_id:
@@ -301,7 +302,7 @@ class GameActions(BaseGameActions):
             duplicate_game_dialog.destroy()
             db_game = get_game_by_field(game.id, "id")
             db_game["name"] = new_name
-            db_game["slug"] = slugify(new_name) if new_name != game.name else game.slug
+            db_game["slug"] = new_slug
             db_game["lastplayed"] = None
             db_game["playtime"] = 0.0
             db_game["configpath"] = new_config_id

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -17,7 +17,7 @@ from lutris.gui.widgets.log_text_view import LogTextView
 from lutris.util import datapath
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
-from lutris.util.strings import gtk_safe
+from lutris.util.strings import gtk_safe, slugify
 
 
 class Dialog(Gtk.Dialog):
@@ -389,6 +389,7 @@ class DuplicateGameDialog(ModalDialog):
         content_area.pack_start(self.grid, True, True, 0)
         self.name_entry = self.add_entry_box(_("Name"), game.name, row=0)
         self.slug_entry = self.add_entry_box(_("Identifier"), game.slug, row=1)
+        self.slug_entry.connect("focus-out-event", self.on_slug_entry_focus_out)
         self.show_all()
 
     def add_entry_box(self, label_text: str, initial_value: str, row: int) -> Gtk.Entry:
@@ -407,10 +408,13 @@ class DuplicateGameDialog(ModalDialog):
 
     @property
     def new_slug(self):
-        return self.slug_entry.get_text()
+        return slugify(self.slug_entry.get_text())
 
-    def on_entry_changed(self, widget):
+    def on_entry_changed(self, _widget):
         self.ok_button.set_sensitive(bool(self.new_name and self.new_slug))
+
+    def on_slug_entry_focus_out(self, *args):
+        self.slug_entry.set_text(self.new_slug)
 
 
 class DirectoryDialog:

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -362,29 +362,33 @@ class QuestionDialog(Gtk.MessageDialog):
         self.destroy()
 
 
-class InputDialog(ModalDialog):
-    """Ask the user for a text input"""
+class DuplicateGameDialog(ModalDialog):
+    """Ask the user for a duplicate game's new name and slug"""
 
-    def __init__(self, dialog_settings):
-        super().__init__(parent=dialog_settings["parent"])
+    def __init__(self, game, parent: Gtk.Window):
+        super().__init__(parent=parent)
         self.set_border_width(12)
-        self.user_value = ""
+        self.new_name = ""
         self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
         self.ok_button = self.add_default_button(Gtk.STOCK_OK, Gtk.ResponseType.OK)
         self.set_default_response(Gtk.ResponseType.OK)
         self.ok_button.set_sensitive(False)
-        self.set_title(dialog_settings["title"])
+        self.set_title(_("Duplicate game?"))
         label = Gtk.Label(visible=True)
-        label.set_markup(dialog_settings["question"])
+        label.set_markup(_(
+            "Do you wish to duplicate %s?\nThe configuration will be duplicated, "
+            "but the games files will <b>not be duplicated</b>.\n"
+            "Please enter the new name for the copy:"
+        ) % gtk_safe(game.name))
         self.get_content_area().pack_start(label, True, True, 12)
-        self.entry = Gtk.Entry(visible=True, activates_default=True)
-        self.entry.connect("changed", self.on_entry_changed)
-        self.get_content_area().pack_start(self.entry, True, True, 12)
-        self.entry.set_text(dialog_settings.get("initial_value") or "")
+        self.name_entry = Gtk.Entry(visible=True, activates_default=True)
+        self.name_entry.connect("changed", self.on_entry_changed)
+        self.get_content_area().pack_start(self.name_entry, True, True, 12)
+        self.name_entry.set_text(game.name or "")
 
     def on_entry_changed(self, widget):
-        self.user_value = widget.get_text()
-        self.ok_button.set_sensitive(bool(self.user_value))
+        self.new_name = widget.get_text()
+        self.ok_button.set_sensitive(bool(self.new_name))
 
 
 class DirectoryDialog:

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -371,7 +371,6 @@ class DuplicateGameDialog(ModalDialog):
         self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
         self.ok_button = self.add_default_button(Gtk.STOCK_OK, Gtk.ResponseType.OK)
         self.set_default_response(Gtk.ResponseType.OK)
-        self.ok_button.set_sensitive(False)
         self.set_title(_("Duplicate game?"))
         label = Gtk.Label(visible=True)
         label.set_markup(_(
@@ -390,6 +389,7 @@ class DuplicateGameDialog(ModalDialog):
         self.name_entry = self.add_entry_box(_("Name"), game.name, row=0)
         self.slug_entry = self.add_entry_box(_("Identifier"), game.slug, row=1)
         self.slug_entry.connect("focus-out-event", self.on_slug_entry_focus_out)
+        self.ok_button.set_sensitive(self.is_ready)
         self.show_all()
 
     def add_entry_box(self, label_text: str, initial_value: str, row: int) -> Gtk.Entry:
@@ -410,8 +410,12 @@ class DuplicateGameDialog(ModalDialog):
     def new_slug(self):
         return slugify(self.slug_entry.get_text())
 
+    @property
+    def is_ready(self):
+        return bool(self.new_name and self.new_slug)
+
     def on_entry_changed(self, _widget):
-        self.ok_button.set_sensitive(bool(self.new_name and self.new_slug))
+        self.ok_button.set_sensitive(self.is_ready)
 
     def on_slug_entry_focus_out(self, *args):
         self.slug_entry.set_text(self.new_slug)


### PR DESCRIPTION
This PR extends the 'Duplicate Game' dialog to also ask for a slug, thus:
![Screenshot from 2024-02-10 09-23-05](https://github.com/lutris/lutris/assets/6507403/17a9086c-0396-4316-b383-02540d6849a0)

Also, there's a header bar for the duplicate game dialog. Did you ever doubt it would come?

Anyway, the default behavior here is to preserve the old slug even if you change the name; the theory is that in most cases, you are creating a new configuration for an old game, not writing a new game inside Lutris. But you can see this, and can override it if you want to.