### PR TITLE
Fix NoneType error in get_game_id function

### DIFF
--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -100,14 +100,22 @@ def get_proton_path_from_bin(wine_path):
 
 
 def get_game_id(game) -> str:
-    games_path = os.path.join(settings.RUNTIME_DIR, "umu-games/umu-games.json")
-    env = game.runner.get_env()
-    if game and env.get("GAMEID") or env.get("UMU_ID"):
-        return env.get("GAMEID") or env.get("UMU_ID")
-    if not os.path.exists(games_path) or not game:
+    if not game:
         return DEFAULT_GAMEID
+
+    envs = game.runner.get_env()
+    game_id = envs.get("GAMEID") or envs.get("UMU_ID")
+    if game_id:
+        return game_id
+
+    games_path = os.path.join(settings.RUNTIME_DIR, "umu-games/umu-games.json")
+
+    if not os.path.exists(games_path):
+        return DEFAULT_GAMEID
+
     with open(games_path, "r", encoding="utf-8") as games_file:
         umu_games = json.load(games_file)
+
     for umu_game in umu_games:
         if (
             umu_game["store"]


### PR DESCRIPTION
Fixes a NoneType error with `game.runner.get_env()`. The previous code did not check if the `game` object was None this resulted in an error when `get_game_id` was called from [winexec](https://github.com/lutris/lutris/blob/b3914c6be78f9dd1da2c8c769eabef9c4a43b300/lutris/runners/commands/wine.py#L338C1-L341C75). Also did a small refactor to make it more readable.