### PR TITLE
new preference setting for having hidden games always hidden on lutris launch

### DIFF
--- a/lutris/gui/config/preferences_box.py
+++ b/lutris/gui/config/preferences_box.py
@@ -14,6 +14,7 @@ class InterfacePreferencesBox(BaseConfigBox):
         "show_tray_icon": _("Show Tray Icon"),
         "dark_theme": _("Use dark theme (requires dark theme variant for Gtk)"),
         "discord_rpc": _("Enable Discord Rich Presence for Available Games"),
+        "hide_hidden_games_on_launch": _("Always keeps hidden games hidden on lutris launch"),
     }
 
     settings_accelerators = {


### PR DESCRIPTION
## What PR adds:
An option to have hidden games be always hidden when you launch lutris.

## Why:
You forget to hide them before closing lutris, then x time later you launch it while someone sees your screen and sees the "hidden" games, which defeats the purpose of them being hidden.

_let me know, if anything needs to be changed :)_