### PR TITLE
Fix "table games has no column named hidden" error

### DIFF
--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -302,7 +302,6 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
             platform=import_runner(self.runner)().get_platform(),
             directory=self.interpreter.target_path,
             installed=1,
-            hidden=0,
             installer_slug=self.slug,
             parent_slug=self.requires,
             year=self.year,


### PR DESCRIPTION
When the hidden column was removed from the games table in schema.py the setting of the column value was never removed from installer.py

This meant on a fresh Lutris install user's cannot install games and are met with "table games has no column named hidden" errors.

This cleans up that incorrect setting of the column value.