### PR TITLE
Improvements to the GameActions

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -171,6 +171,10 @@ class MultiGameActions(GameActions):
 
 
 class SingleGameActions(GameActions):
+    @property
+    def game(self):
+        return self.games[0]
+
     def get_game_actions(self):
         return [
             ("play", _("Play"), self.on_game_launch),
@@ -205,7 +209,7 @@ class SingleGameActions(GameActions):
     def get_displayed_entries(self):
         """Return a dictionary of actions that should be shown for a game"""
 
-        game = self.games[0]
+        game = self.game
         if steam_shortcut.vdf_file_exists():
             has_steam_shortcut = steam_shortcut.shortcut_exists(game)
             is_steam_game = steam_shortcut.is_steam_game(game)
@@ -265,144 +269,139 @@ class SingleGameActions(GameActions):
 
     def on_game_launch(self, *_args):
         """Launch a game"""
-        for game in self.games:
-            if game.is_installed and game.is_db_stored:
-                if not self.application.is_game_running_by_id(game.id):
-                    game.launch(launch_ui_delegate=self.window)
+        game = self.game
+        if game.is_installed and game.is_db_stored:
+            if not self.application.is_game_running_by_id(game.id):
+                game.launch(launch_ui_delegate=self.window)
 
     def on_execute_script_clicked(self, _widget):
         """Execute the game's associated script"""
-        for game in self.games:
-            manual_command = game.runner.system_config.get("manual_command")
-            if path_exists(manual_command):
-                MonitoredCommand(
-                    [manual_command],
-                    include_processes=[os.path.basename(manual_command)],
-                    cwd=game.directory,
-                ).start()
-                logger.info("Running %s in the background", manual_command)
+        game = self.game
+        manual_command = game.runner.system_config.get("manual_command")
+        if path_exists(manual_command):
+            MonitoredCommand(
+                [manual_command],
+                include_processes=[os.path.basename(manual_command)],
+                cwd=game.directory,
+            ).start()
+            logger.info("Running %s in the background", manual_command)
 
     def on_show_logs(self, _widget):
         """Display game log"""
-        for game in self.games:
-            _buffer = game.log_buffer
-            if not _buffer:
-                logger.info("No log for game %s", game)
-            return LogWindow(
-                game=game,
-                buffer=_buffer,
-                application=self.application
-            )
+        game = self.game
+        _buffer = game.log_buffer
+        if not _buffer:
+            logger.info("No log for game %s", game)
+        return LogWindow(
+            game=game,
+            buffer=_buffer,
+            application=self.application
+        )
 
     def on_edit_game_configuration(self, _widget):
         """Edit game preferences"""
-        for game in self.games:
-            self.application.show_window(EditGameConfigDialog, game=game, parent=self.window)
+        self.application.show_window(EditGameConfigDialog, game=self.game, parent=self.window)
 
     def on_edit_game_categories(self, _widget):
         """Edit game categories"""
-        for game in self.games:
-            self.application.show_window(EditGameCategoriesDialog, game=game, parent=self.window)
+        self.application.show_window(EditGameCategoriesDialog, game=self.game, parent=self.window)
 
     def on_browse_files(self, _widget):
         """Callback to open a game folder in the file browser"""
-        for game in self.games:
-            path = game.get_browse_dir()
-            if not path:
-                dialogs.NoticeDialog(_("This game has no installation directory"))
-            elif path_exists(path):
-                open_uri("file://%s" % path)
-            else:
-                dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path)
+        path = self.game.get_browse_dir()
+        if not path:
+            dialogs.NoticeDialog(_("This game has no installation directory"))
+        elif path_exists(path):
+            open_uri("file://%s" % path)
+        else:
+            dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path)
 
     def on_install_dlc_clicked(self, _widget):
-        for game in self.games:
-            game.install_dlc(install_ui_delegate=self.window)
+        self.game.install_dlc(install_ui_delegate=self.window)
 
     def on_update_clicked(self, _widget):
-        for game in self.games:
-            game.install_updates(install_ui_delegate=self.window)
+        self.game.install_updates(install_ui_delegate=self.window)
 
     def on_create_menu_shortcut(self, *_args):
         """Add the selected game to the system's Games menu."""
-        for game in self.games:
-            launch_config_name = self._select_game_launch_config_name(game)
-            if launch_config_name is not None:
-                xdgshortcuts.create_launcher(game.slug, game.id, launch_config_name, menu=True)
+        game = self.game
+        launch_config_name = self._select_game_launch_config_name(game)
+        if launch_config_name is not None:
+            xdgshortcuts.create_launcher(game.slug, game.id, launch_config_name, menu=True)
 
     def on_create_steam_shortcut(self, *_args):
         """Add the selected game to steam as a nonsteam-game."""
-        for game in self.games:
-            launch_config_name = self._select_game_launch_config_name(game)
-            if launch_config_name is not None:
-                steam_shortcut.create_shortcut(game, launch_config_name)
+        game = self.game
+        launch_config_name = self._select_game_launch_config_name(game)
+        if launch_config_name is not None:
+            steam_shortcut.create_shortcut(game, launch_config_name)
 
     def on_create_desktop_shortcut(self, *_args):
         """Create a desktop launcher for the selected game."""
-        for game in self.games:
-            launch_config_name = self._select_game_launch_config_name(game)
-            if launch_config_name is not None:
-                xdgshortcuts.create_launcher(game.slug, game.id, game.name, launch_config_name, desktop=True)
+        game = self.game
+        launch_config_name = self._select_game_launch_config_name(game)
+        if launch_config_name is not None:
+            xdgshortcuts.create_launcher(game.slug, game.id, game.name, launch_config_name, desktop=True)
 
     def on_remove_menu_shortcut(self, *_args):
         """Remove an XDG menu shortcut"""
-        for game in self.games:
-            xdgshortcuts.remove_launcher(game.slug, game.id, menu=True)
+        game = self.game
+        xdgshortcuts.remove_launcher(game.slug, game.id, menu=True)
 
     def on_remove_steam_shortcut(self, *_args):
         """Remove the selected game from list of non-steam apps."""
-        for game in self.games:
-            steam_shortcut.remove_shortcut(game)
+        steam_shortcut.remove_shortcut(self.game)
 
     def on_remove_desktop_shortcut(self, *_args):
         """Remove a .desktop shortcut"""
-        for game in self.games:
-            xdgshortcuts.remove_launcher(game.slug, game.id, desktop=True)
+        game = self.game
+        xdgshortcuts.remove_launcher(game.slug, game.id, desktop=True)
 
     def on_game_duplicate(self, _widget):
-        for game in self.games:
-            duplicate_game_dialog = InputDialog(
-                {
-                    "parent": self.window,
-                    "question": _(
-                        "Do you wish to duplicate %s?\nThe configuration will be duplicated, "
-                        "but the games files will <b>not be duplicated</b>.\n"
-                        "Please enter the new name for the copy:"
-                    ) % gtk_safe(game.name),
-                    "title": _("Duplicate game?"),
-                    "initial_value": game.name
-                }
-            )
-            result = duplicate_game_dialog.run()
-            if result != Gtk.ResponseType.OK:
-                duplicate_game_dialog.destroy()
-                return
-            new_name = duplicate_game_dialog.user_value
+        game = self.game
 
-            old_config_id = game.game_config_id
-            if old_config_id:
-                new_config_id = duplicate_game_config(game.slug, old_config_id)
-            else:
-                new_config_id = None
+        duplicate_game_dialog = InputDialog(
+            {
+                "parent": self.window,
+                "question": _(
+                    "Do you wish to duplicate %s?\nThe configuration will be duplicated, "
+                    "but the games files will <b>not be duplicated</b>.\n"
+                    "Please enter the new name for the copy:"
+                ) % gtk_safe(game.name),
+                "title": _("Duplicate game?"),
+                "initial_value": game.name
+            }
+        )
+        result = duplicate_game_dialog.run()
+        if result != Gtk.ResponseType.OK:
             duplicate_game_dialog.destroy()
-            db_game = get_game_by_field(game.id, "id")
-            db_game["name"] = new_name
-            db_game["slug"] = slugify(new_name) if new_name != game.name else game.slug
-            db_game["lastplayed"] = None
-            db_game["playtime"] = 0.0
-            db_game["configpath"] = new_config_id
-            db_game.pop("id")
-            # Disconnect duplicate from service- there should be at most 1 database game for a service game.
-            db_game.pop("service", None)
-            db_game.pop("service_id", None)
+            return
+        new_name = duplicate_game_dialog.user_value
 
-            game_id = add_game(**db_game)
-            new_game = Game(game_id)
-            new_game.save()
+        old_config_id = game.game_config_id
+        if old_config_id:
+            new_config_id = duplicate_game_config(game.slug, old_config_id)
+        else:
+            new_config_id = None
+        duplicate_game_dialog.destroy()
+        db_game = get_game_by_field(game.id, "id")
+        db_game["name"] = new_name
+        db_game["slug"] = slugify(new_name) if new_name != game.name else game.slug
+        db_game["lastplayed"] = None
+        db_game["playtime"] = 0.0
+        db_game["configpath"] = new_config_id
+        db_game.pop("id")
+        # Disconnect duplicate from service- there should be at most 1 database game for a service game.
+        db_game.pop("service", None)
+        db_game.pop("service_id", None)
 
-            # Download in the background; we'll update the LutrisWindow when this
-            # completes, no need to wait for it.
-            AsyncCall(download_lutris_media, None, db_game["slug"])
+        game_id = add_game(**db_game)
+        new_game = Game(game_id)
+        new_game.save()
+
+        # Download in the background; we'll update the LutrisWindow when this
+        # completes, no need to wait for it.
+        AsyncCall(download_lutris_media, None, db_game["slug"])
 
     def _select_game_launch_config_name(self, game):
         game_config = game.config.game_level.get("game", {})

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -106,8 +106,6 @@ class BaseGameActions:
 
 
 class GameActions(BaseGameActions):
-    """Regroup a list of callbacks for a game"""
-
     @property
     def is_game_launchable(self):
         for game in self.games:
@@ -124,21 +122,76 @@ class GameActions(BaseGameActions):
         return False
 
     def get_game_actions(self):
-        if not self.games:
-            return []
+        return []
 
-        if len(self.games) > 1:
-            return [
-                ("stop", _("Stop"), self.on_game_stop),
-                (None, "-", None),
-                ("favorite", _("Add to favorites"), self.on_add_favorite_game),
-                ("deletefavorite", _("Remove from favorites"), self.on_delete_favorite_game),
-                ("hide", _("Hide game from library"), self.on_hide_game),
-                ("unhide", _("Unhide game from library"), self.on_unhide_game),
-                (None, "-", None),
-                ("remove", _("Remove"), self.on_remove_game),
-            ]
+    def get_displayed_entries(self):
+        """Return a dictionary of actions that should be shown for a game"""
+        return {}
 
+    def get_running_games(self):
+        running_games = []
+        for game in self.games:
+            if game and game.is_db_stored:
+                ids = self.application.get_running_game_ids()
+                for game_id in ids:
+                    if str(game_id) == game.id:
+                        running_games.append(game)
+        return running_games
+
+    def on_game_stop(self, *_args):
+        """Stops the game"""
+        games = self.get_running_games()
+        for game in games:
+            game.force_stop()
+
+    def on_add_favorite_game(self, _widget):
+        """Add to favorite Games list"""
+        for game in self.games:
+            game.mark_as_favorite(True)
+
+    def on_delete_favorite_game(self, _widget):
+        """delete from favorites"""
+        for game in self.games:
+            game.mark_as_favorite(False)
+
+    def on_hide_game(self, _widget):
+        """Add a game to the list of hidden games"""
+        for game in self.games:
+            game.mark_as_hidden(True)
+
+    def on_unhide_game(self, _widget):
+        """Removes a game from the list of hidden games"""
+        for game in self.games:
+            game.mark_as_hidden(False)
+
+
+class MultiGameActions(GameActions):
+    def get_game_actions(self):
+        return [
+            ("stop", _("Stop"), self.on_game_stop),
+            (None, "-", None),
+            ("favorite", _("Add to favorites"), self.on_add_favorite_game),
+            ("deletefavorite", _("Remove from favorites"), self.on_delete_favorite_game),
+            ("hide", _("Hide game from library"), self.on_hide_game),
+            ("unhide", _("Unhide game from library"), self.on_unhide_game),
+            (None, "-", None),
+            ("remove", _("Remove"), self.on_remove_game),
+        ]
+
+    def get_displayed_entries(self):
+        """Return a dictionary of actions that should be shown for a game"""
+        return {
+            "stop": self.is_game_running,
+            "favorite": any(g for g in self.games if not g.is_favorite),
+            "deletefavorite": any(g for g in self.games if g.is_favorite),
+            "hide": any(g for g in self.games if g.is_installed and not g.is_hidden),
+            "unhide": any(g for g in self.games if g.is_hidden),
+            "remove": self.is_game_removable,
+        }
+
+
+class SingleGameActions(GameActions):
+    def get_game_actions(self):
         return [
             ("play", _("Play"), self.on_game_launch),
             ("stop", _("Stop"), self.on_game_stop),
@@ -171,18 +224,6 @@ class GameActions(BaseGameActions):
 
     def get_displayed_entries(self):
         """Return a dictionary of actions that should be shown for a game"""
-        if not self.games:
-            return {}
-
-        if len(self.games) > 1:
-            return {
-                "stop": self.is_game_running,
-                "favorite": any(g for g in self.games if not g.is_favorite),
-                "deletefavorite": any(g for g in self.games if g.is_favorite),
-                "hide": any(g for g in self.games if g.is_installed and not g.is_hidden),
-                "unhide": any(g for g in self.games if g.is_hidden),
-                "remove": self.is_game_removable,
-            }
 
         game = self.games[0]
         if steam_shortcut.vdf_file_exists():
@@ -191,6 +232,7 @@ class GameActions(BaseGameActions):
         else:
             has_steam_shortcut = False
             is_steam_game = False
+
         return {
             "duplicate": game.is_installed,
             "install": self.is_installable,
@@ -248,21 +290,17 @@ class GameActions(BaseGameActions):
                 if not self.application.is_game_running_by_id(game.id):
                     game.launch(launch_ui_delegate=self.window)
 
-    def get_running_games(self):
-        running_games = []
+    def on_execute_script_clicked(self, _widget):
+        """Execute the game's associated script"""
         for game in self.games:
-            if game and game.is_db_stored:
-                ids = self.application.get_running_game_ids()
-                for game_id in ids:
-                    if str(game_id) == game.id:
-                        running_games.append(game)
-        return running_games
-
-    def on_game_stop(self, *_args):
-        """Stops the game"""
-        games = self.get_running_games()
-        for game in games:
-            game.force_stop()
+            manual_command = game.runner.system_config.get("manual_command")
+            if path_exists(manual_command):
+                MonitoredCommand(
+                    [manual_command],
+                    include_processes=[os.path.basename(manual_command)],
+                    cwd=game.directory,
+                ).start()
+                logger.info("Running %s in the background", manual_command)
 
     def on_show_logs(self, _widget):
         """Display game log"""
@@ -276,13 +314,70 @@ class GameActions(BaseGameActions):
                 application=self.application
             )
 
-    def on_update_clicked(self, _widget):
+    def on_edit_game_configuration(self, _widget):
+        """Edit game preferences"""
         for game in self.games:
-            game.install_updates(install_ui_delegate=self.window)
+            self.application.show_window(EditGameConfigDialog, game=game, parent=self.window)
+
+    def on_edit_game_categories(self, _widget):
+        """Edit game categories"""
+        for game in self.games:
+            self.application.show_window(EditGameCategoriesDialog, game=game, parent=self.window)
+
+    def on_browse_files(self, _widget):
+        """Callback to open a game folder in the file browser"""
+        for game in self.games:
+            path = game.get_browse_dir()
+            if not path:
+                dialogs.NoticeDialog(_("This game has no installation directory"))
+            elif path_exists(path):
+                open_uri("file://%s" % path)
+            else:
+                dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path)
 
     def on_install_dlc_clicked(self, _widget):
         for game in self.games:
             game.install_dlc(install_ui_delegate=self.window)
+
+    def on_update_clicked(self, _widget):
+        for game in self.games:
+            game.install_updates(install_ui_delegate=self.window)
+
+    def on_create_menu_shortcut(self, *_args):
+        """Add the selected game to the system's Games menu."""
+        for game in self.games:
+            launch_config_name = self._select_game_launch_config_name(game)
+            if launch_config_name is not None:
+                xdgshortcuts.create_launcher(game.slug, game.id, launch_config_name, menu=True)
+
+    def on_create_steam_shortcut(self, *_args):
+        """Add the selected game to steam as a nonsteam-game."""
+        for game in self.games:
+            launch_config_name = self._select_game_launch_config_name(game)
+            if launch_config_name is not None:
+                steam_shortcut.create_shortcut(game, launch_config_name)
+
+    def on_create_desktop_shortcut(self, *_args):
+        """Create a desktop launcher for the selected game."""
+        for game in self.games:
+            launch_config_name = self._select_game_launch_config_name(game)
+            if launch_config_name is not None:
+                xdgshortcuts.create_launcher(game.slug, game.id, game.name, launch_config_name, desktop=True)
+
+    def on_remove_menu_shortcut(self, *_args):
+        """Remove an XDG menu shortcut"""
+        for game in self.games:
+            xdgshortcuts.remove_launcher(game.slug, game.id, menu=True)
+
+    def on_remove_steam_shortcut(self, *_args):
+        """Remove the selected game from list of non-steam apps."""
+        for game in self.games:
+            steam_shortcut.remove_shortcut(game)
+
+    def on_remove_desktop_shortcut(self, *_args):
+        """Remove a .desktop shortcut"""
+        for game in self.games:
+            xdgshortcuts.remove_launcher(game.slug, game.id, desktop=True)
 
     def on_game_duplicate(self, _widget):
         for game in self.games:
@@ -329,95 +424,6 @@ class GameActions(BaseGameActions):
             # completes, no need to wait for it.
             AsyncCall(download_lutris_media, None, db_game["slug"])
 
-    def on_edit_game_configuration(self, _widget):
-        """Edit game preferences"""
-        for game in self.games:
-            self.application.show_window(EditGameConfigDialog, game=game, parent=self.window)
-
-    def on_add_favorite_game(self, _widget):
-        """Add to favorite Games list"""
-        for game in self.games:
-            game.mark_as_favorite(True)
-
-    def on_delete_favorite_game(self, _widget):
-        """delete from favorites"""
-        for game in self.games:
-            game.mark_as_favorite(False)
-
-    def on_edit_game_categories(self, _widget):
-        """Edit game categories"""
-        for game in self.games:
-            self.application.show_window(EditGameCategoriesDialog, game=game, parent=self.window)
-
-    def on_hide_game(self, _widget):
-        """Add a game to the list of hidden games"""
-        for game in self.games:
-            game.mark_as_hidden(True)
-
-    def on_unhide_game(self, _widget):
-        """Removes a game from the list of hidden games"""
-        for game in self.games:
-            game.mark_as_hidden(False)
-
-    def on_execute_script_clicked(self, _widget):
-        """Execute the game's associated script"""
-        for game in self.games:
-            manual_command = game.runner.system_config.get("manual_command")
-            if path_exists(manual_command):
-                MonitoredCommand(
-                    [manual_command],
-                    include_processes=[os.path.basename(manual_command)],
-                    cwd=game.directory,
-                ).start()
-                logger.info("Running %s in the background", manual_command)
-
-    def on_browse_files(self, _widget):
-        """Callback to open a game folder in the file browser"""
-        for game in self.games:
-            path = game.get_browse_dir()
-            if not path:
-                dialogs.NoticeDialog(_("This game has no installation directory"))
-            elif path_exists(path):
-                open_uri("file://%s" % path)
-            else:
-                dialogs.NoticeDialog(_("Can't open %s \nThe folder doesn't exist.") % path)
-
-    def on_create_menu_shortcut(self, *_args):
-        """Add the selected game to the system's Games menu."""
-        for game in self.games:
-            launch_config_name = self._select_game_launch_config_name(game)
-            if launch_config_name is not None:
-                xdgshortcuts.create_launcher(game.slug, game.id, launch_config_name, menu=True)
-
-    def on_create_steam_shortcut(self, *_args):
-        """Add the selected game to steam as a nonsteam-game."""
-        for game in self.games:
-            launch_config_name = self._select_game_launch_config_name(game)
-            if launch_config_name is not None:
-                steam_shortcut.create_shortcut(game, launch_config_name)
-
-    def on_create_desktop_shortcut(self, *_args):
-        """Create a desktop launcher for the selected game."""
-        for game in self.games:
-            launch_config_name = self._select_game_launch_config_name(game)
-            if launch_config_name is not None:
-                xdgshortcuts.create_launcher(game.slug, game.id, game.name, launch_config_name, desktop=True)
-
-    def on_remove_menu_shortcut(self, *_args):
-        """Remove an XDG menu shortcut"""
-        for game in self.games:
-            xdgshortcuts.remove_launcher(game.slug, game.id, menu=True)
-
-    def on_remove_steam_shortcut(self, *_args):
-        """Remove the selected game from list of non-steam apps."""
-        for game in self.games:
-            steam_shortcut.remove_shortcut(game)
-
-    def on_remove_desktop_shortcut(self, *_args):
-        """Remove a .desktop shortcut"""
-        for game in self.games:
-            xdgshortcuts.remove_launcher(game.slug, game.id, desktop=True)
-
     def _select_game_launch_config_name(self, game):
         game_config = game.config.game_level.get("game", {})
         configs = game_config.get("launch_configs")
@@ -457,12 +463,12 @@ def get_game_actions(games: List[Game], window: Gtk.Window, application=None) ->
         if len(games) == 1:
             game = games[0]
             if game.is_db_stored:
-                return GameActions(games, window, application)
+                return SingleGameActions(games, window, application)
 
             if game.service:
                 return ServiceGameActions(games, window, application)
         elif all(g.is_db_stored for g in games):
-            return GameActions(games, window)
+            return MultiGameActions(games, window)
 
     # If given no games, or the games are not of a kind we can handle,
     # the base class acts as an empty set of actions.

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -6,7 +6,7 @@ from gi.repository import Gdk, Gio, GLib, GObject, Gtk
 from lutris.database.games import get_game_for_service
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
-from lutris.game_actions import BaseGameActions, get_game_actions
+from lutris.game_actions import GameActions, get_game_actions
 from lutris.gui.widgets.contextual_menu import ContextualMenu
 from lutris.gui.widgets.utils import MEDIA_CACHE_INVALIDATED
 from lutris.util.log import logger
@@ -85,10 +85,10 @@ class GameView:
             contextual_menu.popup(event, game_actions)
             return True
 
-    def get_selected_game_actions(self) -> BaseGameActions:
+    def get_selected_game_actions(self) -> GameActions:
         return self.get_game_actions_for_paths(self.get_selected())
 
-    def get_game_actions_for_paths(self, paths) -> BaseGameActions:
+    def get_game_actions_for_paths(self, paths) -> GameActions:
         game_ids = []
         for path in paths:
             game_ids.append(self.get_game_id_for_path(path))


### PR DESCRIPTION
I'll put this in a PR since it may introduce bugs, and it's not very essential.

The ``GameActions`` classes feature many ``for game in self.games`` loops that should actually only iterate once as they are only used with single games. Actually using them with multiple games would not work well- it might open a window or dialog per game or the like. This is not ideal, so let's refactor this.

This PR splits out separate ``SingleGameActions`` and ``MultiGameActions`` classes; the ``MultiGameActions`` are essentially as before, except with fewer ``if`` statements. But many actions are now implemented in ``SingleGameActions`` and need no loop because there is no list- just a game.

``ServiceGameActions`` also now just handles a single game also.

Some actions are in ``GameActions`` because they are shared between the classes, but most of these need their loops to work on multiple games legitimately. Used by itself, ``GameActons`` is a null object- it has no games and no actions.

The one holdout from all this refactoring is the ``on_install_clicked`` which is shared between ``SingleGameActions`` and ``ServiceGameActions`` and has the loop-for-one-game thing still. This could be fixed by adding another base class to the hierarchy, but I did not think this worthwhile for just one method.