### PR TITLE
Fixing locale option for umu

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -33,6 +33,11 @@ def get_launch_parameters(runner, gameplay_info):
     if system_config["locale"] != "":
         env["LC_ALL"] = system_config["locale"]
 
+    if runner.name == "wine":
+        wine_version = runner.runner_config.get("version")
+        if wine_version and "proton" in wine_version.lower():
+            env["HOST_LC_ALL"] = system_config["locale"]
+
     # MangoHud
     if runner.name == "steam":
         logger.info(

--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -8,6 +8,7 @@ from lutris.util import cache_single, system
 from lutris.util.graphics.gpu import GPUS
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
+from lutris.util.wine import proton
 
 
 def get_mangohud_conf(system_config):
@@ -35,7 +36,7 @@ def get_launch_parameters(runner, gameplay_info):
 
     if runner.name == "wine":
         wine_version = runner.runner_config.get("version")
-        if wine_version and "proton" in wine_version.lower():
+        if wine_version and proton.is_proton_path(wine_version):
             env["HOST_LC_ALL"] = system_config["locale"]
 
     # MangoHud


### PR DESCRIPTION
Currently, the locale option under system options -> game execution in Lutris doesn't take effect due to how Proton sets the LC_ALL environment variable for Wine using HOST_LC_ALL (source: [ValveSoftware/Proton](https://github.com/ValveSoftware/Proton/blob/bc4d2acf3ba8c3edd8ba915e520996ed811eaf3c/proton#L1180-L1187)). 

To address this, I've implemented a solution. My approach involves checking if the Wine runner is using a Proton version. If so, I set HOST_LC_ALL to the specified locale accordingly

Would this approach be suitable, or should we expect the user to manually configure the environment variable? 