### PR TITLE
Fancy Game Search

### DIFF
--- a/lutris/database/categories.py
+++ b/lutris/database/categories.py
@@ -69,6 +69,15 @@ def get_category(name):
         return categories[0]
 
 
+def normalized_category_names(name: str) -> List[str]:
+    """Searches for a category name case-insensitively and returns all matching names;
+    if none match, it just returns 'name' as is."""
+    query = "SELECT name FROM categories WHERE name=? COLLATE NOCASE"
+    parameters = (name,)
+    names = [cat["name"] for cat in sql.db_query(settings.DB_PATH, query, parameters)]
+    return names or [name]
+
+
 def get_game_ids_for_categories(included_category_names=None, excluded_category_names=None):
     """Get the ids of games in database."""
     filters = []

--- a/lutris/database/categories.py
+++ b/lutris/database/categories.py
@@ -69,12 +69,22 @@ def get_category(name):
         return categories[0]
 
 
-def normalized_category_names(name: str) -> List[str]:
+def normalized_category_names(name: str, subname_allowed: bool = False) -> List[str]:
     """Searches for a category name case-insensitively and returns all matching names;
-    if none match, it just returns 'name' as is."""
+    if none match, it just returns 'name' as is.
+
+    If subname_allowed is true but name is not a match for any category, we'll look for
+    any category that contains the name as a substring instead before falling back to
+    'name' itself."""
     query = "SELECT name FROM categories WHERE name=? COLLATE NOCASE"
     parameters = (name,)
     names = [cat["name"] for cat in sql.db_query(settings.DB_PATH, query, parameters)]
+
+    if not names and subname_allowed:
+        query = "SELECT name FROM categories WHERE name LIKE ? COLLATE NOCASE"
+        parameters = (f"%{name}%",)
+        names = [cat["name"] for cat in sql.db_query(settings.DB_PATH, query, parameters)]
+
     return names or [name]
 
 

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -1162,12 +1162,22 @@ def import_game(file_path, dest_dir):
 
 
 class GameSearch:
+    flag_texts = {"true": True, "yes": True, "false": False, "no": False}
+
     def __init__(self, text: str) -> None:
         self.text = text
         self.predicates: List[Callable] = []
 
         if text:
-            self.add_predicate(GameSearch.get_text_predicate(text))
+            for part in text.split():
+                if part.casefold().startswith("installed:"):
+                    installed_text = part[10:].casefold()
+                    if installed_text in GameSearch.flag_texts:
+                        installed = GameSearch.flag_texts[installed_text]
+                        self.add_predicate(GameSearch.get_installed_predicate(installed=installed))
+                        continue
+
+                self.add_predicate(GameSearch.get_text_predicate(part))
 
     def __str__(self):
         return self.text

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -9,7 +9,7 @@ import signal
 import subprocess
 import time
 from gettext import gettext as _
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import cast
 
 from gi.repository import Gio, GLib, GObject, Gtk
 
@@ -34,7 +34,6 @@ from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import LOG_BUFFERS, logger
 from lutris.util.process import Process
 from lutris.util.steam.shortcut import remove_shortcut as remove_steam_shortcut
-from lutris.util.strings import strip_accents
 from lutris.util.system import fix_path_case
 from lutris.util.timer import Timer
 from lutris.util.wine import proton
@@ -1159,80 +1158,3 @@ def import_game(file_path, dest_dir):
         service_id=lutris_config["service_id"],
     )
     print("Added game with ID %s" % game_id)
-
-
-class BaseSearch:
-    flag_texts = {"true": True, "yes": True, "false": False, "no": False}
-
-    def __init__(self, text: str) -> None:
-        self.text = text
-        self.predicates: List[Callable] = []
-
-        if text:
-            for part in text.split():
-                if ":" in part:
-                    pos = part.index(":", 1)
-                    name = part[:pos]
-                    value = part[(pos + 1) :]
-                    predicate = self.get_part_predicate(name, value)
-                    if predicate:
-                        self.add_predicate(predicate)
-                        continue
-
-                self.add_predicate(GameSearch.get_text_predicate(part))
-
-    def __str__(self) -> str:
-        return self.text
-
-    def add_predicate(self, predicate: Callable) -> None:
-        self.predicates.append(predicate)
-
-    def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
-        return None
-
-    @property
-    def is_empty(self) -> bool:
-        return not self.predicates
-
-    def matches(self, db_game: Dict[str, Any], service) -> bool:
-        for predicate in self.predicates:
-            if not predicate(db_game, service):
-                return False
-
-        return True
-
-    @staticmethod
-    def get_text_predicate(text: str) -> Callable:
-        stripped = strip_accents(text).casefold()
-
-        def match_text(db_game, service):
-            name = strip_accents(db_game["name"]).casefold()
-            return stripped in name
-
-        return match_text
-
-
-class GameSearch(BaseSearch):
-    def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
-        if name.casefold() == "installed":
-            if value in GameSearch.flag_texts:
-                installed = GameSearch.flag_texts[value]
-                return self.get_installed_predicate(installed)
-
-        return super().get_part_predicate(name, value)
-
-    @classmethod
-    def get_installed_predicate(cls, installed: bool) -> Callable:
-        def match_installed(db_game, service):
-            is_installed = GameSearch._is_installed(db_game, service)
-            return installed == is_installed
-
-        return match_installed
-
-    @classmethod
-    def _is_installed(cls, db_game: Dict[str, Any], service) -> bool:
-        if service:
-            appid = db_game.get("appid")
-            return bool(appid and appid in games_db.get_service_games(service.id))
-
-        return bool(db_game["installed"])

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -9,7 +9,7 @@ import signal
 import subprocess
 import time
 from gettext import gettext as _
-from typing import cast, Any, Dict, Optional
+from typing import Any, Dict, Optional, cast
 
 from gi.repository import Gio, GLib, GObject, Gtk
 
@@ -1174,11 +1174,19 @@ class GameSearch:
     def is_empty(self):
         return not self.stripped and self.installed is None
 
-    def matches(self, db_game: Dict[str, Any], service: 'Service') -> bool:
-        if self.installed is not None and service:
-            not_installed = "appid" in db_game and db_game["appid"] not in games_db.get_service_games(service.id)
-            if self.installed != (not not_installed):
+    def matches(self, db_game: Dict[str, Any], service) -> bool:
+        if self.installed is not None:
+            installed = self._is_installed(db_game, service)
+            if self.installed != installed:
                 return False
 
         name = strip_accents(db_game["name"]).casefold()
         return self.stripped in name
+
+    @staticmethod
+    def _is_installed(db_game: Dict[str, Any], service) -> bool:
+        if service:
+            appid = db_game.get("appid")
+            return bool(appid and appid in games_db.get_service_games(service.id))
+
+        return bool(db_game["installed"])

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -11,7 +11,7 @@ import time
 from gettext import gettext as _
 from typing import cast
 
-from gi.repository import Gio, GLib, GObject, Gtk
+from gi.repository import Gio, GLib, Gtk
 
 from lutris import settings
 from lutris.config import LutrisConfig

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -9,7 +9,7 @@ import signal
 import subprocess
 import time
 from gettext import gettext as _
-from typing import Any, Dict, Optional, cast
+from typing import Any, Callable, Dict, List, cast
 
 from gi.repository import Gio, GLib, GObject, Gtk
 
@@ -1162,26 +1162,47 @@ def import_game(file_path, dest_dir):
 
 
 class GameSearch:
-    def __init__(self, text: str, installed: Optional[bool] = None) -> None:
+    def __init__(self, text: str) -> None:
         self.text = text
-        self.stripped = strip_accents(text).casefold()
-        self.installed = installed
+        self.predicates: List[Callable] = []
+
+        if text:
+            self.add_predicate(GameSearch.get_text_predicate(text))
 
     def __str__(self):
         return self.text
 
+    def add_predicate(self, predicate: Callable) -> None:
+        self.predicates.append(predicate)
+
     @property
     def is_empty(self):
-        return not self.stripped and self.installed is None
+        return not self.predicates
 
     def matches(self, db_game: Dict[str, Any], service) -> bool:
-        if self.installed is not None:
-            installed = self._is_installed(db_game, service)
-            if self.installed != installed:
+        for predicate in self.predicates:
+            if not predicate(db_game, service):
                 return False
 
-        name = strip_accents(db_game["name"]).casefold()
-        return self.stripped in name
+        return True
+
+    @staticmethod
+    def get_text_predicate(text: str) -> Callable:
+        stripped = strip_accents(text).casefold()
+
+        def match_text(db_game, service):
+            name = strip_accents(db_game["name"]).casefold()
+            return stripped in name
+
+        return match_text
+
+    @staticmethod
+    def get_installed_predicate(installed: bool) -> Callable:
+        def match_installed(db_game, service):
+            is_installed = GameSearch._is_installed(db_game, service)
+            return installed == is_installed
+
+        return match_installed
 
     @staticmethod
     def _is_installed(db_game: Dict[str, Any], service) -> bool:

--- a/lutris/gui/config/game_common.py
+++ b/lutris/gui/config/game_common.py
@@ -123,12 +123,13 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
             show_search = current_page_index in self.searchable_page_indices
             self.set_search_entry_visibility(show_search)
 
-    def set_search_entry_visibility(self, show_search, placeholder_text=None):
+    def set_search_entry_visibility(self, show_search, placeholder_text=None, tooltip_markup=None):
         """Explicitly shows or hides the search entry; can also update the placeholder text."""
         header_bar = self.get_header_bar()
         if show_search and self.search_entry:
             header_bar.set_custom_title(self.search_entry)
             self.search_entry.set_placeholder_text(placeholder_text or self.get_search_entry_placeholder())
+            self.search_entry.set_tooltip_markup(tooltip_markup)
         else:
             header_bar.set_custom_title(None)
 

--- a/lutris/gui/config/preferences_dialog.py
+++ b/lutris/gui/config/preferences_dialog.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=no-member
 from gettext import gettext as _
+from textwrap import dedent
 
 from gi.repository import GObject, Gtk
 
@@ -91,7 +92,15 @@ class PreferencesDialog(GameDialogCommon):
         if stack_id == "system-stack":
             self.set_search_entry_visibility(True)
         elif stack_id == "runners-stack":
-            self.set_search_entry_visibility(True, self.runners_box.search_entry_placeholder_text)
+            tooltip_markup = """
+            Enter the name or description of a runner to search for, or use search terms:
+
+            <b>installed:</b><i>true</i>	    Only installed runners.
+            """
+            tooltip_markup = dedent(tooltip_markup).strip()
+            self.set_search_entry_visibility(
+                True, self.runners_box.search_entry_placeholder_text, tooltip_markup=tooltip_markup
+            )
         else:
             self.set_search_entry_visibility(False)
 

--- a/lutris/gui/config/runners_box.py
+++ b/lutris/gui/config/runners_box.py
@@ -8,6 +8,7 @@ from lutris import runners, settings
 from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.widgets.utils import open_uri
+from lutris.search import RunnerSearch
 
 
 class RunnersBox(BaseConfigBox):
@@ -15,7 +16,7 @@ class RunnersBox(BaseConfigBox):
 
     def __init__(self):
         super().__init__()
-        self._filter = ""
+        self._runner_search = RunnerSearch("")
         self.search_entry_placeholder_text = ""
 
         self.add(self.get_section_label(_("Add, remove or configure runners")))
@@ -51,21 +52,21 @@ class RunnersBox(BaseConfigBox):
 
     @property
     def filter(self):
-        return self._filter
+        return self._runner_search.text
 
     @filter.setter
     def filter(self, value):
-        self._filter = value
+        self._runner_search = RunnerSearch(value)
         self._update_row_visibility()
 
     def _update_row_visibility(self):
-        text = self.filter.lower()
+        search = self._runner_search
 
         any_matches = False
         for row in self.runner_listbox.get_children():
             runner_box = row.get_child()
             runner = runner_box.runner
-            match = text in runner.name.lower() or text in runner.description.lower()
+            match = search.matches(runner)
             row.set_visible(match)
             if match:
                 any_matches = True

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -426,8 +426,10 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def filter_games(self, games):
         """Filters a list of games according to the 'installed' and 'text' filters, if those are
         set. But if not, can just return games unchanged."""
-        installed = True if self.filters.get("installed") else None
-        search = GameSearch(self.filters.get("text") or "", installed=installed)
+        search = GameSearch(self.filters.get("text") or "")
+
+        if self.filters.get("installed"):
+            search.add_predicate(GameSearch.get_installed_predicate(installed=True))
 
         if search.is_empty:
             return games

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -426,6 +426,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         return sorted(games, key=lambda game: max(game["installed_at"] or 0, game["lastplayed"] or 0), reverse=True)
 
     def get_game_search(self):
+        """Returns a game-search object for the current view settings and search text; this object
+        is cached so that we need not re-parse the search if it has not changed."""
         text = self.filters.get("text") or ""
         if self.game_search is None or self.game_search.service != self.service or self.game_search.text != text:
             self.game_search = GameSearch(text, self.service)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -427,15 +427,15 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def filter_games(self, games):
         """Filters a list of games according to the 'installed' and 'text' filters, if those are
         set. But if not, can just return games unchanged."""
-        search = GameSearch(self.filters.get("text") or "")
+        search = GameSearch(self.filters.get("text") or "", self.service)
 
         if self.filters.get("installed"):
-            search.add_predicate(GameSearch.get_installed_predicate(installed=True))
+            search.add_predicate(search.get_installed_predicate(installed=True))
 
         if search.is_empty:
             return games
 
-        return [game for game in games if search.matches(game, self.service)]
+        return [game for game in games if search.matches(game)]
 
     def set_service(self, service_name):
         if self.service and self.service.id == service_name:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -37,8 +37,8 @@ from lutris.gui.widgets.gi_composites import GtkTemplate
 from lutris.gui.widgets.sidebar import LutrisSidebar
 from lutris.gui.widgets.utils import load_icon_theme, open_uri
 from lutris.runtime import ComponentUpdater, RuntimeUpdater
-from lutris.services.base import BaseService, SERVICE_GAMES_LOADED, SERVICE_LOGIN, SERVICE_LOGOUT
 from lutris.search import GameSearch
+from lutris.services.base import SERVICE_GAMES_LOADED, SERVICE_LOGIN, SERVICE_LOGOUT
 from lutris.services.lutris import LutrisService
 from lutris.util import datapath
 from lutris.util.jobs import COMPLETED_IDLE_TASK, AsyncCall, schedule_at_idle

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -37,7 +37,8 @@ from lutris.gui.widgets.gi_composites import GtkTemplate
 from lutris.gui.widgets.sidebar import LutrisSidebar
 from lutris.gui.widgets.utils import load_icon_theme, open_uri
 from lutris.runtime import ComponentUpdater, RuntimeUpdater
-from lutris.services.base import SERVICE_GAMES_LOADED, SERVICE_LOGIN, SERVICE_LOGOUT
+from lutris.services.base import BaseService, SERVICE_GAMES_LOADED, SERVICE_LOGIN, SERVICE_LOGOUT
+from lutris.search import GameSearch
 from lutris.services.lutris import LutrisService
 from lutris.util import datapath
 from lutris.util.jobs import COMPLETED_IDLE_TASK, AsyncCall, schedule_at_idle

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -44,13 +44,12 @@ from lutris.util.jobs import COMPLETED_IDLE_TASK, AsyncCall, schedule_at_idle
 from lutris.util.library_sync import LOCAL_LIBRARY_UPDATED, LibrarySyncer
 from lutris.util.log import logger
 from lutris.util.path_cache import MISSING_GAMES, add_to_path_cache
-from lutris.util.strings import get_natural_sort_key, strip_accents
+from lutris.util.strings import get_natural_sort_key
 from lutris.util.system import update_desktop_icons
 
 
 @GtkTemplate(ui=os.path.join(datapath.get(), "ui", "lutris-window.ui"))
-class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
-                   DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
+class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """Handler class for main window signals."""
 
     default_view_type = "grid"
@@ -241,6 +240,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
                 action.connect("change-state", value.callback)
             self.actions[name] = action
             if value.enabled:
+
                 def updater(action=action, value=value):
                     action.props.enabled = value.enabled()
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -982,7 +982,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def on_search_entry_changed(self, entry):
         """Callback for the search input keypresses"""
         self.search_timer_task.unschedule()
-        self.filters["text"] = entry.get_text().lower().strip()
+        self.filters["text"] = entry.get_text().strip()
         self.search_timer_task = schedule_at_idle(self.update_store, delay_seconds=0.5)
 
     @GtkTemplate.Callback

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -21,7 +21,7 @@ from lutris.database import categories as categories_db
 from lutris.database import games as games_db
 from lutris.database.services import ServiceGameCollection
 from lutris.exceptions import EsyncLimitError
-from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game, GameSearch
+from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
 from lutris.gui.config.preferences_dialog import PreferencesDialog

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -36,7 +36,7 @@ class BaseSearch:
                 pos = raw.index(":", 1)
                 name = raw[:pos].strip().casefold()
                 if name in self.tags:
-                    value = raw[(pos + 1) :].strip()
+                    value = raw[(pos + 1):].strip()
                     components.append((name, value, raw))
                     continue
             components.append(("", raw, raw))
@@ -82,7 +82,7 @@ class BaseSearch:
 
 
 class GameSearch(BaseSearch):
-    tags = ["installed", "categorized", "category", "runner", "platform"]
+    tags = ["installed", "favorite", "categorized", "category", "runner", "platform"]
 
     def __init__(self, text: str, service) -> None:
         self.service = service
@@ -95,6 +95,10 @@ class GameSearch(BaseSearch):
         if name.casefold() == "installed" and value in self.flag_texts:
             installed = self.flag_texts[value]
             return self.get_installed_predicate(installed)
+
+        if name.casefold() == "favorite" and value in self.flag_texts:
+            installed = self.flag_texts[value]
+            return self.get_category_predicate("favorite", in_category=installed)
 
         if name.casefold() == "categorized" and value in self.flag_texts:
             categorized = self.flag_texts[value]
@@ -138,13 +142,14 @@ class GameSearch(BaseSearch):
 
         return match_categorized
 
-    def get_category_predicate(self, category: str) -> Callable:
+    def get_category_predicate(self, category: str, in_category: bool = True) -> Callable:
         names = normalized_category_names(category)
         category_game_ids = set(get_game_ids_for_categories(names))
 
         def match_categorized(db_game):
             game_id = db_game["id"]
-            return game_id in category_game_ids
+            game_in_category = game_id in category_game_ids
+            return game_in_category == in_category
 
         return match_categorized
 

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -1,7 +1,11 @@
 from typing import Any, Callable, Dict, List, Optional
 
 from lutris.database import games
-from lutris.database.categories import get_game_ids_for_categories, get_uncategorized_game_ids
+from lutris.database.categories import (
+    get_game_ids_for_categories,
+    get_uncategorized_game_ids,
+    normalized_category_names,
+)
 from lutris.runners.runner import Runner
 from lutris.util.strings import strip_accents
 
@@ -107,7 +111,8 @@ class GameSearch(BaseSearch):
         return match_categorized
 
     def get_category_predicate(self, category: str) -> Callable:
-        category_game_ids = set(get_game_ids_for_categories([category]))
+        names = normalized_category_names(category)
+        category_game_ids = set(get_game_ids_for_categories(names))
 
         def match_categorized(db_game):
             game_id = db_game["id"]

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -8,6 +8,7 @@ from lutris.database.categories import (
     get_uncategorized_game_ids,
     normalized_category_names,
 )
+from lutris.runners import get_runner_human_name
 from lutris.runners.runner import Runner
 from lutris.services import SERVICES
 from lutris.util.strings import parse_playtime_parts, strip_accents
@@ -372,12 +373,14 @@ class GameSearch(BaseSearch):
 
         def match_service(db_game):
             game_service = db_game.get("service")
-            if game_service:
-                if game_service.casefold() == service_name:
-                    return True
+            if not game_service:
+                return False
 
-                service = SERVICES.get(game_service)
-                return service and service_name == service.name.casefold()
+            if game_service.casefold() == service_name:
+                return True
+
+            service = SERVICES.get(game_service)
+            return service and service.name.casefold() == service_name
 
         return match_service
 
@@ -386,7 +389,15 @@ class GameSearch(BaseSearch):
 
         def match_runner(db_game):
             game_runner = db_game.get("runner")
-            return game_runner and game_runner.casefold() == runner_name
+
+            if not game_runner:
+                return False
+
+            if game_runner.casefold() == runner_name:
+                return True
+
+            runner_human_name = get_runner_human_name(game_runner)
+            return runner_human_name.casefold() == runner_name
 
         return match_runner
 

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -358,7 +358,7 @@ class GameSearch(BaseSearch):
         return match_categorized
 
     def get_category_predicate(self, category: str, in_category: bool = True) -> Callable:
-        names = normalized_category_names(category)
+        names = normalized_category_names(category, subname_allowed=True)
         category_game_ids = set(get_game_ids_for_categories(names))
 
         def match_categorized(db_game):
@@ -380,7 +380,7 @@ class GameSearch(BaseSearch):
                 return True
 
             service = SERVICES.get(game_service)
-            return service and service.name.casefold() == service_name
+            return service and service_name in service.name.casefold()
 
         return match_service
 
@@ -397,7 +397,7 @@ class GameSearch(BaseSearch):
                 return True
 
             runner_human_name = get_runner_human_name(game_runner)
-            return runner_human_name.casefold() == runner_name
+            return runner_name in runner_human_name.casefold()
 
         return match_runner
 
@@ -407,10 +407,11 @@ class GameSearch(BaseSearch):
         def match_platform(db_game):
             game_platform = db_game.get("platform")
             if game_platform:
-                return game_platform.casefold() == platform
+                return platform in game_platform.casefold()
             if self.service:
                 platforms = [p.casefold() for p in self.service.get_game_platforms(db_game)]
-                return platform in platforms
+                matches = [p for p in platforms if platform in p]
+                return any(matches)
             return False
 
         return match_platform

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -19,7 +19,7 @@ from lutris.util.tokenization import (
 )
 
 ISOLATED_TOKENS = set([":", "-", "(", ")", "<", ">", ">=", "<="])
-ITEM_STOP_TOKENS = (ISOLATED_TOKENS | set(["OR", "AND"])) - set(["("])
+ITEM_STOP_TOKENS = (ISOLATED_TOKENS | set(["OR", "AND"])) - set(["(", "-"])
 
 SearchPredicate = Callable[[Any], bool]
 

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -1,6 +1,7 @@
 from typing import Any, Callable, Dict, List, Optional
 
 from lutris.database import games
+from lutris.runners.runner import Runner
 from lutris.util.strings import strip_accents
 
 
@@ -67,8 +68,8 @@ class GameSearch(BaseSearch):
 
     def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
         if name.casefold() == "installed":
-            if value in GameSearch.flag_texts:
-                installed = GameSearch.flag_texts[value]
+            if value in self.flag_texts:
+                installed = self.flag_texts[value]
                 return self.get_installed_predicate(installed)
 
         return super().get_part_predicate(name, value)
@@ -86,3 +87,23 @@ class GameSearch(BaseSearch):
             return bool(appid and appid in games.get_service_games(self.service.id))
 
         return bool(db_game["installed"])
+
+
+class RunnerSearch(BaseSearch):
+    def get_candidate_text(self, candidate: Any) -> str:
+        return f"{candidate.name}\n{candidate.description}"
+
+    def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
+        if name.casefold() == "installed":
+            if value in self.flag_texts:
+                installed = self.flag_texts[value]
+                return self.get_installed_predicate(installed)
+
+        return super().get_part_predicate(name, value)
+
+    def get_installed_predicate(self, installed: bool) -> Callable:
+        def match_installed(runner: Runner):
+            is_installed = runner.is_installed()
+            return installed == is_installed
+
+        return match_installed

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -9,7 +9,7 @@ from lutris.database.categories import (
     normalized_category_names,
 )
 from lutris.runners.runner import Runner
-from lutris.util.strings import parse_playtime, strip_accents
+from lutris.util.strings import parse_playtime_parts, strip_accents
 from lutris.util.tokenization import (
     TokenReader,
     clean_token,
@@ -289,7 +289,7 @@ class GameSearch(BaseSearch):
 
         def match_playtime(db_game):
             game_playtime = value_function(db_game)
-            return game_playtime and game_playtime == duration
+            return game_playtime and duration_parts.matches(game_playtime)
 
         operator = tokens.peek_token()
         if operator == ">":
@@ -313,7 +313,8 @@ class GameSearch(BaseSearch):
             raise InvalidSearchTermError("A blank is not a valid duration.")
 
         try:
-            duration = parse_playtime(duration_text)
+            duration_parts = parse_playtime_parts(duration_text)
+            duration = duration_parts.get_total_hours()
         except ValueError as ex:
             raise InvalidSearchTermError(f"'{duration_text}' is not a valid playtime.") from ex
 

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -191,7 +191,9 @@ class BaseSearch:
 
 
 class GameSearch(BaseSearch):
-    tags = set(["installed", "hidden", "favorite", "categorized", "category", "runner", "platform", "playtime"])
+    tags = set(
+        ["installed", "hidden", "favorite", "categorized", "category", "runner", "platform", "playtime", "directory"]
+    )
 
     def __init__(self, text: str, service) -> None:
         self.service = service
@@ -215,6 +217,10 @@ class GameSearch(BaseSearch):
 
         if name == "playtime":
             return self.get_playtime_predicate(tokens)
+
+        if name == "directory":
+            directory = tokens.get_cleaned_token_sequence(stop_tokens=ITEM_STOP_TOKENS) or ""
+            return self.get_directory_predicate(directory)
 
         # All flags handle the 'maybe' option the same way, so we'll
         # group them at the end.
@@ -280,6 +286,13 @@ class GameSearch(BaseSearch):
             raise InvalidSearchTermError(f"'{playtime_text}' is not a valid playtime.") from ex
 
         return matcher
+
+    def get_directory_predicate(self, directory: str) -> Callable:
+        def match_directory(db_game):
+            game_dir = db_game.get("directory")
+            return game_dir and directory in game_dir
+
+        return match_directory
 
     def get_installed_predicate(self, installed: bool) -> Callable:
         def match_installed(db_game):

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -1,0 +1,81 @@
+from typing import Any, Callable, Dict, List, Optional
+
+from lutris.database import games
+from lutris.util.strings import strip_accents
+
+
+class BaseSearch:
+    flag_texts = {"true": True, "yes": True, "false": False, "no": False}
+
+    def __init__(self, text: str) -> None:
+        self.text = text
+        self.predicates: List[Callable] = []
+
+        if text:
+            for part in text.split():
+                if ":" in part:
+                    pos = part.index(":", 1)
+                    name = part[:pos]
+                    value = part[(pos + 1) :]
+                    predicate = self.get_part_predicate(name, value)
+                    if predicate:
+                        self.add_predicate(predicate)
+                        continue
+
+                self.add_predicate(GameSearch.get_text_predicate(part))
+
+    def __str__(self) -> str:
+        return self.text
+
+    def add_predicate(self, predicate: Callable) -> None:
+        self.predicates.append(predicate)
+
+    def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
+        return None
+
+    @property
+    def is_empty(self) -> bool:
+        return not self.predicates
+
+    def matches(self, db_game: Dict[str, Any], service) -> bool:
+        for predicate in self.predicates:
+            if not predicate(db_game, service):
+                return False
+
+        return True
+
+    @staticmethod
+    def get_text_predicate(text: str) -> Callable:
+        stripped = strip_accents(text).casefold()
+
+        def match_text(db_game, service):
+            name = strip_accents(db_game["name"]).casefold()
+            return stripped in name
+
+        return match_text
+
+
+class GameSearch(BaseSearch):
+    def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
+        if name.casefold() == "installed":
+            if value in GameSearch.flag_texts:
+                installed = GameSearch.flag_texts[value]
+                return self.get_installed_predicate(installed)
+
+        return super().get_part_predicate(name, value)
+
+    @classmethod
+    def get_installed_predicate(cls, installed: bool) -> Callable:
+        def match_installed(db_game, service):
+            is_installed = GameSearch._is_installed(db_game, service)
+            return installed == is_installed
+
+        return match_installed
+
+    @classmethod
+    def _is_installed(cls, db_game: Dict[str, Any], service) -> bool:
+        if service:
+            appid = db_game.get("appid")
+            return bool(appid and appid in games.get_service_games(service.id))
+
+        return bool(db_game["installed"])

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -84,6 +84,14 @@ class GameSearch(BaseSearch):
             category = value.strip()
             return self.get_category_predicate(category)
 
+        if name.casefold() == "runner":
+            runner_name = value.strip()
+            return self.get_runner_predicate(runner_name)
+
+        if name.casefold() == "platform":
+            platform = value.strip()
+            return self.get_platform_predicate(platform)
+
         return super().get_part_predicate(name, value)
 
     def get_installed_predicate(self, installed: bool) -> Callable:
@@ -119,6 +127,29 @@ class GameSearch(BaseSearch):
             return game_id in category_game_ids
 
         return match_categorized
+
+    def get_runner_predicate(self, runner_name: str) -> Callable:
+        runner_name = runner_name.casefold()
+
+        def match_runner(db_game):
+            game_runner = db_game.get("runner")
+            return game_runner and game_runner.casefold() == runner_name
+
+        return match_runner
+
+    def get_platform_predicate(self, platform: str) -> Callable:
+        platform = platform.casefold()
+
+        def match_platform(db_game):
+            game_platform = db_game.get("platform")
+            if game_platform:
+                return game_platform.casefold() == platform
+            if self.service:
+                platforms = [p.casefold() for p in self.service.get_game_platforms(db_game)]
+                return platform in platforms
+            return False
+
+        return match_platform
 
 
 class RunnerSearch(BaseSearch):

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -1,4 +1,4 @@
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from lutris.database import games
 from lutris.database.categories import (
@@ -12,39 +12,60 @@ from lutris.util.strings import strip_accents
 
 class BaseSearch:
     flag_texts = {"true": True, "yes": True, "false": False, "no": False}
+    tags = []
 
     def __init__(self, text: str) -> None:
         self.text = text
-        self.predicates: List[Callable] = []
-
-        if text:
-            for part in text.split():
-                if ":" in part:
-                    pos = part.index(":", 1)
-                    name = part[:pos]
-                    value = part[(pos + 1) :]
-                    predicate = self.get_part_predicate(name, value)
-                    if predicate:
-                        self.add_predicate(predicate)
-                        continue
-
-                self.add_predicate(self.get_text_predicate(part))
+        self.predicates: Optional[List[Callable]] = None
 
     def __str__(self) -> str:
         return self.text
 
+    @property
+    def is_empty(self) -> bool:
+        return not self.text
+
+    def get_candidate_text(self, candidate: Any) -> str:
+        return str(candidate)
+
+    def get_components(self) -> List[Tuple[str, str, str]]:
+        components = []
+
+        for raw in self.text.split():
+            if ":" in raw:
+                pos = raw.index(":", 1)
+                name = raw[:pos].strip().casefold()
+                if name in self.tags:
+                    value = raw[(pos + 1) :].strip()
+                    components.append((name, value, raw))
+                    continue
+            components.append(("", raw, raw))
+
+        return components
+
+    def get_predicates(self) -> List[Callable]:
+        if self.predicates is None:
+            predicates = []
+            if self.text:
+                for name, value, raw in self.get_components():
+                    if name:
+                        predicate = self.get_part_predicate(name, value)
+                        if predicate:
+                            predicates.append(predicate)
+                            continue
+
+                    predicates.append(self.get_text_predicate(raw))
+            self.predicates = predicates
+        return self.predicates
+
     def add_predicate(self, predicate: Callable) -> None:
-        self.predicates.append(predicate)
+        self.get_predicates().append(predicate)
 
     def get_part_predicate(self, name: str, value: str) -> Optional[Callable]:
         return None
 
-    @property
-    def is_empty(self) -> bool:
-        return not self.predicates
-
     def matches(self, candidate: Any) -> bool:
-        for predicate in self.predicates:
+        for predicate in self.get_predicates():
             if not predicate(candidate):
                 return False
 
@@ -59,11 +80,10 @@ class BaseSearch:
 
         return match_text
 
-    def get_candidate_text(self, candidate: Any) -> str:
-        return str(candidate)
-
 
 class GameSearch(BaseSearch):
+    tags = ["installed", "categorized", "category", "runner", "platform"]
+
     def __init__(self, text: str, service) -> None:
         self.service = service
         super().__init__(text)
@@ -153,6 +173,8 @@ class GameSearch(BaseSearch):
 
 
 class RunnerSearch(BaseSearch):
+    tags = ["installed"]
+
     def get_candidate_text(self, candidate: Any) -> str:
         return f"{candidate.name}\n{candidate.description}"
 

--- a/lutris/util/strings.py
+++ b/lutris/util/strings.py
@@ -241,10 +241,22 @@ def parse_playtime(text: str) -> float:
         # number of some unit.
         hour_units = ["h", "hr", "hours", "hour", _("hour"), _("hours")]
         minute_units = ["m", "min", "minute", "minutes", _("minute"), _("minutes")]
+        day_units = ["d", _("day"), _("days")]
+        week_units = ["wk", _("week"), _("weeks")]
+        month_units = ["mo", _("month"), _("months")]
+        year_units = ["yr", _("year"), _("years")]
         if unit in hour_units:
             return num
         if unit in minute_units:
             return num / 60
+        if unit in day_units:
+            return num * 24
+        if unit in week_units:
+            return num * 24 * 7
+        if unit in month_units:
+            return num * 24 * 30
+        if unit in year_units:
+            return num * 24 * 365
         raise ValueError(error_message)
 
     # Handle the fancy format made of number unit pairts, like

--- a/lutris/util/tokenization.py
+++ b/lutris/util/tokenization.py
@@ -13,7 +13,7 @@ def clean_token(to_clean: Optional[str]) -> str:
     return to_clean.strip()
 
 
-def tokenize_search(text: str, isolated_tokens: Set[str]) -> Iterable[str]:
+def tokenize_search(text: str, isolated_tokens: Iterable[str]) -> Iterable[str]:
     """Iterates through a text and breaks in into tokens. Every character of the text is present
     in exactly one token returned, all in order, so the original text can be reconstructed by concatenating the
     tokens.
@@ -21,7 +21,10 @@ def tokenize_search(text: str, isolated_tokens: Set[str]) -> Iterable[str]:
     Tokens are separated by whitespace, but also certain characters (isolated_characters) are kept as separate tokens.
     Double-quoted text are protected from further tokenization."""
 
-    def _tokenize():
+    isolating_chars = set(ch for tok in isolated_tokens for ch in tok)
+    isolated_tokens = sorted(isolated_tokens, key=lambda tok: -len(tok))
+
+    def basic_tokenize():
         buffer = ""
         it = iter(text)
         while True:
@@ -33,13 +36,7 @@ def tokenize_search(text: str, isolated_tokens: Set[str]) -> Iterable[str]:
                 yield buffer
                 buffer = ""
 
-            # TODO: Support longer tokens here
-            if ch in isolated_tokens:
-                yield buffer
-                yield ch
-                buffer = ""
-                continue
-            elif ch == '"':
+            if ch == '"':
                 yield buffer
 
                 buffer = ch
@@ -60,8 +57,25 @@ def tokenize_search(text: str, isolated_tokens: Set[str]) -> Iterable[str]:
             buffer += ch
         yield buffer
 
+    def split_isolated_tokens(tokens: Iterable[str]) -> Iterable[str]:
+        for token in tokens:
+            i = 0
+            while i < len(token):
+                if token[i] in isolating_chars:
+                    for candidate in isolated_tokens:
+                        if token[i:].startswith(candidate):
+                            yield token[:i]
+                            yield candidate
+                            token = token[(i + len(candidate)) :]
+                            i = -1  # start again with reduced token!
+                            break
+                i += 1
+            yield token
+
     # Since we blindly return empty buffers, we must now filter them out
-    return filter(lambda t: len(t) > 0, _tokenize())
+    basic = basic_tokenize()
+    isolated = split_isolated_tokens(basic)
+    return filter(lambda t: len(t) > 0, isolated)
 
 
 class TokenReader:
@@ -114,15 +128,16 @@ class TokenReader:
                     buffer = token
                 break
             buffer += token
-        return buffer if buffer else None
+        return clean_token(buffer) if buffer else None
 
     def peek_token(self) -> Optional[str]:
         """Returns the next token, or None if the end of tokens has been reached. However,
         will not advance - repeated calls return the same token."""
-        if self.index >= len(self.tokens):
-            return None
 
-        return self.tokens[self.index]
+        saved_index = self.index
+        token = self.get_token()
+        self.index = saved_index
+        return token
 
     def consume(self, candidate: str) -> bool:
         """If the next token is 'candidate', advances over it and returns True;

--- a/lutris/util/tokenization.py
+++ b/lutris/util/tokenization.py
@@ -142,8 +142,10 @@ class TokenReader:
     def consume(self, candidate: str) -> bool:
         """If the next token is 'candidate', advances over it and returns True;
         if not returns False and leaves the token as it was."""
-        token = self.peek_token()
+        saved_index = self.index
+        token = self.get_token()
         if candidate and token == candidate:
-            self.index += 1
             return True
+
+        self.index = saved_index
         return False

--- a/lutris/util/tokenization.py
+++ b/lutris/util/tokenization.py
@@ -1,0 +1,117 @@
+from typing import Iterable, List, Optional, Set
+
+
+def clean_token(to_clean: Optional[str]) -> str:
+    if to_clean is None:
+        return ""
+
+    if to_clean.startswith('"'):
+        return to_clean[1:-1] if to_clean.endswith('"') else to_clean[1:]
+
+    return to_clean.strip()
+
+
+def tokenize_search(text: str, tags: Iterable[str]) -> Iterable[str]:
+    tag_set = set(tags)
+
+    def _tokenize():
+        buffer = ""
+        it = iter(text)
+        while True:
+            ch = next(it, None)
+            if ch is None:
+                break
+
+            if ch.isspace() != buffer.isspace():
+                yield buffer
+                buffer = ""
+
+            if ch == "-" or ch == "(" or ch == ")":
+                yield buffer
+                yield ch
+                buffer = ""
+                continue
+            elif ch == ":" and buffer.casefold() in tag_set:
+                buffer += ch
+                yield buffer
+                buffer = ""
+                continue
+            elif ch == '"':
+                yield buffer
+
+                buffer = ch
+                while True:
+                    ch = next(it, None)
+                    if ch is None:
+                        break
+
+                    buffer += ch
+
+                    if ch == '"':
+                        break
+
+                yield buffer
+                buffer = ""
+                continue
+
+            buffer += ch
+        yield buffer
+
+    return filter(lambda t: len(t) > 0, _tokenize())
+
+
+def implicitly_join_tokens(tokens: Iterable[str], isolated_tokens: Set[str]) -> Iterable[str]:
+    def is_isolated(t: str):
+        return t.startswith('"') or t in isolated_tokens
+
+    def _join():
+        buffer = ""
+        isolate_next = False
+        for token in tokens:
+            if token.endswith(":"):
+                yield buffer
+                yield token
+                buffer = ""
+                isolate_next = True
+                continue
+
+            if isolate_next or is_isolated(token):
+                yield buffer
+                yield token
+                buffer = ""
+            else:
+                buffer += token
+            isolate_next = False
+        yield buffer
+
+    return filter(lambda t: t and not t.isspace(), _join())
+
+
+class TokenReader:
+    def __init__(self, tokens: List[str]) -> None:
+        self.tokens = tokens
+        self.index = 0
+
+    def is_end_of_tokens(self):
+        return self.index >= len(self.tokens)
+
+    def get_token(self) -> Optional[str]:
+        if self.index >= len(self.tokens):
+            return None
+
+        token = self.tokens[self.index]
+        self.index += 1
+        return token
+
+    def peek_token(self) -> Optional[str]:
+        if self.index >= len(self.tokens):
+            return None
+
+        return self.tokens[self.index]
+
+    def consume(self, candidate: str) -> bool:
+        token = self.peek_token()
+        if token == candidate:
+            self.index += 1
+            return True
+        return False

--- a/lutris/util/tokenization.py
+++ b/lutris/util/tokenization.py
@@ -2,6 +2,8 @@ from typing import Iterable, List, Optional, Set
 
 
 def clean_token(to_clean: Optional[str]) -> str:
+    """Removes quotes from a token, if they are present; if they are not, this strips whitespace
+    off the token."""
     if to_clean is None:
         return ""
 
@@ -11,8 +13,14 @@ def clean_token(to_clean: Optional[str]) -> str:
     return to_clean.strip()
 
 
-def tokenize_search(text: str, tags: Iterable[str]) -> Iterable[str]:
-    tag_set = set(tags)
+def tokenize_search(text: str, isolated_characters: Set[str], tags: Set[str]) -> Iterable[str]:
+    """Iterates through a text and breaks in into tokens. Every character of the text is present
+    in exactly one token returned, all in order, so the original text can be reconstructed by concatenating the
+    tokens.
+
+    Tokens are separated by whitespace, but also certain characters (isolated_characters) are kept as separate tokens.
+    Double-quoted text are protected from further tokenization. Tokens that start with any of the 'tags', followed by
+    a ':' are also separated."""
 
     def _tokenize():
         buffer = ""
@@ -26,12 +34,12 @@ def tokenize_search(text: str, tags: Iterable[str]) -> Iterable[str]:
                 yield buffer
                 buffer = ""
 
-            if ch == "-" or ch == "(" or ch == ")":
+            if ch in isolated_characters:
                 yield buffer
                 yield ch
                 buffer = ""
                 continue
-            elif ch == ":" and buffer.casefold() in tag_set:
+            elif ch == ":" and buffer.casefold() in tags:
                 buffer += ch
                 yield buffer
                 buffer = ""
@@ -57,10 +65,15 @@ def tokenize_search(text: str, tags: Iterable[str]) -> Iterable[str]:
             buffer += ch
         yield buffer
 
+    # Since we blindly return empty buffers, we must now filter them out
     return filter(lambda t: len(t) > 0, _tokenize())
 
 
 def implicitly_join_tokens(tokens: Iterable[str], isolated_tokens: Set[str]) -> Iterable[str]:
+    """Iterates the tokens, but joins together consecutive tokens that aren't quoted and aren't
+    'special'; tags (ending with ':') are protected, along with the tag argument (its next token);
+    any tokens matching 'isolated_tokens' also won't be joined."""
+
     def is_isolated(t: str):
         return t.startswith('"') or t in isolated_tokens
 
@@ -69,6 +82,8 @@ def implicitly_join_tokens(tokens: Iterable[str], isolated_tokens: Set[str]) -> 
         isolate_next = False
         for token in tokens:
             if token.endswith(":"):
+                # If a tag is found, yield it separately, but remember to
+                # yield the next token separately too.
                 yield buffer
                 yield token
                 buffer = ""
@@ -84,18 +99,25 @@ def implicitly_join_tokens(tokens: Iterable[str], isolated_tokens: Set[str]) -> 
             isolate_next = False
         yield buffer
 
+    # Since we blindly return empty buffers, we must now filter them out
     return filter(lambda t: t and not t.isspace(), _join())
 
 
 class TokenReader:
+    """TokenReader reads through a list of tokens, like an iterator. But it can also peek ahead, and you
+    can save and store your 'place' in the token list via the 'index' member."""
+
     def __init__(self, tokens: List[str]) -> None:
         self.tokens = tokens
         self.index = 0
 
     def is_end_of_tokens(self):
+        """True if get_token() and peek_token() will return None."""
         return self.index >= len(self.tokens)
 
     def get_token(self) -> Optional[str]:
+        """Returns the next token, and advances one token in the list. Returns None if
+        the end of tokens has been reached."""
         if self.index >= len(self.tokens):
             return None
 
@@ -104,14 +126,18 @@ class TokenReader:
         return token
 
     def peek_token(self) -> Optional[str]:
+        """Returns the next token, or None if the end of tokens has been reached. However,
+        will not advance - repeated calls return the same token."""
         if self.index >= len(self.tokens):
             return None
 
         return self.tokens[self.index]
 
     def consume(self, candidate: str) -> bool:
+        """If the next token is 'candidate', advances over it and returns True;
+        if not returns False and leaves the token as it was."""
         token = self.peek_token()
-        if token == candidate:
+        if candidate and token == candidate:
             self.index += 1
             return True
         return False

--- a/lutris/util/tokenization.py
+++ b/lutris/util/tokenization.py
@@ -13,14 +13,13 @@ def clean_token(to_clean: Optional[str]) -> str:
     return to_clean.strip()
 
 
-def tokenize_search(text: str, isolated_characters: Set[str], tags: Set[str]) -> Iterable[str]:
+def tokenize_search(text: str, isolated_tokens: Set[str]) -> Iterable[str]:
     """Iterates through a text and breaks in into tokens. Every character of the text is present
     in exactly one token returned, all in order, so the original text can be reconstructed by concatenating the
     tokens.
 
     Tokens are separated by whitespace, but also certain characters (isolated_characters) are kept as separate tokens.
-    Double-quoted text are protected from further tokenization. Tokens that start with any of the 'tags', followed by
-    a ':' are also separated."""
+    Double-quoted text are protected from further tokenization."""
 
     def _tokenize():
         buffer = ""
@@ -34,14 +33,10 @@ def tokenize_search(text: str, isolated_characters: Set[str], tags: Set[str]) ->
                 yield buffer
                 buffer = ""
 
-            if ch in isolated_characters:
+            # TODO: Support longer tokens here
+            if ch in isolated_tokens:
                 yield buffer
                 yield ch
-                buffer = ""
-                continue
-            elif ch == ":" and buffer.casefold() in tags:
-                buffer += ch
-                yield buffer
                 buffer = ""
                 continue
             elif ch == '"':
@@ -69,40 +64,6 @@ def tokenize_search(text: str, isolated_characters: Set[str], tags: Set[str]) ->
     return filter(lambda t: len(t) > 0, _tokenize())
 
 
-def implicitly_join_tokens(tokens: Iterable[str], isolated_tokens: Set[str]) -> Iterable[str]:
-    """Iterates the tokens, but joins together consecutive tokens that aren't quoted and aren't
-    'special'; tags (ending with ':') are protected, along with the tag argument (its next token);
-    any tokens matching 'isolated_tokens' also won't be joined."""
-
-    def is_isolated(t: str):
-        return t.startswith('"') or t in isolated_tokens
-
-    def _join():
-        buffer = ""
-        isolate_next = False
-        for token in tokens:
-            if token.endswith(":"):
-                # If a tag is found, yield it separately, but remember to
-                # yield the next token separately too.
-                yield buffer
-                yield token
-                buffer = ""
-                isolate_next = True
-                continue
-
-            if isolate_next or is_isolated(token):
-                yield buffer
-                yield token
-                buffer = ""
-            else:
-                buffer += token
-            isolate_next = False
-        yield buffer
-
-    # Since we blindly return empty buffers, we must now filter them out
-    return filter(lambda t: t and not t.isspace(), _join())
-
-
 class TokenReader:
     """TokenReader reads through a list of tokens, like an iterator. But it can also peek ahead, and you
     can save and store your 'place' in the token list via the 'index' member."""
@@ -115,15 +76,45 @@ class TokenReader:
         """True if get_token() and peek_token() will return None."""
         return self.index >= len(self.tokens)
 
-    def get_token(self) -> Optional[str]:
+    def get_token(self, skip_space: bool = True) -> Optional[str]:
         """Returns the next token, and advances one token in the list. Returns None if
         the end of tokens has been reached."""
+
+        if skip_space:
+            while self.index < len(self.tokens) and self.tokens[self.index].isspace():
+                self.index += 1
+
         if self.index >= len(self.tokens):
             return None
 
         token = self.tokens[self.index]
         self.index += 1
         return token
+
+    def get_cleaned_token(self) -> Optional[str]:
+        token = self.get_token()
+        if token:
+            return clean_token(token)
+
+        return None
+
+    def get_cleaned_token_sequence(self, stop_tokens: Set[str]) -> Optional[str]:
+        buffer = ""
+        while True:
+            token = self.get_token(skip_space=False)
+            if token is None:
+                break
+            if token in stop_tokens:
+                self.index -= 1
+                break
+            if token.startswith('"'):
+                if buffer:
+                    self.index -= 1
+                else:
+                    buffer = token
+                break
+            buffer += token
+        return buffer if buffer else None
 
     def peek_token(self) -> Optional[str]:
         """Returns the next token, or None if the end of tokens has been reached. However,

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -305,6 +305,15 @@
           <object class="GtkSearchEntry" id="search_entry">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
+            <property name="tooltip-markup" translatable="yes">Enter the name of a game to search for, or use search terms:
+
+&lt;b&gt;installed:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only installed games.
+&lt;b&gt;hidden:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only hidden games.
+&lt;b&gt;favorite:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only favorite games.
+&lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in cateogry &lt;i&gt;x&lt;/i&gt;.
+&lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
+&lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games
+&lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="width-chars">30</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -311,6 +311,7 @@
 &lt;b&gt;hidden:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only hidden games.
 &lt;b&gt;favorite:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only favorite games.
 &lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in cateogry &lt;i&gt;x&lt;/i&gt;.
+&lt;b&gt;source:&lt;/b&gt;&lt;i&gt;steam&lt;/i&gt;			Only Steam games
 &lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
 &lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games
 &lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -310,7 +310,8 @@
 &lt;b&gt;installed:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only installed games.
 &lt;b&gt;hidden:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only hidden games.
 &lt;b&gt;favorite:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only favorite games.
-&lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in cateogry &lt;i&gt;x&lt;/i&gt;.
+&lt;b&gt;categorized:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;		Only games in a category.
+&lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in category &lt;i&gt;x&lt;/i&gt;.
 &lt;b&gt;source:&lt;/b&gt;&lt;i&gt;steam&lt;/i&gt;			Only Steam games
 &lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
 &lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -314,6 +314,7 @@
 &lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
 &lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games
 &lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.
+&lt;b&gt;lastplayed:&lt;/b&gt;&lt;i&gt;&amp;lt;2 days&lt;/i&gt;	Only games played in the last 2 days.
 &lt;b&gt;directory:&lt;/b&gt;&lt;i&gt;game/dir&lt;/i&gt;	Only games at the path.</property>
             <property name="halign">center</property>
             <property name="valign">center</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -313,7 +313,8 @@
 &lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in cateogry &lt;i&gt;x&lt;/i&gt;.
 &lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
 &lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games
-&lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.</property>
+&lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.
+&lt;b&gt;directory:&lt;/b&gt;&lt;i&gt;game/dir&lt;/i&gt;	Only games at the path.</property>
             <property name="halign">center</property>
             <property name="valign">center</property>
             <property name="width-chars">30</property>


### PR DESCRIPTION
This PR adds fancy search terms to the game search, and the runner search to boot. There are logical operators and 'tagged' searches that can match attributes of games. Some of them can override 'built in' filtering, so you can get views otherwise impossible.

There's almost no UI, just some tooltips. But hardcore Linux kernel hackers can probably manage a UI that works rather like Google search.

It's my hope that this will be the foundation for future features. I intend that you should sometime be able to save one o these searches a user-defined dynamic category, for instance. And we want a better UI to build fancy searches that just typing them in. But this seems to me to be a good start.

Stand by for screenshots! All the screenshots!

Here we see OR, which must be in all-caps, to find two sets of games:
![image](https://github.com/lutris/lutris/assets/6507403/579f9643-6997-4d01-b1dc-9fdeeaf90025)

Let's get fancier, with AND and the 'installed' attribute and some parentheses:
![image](https://github.com/lutris/lutris/assets/6507403/34d39e52-5df3-4476-b6c1-04abed0d469f)

AND is mostly redundant though, and we assume AND if you have no conjunction. Like Google, we use "-" for negation, but there's some subtlty here.

Here's a search leaving out that time when there's only war:
![image](https://github.com/lutris/lutris/assets/6507403/bff55f1f-ca09-4f75-898a-53c1076f87b9)

But this still works:
![image](https://github.com/lutris/lutris/assets/6507403/1364d96e-7bc3-4552-827e-02c5b239436c)
Because the - is not initial here. To get it to treat - as negation, an explicit AND can help:
![image](https://github.com/lutris/lutris/assets/6507403/11b35e93-4f66-4cfe-a608-e808bdd1369c)

Because these tags override built in filters, we can do tricks. We can show hidden games in a category:
![image](https://github.com/lutris/lutris/assets/6507403/5c9d73a4-6fd7-4983-bc4e-17550e32fac9)

Just to be extra cute, you can conveniently get both hidden and visible games at once, like this:
![image](https://github.com/lutris/lutris/assets/6507403/41fcb0f6-f43e-4cfe-9ae0-14d85bfddba3)
You could do this with ``hidden:true OR hidden:false`` as well, but this is cuter.

Some tags are a bit fancier. Here's the games that took way too long:
![image](https://github.com/lutris/lutris/assets/6507403/9aa479d6-ba27-4120-bb71-c7199457b432)

But here's a more specific search:
![image](https://github.com/lutris/lutris/assets/6507403/620f9897-0fba-445c-86a0-9339904e9ad7)
Here, the search is matching games where the playtime rounds to 21 hours (ie, nearer that than 20 or 22 hours). This is about the only way to make that useful; exactly 21 hours is very unlikely. But change the search to ``playtime:20 hours 52 minutes`` and it rounds to the minute instead.

Here's one for the last-played time:
![image](https://github.com/lutris/lutris/assets/6507403/2ce016ce-0e10-4e8c-aee6-b4e4baed7cf2)
This is a bit limited. I could find no way to parse a date-time from a user (ie, without a specific format string), so you can only specify last-played in relative terms. These are the games I last played 3 months ago.

Here's a list of the tags supported, taken from the tooltip:
<b>installed:</b><i>true</i>			Only installed games.
<b>hidden:</b><i>true</i>			Only hidden games.
<b>favorite:</b><i>true</i>			Only favorite games.
<b>categorized:</b><i>true</i>			Only games in a category.
<b>category:</b><i>x</i>			Only games in category <i>x</i>.
<b>source:</b><i>steam</i>			Only Steam games
<b>runner:</b><i>wine</i>			Only Wine games
<b>platform:</b><i>windows</i>	Only Windows games
<b>playtime:</b><i>&gt;2 hours</i>	Only games played for more than 2 hours.
<b>lastplayed:</b><i>&lt;2 days</i>	Only games played in the last 2 days.
<b>directory:</b><i>game/dir</i>	Only games at the path.

Finally, this stuff also works in the runners tab of the preferences. Just so I can do this:
![image](https://github.com/lutris/lutris/assets/6507403/e9047d9a-9a7c-47fc-bb9f-8b5777919741)
