### PR TITLE
Kill wineserver via UMU Proton

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -178,11 +178,14 @@ def winekill(prefix, arch=WINE_DEFAULT_ARCH, wine_path=None, env=None, initial_p
     """Kill processes in Wine prefix."""
 
     initial_pids = initial_pids or []
+    steam_data_dir = os.path.expanduser("~/.local/share/Steam/compatibilitytools.d")
     if not env:
         env = {"WINEARCH": arch, "WINEPREFIX": prefix}
-    if proton.is_proton_path(wine_path):
-        command = [proton.get_umu_path(), "runinprefix", "wineboot", "-e"]
+    if proton.is_proton_path(wine_path) and os.path.exists(f"{steam_data_dir}/UMU-Latest"):
+        proton_version = os.path.realpath(f"{steam_data_dir}/UMU-Latest")
+        command = [os.path.join(proton_version, "files", "bin", "wineserver"), "-k"]
         env["GAMEID"] = proton.DEFAULT_GAMEID
+        env["WINEPREFIX"] = prefix
     else:
         if not wine_path:
             if not runner:

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -4,6 +4,7 @@
 import os
 import shlex
 import time
+from gettext import gettext as _
 
 from lutris import runtime, settings
 from lutris.monitored_command import MonitoredCommand
@@ -24,6 +25,8 @@ from lutris.util.wine.wine import (
     is_installed_systemwide,
     is_prefix_directory,
 )
+
+GE_PROTON_LATEST = _("GE-Proton (Latest)")
 
 
 def set_regedit(
@@ -181,7 +184,7 @@ def winekill(prefix, arch=WINE_DEFAULT_ARCH, wine_path=None, env=None, initial_p
     steam_data_dir = os.path.expanduser("~/.local/share/Steam/compatibilitytools.d")
     if not env:
         env = {"WINEARCH": arch, "WINEPREFIX": prefix}
-    if proton.is_proton_path(wine_path) and os.path.exists(f"{steam_data_dir}/UMU-Latest"):
+    if wine_path == GE_PROTON_LATEST and os.path.exists(f"{steam_data_dir}/UMU-Latest"):
         proton_version = os.path.realpath(f"{steam_data_dir}/UMU-Latest")
         command = [os.path.join(proton_version, "files", "bin", "wineserver"), "-k"]
         env["GAMEID"] = proton.DEFAULT_GAMEID


### PR DESCRIPTION
Kills the wineserver process associated with the running prefix via the `wineserver` command in the UMU-Proton directory instead of the `wineboot` command, which had been reported to lead to unreliable results and had relied on the system wineboot. 

The user's current UMU-Proton directory will be resolved via the UMU-Latest symbolic link, which is guaranteed to exist for new installations since https://github.com/Open-Wine-Components/umu-launcher/commit/fd1798f75c80c001bc51f9b1acd6465698333e63. However, umu currently does not recreate this link each run, so the new kill implementation will not work for current UMU users. There will be patch for this shortly, to restore the link each launch.
