### PR TITLE
Fix missing quote syntax error in bug report issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -18,7 +18,7 @@ body:
     id: description
     attributes:
       label: "Bug description"
-      description: "A clear and detailed description of what the bug is.
+      description: "A clear and detailed description of what the bug is."
       placeholder: "Tell us about your problem with Lutris in a clear and  detailed way"
     validations:
       required: true


### PR DESCRIPTION
Fix missing quote syntax error in bug report issue template.

I noticed people using an issue template in previous issues but when creating a new issue, the template is no longer suggested. Visiting the [template source](https://github.com/lutris/lutris/blob/672caf45ab19b4a6f15cac1ecf23f280ecbcba8a/.github/ISSUE_TEMPLATE/bug_report_form.yml), I saw this syntax error pointed out in the GitHub UI:

> [!WARNING]  
> There is a problem with this template
>
> YAML syntax error: (): did not find expected key while parsing a block mapping at line 20 column 7. Learn more about this error.