### PR TITLE
Ensure that LC_ALL gets treated as HOST_LC_ALL for proton compatibility

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -31,13 +31,13 @@ def get_launch_parameters(runner, gameplay_info):
         env["LC_ALL"] = ""
 
     # Set correct LC_ALL depending on user settings
-    if system_config["locale"] != "":
-        env["LC_ALL"] = system_config["locale"]
-
+    locale = system_config.get("locale")
+    if locale:
+        env["LC_ALL"] = locale
     if runner.name == "wine":
         wine_version = runner.runner_config.get("version")
-        if wine_version and proton.is_proton_path(wine_version):
-            env["HOST_LC_ALL"] = system_config["locale"]
+        if wine_version and locale and proton.is_proton_path(wine_version):
+            env["HOST_LC_ALL"] = locale
 
     # MangoHud
     if runner.name == "steam":

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -339,6 +339,10 @@ def wineexec(
         game = None
         wineenv["GAMEID"] = proton.get_game_id(game)
         wineenv["PROTONPATH"] = proton.get_proton_path_from_bin(wine_path)
+        locale = env.get("LC_ALL")
+        host_locale = env.get("HOST_LC_ALL")
+        if locale and not host_locale:
+            wineenv["HOST_LC_ALL"] = locale
 
     baseenv = runner.get_env(disable_runtime=disable_runtime)
     baseenv.update(wineenv)

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1128,6 +1128,12 @@ class wine(Runner):
                     env["PROTONPATH"] = wine_exe[: wine_exe.index("dist/bin")]
                 except ValueError:
                     pass
+
+            locale = env.get("LC_ALL")
+            host_locale = env.get("HOST_LC_ALL")
+            if locale and not host_locale:
+                env["HOST_LC_ALL"] = locale
+
         return env
 
     def get_runtime_env(self):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1120,7 +1120,7 @@ class wine(Runner):
         env["WINEDLLOVERRIDES"] = get_overrides_env(self.dll_overrides)
 
         if proton.is_proton_path(wine_config_version):
-            # In stable versions of proton this can be dist/bin insteasd of files/bin
+            # In stable versions of proton this can be dist/bin instead of files/bin
             if "files/bin" in wine_exe:
                 env["PROTONPATH"] = wine_exe[: wine_exe.index("files/bin")]
             else:


### PR DESCRIPTION
In the previous [pull request](https://github.com/lutris/lutris/pull/5420), I ensured that the HOST_LC_ALL environment variable is set when the locale option is specified under game execution and the runner is Proton. This works, however a many install scripts set LC_ALL directly. This pull request addresses this issue by automatically setting HOST_LC_ALL to LC_ALL if LC_ALL is defined but HOST_LC_ALL is not, and the wine version is Proton. 

To achieve this I first changed wine runner's `get_env` to do the necessary logic to check if there is an LC_ALL and set the HOST_LC_ALL. 

Additionally, modifications were made to the `wineexec` function, as it is called directly in install scripts and does not retrieve the locale environment variable from the runner object, but rather the script itself through the env parameter. Similarly the `wineexec` function now checks that if it got an LC_ALL and the wine version is proton, then set HOST_LC_ALL. 

Lastly a bug fix was made in the `runner_interpreter.py` to ensure that if there is no locale set don't set HOST_LC_ALL to None but leave it untouched.