### PR TITLE
Add UMU-Proton to dropdown menu

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -655,7 +655,7 @@ class Game(GObject.Object):
     def get_store_name(self) -> str:
         store = self.service
         if not store:
-            return ""
+            return "none"
         if self.service == "humblebundle":
             return "humble"
         return store

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -672,10 +672,12 @@ class Game(GObject.Object):
 
         if env.get("WINEARCH") == "win32" and "umu" in " ".join(command):
             raise RuntimeError("Proton is not compatible with 32bit prefixes")
-
         # Allow user to override default umu environment variables to apply fixes
         env["GAMEID"] = proton.get_game_id(self)
         env["STORE"] = env.get("STORE") or self.get_store_name()
+
+        if env.get("WINE") == proton.PROTON_LATEST:  # GE-Proton, not UMU-Proton
+            env["PROTONPATH"] = "GE-Proton"
 
         # Some environment variables for the use of custom pre-launch and post-exit scripts.
         env["GAME_NAME"] = self.name

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -737,7 +737,7 @@ class wine(Runner):
         """
         if version is None:
             version = self.read_version_from_config()
-        if version == proton.GE_PROTON_LATEST:
+        if version == proton.GE_PROTON_LATEST or version == proton.PROTON_LATEST:
             return version
         wine_path = self.get_path_for_version(version)
         if system.path_exists(wine_path):

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -9,7 +9,8 @@ from lutris import settings
 from lutris.util import system
 from lutris.util.steam.config import get_steamapps_dirs
 
-GE_PROTON_LATEST = _("GE-Proton (Latest)")
+GE_PROTON_LATEST = _("UMU-Proton (Latest)")
+PROTON_LATEST = _("GE-Proton (Latest)")
 DEFAULT_GAMEID = "umu-default"
 
 
@@ -71,7 +72,7 @@ def list_proton_versions() -> List[str]:
     umu_path = get_umu_path()
     if not umu_path:
         return []
-    versions = [GE_PROTON_LATEST]
+    versions = [GE_PROTON_LATEST, PROTON_LATEST]
     for proton_path in get_proton_paths():
         for version in [p for p in os.listdir(proton_path) if "Proton" in p]:
             path = os.path.join(proton_path, version, "dist/bin/wine")


### PR DESCRIPTION
Currently in the Lutris client when using umu, UMU-Proton is used as the wine version instead of GE-Proton despite the dropdown menu listing 'GE-Proton (Latest)'. This is misleading and for users to use the real GE-Proton, the environment variable `PROTONPATH=GE-Proton` needs to be added in the System Options menu. This pull request adds UMU-Proton to the wine version dropdown menu and ensures the default value for the `STORE` environment variable is 'none' to ensure the UMU database is referenced for umu gamefixes such as [umu-starcitizen](https://github.com/Open-Wine-Components/umu-protonfixes/blob/master/gamefixes-umu/umu-starcitizen.py).
