### PR TITLE
metainfo: Add developer

### DIFF
--- a/share/metainfo/net.lutris.Lutris.metainfo.xml
+++ b/share/metainfo/net.lutris.Lutris.metainfo.xml
@@ -6,6 +6,9 @@
   <metadata_license>CC0-1.0</metadata_license>
   <translation type="gettext">lutris</translation>
   <developer_name translatable="no">Lutris Team</developer_name>
+  <developer id="net.lutris">
+    <name translatable="no">Lutris Team</name>
+  </developer>
   <update_contact>mathieucomandon@gmail.com</update_contact>
   <name translatable="no">Lutris</name>
   <summary>Video game preservation platform</summary>


### PR DESCRIPTION
AppStream 1.0 deprecated developer_name, we cannot remove it yet since some frontends still use it, but we add its replacement.

See https://www.freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer.