### PR TITLE
Fix shortcuts for launch_config options

### DIFF
--- a/lutris/api.py
+++ b/lutris/api.py
@@ -501,7 +501,6 @@ def format_installer_url(installer_info):
     if launch_config_name:
         parts.append(launch_config_name)
 
-    parts = [urllib.parse.quote(str(part)) for part in parts]
     path = "/".join(parts)
 
     if revision:

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -333,7 +333,7 @@ class SingleGameActions(GameActions):
         game = self.game
         launch_config_name = self._select_game_launch_config_name(game)
         if launch_config_name is not None:
-            xdgshortcuts.create_launcher(game.slug, game.id, launch_config_name, menu=True)
+            xdgshortcuts.create_launcher(game.slug, game.id, game.name, launch_config_name, menu=True)
 
     def on_create_steam_shortcut(self, *_args):
         """Add the selected game to steam as a nonsteam-game."""

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -68,7 +68,7 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
         Icon={}
         Exec=env LUTRIS_SKIP_INIT=1 {} {}
         Categories=Game
-        """.format(game_name, "lutris_{}".format(game_slug), lutris_executable, shlex.quote(url))
+        """.format(launch_config_name or game_name, "lutris_{}".format(game_slug), lutris_executable, shlex.quote(url))
     )
 
     launcher_filename = get_xdg_basename(game_slug, game_id)


### PR DESCRIPTION
There where multiple issues with shortcuts for `launch_config` options:
- The `name` tag didn't change for any `launch_config` and displayed the main `game_name` instead
- `Exec` links where broken:
```py
Exec=env LUTRIS_SKIP_INIT=1 lutris lutris:rungameid/1/Game%20-%Config
```
instead of : 
```py
Exec=env LUTRIS_SKIP_INIT=1 lutris lutris:rungameid/1/Game - Config
```
- the `game.name` var not being passed correctly in `game_actions.py`, resulting in the `name` tag missing which caused the shortcut to display the file name (e.g `net.lutris.game-config-1.desktop`) instead of the actual game name.

