### PR TITLE
Honor user's umu environment variables if set

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -672,8 +672,10 @@ class Game(GObject.Object):
 
         if env.get("WINEARCH") == "win32" and "umu" in " ".join(command):
             raise RuntimeError("Proton is not compatible with 32bit prefixes")
+
+        # Allow user to override default umu environment variables to apply fixes
         env["GAMEID"] = proton.get_game_id(self)
-        env["STORE"] = self.get_store_name()
+        env["STORE"] = env.get("STORE") or self.get_store_name()
 
         # Some environment variables for the use of custom pre-launch and post-exit scripts.
         env["GAME_NAME"] = self.name

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -99,8 +99,11 @@ def get_proton_path_from_bin(wine_path):
     return os.path.abspath(os.path.join(os.path.dirname(wine_path), "../../"))
 
 
-def get_game_id(game):
+def get_game_id(game) -> str:
     games_path = os.path.join(settings.RUNTIME_DIR, "umu-games/umu-games.json")
+    env = game.runner.get_env()
+    if game and env.get("GAMEID") or env.get("UMU_ID"):
+        return env.get("GAMEID") or env.get("UMU_ID")
     if not os.path.exists(games_path) or not game:
         return DEFAULT_GAMEID
     with open(games_path, "r", encoding="utf-8") as games_file:


### PR DESCRIPTION
For non-steam games, umu depends on the `GAMEID` and the `STORE` environment variables to apply fixes to the WINE prefix, and currently the Lutris client does not allow overriding the default values of these variables after setting their own in the _Environment Variables_ section. 

![umu](https://github.com/lutris/lutris/assets/100738684/928ac5ef-135e-4c1d-b4b4-9d09583a38f6)


This pull request makes it so the client can allow the user to override them to apply an existing umu protonfix to the running game.
