### PR TITLE
Separate Game and GameLauncher classes

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -1,44 +1,31 @@
 """Module that actually runs the games."""
 
-# pylint: disable=too-many-public-methods disable=too-many-lines
+from __future__ import annotations
+
 import json
 import os
-import shlex
 import shutil
-import signal
-import subprocess
-import time
 from gettext import gettext as _
 from typing import cast
 
-from gi.repository import Gio, GLib, GObject, Gtk
+from gi.repository import Gio, GObject
 
 from lutris import settings
 from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.database import sql
-from lutris.exception_backstops import watch_game_errors
-from lutris.exceptions import GameConfigError, InvalidGameMoveError, MissingExecutableError
+from lutris.exceptions import GameConfigError, InvalidGameMoveError
+from lutris.game_launcher import GameLauncher
 from lutris.installer import InstallationKind
-from lutris.monitored_command import MonitoredCommand
-from lutris.runner_interpreter import export_bash_script, get_launch_parameters
+from lutris.runner_interpreter import export_bash_script
 from lutris.runners import import_runner, is_valid_runner_name
 from lutris.runners.runner import Runner
-from lutris.util import discord, extract, jobs, linux, strings, system, xdgshortcuts
-from lutris.util.display import DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, disable_compositing, enable_compositing
-from lutris.util.graphics.xephyr import get_xephyr_command
-from lutris.util.graphics.xrandr import turn_off_except
-from lutris.util.linux import LINUX_SYSTEM
+from lutris.util import extract, jobs, strings, system, xdgshortcuts
 from lutris.util.log import LOG_BUFFERS, logger
-from lutris.util.process import Process
 from lutris.util.steam.shortcut import remove_shortcut as remove_steam_shortcut
 from lutris.util.system import fix_path_case
-from lutris.util.timer import Timer
-from lutris.util.wine import proton
 from lutris.util.yaml import write_yaml_to_file
-
-HEARTBEAT_DELAY = 2000
 
 
 class Game(GObject.Object):
@@ -46,22 +33,8 @@ class Game(GObject.Object):
     and running it.
     """
 
-    now_playing_path = os.path.join(settings.CACHE_DIR, "now-playing.txt")
-
-    STATE_STOPPED = "stopped"
-    STATE_LAUNCHING = "launching"
-    STATE_RUNNING = "running"
-
     PRIMARY_LAUNCH_CONFIG_NAME = "(primary)"
-
     __gsignals__ = {
-        # SIGNAL_RUN_LAST works around bug https://gitlab.gnome.org/GNOME/glib/-/issues/513
-        # fix merged Dec 2020, but we support older GNOME!
-        "game-error": (GObject.SIGNAL_RUN_LAST, bool, (object,)),
-        "game-unhandled-error": (GObject.SIGNAL_RUN_FIRST, None, (object,)),
-        "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
-        "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
-        "game-stopped": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-updated": (GObject.SIGNAL_RUN_FIRST, None, ()),
         "game-installed": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
@@ -73,16 +46,16 @@ class Game(GObject.Object):
         # Load attributes from database
         game_data = games_db.get_game_by_field(game_id, "id")
 
-        self.slug = game_data.get("slug") or ""
-        self._runner_name = game_data.get("runner") or ""
-        self.directory = game_data.get("directory") or ""
-        self.name = game_data.get("name") or ""
-        self.sortname = game_data.get("sortname") or ""
-        self.game_config_id = game_data.get("configpath") or ""
-        self.is_installed = bool(game_data.get("installed") and self.game_config_id)
-        self.platform = game_data.get("platform") or ""
-        self.year = game_data.get("year") or ""
-        self.lastplayed = game_data.get("lastplayed") or 0
+        self.slug: str = game_data.get("slug") or ""
+        self._runner_name: str = game_data.get("runner") or ""
+        self.directory: str = game_data.get("directory") or ""
+        self.name: str = game_data.get("name") or ""
+        self.sortname: str = game_data.get("sortname") or ""
+        self.game_config_id: str = game_data.get("configpath") or ""
+        self.is_installed: bool = bool(game_data.get("installed") and self.game_config_id)
+        self.platform: str = game_data.get("platform") or ""
+        self.year: str = game_data.get("year") or ""
+        self.lastplayed: int = game_data.get("lastplayed") or 0
         self.custom_images = set()
         if game_data.get("has_custom_banner"):
             self.custom_images.add("banner")
@@ -92,30 +65,15 @@ class Game(GObject.Object):
             self.custom_images.add("coverart_big")
         self.service = game_data.get("service")
         self.appid = game_data.get("service_id")
-        self.playtime = float(game_data.get("playtime") or 0.0)
+        self.playtime: float = float(game_data.get("playtime") or 0.0)
         self.discord_id = game_data.get("discord_id")  # Discord App ID for RPC
 
-        self._config = None
+        self._config: LutrisConfig = None
         self._runner = None
-
-        self.game_uuid = None
-        self.game_thread = None
-        self.antimicro_thread = None
-        self.prelaunch_pids = None
-        self.prelaunch_executor = None
-        self.heartbeat = None
-        self.killswitch = None
-        self.state = self.STATE_STOPPED
-        self.game_runtime_config = {}
-        self.resolution_changed = False
-        self.compositor_disabled = False
-        self.original_outputs = None
-        self._log_buffer = None
-        self.timer = Timer()
-        self.screen_saver_inhibitor_cookie = None
+        self.game_launcher = GameLauncher(self)
 
     @staticmethod
-    def create_empty_service_game(db_game, service):
+    def create_empty_service_game(db_game, service) -> Game:
         """Creates a Game from the database data from ServiceGameCollection, which is
         not a real game, but which can be used to install. Such a game has no ID, but
         has an 'appid' and slug."""
@@ -229,41 +187,15 @@ class Game(GObject.Object):
                 self.remove_category(".hidden")
 
     @property
-    def log_buffer(self):
-        """Access the log buffer object, creating it if necessary"""
-        _log_buffer = LOG_BUFFERS.get(self.id)
-        if _log_buffer:
-            return _log_buffer
-        _log_buffer = Gtk.TextBuffer()
-        _log_buffer.create_tag("warning", foreground="red")
-        if self.game_thread:
-            self.game_thread.set_log_buffer(self._log_buffer)
-            _log_buffer.set_text(self.game_thread.stdout)
-        LOG_BUFFERS[self.id] = _log_buffer
-        return _log_buffer
-
-    @property
-    def formatted_playtime(self):
+    def formatted_playtime(self) -> str:
         """Return a human-readable formatted play time"""
         return strings.get_formatted_playtime(self.playtime)
 
-    def signal_error(self, error):
-        """Reports an error by firing game-error. If handled, it returns
-        True to indicate it handled it, and that's it. If not, this fires
-        game-unhandled-error, which is actually handled via an emission hook
-        and should not be connected otherwise.
-
-        This allows special error handling to be set up for a particular Game, but
-        there's always some handling."""
-        handled = self.emit("game-error", error)
-        if not handled:
-            self.emit("game-unhandled-error", error)
-
-    def get_browse_dir(self):
+    def get_browse_dir(self) -> str:
         """Return the path to open with the Browse Files action."""
         return self.resolve_game_path()
 
-    def resolve_game_path(self):
+    def resolve_game_path(self) -> str:
         """Return the game's directory; if it is not known this will try to find
         it. This can still return an empty string if it can't do that."""
         if self.directory:
@@ -273,9 +205,9 @@ class Game(GObject.Object):
         return ""
 
     @property
-    def config(self):
+    def config(self) -> LutrisConfig:
         if not self.is_installed or not self.game_config_id:
-            return None
+            raise ValueError("Tried to access config of uninstalled")
         if not self._config:
             self._config = LutrisConfig(runner_slug=self.runner_name, game_config_id=self.game_config_id)
         return self._config
@@ -323,18 +255,7 @@ class Game(GObject.Object):
         if value:
             self._runner_name = value.name
 
-    def set_desktop_compositing(self, enable):
-        """Enables or disables compositing"""
-        if enable:
-            if self.compositor_disabled:
-                enable_compositing()
-                self.compositor_disabled = False
-        else:
-            if not self.compositor_disabled:
-                disable_compositing()
-                self.compositor_disabled = True
-
-    def install(self, launch_ui_delegate):
+    def install(self, launch_ui_delegate) -> None:
         """Request installation of a game"""
         if not self.slug:
             raise ValueError("Invalid game passed: %s" % self)
@@ -363,8 +284,8 @@ class Game(GObject.Object):
                 return True
 
             game = Game(game_id)
-            game.connect("game-error", on_error)
-            game.launch(launch_ui_delegate)
+            game.game_launcher.connect("game-error", on_error)
+            game.game_launcher.launch(launch_ui_delegate)
 
     def install_updates(self, install_ui_delegate):
         service = install_ui_delegate.get_service(self.service)
@@ -432,7 +353,7 @@ class Game(GObject.Object):
         games_db.delete_game(self.id)
         self._id = None
 
-    def set_platform_from_runner(self):
+    def set_platform_from_runner(self) -> None:
         """Set the game's platform from the runner"""
         if not self.has_runner:
             logger.warning("Game has no runner, can't set platform")
@@ -441,7 +362,7 @@ class Game(GObject.Object):
         if not self.platform:
             logger.warning("The %s runner didn't provide a platform for %s", self.runner.human_name, self)
 
-    def save(self, no_signal=False):
+    def save(self, no_signal=False) -> None:
         """
         Save the game's config and metadata.
         """
@@ -478,148 +399,19 @@ class Game(GObject.Object):
         if not no_signal:
             self.emit("game-updated")
 
-    def save_platform(self):
+    def save_platform(self) -> None:
         """Save only the platform field- do not restore any other values the user may have changed
         in another window."""
         games_db.update_existing(id=self.id, slug=self.slug, platform=self.platform)
         self.emit("game-updated")
 
-    def save_lastplayed(self):
+    def save_lastplayed(self) -> None:
         """Save only the lastplayed field- do not restore any other values the user may have changed
         in another window."""
         games_db.update_existing(id=self.id, slug=self.slug, lastplayed=self.lastplayed, playtime=self.playtime)
         self.emit("game-updated")
 
-    def check_launchable(self):
-        """Verify that the current game can be launched, and raises exceptions if not."""
-        if not self.is_installed or not self.is_db_stored:
-            logger.error("%s (%s) not installed", self, self.id)
-            raise GameConfigError(_("Tried to launch a game that isn't installed."))
-        if not self.has_runner:
-            raise GameConfigError(_("Invalid game configuration: Missing runner"))
-
-        return True
-
-    def restrict_to_display(self, display):
-        outputs = DISPLAY_MANAGER.get_config()
-        if display == "primary":
-            display = None
-            for output in outputs:
-                if output.primary:
-                    display = output.name
-                    break
-            if not display:
-                logger.warning("No primary display set")
-        else:
-            found = False
-            for output in outputs:
-                if output.name == display:
-                    found = True
-                    break
-            if not found:
-                logger.warning("Selected display %s not found", display)
-                display = None
-        if display:
-            turn_off_except(display)
-            time.sleep(3)
-            return True
-        return False
-
-    def start_xephyr(self, display=":2"):
-        """Start a monitored Xephyr instance"""
-        if not system.can_find_executable("Xephyr"):
-            raise GameConfigError(_("Unable to find Xephyr, install it or disable the Xephyr option"))
-        xephyr_command = get_xephyr_command(display, self.runner.system_config)
-        xephyr_thread = MonitoredCommand(xephyr_command)
-        xephyr_thread.start()
-        time.sleep(3)
-        return display
-
-    def start_antimicrox(self, antimicro_config):
-        """Start Antimicrox with a given config path"""
-        if LINUX_SYSTEM.is_flatpak():
-            antimicro_command = ["flatpak-spawn", "--host", "antimicrox"]
-        else:
-            try:
-                antimicro_command = [system.find_required_executable("antimicrox")]
-            except MissingExecutableError as ex:
-                raise GameConfigError(
-                    _("Unable to find Antimicrox, install it or disable the Antimicrox option")
-                ) from ex
-
-        logger.info("Starting Antimicro")
-        antimicro_command += ["--hidden", "--tray", "--profile", antimicro_config]
-        self.antimicro_thread = MonitoredCommand(antimicro_command)
-        self.antimicro_thread.start()
-
-    def start_prelaunch_command(self, wait_for_completion=False):
-        """Start the prelaunch command specified in the system options"""
-        prelaunch_command = self.runner.system_config.get("prelaunch_command")
-        command_array = shlex.split(prelaunch_command)
-        if not system.path_exists(command_array[0]):
-            logger.warning("Command %s not found", command_array[0])
-            return
-        env = self.game_runtime_config["env"]
-        if wait_for_completion:
-            logger.info("Prelauch command: %s, waiting for completion", prelaunch_command)
-            # Monitor the prelaunch command and wait until it has finished
-            system.execute(command_array, env=env, cwd=self.resolve_game_path())
-        else:
-            logger.info("Prelaunch command %s launched in the background", prelaunch_command)
-            self.prelaunch_executor = MonitoredCommand(
-                command_array,
-                include_processes=[os.path.basename(command_array[0])],
-                env=env,
-                cwd=self.resolve_game_path(),
-            )
-            self.prelaunch_executor.start()
-
-    def get_terminal(self):
-        """Return the terminal used to run the game into or None if the game is not run from a terminal.
-        Remember that only games using text mode should use the terminal.
-        """
-        if self.runner.system_config.get("terminal"):
-            terminal = self.runner.system_config.get("terminal_app", linux.get_default_terminal())
-            if terminal and not system.can_find_executable(terminal):
-                raise GameConfigError(_("The selected terminal application could not be launched:\n%s") % terminal)
-            return terminal
-
-    def get_killswitch(self):
-        """Return the path to a file that is monitored during game execution.
-        If the file stops existing, the game is stopped.
-        """
-        killswitch = self.runner.system_config.get("killswitch")
-        # Prevent setting a killswitch to a file that doesn't exists
-        if killswitch and system.path_exists(self.killswitch):
-            return killswitch
-
-    def get_gameplay_info(self, launch_ui_delegate):
-        """Return the information provided by a runner's play method.
-        It checks for possible errors and raises exceptions if they occur.
-
-        This may invoke methods on the delegates to make decisions,
-        and this may show UI.
-
-        This returns an empty dictionary if the user cancels this UI,
-        in which case the game should not be run.
-        """
-
-        gameplay_info = self.runner.play()
-
-        if "working_dir" not in gameplay_info:
-            gameplay_info["working_dir"] = self.runner.working_dir
-
-        config = launch_ui_delegate.select_game_launch_config(self)
-
-        if config is None:
-            return {}  # no error here- the user cancelled out
-
-        if config:  # empty dict for primary configuration
-            self.runner.apply_launch_config(gameplay_info, config)
-
-        return gameplay_info
-
-    def get_path_from_config(self):
+    def get_path_from_config(self) -> str:
         """Return the path of the main entry point for a game"""
         if not self.config:
             logger.warning("%s has no configuration", self)
@@ -660,366 +452,7 @@ class Game(GObject.Object):
             return "humble"
         return store
 
-    @watch_game_errors(game_stop_result=False)
-    def configure_game(self, launch_ui_delegate):
-        """Get the game ready to start, applying all the options.
-        This method sets the game_runtime_config attribute.
-        """
-        gameplay_info = self.get_gameplay_info(launch_ui_delegate)
-        if not gameplay_info:  # if user cancelled - not an error
-            return False
-        command, env = get_launch_parameters(self.runner, gameplay_info)
-
-        if env.get("WINEARCH") == "win32" and "umu" in " ".join(command):
-            raise RuntimeError("Proton is not compatible with 32bit prefixes")
-
-        # Allow user to override default umu environment variables to apply fixes
-        env["GAMEID"] = proton.get_game_id(self)
-        env["STORE"] = env.get("STORE") or self.get_store_name()
-
-        # Some environment variables for the use of custom pre-launch and post-exit scripts.
-        env["GAME_NAME"] = self.name
-        if self.directory:
-            env["GAME_DIRECTORY"] = self.directory
-
-        self.game_runtime_config = {
-            "args": command,
-            "env": env,
-            "terminal": self.get_terminal(),
-            "include_processes": shlex.split(self.runner.system_config.get("include_processes", "")),
-            "exclude_processes": shlex.split(self.runner.system_config.get("exclude_processes", "")),
-        }
-
-        if "working_dir" in gameplay_info:
-            self.game_runtime_config["working_dir"] = gameplay_info["working_dir"]
-
-        # Input control
-        if self.runner.system_config.get("use_us_layout"):
-            system.set_keyboard_layout("us")
-
-        # Display control
-        self.original_outputs = DISPLAY_MANAGER.get_config()
-
-        if self.runner.system_config.get("disable_compositor"):
-            self.set_desktop_compositing(False)
-
-        if self.runner.system_config.get("disable_screen_saver"):
-            self.screen_saver_inhibitor_cookie = SCREEN_SAVER_INHIBITOR.inhibit(self.name)
-
-        if self.runner.system_config.get("display") != "off":
-            self.resolution_changed = self.restrict_to_display(self.runner.system_config.get("display"))
-
-        resolution = self.runner.system_config.get("resolution")
-        if resolution != "off":
-            DISPLAY_MANAGER.set_resolution(resolution)
-            time.sleep(3)
-            self.resolution_changed = True
-
-        xephyr = self.runner.system_config.get("xephyr") or "off"
-        if xephyr != "off":
-            env["DISPLAY"] = self.start_xephyr()
-
-        antimicro_config = self.runner.system_config.get("antimicro_config")
-        if system.path_exists(antimicro_config):
-            self.start_antimicrox(antimicro_config)
-
-        # Execution control
-        self.killswitch = self.get_killswitch()
-
-        if self.runner.system_config.get("prelaunch_command"):
-            self.start_prelaunch_command(self.runner.system_config.get("prelaunch_wait"))
-
-        self.start_game()
-        return True
-
-    @watch_game_errors(game_stop_result=False)
-    def launch(self, launch_ui_delegate):
-        """Request launching a game. The game may not be installed yet."""
-        if not self.check_launchable():
-            logger.error("Game is not launchable")
-            return False
-
-        if not launch_ui_delegate.check_game_launchable(self):
-            return False
-
-        self.reload_config()  # Reload the config before launching it.
-
-        if self.id in LOG_BUFFERS:  # Reset game logs on each launch
-            log_buffer = LOG_BUFFERS[self.id]
-            log_buffer.delete(log_buffer.get_start_iter(), log_buffer.get_end_iter())
-
-        self.state = self.STATE_LAUNCHING
-        self.prelaunch_pids = system.get_running_pid_list()
-
-        if not self.prelaunch_pids:
-            logger.error("No prelaunch PIDs could be obtained. Game stop may be ineffective.")
-            self.prelaunch_pids = None
-
-        self.emit("game-start")
-
-        @watch_game_errors(game_stop_result=False, game=self)
-        def configure_game(_ignored, error):
-            if error:
-                raise error
-            self.configure_game(launch_ui_delegate)
-
-        jobs.AsyncCall(self.runner.prelaunch, configure_game)
-        return True
-
-    def start_game(self):
-        """Run a background command to launch the game"""
-        self.game_thread = MonitoredCommand(
-            self.game_runtime_config["args"],
-            title=self.name,
-            runner=self.runner,
-            cwd=self.game_runtime_config.get("working_dir"),
-            env=self.game_runtime_config["env"],
-            term=self.game_runtime_config["terminal"],
-            log_buffer=self.log_buffer,
-            include_processes=self.game_runtime_config["include_processes"],
-            exclude_processes=self.game_runtime_config["exclude_processes"],
-        )
-        if hasattr(self.runner, "stop"):
-            self.game_thread.stop_func = self.runner.stop
-        self.game_uuid = self.game_thread.env["LUTRIS_GAME_UUID"]
-        self.game_thread.start()
-        self.timer.start()
-        self.state = self.STATE_RUNNING
-        self.emit("game-started")
-
-        # Game is running, let's update discord status
-        if settings.read_setting("discord_rpc") == "True" and self.discord_id:
-            try:
-                discord.client.update(self.discord_id)
-            except AssertionError:
-                pass
-
-        self.heartbeat = GLib.timeout_add(HEARTBEAT_DELAY, self.beat)
-        with open(self.now_playing_path, "w", encoding="utf-8") as np_file:
-            np_file.write(self.name)
-
-    def force_stop(self):
-        # If force_stop_game fails, wait a few seconds and try SIGKILL on any survivors
-
-        def force_stop_game():
-            self.runner.force_stop_game(self)
-            return not self.get_stop_pids()
-
-        def force_stop_game_cb(all_dead, error):
-            if error:
-                self.signal_error(error)
-            elif all_dead:
-                self.stop_game()
-            else:
-                self.force_kill_delayed()
-
-        jobs.AsyncCall(force_stop_game, force_stop_game_cb)
-
-    def force_kill_delayed(self, death_watch_seconds=5, death_watch_interval_seconds=0.5):
-        """Forces termination of a running game, but only after a set time has elapsed;
-        Invokes stop_game() when the game is dead."""
-
-        def death_watch():
-            """Wait for the processes to die; kill them if they do not."""
-            for _n in range(int(death_watch_seconds / death_watch_interval_seconds)):
-                time.sleep(death_watch_interval_seconds)
-                if not self.get_stop_pids():
-                    return
-
-            # Once we get past the time limit, starting killing!
-            self.kill_processes(signal.SIGKILL)
-
-        def death_watch_cb(_result, error):
-            """Called after the death watch to more firmly kill any survivors."""
-            if error:
-                self.signal_error(error)
-
-            # If we still can't kill everything, we'll still say we stopped it.
-            self.stop_game()
-
-        jobs.AsyncCall(death_watch, death_watch_cb)
-
-    def kill_processes(self, sig):
-        """Sends a signal to a process list, logging errors."""
-        pids = self.get_stop_pids()
-
-        for pid in pids:
-            try:
-                os.kill(int(pid), sig)
-            except ProcessLookupError as ex:
-                logger.debug("Failed to kill game process: %s", ex)
-            except PermissionError:
-                logger.debug("Permission to kill process %s denied", pid)
-
-    def get_stop_pids(self):
-        """Finds the PIDs of processes that need killin'!"""
-        pids = self.get_game_pids()
-        if self.game_thread and self.game_thread.game_process:
-            if self.game_thread.game_process.poll() is None:
-                pids.add(self.game_thread.game_process.pid)
-        return pids
-
-    def get_game_pids(self):
-        """Return a list of processes belonging to the Lutris game"""
-        if not self.game_uuid:
-            logger.error("No LUTRIS_GAME_UUID recorded. The game's PIDs cannot be computed.")
-            return set()
-
-        new_pids = self.get_new_pids()
-
-        game_folder = self.resolve_game_path()
-        folder_pids = set()
-        for pid in new_pids:
-            cmdline = Process(pid).cmdline or ""
-            # pressure-vessel: This could potentially pick up PIDs not started by lutris?
-            if game_folder in cmdline or "pressure-vessel" in cmdline:
-                folder_pids.add(pid)
-
-        uuid_pids = set(pid for pid in new_pids if Process(pid).environ.get("LUTRIS_GAME_UUID") == self.game_uuid)
-
-        return folder_pids & uuid_pids
-
-    def get_new_pids(self):
-        """Return list of PIDs started since the game was launched"""
-        if self.prelaunch_pids:
-            return set(system.get_running_pid_list()) - set(self.prelaunch_pids)
-
-        logger.error("No prelaunch PIDs recorded. The game's PIDs cannot be computed.")
-        return set()
-
-    def stop_game(self):
-        """Cleanup after a game as stopped"""
-        duration = self.timer.duration
-        logger.debug("%s has run for %d seconds", self, duration)
-        if duration < 5:
-            logger.warning("The game has run for a very short time, did it crash?")
-            # Inspect why it could have crashed
-
-        self.state = self.STATE_STOPPED
-        self.emit("game-stopped")
-        if os.path.exists(self.now_playing_path):
-            os.unlink(self.now_playing_path)
-        if not self.timer.finished:
-            self.timer.end()
-            self.playtime += self.timer.duration / 3600
-            logger.debug("Playtime: %s", self.formatted_playtime)
-
-    @watch_game_errors(game_stop_result=False)
-    def beat(self):
-        """Watch the game's process(es)."""
-        if self.game_thread.error:
-            self.on_game_quit()
-            raise RuntimeError(_("<b>Error lauching the game:</b>\n") + self.game_thread.error)
-
-        # The killswitch file should be set to a device (ie. /dev/input/js0)
-        # When that device is unplugged, the game is forced to quit.
-        killswitch_engage = self.killswitch and not system.path_exists(self.killswitch)
-        if killswitch_engage:
-            logger.warning("File descriptor no longer present, force quit the game")
-            self.force_stop()
-            return False
-        game_pids = self.get_game_pids()
-        runs_only_prelaunch = False
-        if self.prelaunch_executor and self.prelaunch_executor.is_running:
-            runs_only_prelaunch = game_pids == {self.prelaunch_executor.game_process.pid}
-        if runs_only_prelaunch or (not self.game_thread.is_running and not game_pids):
-            logger.debug("Game thread stopped")
-            self.on_game_quit()
-            return False
-        return True
-
-    def stop(self):
-        """Stops the game"""
-        if self.state == self.STATE_STOPPED:
-            logger.debug("Game already stopped")
-            return
-
-        logger.info("Stopping %s", self)
-
-        if self.game_thread:
-
-            def stop_cb(_result, error):
-                if error:
-                    self.signal_error(error)
-
-            jobs.AsyncCall(self.game_thread.stop, stop_cb)
-        self.stop_game()
-
-    def on_game_quit(self):
-        """Restore some settings and cleanup after game quit."""
-
-        if self.prelaunch_executor and self.prelaunch_executor.is_running:
-            logger.info("Stopping prelaunch script")
-            self.prelaunch_executor.stop()
-
-        # We need to do some cleanup before we emit game-stop as this can
-        # trigger Lutris shutdown
-
-        if self.screen_saver_inhibitor_cookie is not None:
-            SCREEN_SAVER_INHIBITOR.uninhibit(self.screen_saver_inhibitor_cookie)
-            self.screen_saver_inhibitor_cookie = None
-
-        self.heartbeat = None
-        if self.state != self.STATE_STOPPED:
-            logger.warning("Game still running (state: %s)", self.state)
-            self.stop()
-
-        # Check for post game script
-        postexit_command = self.runner.system_config.get("postexit_command")
-        if postexit_command:
-            command_array = shlex.split(postexit_command)
-            if system.path_exists(command_array[0]):
-                logger.info("Running post-exit command: %s", postexit_command)
-                postexit_thread = MonitoredCommand(
-                    command_array,
-                    include_processes=[os.path.basename(postexit_command)],
-                    env=self.game_runtime_config["env"],
-                    cwd=self.resolve_game_path(),
-                )
-                postexit_thread.start()
-
-        quit_time = time.strftime("%a, %d %b %Y %H:%M:%S", time.localtime())
-        logger.debug("%s stopped at %s", self.name, quit_time)
-        self.lastplayed = int(time.time())
-        self.save_lastplayed()
-
-        os.chdir(os.path.expanduser("~"))
-
-        if self.antimicro_thread:
-            self.antimicro_thread.stop()
-
-        if self.resolution_changed or self.runner.system_config.get("reset_desktop"):
-            DISPLAY_MANAGER.set_resolution(self.original_outputs)
-
-        if self.compositor_disabled:
-            self.set_desktop_compositing(True)
-
-        if self.runner.system_config.get("use_us_layout"):
-            with subprocess.Popen(["setxkbmap"], env=os.environ) as setxkbmap:
-                setxkbmap.communicate()
-
-        # Clear Discord Client Status
-        if settings.read_setting("discord_rpc") == "True" and self.discord_id:
-            discord.client.clear()
-
-        self.process_return_codes()
-
-    def process_return_codes(self):
-        """Do things depending on how the game quitted."""
-        if self.game_thread.return_code == 127:
-            # Error missing shared lib
-            error = "error while loading shared lib"
-            error_lines = strings.lookup_strings_in_text(error, self.game_thread.stdout)
-            if error_lines:
-                raise RuntimeError(_("<b>Error: Missing shared library.</b>\n\n%s") % error_lines[0])
-
-        if self.game_thread.return_code == 1:
-            # Error Wine version conflict
-            error = "maybe the wrong wineserver"
-            if strings.lookup_strings_in_text(error, self.game_thread.stdout):
-                raise RuntimeError(_("<b>Error: A different Wine version is already using the same Wine prefix.</b>"))
-
-    def write_script(self, script_path, launch_ui_delegate):
+    def write_script(self, script_path, launch_ui_delegate) -> None:
         """Output the launch argument in a bash script"""
         gameplay_info = self.get_gameplay_info(launch_ui_delegate)
         if not gameplay_info:
@@ -1027,7 +460,7 @@ class Game(GObject.Object):
             return
         export_bash_script(self.runner, gameplay_info, script_path)
 
-    def move(self, new_location, no_signal=False):
+    def move(self, new_location, no_signal=False) -> str:
         logger.info("Moving %s to %s", self, new_location)
         new_config = ""
         old_location = self.directory
@@ -1065,13 +498,13 @@ class Game(GObject.Object):
             )
         return target_directory
 
-    def set_location(self, new_location):
+    def set_location(self, new_location) -> str:
         target_directory = self._get_move_target_directory(new_location)
         self.directory = target_directory
         self.save()
         return target_directory
 
-    def _get_move_target_directory(self, new_location):
+    def _get_move_target_directory(self, new_location) -> str:
         old_location = self.directory
         if old_location and os.path.exists(old_location):
             game_directory = os.path.basename(old_location)

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -454,7 +454,7 @@ class Game(GObject.Object):
 
     def write_script(self, script_path, launch_ui_delegate) -> None:
         """Output the launch argument in a bash script"""
-        gameplay_info = self.get_gameplay_info(launch_ui_delegate)
+        gameplay_info = self.game_launcher.get_gameplay_info(launch_ui_delegate)
         if not gameplay_info:
             # User cancelled; errors are raised as exceptions instead of this
             return
@@ -513,7 +513,7 @@ class Game(GObject.Object):
         return new_location
 
 
-def export_game(slug, dest_dir):
+def export_game(slug, dest_dir) -> None:
     """Export a full game folder along with some lutris metadata"""
     # List of runner where we know for sure that 1 folder = 1 game.
     # For runners that handle ROMs, we have to handle this more finely.
@@ -546,7 +546,7 @@ def export_game(slug, dest_dir):
     logger.info("%s exported to %s", slug, archive_path)
 
 
-def import_game(file_path, dest_dir):
+def import_game(file_path, dest_dir) -> None:
     """Import a game in Lutris"""
     if not os.path.exists(file_path):
         raise RuntimeError("No file %s" % file_path)

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -79,7 +79,7 @@ class GameActions:
         """Stops the game"""
         games = self.get_running_games()
         for game in games:
-            game.force_stop()
+            game.game_launcher.force_stop()
 
     def get_running_games(self):
         running_games = []
@@ -300,7 +300,7 @@ class SingleGameActions(GameActions):
         game = self.game
         if game.is_installed and game.is_db_stored:
             if not self.application.is_game_running_by_id(game.id):
-                game.launch(launch_ui_delegate=self.window)
+                game.game_launcher.launch(launch_ui_delegate=self.window)
 
     def on_execute_script_clicked(self, _widget):
         """Execute the game's associated script"""

--- a/lutris/game_launcher.py
+++ b/lutris/game_launcher.py
@@ -1,0 +1,596 @@
+from __future__ import annotations
+
+import os
+import shlex
+import signal
+import subprocess
+import time
+from gettext import gettext as _
+from typing import TYPE_CHECKING
+
+from gi.repository import GLib, GObject, Gtk
+
+from lutris import settings
+from lutris.exception_backstops import watch_game_errors
+from lutris.exceptions import GameConfigError, MissingExecutableError
+from lutris.monitored_command import MonitoredCommand
+from lutris.runner_interpreter import get_launch_parameters
+from lutris.util import discord, jobs, linux, strings, system
+from lutris.util.display import DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, disable_compositing, enable_compositing
+from lutris.util.graphics.xephyr import get_xephyr_command
+from lutris.util.graphics.xrandr import turn_off_except
+from lutris.util.linux import LINUX_SYSTEM
+from lutris.util.log import LOG_BUFFERS, logger
+from lutris.util.process import Process
+from lutris.util.timer import Timer
+from lutris.util.wine import proton
+
+if TYPE_CHECKING:
+    from lutris.game import Game
+
+HEARTBEAT_DELAY = 2000
+
+
+class GameLauncher(GObject.Object):
+    __gsignals__ = {
+        # SIGNAL_RUN_LAST works around bug https://gitlab.gnome.org/GNOME/glib/-/issues/513
+        # fix merged Dec 2020, but we support older GNOME!
+        "game-error": (GObject.SIGNAL_RUN_LAST, bool, (object,)),
+        "game-unhandled-error": (GObject.SIGNAL_RUN_FIRST, None, (object,)),
+        "game-start": (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "game-started": (GObject.SIGNAL_RUN_FIRST, None, ()),
+        "game-stopped": (GObject.SIGNAL_RUN_FIRST, None, ()),
+    }
+    now_playing_path = os.path.join(settings.CACHE_DIR, "now-playing.txt")
+
+    STATE_STOPPED = "stopped"
+    STATE_LAUNCHING = "launching"
+    STATE_RUNNING = "running"
+
+    def __init__(self, game: Game):
+        super().__init__()
+        self.game = game
+        self.state: str = self.STATE_STOPPED
+        self.heartbeat = None
+        self.killswitch = None
+        self.game_uuid: str = None
+        self.game_thread: MonitoredCommand = None
+        self.antimicro_thread: MonitoredCommand = None
+        self.prelaunch_pids = None
+        self.prelaunch_executor = None
+        self.game_runtime_config = {}
+        self.resolution_changed: bool = False
+        self.compositor_disabled: bool = False
+        self.original_outputs = None
+        self._log_buffer = None
+        self.timer = Timer()
+        self.screen_saver_inhibitor_cookie = None
+
+    @property
+    def runner(self):
+        return self.game.runner
+
+    @property
+    def log_buffer(self) -> Gtk.TextBuffer:
+        """Access the log buffer object, creating it if necessary"""
+        _log_buffer = LOG_BUFFERS.get(self.game.id)
+        if _log_buffer:
+            return _log_buffer
+        _log_buffer = Gtk.TextBuffer()
+        _log_buffer.create_tag("warning", foreground="red")
+        if self.game_thread:
+            self.game_thread.set_log_buffer(self._log_buffer)
+            _log_buffer.set_text(self.game_thread.stdout)
+        LOG_BUFFERS[self.game.id] = _log_buffer
+        return _log_buffer
+
+    def signal_error(self, error) -> None:
+        """Reports an error by firing game-error. If handled, it returns
+        True to indicate it handled it, and that's it. If not, this fires
+        game-unhandled-error, which is actually handled via an emission hook
+        and should not be connected otherwise.
+
+        This allows special error handling to be set up for a particular Game, but
+        there's always some handling."""
+        handled = self.emit("game-error", error)
+        if not handled:
+            self.emit("game-unhandled-error", error)
+
+    def check_launchable(self) -> bool:
+        """Verify that the current game can be launched, and raises exceptions if not."""
+        if not self.game.is_installed or not self.game.is_db_stored:
+            logger.error("%s (%s) not installed", self, self.id)
+            raise GameConfigError(_("Tried to launch a game that isn't installed."))
+        if not self.game.has_runner:
+            raise GameConfigError(_("Invalid game configuration: Missing runner"))
+
+        return True
+
+    def restrict_to_display(self, display):
+        outputs = DISPLAY_MANAGER.get_config()
+        if display == "primary":
+            display = None
+            for output in outputs:
+                if output.primary:
+                    display = output.name
+                    break
+            if not display:
+                logger.warning("No primary display set")
+        else:
+            found = False
+            for output in outputs:
+                if output.name == display:
+                    found = True
+                    break
+            if not found:
+                logger.warning("Selected display %s not found", display)
+                display = None
+        if display:
+            turn_off_except(display)
+            time.sleep(3)
+            return True
+        return False
+
+    def start_xephyr(self, display=":2"):
+        """Start a monitored Xephyr instance"""
+        if not system.can_find_executable("Xephyr"):
+            raise GameConfigError(_("Unable to find Xephyr, install it or disable the Xephyr option"))
+        xephyr_command = get_xephyr_command(display, self.game.runner.system_config)
+        xephyr_thread = MonitoredCommand(xephyr_command)
+        xephyr_thread.start()
+        time.sleep(3)
+        return display
+
+    def start_antimicrox(self, antimicro_config):
+        """Start Antimicrox with a given config path"""
+        if LINUX_SYSTEM.is_flatpak():
+            antimicro_command = ["flatpak-spawn", "--host", "antimicrox"]
+        else:
+            try:
+                antimicro_command = [system.find_required_executable("antimicrox")]
+            except MissingExecutableError as ex:
+                raise GameConfigError(
+                    _("Unable to find Antimicrox, install it or disable the Antimicrox option")
+                ) from ex
+
+        logger.info("Starting Antimicro")
+        antimicro_command += ["--hidden", "--tray", "--profile", antimicro_config]
+        self.antimicro_thread = MonitoredCommand(antimicro_command)
+        self.antimicro_thread.start()
+
+    def start_prelaunch_command(self, wait_for_completion=False):
+        """Start the prelaunch command specified in the system options"""
+        prelaunch_command = self.game.runner.system_config.get("prelaunch_command")
+        command_array = shlex.split(prelaunch_command)
+        if not system.path_exists(command_array[0]):
+            logger.warning("Command %s not found", command_array[0])
+            return
+        env = self.game_runtime_config["env"]
+        if wait_for_completion:
+            logger.info("Prelauch command: %s, waiting for completion", prelaunch_command)
+            # Monitor the prelaunch command and wait until it has finished
+            system.execute(command_array, env=env, cwd=self.game.resolve_game_path())
+        else:
+            logger.info("Prelaunch command %s launched in the background", prelaunch_command)
+            self.prelaunch_executor = MonitoredCommand(
+                command_array,
+                include_processes=[os.path.basename(command_array[0])],
+                env=env,
+                cwd=self.game.resolve_game_path(),
+            )
+            self.prelaunch_executor.start()
+
+    def get_terminal(self):
+        """Return the terminal used to run the game into or None if the game is not run from a terminal.
+        Remember that only games using text mode should use the terminal.
+        """
+        if self.game.runner.system_config.get("terminal"):
+            terminal = self.game.runner.system_config.get("terminal_app", linux.get_default_terminal())
+            if terminal and not system.can_find_executable(terminal):
+                raise GameConfigError(_("The selected terminal application could not be launched:\n%s") % terminal)
+            return terminal
+
+    def get_killswitch(self):
+        """Return the path to a file that is monitored during game execution.
+        If the file stops existing, the game is stopped.
+        """
+        killswitch = self.game.runner.system_config.get("killswitch")
+        # Prevent setting a killswitch to a file that doesn't exists
+        if killswitch and system.path_exists(self.killswitch):
+            return killswitch
+
+    def get_gameplay_info(self, launch_ui_delegate) -> dict:
+        """Return the information provided by a runner's play method.
+        It checks for possible errors and raises exceptions if they occur.
+
+        This may invoke methods on the delegates to make decisions,
+        and this may show UI.
+
+        This returns an empty dictionary if the user cancels this UI,
+        in which case the game should not be run.
+        """
+
+        gameplay_info = self.runner.play()
+
+        if "working_dir" not in gameplay_info:
+            gameplay_info["working_dir"] = self.runner.working_dir
+
+        config = launch_ui_delegate.select_game_launch_config(self)
+
+        if config is None:
+            return {}  # no error here- the user cancelled out
+
+        if config:  # empty dict for primary configuration
+            self.runner.apply_launch_config(gameplay_info, config)
+
+        return gameplay_info
+
+    @watch_game_errors(game_stop_result=False)
+    def configure_game(self, launch_ui_delegate) -> bool:
+        """Get the game ready to start, applying all the options.
+        This method sets the game_runtime_config attribute.
+        """
+        gameplay_info = self.get_gameplay_info(launch_ui_delegate)
+        if not gameplay_info:  # if user cancelled - not an error
+            return False
+        command, env = get_launch_parameters(self.runner, gameplay_info)
+
+        if env.get("WINEARCH") == "win32" and "umu" in " ".join(command):
+            raise RuntimeError("Proton is not compatible with 32bit prefixes")
+
+        # Allow user to override default umu environment variables to apply fixes
+        env["GAMEID"] = proton.get_game_id(self.game)
+        env["STORE"] = env.get("STORE") or self.game.get_store_name()
+
+        # Some environment variables for the use of custom pre-launch and post-exit scripts.
+        env["GAME_NAME"] = self.game.name
+        if self.game.directory:
+            env["GAME_DIRECTORY"] = self.game.directory
+
+        self.game_runtime_config = {
+            "args": command,
+            "env": env,
+            "terminal": self.get_terminal(),
+            "include_processes": shlex.split(self.runner.system_config.get("include_processes", "")),
+            "exclude_processes": shlex.split(self.runner.system_config.get("exclude_processes", "")),
+        }
+
+        if "working_dir" in gameplay_info:
+            self.game_runtime_config["working_dir"] = gameplay_info["working_dir"]
+
+        # Input control
+        if self.runner.system_config.get("use_us_layout"):
+            system.set_keyboard_layout("us")
+
+        # Display control
+        self.original_outputs = DISPLAY_MANAGER.get_config()
+
+        if self.runner.system_config.get("disable_compositor"):
+            self._set_desktop_compositing(False)
+
+        if self.runner.system_config.get("disable_screen_saver"):
+            self.screen_saver_inhibitor_cookie = SCREEN_SAVER_INHIBITOR.inhibit(self.game.name)
+
+        if self.runner.system_config.get("display") != "off":
+            self.resolution_changed = self.restrict_to_display(self.runner.system_config.get("display"))
+
+        resolution = self.runner.system_config.get("resolution")
+        if resolution != "off":
+            DISPLAY_MANAGER.set_resolution(resolution)
+            time.sleep(3)
+            self.resolution_changed = True
+
+        xephyr = self.runner.system_config.get("xephyr") or "off"
+        if xephyr != "off":
+            env["DISPLAY"] = self.start_xephyr()
+
+        antimicro_config = self.runner.system_config.get("antimicro_config")
+        if system.path_exists(antimicro_config):
+            self.start_antimicrox(antimicro_config)
+
+        # Execution control
+        self.killswitch = self.get_killswitch()
+
+        if self.runner.system_config.get("prelaunch_command"):
+            self.start_prelaunch_command(self.runner.system_config.get("prelaunch_wait"))
+
+        self._start_game()
+        return True
+
+    def _set_desktop_compositing(self, enable) -> None:
+        """Enables or disables compositing"""
+        if enable:
+            if self.compositor_disabled:
+                enable_compositing()
+                self.compositor_disabled = False
+        else:
+            if not self.compositor_disabled:
+                disable_compositing()
+                self.compositor_disabled = True
+
+    @watch_game_errors(game_stop_result=False)
+    def launch(self, launch_ui_delegate) -> bool:
+        """Request launching a game. The game may not be installed yet."""
+        if not self.check_launchable():
+            logger.error("Game is not launchable")
+            return False
+
+        if not launch_ui_delegate.check_game_launchable(self):
+            return False
+
+        self.game.reload_config()  # Reload the config before launching it.
+
+        if self.game.id in LOG_BUFFERS:  # Reset game logs on each launch
+            log_buffer = LOG_BUFFERS[self.game.id]
+            log_buffer.delete(log_buffer.get_start_iter(), log_buffer.get_end_iter())
+
+        self.state = self.STATE_LAUNCHING
+        self.prelaunch_pids = system.get_running_pid_list()
+
+        if not self.prelaunch_pids:
+            logger.error("No prelaunch PIDs could be obtained. Game stop may be ineffective.")
+            self.prelaunch_pids = None
+
+        self.emit("game-start")
+
+        @watch_game_errors(game_stop_result=False, game_launcher=self)
+        def configure_game(_ignored, error):
+            if error:
+                raise error
+            self.configure_game(launch_ui_delegate)
+
+        jobs.AsyncCall(self.runner.prelaunch, configure_game)
+        return True
+
+    def _start_game(self) -> None:
+        """Run a background command to launch the game"""
+        self.game_thread = MonitoredCommand(
+            self.game_runtime_config["args"],
+            title=self.game.name,
+            runner=self.runner,
+            cwd=self.game_runtime_config.get("working_dir"),
+            env=self.game_runtime_config["env"],
+            term=self.game_runtime_config["terminal"],
+            log_buffer=self.log_buffer,
+            include_processes=self.game_runtime_config["include_processes"],
+            exclude_processes=self.game_runtime_config["exclude_processes"],
+        )
+        if hasattr(self.runner, "stop"):
+            self.game_thread.stop_func = self.runner.stop
+        self.game_uuid = self.game_thread.env["LUTRIS_GAME_UUID"]
+        self.game_thread.start()
+        self.timer.start()
+        self.state = self.STATE_RUNNING
+        self.emit("game-started")
+
+        # Game is running, let's update discord status
+        if settings.read_setting("discord_rpc") == "True" and self.game.discord_id:
+            try:
+                discord.client.update(self.game.discord_id)
+            except AssertionError:
+                pass
+
+        self.heartbeat = GLib.timeout_add(HEARTBEAT_DELAY, self._beat)
+        with open(self.now_playing_path, "w", encoding="utf-8") as np_file:
+            np_file.write(self.game.name)
+
+    def force_stop(self) -> None:
+        # If force_stop_game fails, wait a few seconds and try SIGKILL on any survivors
+
+        def force_stop_game() -> bool:
+            self.runner.force_stop_game(self)
+            return not self._get_stop_pids()
+
+        def force_stop_game_cb(all_dead, error):
+            if error:
+                self.signal_error(error)
+            elif all_dead:
+                self.stop_game()
+            else:
+                self._force_kill_delayed()
+
+        jobs.AsyncCall(force_stop_game, force_stop_game_cb)
+
+    def _force_kill_delayed(self, death_watch_seconds=5, death_watch_interval_seconds=0.5) -> None:
+        """Forces termination of a running game, but only after a set time has elapsed;
+        Invokes stop_game() when the game is dead."""
+
+        def death_watch() -> None:
+            """Wait for the processes to die; kill them if they do not."""
+            for _n in range(int(death_watch_seconds / death_watch_interval_seconds)):
+                time.sleep(death_watch_interval_seconds)
+                if not self._get_stop_pids():
+                    return
+
+            # Once we get past the time limit, starting killing!
+            self.kill_processes(signal.SIGKILL)
+
+        def _death_watch_cb(_result, error):
+            """Called after the death watch to more firmly kill any survivors."""
+            if error:
+                self.signal_error(error)
+
+            # If we still can't kill everything, we'll still say we stopped it.
+            self.stop_game()
+
+        jobs.AsyncCall(death_watch, _death_watch_cb)
+
+    def kill_processes(self, sig) -> None:
+        """Sends a signal to a process list, logging errors."""
+        pids = self._get_stop_pids()
+
+        for pid in pids:
+            try:
+                os.kill(int(pid), sig)
+            except ProcessLookupError as ex:
+                logger.debug("Failed to kill game process: %s", ex)
+            except PermissionError:
+                logger.debug("Permission to kill process %s denied", pid)
+
+    def _get_stop_pids(self) -> set:
+        """Finds the PIDs of processes that need killin'!"""
+        pids = self._get_game_pids()
+        if self.game_thread and self.game_thread.game_process:
+            if self.game_thread.game_process.poll() is None:
+                pids.add(self.game_thread.game_process.pid)
+        return pids
+
+    def _get_game_pids(self) -> set:
+        """Return a list of processes belonging to the Lutris game"""
+        if not self.game_uuid:
+            logger.error("No LUTRIS_GAME_UUID recorded. The game's PIDs cannot be computed.")
+            return set()
+
+        new_pids = self._get_new_pids()
+
+        game_folder = self.game.resolve_game_path()
+        folder_pids = set()
+        for pid in new_pids:
+            cmdline = Process(pid).cmdline or ""
+            # pressure-vessel: This could potentially pick up PIDs not started by lutris?
+            if game_folder in cmdline or "pressure-vessel" in cmdline:
+                folder_pids.add(pid)
+
+        uuid_pids = set(pid for pid in new_pids if Process(pid).environ.get("LUTRIS_GAME_UUID") == self.game_uuid)
+
+        return folder_pids & uuid_pids
+
+    def _get_new_pids(self) -> set:
+        """Return list of PIDs started since the game was launched"""
+        if self.prelaunch_pids:
+            return set(system.get_running_pid_list()) - set(self.prelaunch_pids)
+
+        logger.error("No prelaunch PIDs recorded. The game's PIDs cannot be computed.")
+        return set()
+
+    def stop_game(self) -> None:
+        """Cleanup after a game as stopped"""
+        duration = self.timer.duration
+        logger.debug("%s has run for %d seconds", self, duration)
+        if duration < 5:
+            logger.warning("The game has run for a very short time, did it crash?")
+            # Inspect why it could have crashed
+
+        self.state = self.STATE_STOPPED
+        self.emit("game-stopped")
+        if os.path.exists(self.now_playing_path):
+            os.unlink(self.now_playing_path)
+        if not self.timer.finished:
+            self.timer.end()
+            self.game.playtime += self.timer.duration / 3600
+
+    @watch_game_errors(game_stop_result=False)
+    def _beat(self) -> bool:
+        """Watch the game's process(es)."""
+        if self.game_thread.error:
+            self._on_game_quit()
+            raise RuntimeError(_("<b>Error lauching the game:</b>\n") + self.game_thread.error)
+
+        # The killswitch file should be set to a device (ie. /dev/input/js0)
+        # When that device is unplugged, the game is forced to quit.
+        killswitch_engage = self.killswitch and not system.path_exists(self.killswitch)
+        if killswitch_engage:
+            logger.warning("File descriptor no longer present, force quit the game")
+            self.force_stop()
+            return False
+        game_pids = self._get_game_pids()
+        runs_only_prelaunch = False
+        if self.prelaunch_executor and self.prelaunch_executor.is_running:
+            runs_only_prelaunch = game_pids == {self.prelaunch_executor.game_process.pid}
+        if runs_only_prelaunch or (not self.game_thread.is_running and not game_pids):
+            logger.debug("Game thread stopped.")
+            logger.debug("Game PIDs: %s", game_pids)
+            self._on_game_quit()
+            return False
+        return True
+
+    def _stop(self) -> None:
+        """Stops the game"""
+        if self.state == self.STATE_STOPPED:
+            logger.debug("Game already stopped")
+            return
+
+        logger.info("Stopping %s", self)
+
+        if self.game_thread:
+
+            def stop_cb(_result, error):
+                if error:
+                    self.signal_error(error)
+
+            jobs.AsyncCall(self.game_thread.stop, stop_cb)
+        self.stop_game()
+
+    def _on_game_quit(self) -> None:
+        """Restore some settings and cleanup after game quit."""
+
+        if self.prelaunch_executor and self.prelaunch_executor.is_running:
+            logger.info("Stopping prelaunch script")
+            self.prelaunch_executor.stop()
+
+        # We need to do some cleanup before we emit game-stop as this can
+        # trigger Lutris shutdown
+
+        if self.screen_saver_inhibitor_cookie is not None:
+            SCREEN_SAVER_INHIBITOR.uninhibit(self.screen_saver_inhibitor_cookie)
+            self.screen_saver_inhibitor_cookie = None
+
+        self.heartbeat = None
+        if self.state != self.STATE_STOPPED:
+            logger.warning("Game still running (state: %s)", self.state)
+            self._stop()
+
+        # Check for post game script
+        postexit_command = self.runner.system_config.get("postexit_command")
+        if postexit_command:
+            command_array = shlex.split(postexit_command)
+            if system.path_exists(command_array[0]):
+                logger.info("Running post-exit command: %s", postexit_command)
+                postexit_thread = MonitoredCommand(
+                    command_array,
+                    include_processes=[os.path.basename(postexit_command)],
+                    env=self.game_runtime_config["env"],
+                    cwd=self.resolve_game_path(),
+                )
+                postexit_thread.start()
+
+        quit_time = time.strftime("%a, %d %b %Y %H:%M:%S", time.localtime())
+        logger.debug("%s stopped at %s", self.game.name, quit_time)
+        self.lastplayed = int(time.time())
+        self.game.save_lastplayed()
+
+        os.chdir(os.path.expanduser("~"))
+
+        if self.antimicro_thread:
+            self.antimicro_thread.stop()
+
+        if self.resolution_changed or self.runner.system_config.get("reset_desktop"):
+            DISPLAY_MANAGER.set_resolution(self.original_outputs)
+
+        if self.compositor_disabled:
+            self._set_desktop_compositing(True)
+
+        if self.runner.system_config.get("use_us_layout"):
+            with subprocess.Popen(["setxkbmap"], env=os.environ) as setxkbmap:
+                setxkbmap.communicate()
+
+        # Clear Discord Client Status
+        if settings.read_setting("discord_rpc") == "True" and self.game.discord_id:
+            discord.client.clear()
+
+        self._process_return_codes()
+
+    def _process_return_codes(self):
+        """Do things depending on how the game quitted."""
+        if self.game_thread.return_code == 127:
+            # Error missing shared lib
+            error = "error while loading shared lib"
+            error_lines = strings.lookup_strings_in_text(error, self.game_thread.stdout)
+            if error_lines:
+                raise RuntimeError(_("<b>Error: Missing shared library.</b>\n\n%s") % error_lines[0])
+
+        if self.game_thread.return_code == 1:
+            # Error Wine version conflict
+            error = "maybe the wrong wineserver"
+            if strings.lookup_strings_in_text(error, self.game_thread.stdout):
+                raise RuntimeError(_("<b>Error: A different Wine version is already using the same Wine prefix.</b>"))

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -437,7 +437,7 @@ class Application(Gtk.Application):
             return True
 
         game = Game(db_game["id"])
-        game.connect("game-error", on_error)
+        game.game_launcher.connect("game-error", on_error)
         game.reload_config()
         game.write_script(script_path, self.launch_ui_delegate)
 

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -4,6 +4,7 @@ from gi.repository import Gdk, Gtk
 
 from lutris.exceptions import UnavailableRunnerError
 from lutris.game import Game
+from lutris.game_launcher import GameLauncher
 from lutris.gui import dialogs
 from lutris.gui.dialogs.download import DownloadDialog
 from lutris.services import get_enabled_services
@@ -153,7 +154,8 @@ class DialogLaunchUIDelegate(LaunchUIDelegate):
 
         return True
 
-    def select_game_launch_config(self, game):
+    def select_game_launch_config(self, game_launcher: GameLauncher):
+        game = game_launcher.game
         game_config = game.config.game_level.get("game", {})
         configs = game_config.get("launch_configs")
 

--- a/lutris/gui/dialogs/game_import.py
+++ b/lutris/gui/dialogs/game_import.py
@@ -28,7 +28,7 @@ class ImportGameDialog(ModelessDialog):
         self.category_labels = {}
         self.error_labels = {}
         self.launch_buttons = {}
-        self.platform = None
+        self.platform: str = None
         self.search_call = None
         self.set_size_request(500, 560)
 
@@ -172,7 +172,7 @@ class ImportGameDialog(ModelessDialog):
                 if self.import_rom(rom_set, filename):
                     break
 
-    def import_rom(self, rom_set, filename):
+    def import_rom(self, rom_set, filename) -> bool:
         """Tries to install a specific ROM, or reports failure. Returns True if
         successful, False if not."""
         try:
@@ -190,7 +190,7 @@ class ImportGameDialog(ModelessDialog):
             for rom in rom_set["roms"]:
                 self.display_new_game_info(filename, rom_set, rom["md5"])
                 game_id = self.add_game(rom_set, filename)
-                game = Game(game_id)
+                game = Game(str(game_id))
                 game.emit("game-installed")
                 game.emit("game-updated")
                 self.enable_game_launch(filename, game)
@@ -203,19 +203,19 @@ class ImportGameDialog(ModelessDialog):
 
         return False
 
-    def enable_game_launch(self, filename, game):
+    def enable_game_launch(self, filename, game: Game) -> None:
         launch_button = self.launch_buttons[filename]
         launch_button.set_sensitive(True)
         launch_button.connect("clicked", self.on_launch_clicked, game)
 
-    def on_launch_clicked(self, _button, game):
+    def on_launch_clicked(self, _button, game: Game) -> None:
         # We can't use this window as the delegate because we
         # are destroying it.
         application = Gio.Application.get_default()
-        game.launch(application.launch_ui_delegate)
+        game.game_launcher.launch(application.launch_ui_delegate)
         self.destroy()
 
-    def display_existing_game_info(self, filename, game):
+    def display_existing_game_info(self, filename, game: Game) -> None:
         label = self.checksum_labels[filename]
         label.set_markup("<i>%s</i>" % _("Game already installed in Lutris"))
         label.show()
@@ -226,7 +226,7 @@ class ImportGameDialog(ModelessDialog):
         label.set_text(category)
         label.show()
 
-    def display_new_game_info(self, filename, rom_set, checksum):
+    def display_new_game_info(self, filename, rom_set, checksum) -> None:
         label = self.checksum_labels[filename]
         label.set_text(checksum)
         label.show()
@@ -241,12 +241,12 @@ class ImportGameDialog(ModelessDialog):
         if not self.platform:
             raise RuntimeError(_("The platform '%s' is unknown to Lutris.") % category)
 
-    def add_game(self, rom_set, filepath):
+    def add_game(self, rom_set, filepath) -> int:
         name = clean_rom_name(rom_set["name"])
         logger.info("Installing %s", name)
 
         try:
-            installer = deepcopy(DEFAULT_INSTALLERS[self.platform])
+            installer: dict = deepcopy(DEFAULT_INSTALLERS[self.platform])
         except KeyError as error:
             raise RuntimeError(
                 _("Lutris does not have a default installer for the '%s' platform.") % self.platform

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -7,6 +7,7 @@ from lutris.database.games import get_game_for_service
 from lutris.database.services import ServiceGameCollection
 from lutris.game import Game
 from lutris.game_actions import GameActions, get_game_actions
+from lutris.game_launcher import GameLauncher
 from lutris.gui.widgets.contextual_menu import ContextualMenu
 from lutris.gui.widgets.utils import MEDIA_CACHE_INVALIDATED
 from lutris.util.log import logger
@@ -38,7 +39,7 @@ class GameView:
         self.connect("button-press-event", self.popup_contextual_menu)
         self.connect("key-press-event", self.handle_key_press)
 
-        self.game_start_hook_id = GObject.add_emission_hook(Game, "game-start", self.on_game_start)
+        self.game_start_hook_id = GObject.add_emission_hook(GameLauncher, "game-start", self.on_game_start)
 
     def set_game_store(self, game_store):
         self.game_store = game_store
@@ -150,7 +151,7 @@ class GameView:
     def get_game_id_for_path(self, path):
         raise NotImplementedError()
 
-    def on_game_start(self, game):
+    def on_game_start(self, game_launcher: GameLauncher):
         """On game start, we trigger an animation to show the game is starting; it runs at least
         one cycle, but continues until the game exits the STATE_LAUNCHING state."""
 
@@ -181,8 +182,8 @@ class GameView:
             if elapsed > cycle_time:
                 # Check for stopping and pausing only at cycle end, so we don't do it too often,
                 # and to avoid a janky looking visible snap-back to full size.
-                if game.state != game.STATE_LAUNCHING:
-                    if self.image_renderer.inset_game(game.id, 0.0):
+                if game_launcher.state != game_launcher.STATE_LAUNCHING:
+                    if self.image_renderer.inset_game(game_launcher.game.id, 0.0):
                         self.queue_draw()
                     return False
 
@@ -201,7 +202,7 @@ class GameView:
             else:
                 fraction = max_indent * (cycle * 2 / cycle_time)
 
-            if self.image_renderer.inset_game(game.id, fraction):
+            if self.image_renderer.inset_game(game_launcher.game.id, fraction):
                 self.queue_draw()
 
             return True  # Return True to call again after another timeout

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -11,6 +11,7 @@ from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.game import Game
+from lutris.game_launcher import GameLauncher
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
@@ -351,8 +352,8 @@ class LutrisSidebar(Gtk.ListBox):
         GObject.add_emission_hook(RunnerConfigDialog, "runner-updated", self.update_runner_rows)
         GObject.add_emission_hook(ScriptInterpreter, "runners-installed", self.update_rows)
         GObject.add_emission_hook(ServicesBox, "services-changed", self.update_rows)
-        GObject.add_emission_hook(Game, "game-start", self.on_game_start)
-        GObject.add_emission_hook(Game, "game-stopped", self.on_game_stopped)
+        GObject.add_emission_hook(GameLauncher, "game-start", self.on_game_start)
+        GObject.add_emission_hook(GameLauncher, "game-stopped", self.on_game_stopped)
         GObject.add_emission_hook(Game, "game-updated", self.update_rows)
         GObject.add_emission_hook(BaseService, "service-login", self.on_service_auth_changed)
         GObject.add_emission_hook(BaseService, "service-logout", self.on_service_auth_changed)
@@ -615,12 +616,12 @@ class LutrisSidebar(Gtk.ListBox):
         self.invalidate_filter()
         return True
 
-    def on_game_start(self, _game):
+    def on_game_start(self, _game_launcher: GameLauncher):
         """Show the "running" section when a game start"""
         self.running_row.show()
         return True
 
-    def on_game_stopped(self, _game):
+    def on_game_stopped(self, _game_launcher: GameLauncher):
         """Hide the "running" section when no games are running"""
         if not self.application.has_running_games:
             self.running_row.hide()
@@ -630,19 +631,19 @@ class LutrisSidebar(Gtk.ListBox):
 
         return True
 
-    def on_service_auth_changed(self, service):
+    def on_service_auth_changed(self, service: BaseService):
         if service.id in self.service_rows:
             self.service_rows[service.id].create_button_box()
             self.service_rows[service.id].update_buttons()
         return True
 
-    def on_service_games_updating(self, service):
+    def on_service_games_updating(self, service: BaseService):
         if service.id in self.service_rows:
             self.service_rows[service.id].is_updating = True
             self.service_rows[service.id].update_buttons()
         return True
 
-    def on_service_games_updated(self, service):
+    def on_service_games_updated(self, service: BaseService):
         if service.id in self.service_rows:
             self.service_rows[service.id].is_updating = False
             self.service_rows[service.id].update_buttons()

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -145,12 +145,12 @@ class linux(Runner):
 
         return command
 
-    def get_command(self):
+    def get_command(self) -> list:
         # There's no command for a Linux game; the game executable
         # is the first thing in the game's command line, not any runner thing.
         return []
 
-    def play(self):
+    def play(self) -> dict:
         """Run native game."""
         launch_info = {}
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -3,7 +3,7 @@
 import os
 import signal
 from gettext import gettext as _
-from typing import Any, Callable, Dict, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
 from lutris import runtime, settings
 from lutris.api import format_runner_version, get_default_runner_version_info
@@ -18,10 +18,14 @@ from lutris.util.graphics.gpu import GPUS
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 
+if TYPE_CHECKING:
+    from lutris.game_launcher import GameLauncher
+
 
 class Runner:  # pylint: disable=too-many-public-methods
     """Generic runner (base class for other runners)."""
 
+    human_name = ""
     multiple_versions = False
     platforms = []
     runnable_alone = False
@@ -548,12 +552,16 @@ class Runner:  # pylint: disable=too-many-public-methods
                 break
         return output
 
-    def force_stop_game(self, game):
+    def force_stop_game(self, game_launcher: "GameLauncher") -> None:
         """Stop the running game. If this leaves any game processes running,
         the caller will SIGKILL them (after a delay)."""
-        game.kill_processes(signal.SIGTERM)
+        game_launcher.kill_processes(signal.SIGTERM)
 
     def extract_icon(self, game_slug):
         """The config UI calls this to extract the game icon. Most runners do not
         support this and do nothing. This is not called if a custom icon is installed
         for the game."""
+
+    def play(self) -> dict:
+        """Dummy method to be implemented by subclasses"""
+        return {}

--- a/lutris/scanners/default_installers.py
+++ b/lutris/scanners/default_installers.py
@@ -1,4 +1,6 @@
-DEFAULT_INSTALLERS = {
+from typing import Dict
+
+DEFAULT_INSTALLERS: Dict[str, dict] = {
     "3do": {
         "runner": "libretro",
         "game": {"core": "opera", "main_file": "rom"},

--- a/lutris/util/savesync.py
+++ b/lutris/util/savesync.py
@@ -37,7 +37,8 @@ class SaveInfo:
         basedir = save_config.get("basedir") or self.game.directory
         if not basedir:
             raise ValueError("No save directory provided")
-        prefix_path = os.path.dirname(self.game.config.game_config.get("exe"))
+        exe_path: str = self.game.config.game_config.get("exe") or ""
+        prefix_path = os.path.dirname(exe_path)
 
         if self.game.runner_name == "wine":
             prefix_path = self.game.config.game_config.get("prefix", "")

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -1,13 +1,18 @@
 """Utility module to deal with Proton and umu"""
 
+from __future__ import annotations
+
 import json
 import os
 from gettext import gettext as _
-from typing import Generator, List, Optional
+from typing import TYPE_CHECKING, Generator, List, Optional
 
 from lutris import settings
 from lutris.util import system
 from lutris.util.steam.config import get_steamapps_dirs
+
+if TYPE_CHECKING:
+    from lutris.game import Game
 
 GE_PROTON_LATEST = _("GE-Proton (Latest)")
 DEFAULT_GAMEID = "umu-default"
@@ -99,7 +104,7 @@ def get_proton_path_from_bin(wine_path):
     return os.path.abspath(os.path.join(os.path.dirname(wine_path), "../../"))
 
 
-def get_game_id(game) -> str:
+def get_game_id(game: Game) -> str:
     games_path = os.path.join(settings.RUNTIME_DIR, "umu-games/umu-games.json")
     env = game.runner.get_env()
     if game and env.get("GAMEID") or env.get("UMU_ID"):


### PR DESCRIPTION
In order to avoid growing the Game class beyond what's reasonable, I've separated it into 2 classes. The Game class handles what is related to the game's data and also its management on the filesystem. The GameLauncher class handles the game execution and what's related to it. 

This is quite a substantial change and there are possibly still some bugs. I tried to add a maximum of type hints to avoid as many errors as possible.  I did some testing, native games and umu are working but there is still an issue with wine games which I suspect is something I missed related to PID tracking.