### PR TITLE
Update ULWGL paths

### DIFF
--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -24,14 +24,14 @@ def get_ulwgl_path():
     if system.can_find_executable("ulwgl-run"):
         return system.find_executable("ulwgl-run")
     path_candidates = (
-        os.path.expanduser("~/.local/share"),
+        "/app/share",  # prioritize flatpak due to non-rolling release distros
         "/usr/local/share",
         "/usr/share",
         "/opt",
         settings.RUNTIME_DIR,
     )
     for path_candidate in path_candidates:
-        script_path = os.path.join(path_candidate, "ULWGL", "ulwgl_run.py")
+        script_path = os.path.join(path_candidate, "ulwgl", "ulwgl_run.py")
         if system.path_exists(script_path):
             return script_path
 


### PR DESCRIPTION
The current model expects clients to install ULWGL as a system package (e.g., flatpak, system package) then execute, and this patch fixes the problem where the path ~/.local/share/ULWGL was the first path candidate which would cause lutris to run outdated files while the updated files were pulled from the runtime.

To ensure the ULWGL launcher and runtime files are synchronized or updated, lutris should never starts ulwgl_run.py in ~/.local/share/ULWGL and that lutris prioritizes the system package then the lutris runtime directory. 

However, depending on the team's preference, the runtime directory can be preferred to account for distributions or users that do not update their system packages frequently.
