### PR TITLE
Multi-Select Support for 'Categories'

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -157,6 +157,10 @@ class GameActions:
         dlg = application.show_window(UninstallDialog, parent=self.window)
         dlg.add_games(game_ids)
 
+    def on_edit_game_categories(self, _widget):
+        """Edit game categories"""
+        self.application.show_window(EditGameCategoriesDialog, games=self.get_games(), parent=self.window)
+
 
 class MultiGameActions(GameActions):
     """This actions class handles actions on multiple games together, and only iof they
@@ -174,6 +178,7 @@ class MultiGameActions(GameActions):
         return [
             ("stop", _("Stop"), self.on_game_stop),
             (None, "-", None),
+            ("category", _("Categories"), self.on_edit_game_categories),
             ("favorite", _("Add to favorites"), self.on_add_favorite_game),
             ("deletefavorite", _("Remove from favorites"), self.on_delete_favorite_game),
             ("hide", _("Hide game from library"), self.on_hide_game),
@@ -185,6 +190,7 @@ class MultiGameActions(GameActions):
     def get_displayed_entries(self):
         return {
             "stop": self.is_game_running,
+            "category": True,
             "favorite": any(g for g in self.games if not g.is_favorite),
             "deletefavorite": any(g for g in self.games if g.is_favorite),
             "hide": any(g for g in self.games if g.is_installed and not g.is_hidden),
@@ -308,10 +314,6 @@ class SingleGameActions(GameActions):
     def on_edit_game_configuration(self, _widget):
         """Edit game preferences"""
         self.application.show_window(EditGameConfigDialog, game=self.game, parent=self.window)
-
-    def on_edit_game_categories(self, _widget):
-        """Edit game categories"""
-        self.application.show_window(EditGameCategoriesDialog, game=self.game, parent=self.window)
 
     def on_browse_files(self, _widget):
         """Callback to open a game folder in the file browser"""

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -159,11 +159,18 @@ class GameActions:
 
     def on_edit_game_categories(self, _widget):
         """Edit game categories"""
+        games = self.get_games()
+        if len(games) == 1:
+            # Individual games get individual separate windows
+            self.application.show_window(EditGameCategoriesDialog, game=games[0], parent=self.window)
+        else:
 
-        def add_games(window):
-            window.add_games(self.get_games())
+            def add_games(window):
+                window.add_games(self.get_games())
 
-        self.application.show_window(EditGameCategoriesDialog, update_function=add_games, parent=self.window)
+            # Multi-select means a common categories window for all of them; we can wind
+            # up adding games to it if it's already open
+            self.application.show_window(EditGameCategoriesDialog, update_function=add_games, parent=self.window)
 
 
 class MultiGameActions(GameActions):

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -159,8 +159,11 @@ class GameActions:
 
     def on_edit_game_categories(self, _widget):
         """Edit game categories"""
-        dlg = self.application.show_window(EditGameCategoriesDialog, parent=self.window)
-        dlg.add_games(self.get_games())
+
+        def add_games(window):
+            window.add_games(self.get_games())
+
+        self.application.show_window(EditGameCategoriesDialog, update_function=add_games, parent=self.window)
 
 
 class MultiGameActions(GameActions):

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -159,7 +159,8 @@ class GameActions:
 
     def on_edit_game_categories(self, _widget):
         """Edit game categories"""
-        self.application.show_window(EditGameCategoriesDialog, games=self.get_games(), parent=self.window)
+        dlg = self.application.show_window(EditGameCategoriesDialog, parent=self.window)
+        dlg.add_games(self.get_games())
 
 
 class MultiGameActions(GameActions):

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -7,6 +7,7 @@ from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.game import Game
 from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
+from lutris.util.strings import get_natural_sort_key
 
 
 class EditCategoryGamesDialog(SavableModelessDialog):
@@ -17,9 +18,9 @@ class EditCategoryGamesDialog(SavableModelessDialog):
 
         self.category = category["name"]
         self.category_id = category["id"]
-        self.available_games = [
-            Game(x["id"]) for x in games_db.get_games(sorts=[("installed", "DESC"), ("name", "COLLATE NOCASE ASC")])
-        ]
+        self.available_games = sorted(
+            [Game(x["id"]) for x in games_db.get_games()], key=lambda g: (g.is_installed, get_natural_sort_key(g.name))
+        )
         self.category_games = [Game(x) for x in categories_db.get_game_ids_for_categories([self.category])]
         self.grid = Gtk.Grid()
 

--- a/lutris/gui/config/edit_game_categories.py
+++ b/lutris/gui/config/edit_game_categories.py
@@ -31,7 +31,7 @@ class EditGameCategoriesDialog(SavableModelessDialog):
         self.vbox.pack_start(self._create_category_checkboxes(), True, True, 0)
         self.vbox.pack_start(self._create_add_category(), False, False, 0)
 
-        self.show_all()
+        self.vbox.show_all()
 
     def add_games(self, games: Sequence[Game]) -> None:
         def mark_category_checkbox(checkbox, included):

--- a/lutris/gui/config/edit_game_categories.py
+++ b/lutris/gui/config/edit_game_categories.py
@@ -13,8 +13,10 @@ from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
 class EditGameCategoriesDialog(SavableModelessDialog):
     """Game category edit dialog."""
 
-    def __init__(self, parent):
-        super().__init__(_("Categories"), parent=parent, border_width=10)
+    def __init__(self, game=None, parent=None):
+        title = game.name if game else _("Categories")
+
+        super().__init__(title, parent=parent, border_width=10)
         self.set_default_size(350, 250)
 
         self.category_checkboxes = {}
@@ -30,6 +32,9 @@ class EditGameCategoriesDialog(SavableModelessDialog):
         self.vbox.set_spacing(10)
         self.vbox.pack_start(self._create_category_checkboxes(), True, True, 0)
         self.vbox.pack_start(self._create_add_category(), False, False, 0)
+
+        if game:
+            self.add_games([game])
 
         self.vbox.show_all()
 
@@ -61,8 +66,11 @@ class EditGameCategoriesDialog(SavableModelessDialog):
             if g.id not in self.game_ids:
                 add_game(g)
 
-        title = self.games[0].name if len(self.games) == 1 else _("%d games") % len(self.games)
-        self.set_title(title)
+        if len(self.games) > 1:
+            subtitle = _("%d games") % len(self.games)
+            header_bar = self.get_header_bar()
+            if header_bar:
+                header_bar.set_subtitle(subtitle)
 
     def _create_category_checkboxes(self):
         frame = Gtk.Frame()
@@ -70,10 +78,10 @@ class EditGameCategoriesDialog(SavableModelessDialog):
 
         for category in self.categories:
             label = category
-            checkbutton_option = Gtk.CheckButton(label)
-            checkbutton_option.connect("toggled", self.on_checkbutton_toggled)
-            self.checkbox_grid.attach_next_to(checkbutton_option, None, Gtk.PositionType.BOTTOM, 3, 1)
-            self.category_checkboxes[category] = checkbutton_option
+            checkbutton = Gtk.CheckButton(label)
+            checkbutton.connect("toggled", self.on_checkbutton_toggled)
+            self.checkbox_grid.attach_next_to(checkbutton, None, Gtk.PositionType.BOTTOM, 3, 1)
+            self.category_checkboxes[category] = checkbutton
 
         scrolledwindow.add(self.checkbox_grid)
         frame.add(scrolledwindow)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -21,6 +21,7 @@ from lutris.runners import InvalidRunnerError
 from lutris.services import SERVICES
 from lutris.services.base import AuthTokenExpiredError, BaseService
 from lutris.util.library_sync import LOCAL_LIBRARY_SYNCED, LOCAL_LIBRARY_SYNCING
+from lutris.util.strings import get_natural_sort_key
 
 TYPE = 0
 SLUG = 1
@@ -252,6 +253,10 @@ class CategorySidebarRow(SidebarRow):
         self.category = category
 
         self._sort_name = locale.strxfrm(category["name"])
+
+    @property
+    def sort_key(self):
+        return get_natural_sort_key(self.name)
 
     def get_actions(self):
         """Return the definition of buttons to be added to the row"""


### PR DESCRIPTION
This PR adds the Categories command to the game-actions when selecting multiple games. This makes it easier to categorize a bunch of games. You can use Lutris's filtering features to find the games, then select games and categorize them in bunches.

Previously you could do the changes one game at a time, or use the edit-category dialog- but with no filtering or anything, just a big stack of check-boxes.

Here's what it looks like when you multi-select and use the 'Categories' command.

![Screenshot from 2024-03-23 09-26-34](https://github.com/lutris/lutris/assets/6507403/0613774a-6f10-42a9-9777-e57ccea6e949)

Check 'em off an go! But if some games were in categories already, you might see this:

![Screenshot from 2024-03-23 09-25-44](https://github.com/lutris/lutris/assets/6507403/985c4710-d36d-4de8-a838-8648f6be0b8b)

The 'inconsistent' check-boxes can be checked and unchecked, but if left inconsistent then those categories are not updated when you save.

When you do save (with a multi-select) you get a warning dialog:

![Screenshot from 2024-03-23 09-26-01](https://github.com/lutris/lutris/assets/6507403/7529e411-8a1c-46a9-af5b-b22b5cd7fb4c)

This is mainly to warn you that this is more than a single game's categories, but the count is accurate- it works out which games require changes, which may not be all you have selected.

Finally, this isn't like 'uninstall games'- you can still get a 'Categories' window for one game at a time, to view side by side say. This means it's possible to get overlapping dialogs, where you are editing the same game in more than one dialog. But that was possible anyway, because you can show the edit dialog for the category itself at the same time.

Resolves #5372