### PR TITLE
Link update

### DIFF
--- a/lutris/runners/atari800.py
+++ b/lutris/runners/atari800.py
@@ -21,7 +21,7 @@ class atari800(Runner):
     human_name = _("Atari800")
     platforms = [_("Atari 8bit computers")]  # FIXME try to determine the actual computer used
     runner_executable = "atari800/bin/atari800"
-    bios_url = "http://kent.dl.sourceforge.net/project/atari800/ROM/Original%20XL%20ROM/xf25.zip"
+    bios_url = "https://netactuate.dl.sourceforge.net/project/atari800/ROM/Original%20XL%20ROM/xf25.zip?viasf=1"
     description = _("Atari 400, 800 and XL emulator")
     bios_checksums = {
         "xlxe_rom": "06daac977823773a3eea3422fd26a703",

--- a/share/lutris/json/microm8.json
+++ b/share/lutris/json/microm8.json
@@ -3,7 +3,7 @@
     "description": "microM8 is an Apple II emulator",
     "platforms": ["Apple IIe"],
     "runner_executable": "microm8/microm8",
-    "download_url": "https://paleotronic.com/download/microm8-linux.zip",
+    "download_url": "https://github.com/paleotronic/microm8-gui/releases/download/v1.1/microm8-gui-linux.zip",
     "game_options": [
         {
             "option": "main_file",


### PR DESCRIPTION
- Atari800's dead link changed by the current one.
- MicroM8's insecure or suspicious link changed by the current one.