### PR TITLE
Convert the 'Hidden' flag to a category

### DIFF
--- a/lutris/database/schema.py
+++ b/lutris/database/schema.py
@@ -86,10 +86,6 @@ DATABASE = {
             "type": "REAL"
         },
         {
-            "name": "hidden",
-            "type": "INTEGER"
-        },
-        {
             "name": "service",
             "type": "TEXT"
         },

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -170,11 +170,6 @@ class Game(GObject.Object):
         """Return whether the game can be upgraded"""
         return self.is_installed and self.service in ["gog", "itchio"]
 
-    @property
-    def is_favorite(self):
-        """Return whether the game is in the user's favorites"""
-        return "favorite" in self.get_categories()
-
     def get_categories(self):
         """Return the categories the game is in."""
         return categories_db.get_categories_in_game(self.id) if self.is_db_stored else []
@@ -218,25 +213,33 @@ class Game(GObject.Object):
         if not no_signal:
             self.emit("game-updated")
 
-    def add_to_favorites(self):
-        """Add the game to the 'favorite' category"""
-        self.add_category("favorite")
+    @property
+    def is_favorite(self) -> bool:
+        """Return whether the game is in the user's favorites"""
+        return "favorite" in self.get_categories()
 
-    def remove_from_favorites(self):
-        """Remove game from favorites"""
-        self.remove_category("favorite")
+    def mark_as_favorite(self, is_favorite: bool) -> None:
+        """Place the game in the favorite's category, or remove it.
+        This change is applied at once, and does not need to be saved."""
+        if self.is_favorite != bool(is_favorite):
+            if is_favorite:
+                self.add_category("favorite")
+            else:
+                self.remove_category("favorite")
 
     @property
-    def is_hidden(self):
+    def is_hidden(self) -> bool:
         """Return whether the game is in the user's favorites"""
         return ".hidden" in self.get_categories()
 
-    def set_hidden(self, is_hidden):
-        """Do not show this game in the UI"""
-        if is_hidden:
-            self.add_category(".hidden")
-        else:
-            self.remove_category(".hidden")
+    def mark_as_hidden(self, is_hidden: bool) -> None:
+        """Place the game in the hidden category, or remove it.
+        This change is applied at once, and does not need to be saved."""
+        if self.is_hidden != bool(is_hidden):
+            if is_hidden:
+                self.add_category(".hidden")
+            else:
+                self.remove_category(".hidden")
 
     @property
     def log_buffer(self):

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -337,14 +337,12 @@ class GameActions(BaseGameActions):
     def on_add_favorite_game(self, _widget):
         """Add to favorite Games list"""
         for game in self.games:
-            if not game.is_favorite:
-                game.add_to_favorites()
+            game.mark_as_favorite(True)
 
     def on_delete_favorite_game(self, _widget):
         """delete from favorites"""
         for game in self.games:
-            if game.is_favorite:
-                game.remove_from_favorites()
+            game.mark_as_favorite(False)
 
     def on_edit_game_categories(self, _widget):
         """Edit game categories"""
@@ -354,14 +352,12 @@ class GameActions(BaseGameActions):
     def on_hide_game(self, _widget):
         """Add a game to the list of hidden games"""
         for game in self.games:
-            if not game.is_hidden:
-                game.set_hidden(True)
+            game.mark_as_hidden(True)
 
     def on_unhide_game(self, _widget):
         """Removes a game from the list of hidden games"""
         for game in self.games:
-            if game.is_hidden:
-                game.set_hidden(False)
+            game.mark_as_hidden(False)
 
     def on_execute_script_clicked(self, _widget):
         """Execute the game's associated script"""

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -476,16 +476,7 @@ class Application(Gtk.Application):
 
         logger.info("Starting Lutris %s", settings.VERSION)
         init_lutris()
-
-        # Perform migrations early if any command line options
-        # might require it to be done, just in case. We migrate
-        # also during the init dialog, but it should be harmless
-        # to do it twice.
-        #
-        # This way, in typical lutris usage, you get to see the
-        # init dialog when migration is happening.
-        if argc:
-            migrate()
+        migrate()
 
         run_all_checks()
         if options.contains("dest"):

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -881,7 +881,6 @@ class Application(Gtk.Application):
                 "platform": game["platform"] or None,
                 "year": game["year"] or None,
                 "directory": game["directory"] or None,
-                "hidden": bool(game["hidden"]),
                 "playtime": (
                     str(timedelta(hours=game["playtime"]))
                     if game["playtime"] else None

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -20,7 +20,7 @@ class EditCategoryGamesDialog(SavableModelessDialog):
         self.available_games = [Game(x['id']) for x in games_db.get_games(sorts=[("installed", "DESC"),
                                                                                  ("name", "COLLATE NOCASE ASC")
                                                                                  ])]
-        self.category_games = [Game(x) for x in categories_db.get_game_ids_for_category(self.category)]
+        self.category_games = [Game(x) for x in categories_db.get_game_ids_for_categories([self.category])]
         self.grid = Gtk.Grid()
 
         self.set_default_size(500, 350)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -197,9 +197,7 @@ class LutrisWindow(Gtk.ApplicationWindow,
                 accel="F9",
             ),
             "show-hidden-games": Action(
-                self.hidden_state_change,
-                type="b",
-                default=self.show_hidden_games,
+                self.on_show_hidden_clicked,
                 enabled=lambda: self.is_show_hidden_sensitive,
                 accel="<Primary>h",
             ),
@@ -275,11 +273,10 @@ class LutrisWindow(Gtk.ApplicationWindow,
         """True if the hidden checkbox will be effective; service views ignore it."""
         return not self.filters.get("service")
 
-    def hidden_state_change(self, action, value):
+    def on_show_hidden_clicked(self, action, value):
         """Hides or shows the hidden games"""
-        action.set_state(value)
-        settings.write_setting("show_hidden_games", str(value).lower(), section="lutris")
-        self.update_store()
+        self.sidebar.hidden_row.show()
+        self.sidebar.selected_category = "category", ".hidden"
 
     @property
     def current_view_type(self):
@@ -1029,9 +1026,6 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
     def is_game_displayed(self, game):
         """Return whether a game should be displayed on the view"""
-        if game.is_hidden and not self.show_hidden_games:
-            return False
-
         row = self.sidebar.get_selected_row()
 
         if row:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -986,6 +986,9 @@ class LutrisWindow(Gtk.ApplicationWindow,
         self._bind_zoom_adjustment()
         self.redraw_view()
 
+        if row_type != "category" or row_id != ".hidden":
+            self.sidebar.hidden_row.hide()
+
         if not MISSING_GAMES.is_initialized or (row_type == "dynamic_category" and row_id == "missing"):
             MISSING_GAMES.update_all_missing()
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -270,8 +270,8 @@ class LutrisWindow(Gtk.ApplicationWindow,
 
     @property
     def is_show_hidden_sensitive(self):
-        """True if the hidden checkbox will be effective; service views ignore it."""
-        return not self.filters.get("service")
+        """True if there are any hiden games to show."""
+        return bool(categories_db.get_game_ids_for_categories([".hidden"]))
 
     def on_show_hidden_clicked(self, action, value):
         """Hides or shows the hidden games"""
@@ -526,6 +526,9 @@ class LutrisWindow(Gtk.ApplicationWindow,
         if filter_text:
             if self.filters.get("category") == "favorite":
                 self.show_label(_("Add a game matching '%s' to your favorites to see it here.") % filter_text)
+            elif self.filters.get("category") == ".hidden":
+                self.show_label(
+                    _("No hidden games matching '%s' found.") % filter_text)
             elif self.filters.get("installed") and has_uninstalled_games:
                 self.show_label(
                     _("No installed games matching '%s' found. Press Ctrl+I to show uninstalled games.") % filter_text)
@@ -534,6 +537,8 @@ class LutrisWindow(Gtk.ApplicationWindow,
         else:
             if self.filters.get("category") == "favorite":
                 self.show_label(_("Add games to your favorites to see them here."))
+            elif self.filters.get("category") == ".hidden":
+                self.show_label(_("No games are hidden."))
             elif self.filters.get("installed") and has_uninstalled_games:
                 self.show_label(_("No installed games found. Press Ctrl+I to show uninstalled games."))
             elif (
@@ -1051,6 +1056,8 @@ class LutrisWindow(Gtk.ApplicationWindow,
     def on_game_updated(self, game):
         """Updates an individual entry in the view when a game is updated"""
         add_to_path_cache(game)
+        self.update_action_state()
+
         if self.service:
             db_game = self.service.get_service_db_game(game)
         else:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1036,7 +1036,11 @@ class LutrisWindow(Gtk.ApplicationWindow,
             # If the update took the row out of this view's category, we'll need
             # to update the view to reflect that.
             if row.type in ("category", "user_category"):
-                if row.id != "all" and row.id not in game.get_categories():
+                categories = game.get_categories()
+                if row.id != ".hidden" and ".hidden" in categories:
+                    return False
+
+                if row.id != "all" and row.id not in categories:
                     return False
 
         return True

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -344,6 +344,7 @@ class LutrisSidebar(Gtk.ListBox):
         self.category_rows = {}
         # A dummy objects that allows inspecting why/when we have a show() call on the object.
         self.running_row = DummyRow()
+        self.hidden_row = DummyRow()
         self.missing_row = DummyRow()
         self.row_headers = {
             "library": SidebarHeader(_("Library"), header_index=0),
@@ -416,14 +417,15 @@ class LutrisSidebar(Gtk.ListBox):
                 Gtk.Image.new_from_icon_name("favorite-symbolic", Gtk.IconSize.MENU)
             )
         )
-        self.add(
-            SidebarRow(
-                ".hidden",
-                "category",
-                _("Hidden"),
-                Gtk.Image.new_from_icon_name("action-unavailable-symbolic", Gtk.IconSize.MENU)
-            )
+
+        self.hidden_row = SidebarRow(
+            ".hidden",
+            "category",
+            _("Hidden"),
+            Gtk.Image.new_from_icon_name("action-unavailable-symbolic", Gtk.IconSize.MENU)
         )
+        self.add(self.hidden_row)
+
         self.missing_row = SidebarRow(
             "missing",
             "dynamic_category",
@@ -441,6 +443,7 @@ class LutrisSidebar(Gtk.ListBox):
         # I wanted this to be on top but it really messes with the headers when showing/hiding the row.
         self.add(self.running_row)
         self.show_all()
+        self.hidden_row.hide()
         self.missing_row.hide()
         self.running_row.hide()
 

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -462,10 +462,19 @@ class LutrisSidebar(Gtk.ListBox):
         """Selects the row for the category indicated by a category tuple,
         like ('service', 'lutris')"""
         selected_row_type, selected_row_id = value or ("category", "all")
-        for row in self.get_children():
+        children = list(self.get_children())
+        for row in children:
             if row.type == selected_row_type and row.id == selected_row_id:
-                self.select_row(row)
+                if row.get_visible():
+                    self.select_row(row)
+                    return
+
                 break
+
+        for row in children:
+            if row.get_visible():
+                self.select_row(row)
+                return
 
     def _filter_func(self, row):
         def is_runner_visible(runner_name):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -416,6 +416,14 @@ class LutrisSidebar(Gtk.ListBox):
                 Gtk.Image.new_from_icon_name("favorite-symbolic", Gtk.IconSize.MENU)
             )
         )
+        self.add(
+            SidebarRow(
+                ".hidden",
+                "category",
+                _("Hidden"),
+                Gtk.Image.new_from_icon_name("action-unavailable-symbolic", Gtk.IconSize.MENU)
+            )
+        )
         self.missing_row = SidebarRow(
             "missing",
             "dynamic_category",

--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -3,7 +3,7 @@ import importlib
 from lutris import settings
 from lutris.util.log import logger
 
-MIGRATION_VERSION = 13  # Never decrease this number
+MIGRATION_VERSION = 14  # Never decrease this number
 
 # Replace deprecated migrations with empty lists
 MIGRATIONS = [
@@ -14,6 +14,7 @@ MIGRATIONS = [
     ["migrate_banners"],
     ["retrieve_discord_appids"],
     ["migrate_sortname"],
+    ["migrate_hidden_category"]
 ]
 
 

--- a/lutris/migrations/migrate_hidden_category.py
+++ b/lutris/migrations/migrate_hidden_category.py
@@ -1,0 +1,21 @@
+from sqlite3 import OperationalError
+
+from lutris.database.games import get_games
+from lutris.game import Game
+from lutris.util.log import logger
+
+
+def migrate():
+    """Put all previously hidden games into the new '.hidden' category."""
+    logger.info("Moving hidden games to the '.hidden' category")
+    try:
+        game_ids = [g["id"] for g in get_games(filters={"hidden": 1})]
+    except OperationalError:
+        # A brand-new DB will not have the hidden column at all,
+        # so no migration is required.
+        return
+
+    for game_id in game_ids:
+        game = Game(game_id)
+        game.set_hidden(True)
+        logger.info("Migrated '%s' to '.hidden' category.", game.name)

--- a/lutris/migrations/migrate_hidden_category.py
+++ b/lutris/migrations/migrate_hidden_category.py
@@ -17,5 +17,5 @@ def migrate():
 
     for game_id in game_ids:
         game = Game(game_id)
-        game.set_hidden(True)
+        game.mark_as_hidden(True)
         logger.info("Migrated '%s' to '.hidden' category.", game.name)

--- a/lutris/migrations/migrate_hidden_ids.py
+++ b/lutris/migrations/migrate_hidden_ids.py
@@ -19,5 +19,5 @@ def migrate():
         return []
     for game_id in game_ids:
         game = Game(game_id)
-        game.set_hidden(True)
+        game.mark_as_hidden(True)
     settings.write_setting("library_ignores", '', section="lutris")

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -514,9 +514,9 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="receives-default">False</property>
-            <property name="action-name">win.show-hidden-games</property>
-            <property name="text" translatable="yes">Show _Hidden Games</property>
-            <accelerator key="h" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
+            <property name="action-name">win.show-side-panel</property>
+            <property name="text" translatable="yes">Show Side _Panel</property>
+            <accelerator key="0xffffff" signal="clicked"/>
           </object>
           <packing>
             <property name="expand">False</property>
@@ -529,9 +529,9 @@
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="receives-default">False</property>
-            <property name="action-name">win.show-side-panel</property>
-            <property name="text" translatable="yes">Show Side _Panel</property>
-            <accelerator key="0xffffff" signal="clicked"/>
+            <property name="action-name">win.show-hidden-games</property>
+            <property name="text" translatable="yes">Show _Hidden Games</property>
+            <accelerator key="h" signal="clicked" modifiers="GDK_CONTROL_MASK"/>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
This PR does two things; it migrates the current 'hidden' flag on games into a category named ".hidden"- this should provide technical advantages for the Lutris website sync feature.

Also, this PR provides a more category-like UI for the beast.

You still hide games with the context menu, but the hamburger menu looks a little different:
![Screenshot from 2024-02-17 08-33-51](https://github.com/lutris/lutris/assets/6507403/208a2c9c-592c-41b5-a3f3-8f887c6e34e6)
No more checkbox. I moved it down one item to keep the remaining checkboxes together, just for cosmetics.

When you click 'Show Hidden Games', you get this:
![Screenshot from 2024-02-17 08-34-03](https://github.com/lutris/lutris/assets/6507403/6ac63696-97cf-4c23-98d7-65045dc1387d)
The hidden category is revealed! Only hidden games appear, which makes finding your hidden games easy. You can use multi-select to unhide them all. I love it when a plan comes together!

Selecting any other view will make this hidden category disappear again at once. Also, when you start Lutris it will refuse to select a view that is hidden- this new one, and also this applies to the 'Running' view. Instead it will select the first visible one, which should be 'Games'. Hidden means hidden!

This PR includes a migration for the hidden flag, and drops the 'hidden' column from the schema, but does not try to drop the column from existing databases- doing so would break the migration. If that column is missing, however, the migration just does nothing.

Resolves #5312