### PR TITLE
Splash Screen Notification to Log In & Sync your Library

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -21,7 +21,7 @@ from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
 from lutris.gui.config.preferences_dialog import PreferencesDialog
-from lutris.gui.dialogs import ErrorDialog
+from lutris.gui.dialogs import ErrorDialog, ClientLoginDialog
 from lutris.gui.dialogs.delegates import DialogInstallUIDelegate, DialogLaunchUIDelegate
 from lutris.gui.dialogs.game_import import ImportGameDialog
 from lutris.gui.download_queue import DownloadQueue
@@ -829,8 +829,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
 
     @GtkTemplate.Callback
     def on_lutris_log_in_button_clicked(self, _button):
-        service = LutrisService()
-        service.login(parent=self)
+        ClientLoginDialog(parent=self)
 
     def on_service_games_updated(self, service):
         """Request a view update when service games are loaded"""

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -63,8 +63,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     download_revealer: Gtk.Revealer = GtkTemplate.Child()
     game_view_spinner: Gtk.Spinner = GtkTemplate.Child()
     notification_revealer: Gtk.Revealer = GtkTemplate.Child()
-    lutris_log_in_button: Gtk.Button = GtkTemplate.Child()
-    turn_on_library_sync_button: Gtk.Button = GtkTemplate.Child()
+    lutris_log_in_label: Gtk.Label = GtkTemplate.Child()
+    turn_on_library_sync_label: Gtk.Label = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs):
         width = int(settings.read_setting("width") or self.default_width)
@@ -838,22 +838,22 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         show_notification = self.is_showing_splash()
         if show_notification:
             if not read_user_info():
-                self.lutris_log_in_button.show()
-                self.turn_on_library_sync_button.hide()
+                self.lutris_log_in_label.show()
+                self.turn_on_library_sync_label.hide()
             elif not settings.read_bool_setting("library_sync_enabled"):
-                self.lutris_log_in_button.hide()
-                self.turn_on_library_sync_button.show()
+                self.lutris_log_in_label.hide()
+                self.turn_on_library_sync_label.show()
             else:
                 show_notification = False
 
         self.notification_revealer.set_reveal_child(show_notification)
 
     @GtkTemplate.Callback
-    def on_lutris_log_in_button_clicked(self, _button):
+    def on_lutris_log_in_label_activate_link(self, _label, _url):
         ClientLoginDialog(parent=self)
 
     @GtkTemplate.Callback
-    def on_turn_on_library_sync_button_clicked(self, _button):
+    def on_turn_on_library_sync_label_activate_link(self, _label, _url):
         settings.write_setting("library_sync_enabled", True)
         self.sync_library(force=True)
         self.update_notification()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -10,8 +10,7 @@ from urllib.parse import unquote, urlparse
 from gi.repository import Gdk, Gio, GLib, GObject, Gtk
 
 from lutris import services, settings
-from lutris.api import read_user_info, LUTRIS_ACCOUNT_DISCONNECTED
-from lutris.api import LUTRIS_ACCOUNT_CONNECTED
+from lutris.api import LUTRIS_ACCOUNT_CONNECTED, LUTRIS_ACCOUNT_DISCONNECTED, read_user_info
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.database.services import ServiceGameCollection
@@ -21,7 +20,7 @@ from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
 from lutris.gui.config.preferences_dialog import PreferencesDialog
-from lutris.gui.dialogs import ErrorDialog, ClientLoginDialog
+from lutris.gui.dialogs import ClientLoginDialog, ErrorDialog
 from lutris.gui.dialogs.delegates import DialogInstallUIDelegate, DialogLaunchUIDelegate
 from lutris.gui.dialogs.game_import import ImportGameDialog
 from lutris.gui.download_queue import DownloadQueue
@@ -64,6 +63,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     download_revealer: Gtk.Revealer = GtkTemplate.Child()
     game_view_spinner: Gtk.Spinner = GtkTemplate.Child()
     notification_revealer: Gtk.Revealer = GtkTemplate.Child()
+    lutris_log_in_button: Gtk.Button = GtkTemplate.Child()
+    turn_on_library_sync_button: Gtk.Button = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs):
         width = int(settings.read_setting("width") or self.default_width)
@@ -568,8 +569,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             else:
                 self.show_label(_("No games found"))
 
-        self.update_notification()
-
     def update_store(self, *_args, **_kwargs):
         service_id = self.filters.get("service")
         service = self.service
@@ -630,6 +629,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 self.hide_overlay()
             else:
                 self.show_empty_label()
+
+            self.update_notification()
 
         self.search_timer_id = None
 
@@ -834,12 +835,28 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.filters["installed"] = filter_installed
 
     def update_notification(self):
-        show_notification = not read_user_info() and self.is_showing_splash()
+        show_notification = self.is_showing_splash()
+        if show_notification:
+            if not read_user_info():
+                self.lutris_log_in_button.show()
+                self.turn_on_library_sync_button.hide()
+            elif not settings.read_bool_setting("library_sync_enabled"):
+                self.lutris_log_in_button.hide()
+                self.turn_on_library_sync_button.show()
+            else:
+                show_notification = False
+
         self.notification_revealer.set_reveal_child(show_notification)
 
     @GtkTemplate.Callback
     def on_lutris_log_in_button_clicked(self, _button):
         ClientLoginDialog(parent=self)
+
+    @GtkTemplate.Callback
+    def on_turn_on_library_sync_button_clicked(self, _button):
+        settings.write_setting("library_sync_enabled", True)
+        self.sync_library(force=True)
+        self.update_notification()
 
     def on_service_games_updated(self, service):
         """Request a view update when service games are loaded"""
@@ -1075,6 +1092,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             self.rebuild_view("grid")
         else:
             self.update_view_settings()
+        self.update_notification()
         return True
 
     def is_game_displayed(self, game):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -10,6 +10,7 @@ from urllib.parse import unquote, urlparse
 from gi.repository import Gdk, Gio, GLib, GObject, Gtk
 
 from lutris import services, settings
+from lutris.api import read_user_info
 from lutris.api import LUTRIS_ACCOUNT_CONNECTED
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
@@ -44,7 +45,8 @@ from lutris.util.system import update_desktop_icons
 
 
 @GtkTemplate(ui=os.path.join(datapath.get(), "ui", "lutris-window.ui"))
-class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
+class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
+                   DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """Handler class for main window signals."""
 
     default_view_type = "grid"
@@ -62,6 +64,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     viewtype_icon = GtkTemplate.Child()
     download_revealer: Gtk.Revealer = GtkTemplate.Child()
     game_view_spinner: Gtk.Spinner = GtkTemplate.Child()
+    notification_revealer: Gtk.Revealer = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs):
         width = int(settings.read_setting("width") or self.default_width)
@@ -135,6 +138,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.game_revealer.add(self.revealer_box)
 
         self.update_action_state()
+        self.update_notification()
 
         GObject.add_emission_hook(BaseService, "service-login", self.on_service_login)
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_logout)
@@ -228,7 +232,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 action.connect("change-state", value.callback)
             self.actions[name] = action
             if value.enabled:
-
                 def updater(action=action, value=value):
                     action.props.enabled = value.enabled()
 
@@ -819,6 +822,15 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         settings.write_setting("filter_installed", bool(filter_installed))
         self.filters["installed"] = filter_installed
 
+    def update_notification(self):
+        logged_in = bool(read_user_info())
+        self.notification_revealer.set_reveal_child(not logged_in)
+
+    @GtkTemplate.Callback
+    def on_lutris_log_in_button_clicked(self, _button):
+        service = LutrisService()
+        service.login(parent=self)
+
     def on_service_games_updated(self, service):
         """Request a view update when service games are loaded"""
         if self.service and service.id == self.service.id:
@@ -844,6 +856,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             self.move(int(self.window_x), int(self.window_y))
 
     def on_service_login(self, service):
+        self.update_notification()
         service.start_reload(self._service_reloaded_cb)
         return True
 
@@ -852,6 +865,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             dialogs.ErrorDialog(error, parent=self)
 
     def on_service_logout(self, service):
+        self.update_notification()
         if self.service and service.id == self.service.id:
             self.update_store()
         return True

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -10,7 +10,7 @@ from urllib.parse import unquote, urlparse
 from gi.repository import Gdk, Gio, GLib, GObject, Gtk
 
 from lutris import services, settings
-from lutris.api import read_user_info
+from lutris.api import read_user_info, LUTRIS_ACCOUNT_DISCONNECTED
 from lutris.api import LUTRIS_ACCOUNT_CONNECTED
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
@@ -150,6 +150,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
         GObject.add_emission_hook(PreferencesDialog, "settings-changed", self.on_settings_changed)
         MISSING_GAMES.updated.register(self.update_missing_games_sidebar_row)
         LUTRIS_ACCOUNT_CONNECTED.register(self.on_lutris_account_connected)
+        LUTRIS_ACCOUNT_DISCONNECTED.register(self.on_lutris_account_disconnected)
         LOCAL_LIBRARY_UPDATED.register(self.on_local_library_updated)
 
         # Finally trigger the initialization of the view here
@@ -871,7 +872,11 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
         return True
 
     def on_lutris_account_connected(self):
+        self.update_notification()
         self.sync_library(force=True)
+
+    def on_lutris_account_disconnected(self):
+        self.update_notification()
 
     def on_local_library_updated(self):
         self.redraw_view()

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -121,12 +121,12 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkButton" id="lutris_log_in_button">
-                            <property name="label" translatable="yes">Log In</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
-                            <property name="no-show-all">True</property>
-                            <signal name="clicked" handler="on_lutris_log_in_button_clicked" swapped="no"/>
+                          <object class="GtkLabel" id="lutris_log_in_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">&lt;a href=""&gt;Log In&lt;/a&gt;</property>
+                            <property name="use-markup">True</property>
+                            <signal name="activate-link" handler="on_lutris_log_in_label_activate_link" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -136,12 +136,12 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkButton" id="turn_on_library_sync_button">
-                            <property name="label" translatable="yes">Turn on Library Sync</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
-                            <property name="no-show-all">True</property>
-                            <signal name="clicked" handler="on_turn_on_library_sync_button_clicked" swapped="no"/>
+                          <object class="GtkLabel" id="turn_on_library_sync_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">&lt;a href=""&gt;Turn on Library Sync&lt;/a&gt;</property>
+                            <property name="use-markup">True</property>
+                            <signal name="activate-link" handler="on_turn_on_library_sync_label_activate_link" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -111,7 +111,7 @@
                           <object class="GtkLabel" id="notification_label">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Log in to &lt;a href="https://lutris.net/"&gt;Lutris.net&lt;/a&gt; to view your game library</property>
+                            <property name="label" translatable="yes">Login to &lt;a href="https://lutris.net/"&gt;Lutris.net&lt;/a&gt; to view your game library</property>
                             <property name="use-markup">True</property>
                           </object>
                           <packing>
@@ -124,7 +124,7 @@
                           <object class="GtkLabel" id="lutris_log_in_label">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">&lt;a href=""&gt;Log In&lt;/a&gt;</property>
+                            <property name="label" translatable="yes">&lt;a href=""&gt;Login&lt;/a&gt;</property>
                             <property name="use-markup">True</property>
                             <signal name="activate-link" handler="on_lutris_log_in_label_activate_link" swapped="no"/>
                           </object>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -97,6 +97,70 @@
                 <property name="hexpand">True</property>
                 <property name="orientation">vertical</property>
                 <child>
+                  <object class="GtkRevealer" id="notification_revealer">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="transition-type">none</property>
+                    <property name="reveal-child">True</property>
+                    <child>
+                      <object class="GtkBox" id="notification_box">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkLabel" id="notification_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Log in to Lutris.net to view your game library</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="lutris_log_in_button">
+                            <property name="label" translatable="yes">Log In</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack-type">end</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="lutris_create_account_button">
+                            <property name="label" translatable="yes">Create Account</property>
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack-type">end</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <style>
+                          <class name="in-app-notification"/>
+                          <class name="app-notification"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkOverlay">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -143,7 +207,7 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
@@ -158,7 +222,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
               </object>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -111,7 +111,8 @@
                           <object class="GtkLabel" id="notification_label">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Log in to Lutris.net to view your game library</property>
+                            <property name="label" translatable="yes">Log in to &lt;a href="https://lutris.net/"&gt;Lutris.net&lt;/a&gt; to view your game library</property>
+                            <property name="use-markup">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -132,20 +133,6 @@
                             <property name="fill">True</property>
                             <property name="pack-type">end</property>
                             <property name="position">1</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="lutris_create_account_button">
-                            <property name="label" translatable="yes">Create Account</property>
-                            <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="receives-default">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="pack-type">end</property>
-                            <property name="position">2</property>
                           </packing>
                         </child>
                         <style>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -123,9 +123,9 @@
                         <child>
                           <object class="GtkButton" id="lutris_log_in_button">
                             <property name="label" translatable="yes">Log In</property>
-                            <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
+                            <property name="no-show-all">True</property>
                             <signal name="clicked" handler="on_lutris_log_in_button_clicked" swapped="no"/>
                           </object>
                           <packing>
@@ -133,6 +133,21 @@
                             <property name="fill">True</property>
                             <property name="pack-type">end</property>
                             <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="turn_on_library_sync_button">
+                            <property name="label" translatable="yes">Turn on Library Sync</property>
+                            <property name="can-focus">True</property>
+                            <property name="receives-default">True</property>
+                            <property name="no-show-all">True</property>
+                            <signal name="clicked" handler="on_turn_on_library_sync_button_clicked" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack-type">end</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                         <style>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -125,6 +125,7 @@
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
                             <property name="receives-default">True</property>
+                            <signal name="clicked" handler="on_lutris_log_in_button_clicked" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -44,3 +44,7 @@
     padding: 5px;
     border-radius: 0
 }
+
+.in-app-notification label link {
+    color: unset;
+}

--- a/share/lutris/ui/lutris.css
+++ b/share/lutris/ui/lutris.css
@@ -39,3 +39,8 @@
   color: @theme_text_color;
   background-color: @theme_base_color;
 }
+
+.in-app-notification {
+    padding: 5px;
+    border-radius: 0
+}


### PR DESCRIPTION
This is meant to improve the experience on a new install of Lutris; it guides users towards having a Lutris.net account with their games. This appears only with the splash screen, so once you have games set up you will not see it.

If you have no games and are not logged in, then you get this:
![Screenshot from 2024-03-09 10-11-15](https://github.com/lutris/lutris/assets/6507403/76a87456-2e16-4590-b3b9-1f03d2917fb7)

The notification has a link to Lutris.net in it; we might want some snazzier way to create a new Lutris account, but I don't know how we're going to do that. It's something at least.

Click the Log In button to get the login in dialog, and once you are logged in you will likely see this:
![Screenshot from 2024-03-09 10-11-28](https://github.com/lutris/lutris/assets/6507403/3f0d47f9-7382-4eff-93d3-eed2b505bb28)

If you have not turned on sync, you can now click that button to turn it on, and a full sync will begin. If you have already turned on sync in Preferences, we skip this step and start the sync at once. You'll see this:
![Screenshot from 2024-03-09 10-11-33](https://github.com/lutris/lutris/assets/6507403/ab5741c3-bcfd-4b9a-95a9-9fb4c38c6fa1)
No more bar, but there is a spinner in the Games sidebar row, similar to what we used to have in the Lutris sidebar row.

The notification bar is wall-to-wall by @strycore's recommendation, and is styled with the GTK 'app-notification' style, so themes should be able to control it if they wish to. I just added some more CSS to unround the corners and remove the coloring of the links (it's illegible in default link blue).

I'm using links instead of buttons here to keep the bar small; it pushes the splash screen downwards, just a bit, and that actually makes the 'Connect to Services' graphics *better* aligned in my opinion.