### PR TITLE
Saved Searches

### DIFF
--- a/lutris/database/categories.py
+++ b/lutris/database/categories.py
@@ -47,7 +47,7 @@ def strip_category_name(name):
 
 
 def is_reserved_category(name):
-    """True of name is None, blank or is a name Lutris uses internally, or
+    """True if name is None, blank or is a name Lutris uses internally, or
     starts with '.' for future expansion."""
     return not name or name[0] == "." or name in ["all", "favorite"]
 
@@ -65,9 +65,16 @@ def get_all_games_categories():
     return games_categories
 
 
-def get_category(name):
+def get_category_by_name(name):
     """Return a category by name"""
     categories = sql.db_select(settings.DB_PATH, "categories", condition=("name", name))
+    if categories:
+        return categories[0]
+
+
+def get_category_by_id(category_id):
+    """Return a category by name"""
+    categories = sql.db_select(settings.DB_PATH, "categories", condition=("id", category_id))
     if categories:
         return categories[0]
 
@@ -93,7 +100,7 @@ def normalized_category_names(name: str, subname_allowed: bool = False) -> List[
 
 def get_search_for_category(category_name: str) -> Optional[str]:
     if category_name and category_name != "all":
-        category = get_category(category_name)
+        category = get_category_by_name(category_name)
         if category:
             search = category.get("search")
             if search:
@@ -170,28 +177,32 @@ def get_categories_in_game(game_id):
     return [category["name"] for category in sql.db_query(settings.DB_PATH, query, (game_id,))]
 
 
-def add_category(category_name, search: str = None):
+def add_category(category_name, search: str = None, no_signal: bool = False):
     """Add a category to the database"""
     cat = sql.db_insert(settings.DB_PATH, "categories", {"name": category_name, "search": search})
-    CATEGORIES_UPDATED.fire()
+    if not no_signal:
+        CATEGORIES_UPDATED.fire()
     return cat
 
 
-def rename_category(category_id: int, new_name: str) -> None:
-    query = "UPDATE categories SET name=? WHERE id=?"
+def redefine_category(category_id: int, new_name: str, new_search: str = None, no_signal: bool = False) -> None:
+    query = "UPDATE categories SET name=?, search=? WHERE id=?"
 
     with sql.db_cursor(settings.DB_PATH) as cursor:
-        sql.cursor_execute(cursor, query, (new_name, category_id))
-    CATEGORIES_UPDATED.fire()
+        sql.cursor_execute(cursor, query, (new_name, new_search, category_id))
+    if not no_signal:
+        CATEGORIES_UPDATED.fire()
 
 
-def remove_category(category_id: int) -> None:
+def remove_category(category_id: int, no_signal: bool = False) -> None:
     queries = ["DELETE FROM games_categories WHERE category_id=?", "DELETE FROM categories WHERE id=?"]
 
     for query in queries:
         with sql.db_cursor(settings.DB_PATH) as cursor:
             sql.cursor_execute(cursor, query, (category_id,))
-    CATEGORIES_UPDATED.fire()
+
+    if not no_signal:
+        CATEGORIES_UPDATED.fire()
 
 
 def add_game_to_category(game_id, category_id):

--- a/lutris/database/categories.py
+++ b/lutris/database/categories.py
@@ -177,15 +177,20 @@ def add_category(category_name, search: str = None):
     return cat
 
 
+def rename_category(category_id: int, new_name: str) -> None:
+    query = "UPDATE categories SET name=? WHERE id=?"
+
+    with sql.db_cursor(settings.DB_PATH) as cursor:
+        sql.cursor_execute(cursor, query, (new_name, category_id))
+    CATEGORIES_UPDATED.fire()
+
+
 def remove_category(category_id: int) -> None:
-    queries = [
-        "DELETE FROM games_categories WHERE category_id=?",
-        "DELETE FROM categories WHERE id=?"
-    ]
+    queries = ["DELETE FROM games_categories WHERE category_id=?", "DELETE FROM categories WHERE id=?"]
 
     for query in queries:
         with sql.db_cursor(settings.DB_PATH) as cursor:
-            sql.cursor_execute(cursor, query, (category_id, ))
+            sql.cursor_execute(cursor, query, (category_id,))
     CATEGORIES_UPDATED.fire()
 
 

--- a/lutris/database/saved_searches.py
+++ b/lutris/database/saved_searches.py
@@ -1,0 +1,72 @@
+import re
+from typing import Dict, List, Optional, Union
+
+from lutris import settings
+from lutris.database import sql
+from lutris.gui.widgets import NotificationSource
+
+SAVED_SEARCHES_UPDATED = NotificationSource()
+
+
+def strip_saved_search_name(name):
+    """This strips the name given, and also removes extra internal whitespace."""
+    name = (name or "").strip()
+    name = re.sub(" +", " ", name)  # Remove excessive whitespaces
+    return name
+
+
+def get_saved_searches() -> List[Dict[str, Union[int, str]]]:
+    """Get the list of every category in database."""
+    # Categories look like [{"id": 1, "name": "My Category"}, ...]
+    return sql.db_select(settings.DB_PATH, "saved_searches")
+
+
+def get_saved_search_by_name(name: str):
+    """Return a category by name"""
+    categories = sql.db_select(settings.DB_PATH, "saved_searches", condition=("name", name))
+    if categories:
+        return categories[0]
+
+
+def get_saved_search_by_id(saved_search_id: int):
+    """Return a category by name"""
+    categories = sql.db_select(settings.DB_PATH, "saved_searches", condition=("id", saved_search_id))
+    if categories:
+        return categories[0]
+
+
+def get_search_for_saved_search(name: str) -> Optional[str]:
+    if name:
+        category = get_saved_search_by_name(name)
+        if category:
+            search = category.get("search")
+            if search:
+                return search
+    return None
+
+
+def add_saved_search(name: str, search: str, no_signal: bool = False):
+    """Add a category to the database"""
+    cat = sql.db_insert(settings.DB_PATH, "saved_searches", {"name": name, "search": search})
+    if not no_signal:
+        SAVED_SEARCHES_UPDATED.fire()
+    return cat
+
+
+def redefine_saved_search(saved_search_id: int, new_name: str, new_search: str = None, no_signal: bool = False) -> None:
+    query = "UPDATE saved_searches SET name=?, search=? WHERE id=?"
+
+    with sql.db_cursor(settings.DB_PATH) as cursor:
+        sql.cursor_execute(cursor, query, (new_name, new_search, saved_search_id))
+    if not no_signal:
+        SAVED_SEARCHES_UPDATED.fire()
+
+
+def remove_saved_search(category_id: int, no_signal: bool = False) -> None:
+    query = "DELETE FROM saved_searches WHERE id=?"
+
+    with sql.db_cursor(settings.DB_PATH) as cursor:
+        sql.cursor_execute(cursor, query, (category_id,))
+
+    if not no_signal:
+        SAVED_SEARCHES_UPDATED.fire()

--- a/lutris/database/schema.py
+++ b/lutris/database/schema.py
@@ -53,6 +53,7 @@ DATABASE = {
     "categories": [
         {"name": "id", "type": "INTEGER", "indexed": True},
         {"name": "name", "type": "TEXT", "unique": True},
+        {"name": "search", "type": "TEXT", "unique": False},
     ],
     "games_categories": [
         {"name": "game_id", "type": "INTEGER", "indexed": False},

--- a/lutris/database/schema.py
+++ b/lutris/database/schema.py
@@ -53,11 +53,15 @@ DATABASE = {
     "categories": [
         {"name": "id", "type": "INTEGER", "indexed": True},
         {"name": "name", "type": "TEXT", "unique": True},
-        {"name": "search", "type": "TEXT", "unique": False},
     ],
     "games_categories": [
         {"name": "game_id", "type": "INTEGER", "indexed": False},
         {"name": "category_id", "type": "INTEGER", "indexed": False},
+    ],
+    "saved_searches": [
+        {"name": "id", "type": "INTEGER", "indexed": True},
+        {"name": "name", "type": "TEXT", "unique": True},
+        {"name": "search", "type": "TEXT", "unique": False},
     ],
 }
 

--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -115,3 +115,9 @@ class FsyncUnsupportedError(Exception):
             message = _("Your kernel is not patched for fsync." " Please get a patched kernel to use fsync.")
 
         super().__init__(message, *args, **kwarg)
+
+
+class InvalidSearchTermError(ValueError):
+    def __init__(self, message: str, *args, **kwargs) -> None:
+        super().__init__(message, *args, **kwargs)
+        self.message = message

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -179,7 +179,7 @@ class Game:
         if not self.is_db_stored:
             raise RuntimeError("Games that do not have IDs cannot belong to categories.")
 
-        category = categories_db.get_category(category_name)
+        category = categories_db.get_category_by_name(category_name)
         if category is None:
             category_id = categories_db.add_category(category_name)
         else:
@@ -194,7 +194,7 @@ class Game:
         if not self.is_db_stored:
             return
 
-        category = categories_db.get_category(category_name)
+        category = categories_db.get_category_by_name(category_name)
         if category is None:
             return
         category_id = category["id"]

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -73,6 +73,7 @@ class EditCategoryGamesDialog(SavableModelessDialog):
         if dlg.result == Gtk.ResponseType.YES:
             for game in self.category_games:
                 game.remove_category(self.category)
+            categories_db.remove_category(self.category_id)
             self.destroy()
 
     def on_save(self, _button):

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -138,6 +138,7 @@ class EditCategoryGamesDialog(SavableModelessDialog):
                     if game_id not in added_game_ids and game_id not in removed_game_ids:
                         updated_games[game_id] = game
 
+        # Apply category changes and fire GAME_UPDATED as needed after everything
         for game_id in added_game_ids:
             game = self._get_game(game_id)
             game.add_category(new_name, no_signal=True)

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -131,7 +131,7 @@ class EditCategoryGamesDialog(SavableModelessDialog):
                 removed_game_ids = category_games_ids
                 added_game_ids = checked_game_ids
             else:
-                categories_db.rename_category(self.category_id, new_name)
+                categories_db.redefine_category(self.category_id, new_name)
                 old_name = new_name
 
                 for game_id, game in self.category_games.items():

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -23,7 +23,7 @@ class EditCategoryGamesDialog(SavableModelessDialog):
             [Game(x["id"]) for x in games_db.get_games()], key=lambda g: (g.is_installed, get_natural_sort_key(g.name))
         )
         self.category_games = {
-            game_id: Game(id) for game_id in categories_db.get_game_ids_for_categories([self.category])
+            game_id: Game(game_id) for game_id in categories_db.get_game_ids_for_categories([self.category])
         }
         self.grid = Gtk.Grid()
 

--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -16,8 +16,8 @@ from lutris.search import FLAG_TEXTS, GameSearch
 from lutris.search_predicate import AndPredicate, SearchPredicate, format_flag
 
 
-class EditSearchCategoryDialog(SavableModelessDialog):
-    """Games assigned to category dialog."""
+class EditSavedSearchDialog(SavableModelessDialog):
+    """A dialog to edit saved searches."""
 
     def __init__(self, parent, saved_search: SavedSearch) -> None:
         self.saved_search = copy(saved_search)

--- a/lutris/gui/config/edit_search_category.py
+++ b/lutris/gui/config/edit_search_category.py
@@ -1,0 +1,68 @@
+# pylint: disable=no-member
+from gettext import gettext as _
+
+from gi.repository import Gtk
+
+from lutris.database import categories as categories_db
+from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
+
+
+class EditSearchCategoryDialog(SavableModelessDialog):
+    """Games assigned to category dialog."""
+
+    def __init__(self, parent, category):
+        super().__init__(_("Configure %s") % category["name"], parent=parent, border_width=10)
+
+        self.category = category["name"]
+        self.category_id = category["id"]
+        self.search = category["search"]
+
+        self.set_default_size(500, 350)
+
+        self.vbox.set_homogeneous(False)
+        self.vbox.set_spacing(10)
+        name_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        name_label = Gtk.Label(_("Name"))
+        self.name_entry = Gtk.Entry()
+        self.name_entry.set_text(self.category)
+        name_box.pack_start(name_label, False, False, 0)
+        name_box.pack_start(self.name_entry, True, True, 0)
+
+        self.vbox.pack_start(name_box, False, False, 0)
+        # self.vbox.pack_start(self._create_games_checkboxes(), True, True, 0)
+
+        delete_button = self.add_styled_button(Gtk.STOCK_DELETE, Gtk.ResponseType.NONE, css_class="destructive-action")
+        delete_button.connect("clicked", self.on_delete_clicked)
+
+        self.show_all()
+
+    def on_delete_clicked(self, _button):
+        dlg = QuestionDialog(
+            {
+                "title": _("Do you want to delete the category '%s'?") % self.category,
+                "question": _(
+                    "This will permanently destroy the category, but the games themselves will not be deleted."
+                ),
+                "parent": self,
+            }
+        )
+        if dlg.result == Gtk.ResponseType.YES:
+            categories_db.remove_category(self.category_id)
+            self.destroy()
+
+    def on_save(self, _button: Gtk.Button) -> None:
+        """Save game info and destroy widget."""
+        old_name: str = self.category
+        new_name: str = categories_db.strip_category_name(self.name_entry.get_text())
+
+        # Rename the category if required, and if this is not a merge
+        if new_name and old_name != new_name:
+            if categories_db.is_reserved_category(new_name):
+                raise RuntimeError(_("'%s' is a reserved category name.") % new_name)
+
+            if new_name in (c["name"] for c in categories_db.get_categories()):
+                raise RuntimeError(_("'%s' is already a category, and search-based categories can't be merged."))
+            else:
+                categories_db.rename_category(self.category_id, new_name)
+
+        self.destroy()

--- a/lutris/gui/config/edit_search_category.py
+++ b/lutris/gui/config/edit_search_category.py
@@ -98,10 +98,10 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         self._add_service_widget(0)
         self._add_runner_widget(1)
         self._add_platform_widget(2)
-        self._add_flag_widget(3, _("Installed:"), "installed")
-        self._add_flag_widget(4, _("Favorite:"), "favorite")
-        self._add_flag_widget(5, _("Hidden:"), "hidden")
-        self._add_flag_widget(6, _("Categorized:"), "categorized")
+        self._add_flag_widget(3, _("Installed"), "installed")
+        self._add_flag_widget(4, _("Favorite"), "favorite")
+        self._add_flag_widget(5, _("Hidden"), "hidden")
+        self._add_flag_widget(6, _("Categorized"), "categorized")
 
     def _change_search_flag(self, tag: str, flag: Optional[bool]):
         search = GameSearch(self.search)

--- a/lutris/gui/config/edit_search_category.py
+++ b/lutris/gui/config/edit_search_category.py
@@ -16,7 +16,8 @@ class EditSearchCategoryDialog(SavableModelessDialog):
     def __init__(self, parent, category: Dict[str, Any]) -> None:
         self.category = category.get("name") or "New Category"
         self.category_id = category.get("id")
-        self.search = category.get("search") or ""
+        self.original_search = category.get("search") or ""
+        self.search = self.original_search
         title = _("Configure %s") % self.category
 
         super().__init__(title, parent=parent, border_width=10)
@@ -52,7 +53,9 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         search = GameSearch(self.search)
         predicate = search.get_predicate()
         self._add_flag_widget(0, _("Installed:"), "installed", predicate)
-        self._add_flag_widget(1, _("Categorized:"), "categorized", predicate)
+        self._add_flag_widget(1, _("Favorite:"), "favorite", predicate)
+        self._add_flag_widget(2, _("Hidden:"), "hidden", predicate)
+        self._add_flag_widget(3, _("Categorized:"), "categorized", predicate)
 
     def _change_search_flag(self, tag: str, flag: Optional[bool]):
         search = GameSearch(self.search)
@@ -121,7 +124,7 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         """Save game info and destroy widget."""
         old_name: str = self.category
         new_name: str = categories_db.strip_category_name(self.name_entry.get_text())
-        old_search: str = self.search
+        old_search: str = self.original_search
         new_search: str = str(GameSearch(self.search_entry.get_text()))
 
         if not new_name:

--- a/lutris/gui/config/edit_search_category.py
+++ b/lutris/gui/config/edit_search_category.py
@@ -22,7 +22,7 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         title = _("Configure %s") % self.category
 
         super().__init__(title, parent=parent, border_width=10)
-        self.set_default_size(500, -1)
+        self.set_default_size(500, 400)
 
         self.vbox.set_homogeneous(False)
         self.vbox.set_spacing(10)
@@ -30,11 +30,18 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         self.name_entry = self._add_entry_box(_("Name"), self.category)
         self.search_entry = self._add_entry_box(_("Search"), self.search)
 
-        self.components_grid = Gtk.Grid(row_spacing=6, column_spacing=6)
+        self.components_grid = Gtk.Grid(row_spacing=6, column_spacing=6, margin=6)
+        scrolled_window = Gtk.ScrolledWindow(visible=True)
+        scrolled_window.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
+        components_frame = Gtk.Frame(visible=True)
+        components_frame.get_style_context().add_class("info-frame")
+        components_frame.add(scrolled_window)
+        scrolled_window.add(self.components_grid)
+
         self.predicate_widget_functions: Dict[str, Callable[[SearchPredicate], None]] = {}
         self.updating_predicate_widgets = False
         self._add_component_widgets()
-        self.vbox.pack_start(self.components_grid, True, True, 0)
+        self.vbox.pack_start(components_frame, True, True, 0)
 
         delete_button = self.add_styled_button(Gtk.STOCK_DELETE, Gtk.ResponseType.NONE, css_class="destructive-action")
         delete_button.connect("clicked", self.on_delete_clicked)

--- a/lutris/gui/config/edit_search_category.py
+++ b/lutris/gui/config/edit_search_category.py
@@ -6,6 +6,7 @@ from gi.repository import Gtk
 
 from lutris.database import categories as categories_db
 from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
+from lutris.search import GameSearch
 
 
 class EditSearchCategoryDialog(SavableModelessDialog):
@@ -22,14 +23,10 @@ class EditSearchCategoryDialog(SavableModelessDialog):
 
         self.vbox.set_homogeneous(False)
         self.vbox.set_spacing(10)
-        name_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
-        name_label = Gtk.Label(_("Name"))
-        self.name_entry = Gtk.Entry()
-        self.name_entry.set_text(self.category)
-        name_box.pack_start(name_label, False, False, 0)
-        name_box.pack_start(self.name_entry, True, True, 0)
 
-        self.vbox.pack_start(name_box, False, False, 0)
+        self.name_entry = self._add_entry_box(_("Name"), self.category)
+        self.search_entry = self._add_entry_box(_("Search"), self.search)
+
         # self.vbox.pack_start(self._create_games_checkboxes(), True, True, 0)
 
         delete_button = self.add_styled_button(Gtk.STOCK_DELETE, Gtk.ResponseType.NONE, css_class="destructive-action")
@@ -37,6 +34,16 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         delete_button.set_sensitive(bool(self.category_id))
 
         self.show_all()
+
+    def _add_entry_box(self, label: str, text: str) -> Gtk.Entry:
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
+        entry_label = Gtk.Label(label)
+        entry = Gtk.Entry()
+        entry.set_text(text)
+        hbox.pack_start(entry_label, False, False, 0)
+        hbox.pack_start(entry, True, True, 0)
+        self.vbox.pack_start(hbox, False, False, 0)
+        return entry
 
     def on_delete_clicked(self, _button):
         dlg = QuestionDialog(
@@ -56,21 +63,24 @@ class EditSearchCategoryDialog(SavableModelessDialog):
         """Save game info and destroy widget."""
         old_name: str = self.category
         new_name: str = categories_db.strip_category_name(self.name_entry.get_text())
+        old_search: str = self.search
+        new_search: str = str(GameSearch(self.search_entry.get_text()))
+
+        if not new_name:
+            new_name = old_name
 
         if categories_db.is_reserved_category(new_name):
             raise RuntimeError(_("'%s' is a reserved category name.") % new_name)
 
-        if not self.category_id:
-            # Creating new category!
-            categories_db.add_category(category_name=new_name, search=self.search)
-        elif new_name and old_name != new_name:
-            # Rename existing category
-            if categories_db.is_reserved_category(new_name):
-                raise RuntimeError(_("'%s' is a reserved category name.") % new_name)
-
+        if old_name != new_name:
             if new_name in (c["name"] for c in categories_db.get_categories()):
                 raise RuntimeError(_("'%s' is already a category, and search-based categories can't be merged."))
-            else:
-                categories_db.rename_category(self.category_id, new_name)
+
+        if not self.category_id:
+            # Creating new category!
+            categories_db.add_category(category_name=new_name, search=new_search)
+        elif old_name != new_name or old_search != new_search:
+            # Changing an existing category.
+            categories_db.redefine_category(self.category_id, new_name, new_search)
 
         self.destroy()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -19,7 +19,7 @@ from lutris.api import (
 )
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
-from lutris.database.categories import get_search_for_category, add_category
+from lutris.database.categories import add_category, get_search_for_category
 from lutris.database.services import ServiceGameCollection
 from lutris.exceptions import EsyncLimitError
 from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game
@@ -51,8 +51,7 @@ from lutris.util.system import update_desktop_icons
 
 
 @GtkTemplate(ui=os.path.join(datapath.get(), "ui", "lutris-window.ui"))
-class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
-                   DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
+class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """Handler class for main window signals."""
 
     default_view_type = "grid"
@@ -245,6 +244,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
                 action.connect("change-state", value.callback)
             self.actions[name] = action
             if value.enabled:
+
                 def updater(action=action, value=value):
                     action.props.enabled = value.enabled()
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -40,6 +40,7 @@ from lutris.gui.widgets.sidebar import LutrisSidebar
 from lutris.gui.widgets.utils import load_icon_theme, open_uri
 from lutris.runtime import ComponentUpdater, RuntimeUpdater
 from lutris.search import GameSearch
+from lutris.search_predicate import NotPredicate
 from lutris.services.base import SERVICE_GAMES_LOADED, SERVICE_LOGIN, SERVICE_LOGOUT
 from lutris.services.lutris import LutrisService, sync_media
 from lutris.util import datapath
@@ -462,7 +463,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             category = self.filters.get("category") or "all"
 
             if category != ".hidden" and not search.has_component("hidden"):
-                search = search.with_predicate(search.get_category_predicate(".hidden", False))
+                search = search.with_predicate(NotPredicate(search.get_category_predicate(".hidden")))
 
             searches = [search]
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -27,7 +27,7 @@ from lutris.exceptions import EsyncLimitError, InvalidSearchTermError
 from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
-from lutris.gui.config.edit_search_category import EditSearchCategoryDialog
+from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
 from lutris.gui.config.preferences_dialog import PreferencesDialog
 from lutris.gui.dialogs import ClientLoginDialog, ErrorDialog, QuestionDialog, get_error_handler, register_error_handler
 from lutris.gui.dialogs.delegates import DialogInstallUIDelegate, DialogLaunchUIDelegate
@@ -317,7 +317,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def on_add_search_category(self, action, value):
         search = self.get_game_search()
         new_search = saved_searches_db.SavedSearch(0, "", str(search))
-        dlg = EditSearchCategoryDialog(saved_search=new_search, parent=self)
+        dlg = EditSavedSearchDialog(saved_search=new_search, parent=self)
         dlg.show()
 
     @property

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -19,7 +19,7 @@ from lutris.api import (
 )
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
-from lutris.database.categories import get_search_for_category
+from lutris.database.categories import get_search_for_category, add_category
 from lutris.database.services import ServiceGameCollection
 from lutris.exceptions import EsyncLimitError
 from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game
@@ -51,7 +51,8 @@ from lutris.util.system import update_desktop_icons
 
 
 @GtkTemplate(ui=os.path.join(datapath.get(), "ui", "lutris-window.ui"))
-class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
+class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate,
+                   DialogInstallUIDelegate):  # pylint: disable=too-many-public-methods
     """Handler class for main window signals."""
 
     default_view_type = "grid"
@@ -244,7 +245,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 action.connect("change-state", value.callback)
             self.actions[name] = action
             if value.enabled:
-
                 def updater(action=action, value=value):
                     action.props.enabled = value.enabled()
 
@@ -309,7 +309,9 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.sidebar.selected_category = "category", ".hidden"
 
     def on_add_search_category(self, action, value):
-        pass
+        search = self.get_game_search()
+        if not search.is_empty:
+            add_category("Boop", str(search))
 
     @property
     def can_add_search_category(self) -> bool:

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -19,12 +19,13 @@ from lutris.api import (
 )
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
-from lutris.database.categories import add_category, get_search_for_category
+from lutris.database.categories import get_search_for_category
 from lutris.database.services import ServiceGameCollection
 from lutris.exceptions import EsyncLimitError
 from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
+from lutris.gui.config.edit_search_category import EditSearchCategoryDialog
 from lutris.gui.config.preferences_dialog import PreferencesDialog
 from lutris.gui.dialogs import ClientLoginDialog, ErrorDialog, QuestionDialog, get_error_handler, register_error_handler
 from lutris.gui.dialogs.delegates import DialogInstallUIDelegate, DialogLaunchUIDelegate
@@ -311,7 +312,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def on_add_search_category(self, action, value):
         search = self.get_game_search()
         if not search.is_empty:
-            add_category("Boop", str(search))
+            dlg = EditSearchCategoryDialog(category={"search": str(search)}, parent=self)
+            dlg.show()
 
     @property
     def can_add_search_category(self) -> bool:

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -15,7 +15,7 @@ from lutris.database.categories import CATEGORIES_UPDATED
 from lutris.database.saved_searches import SAVED_SEARCHES_UPDATED
 from lutris.game import GAME_START, GAME_STOPPED, GAME_UPDATED, Game
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
-from lutris.gui.config.edit_search_category import EditSearchCategoryDialog
+from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
@@ -319,7 +319,7 @@ class SavedSearchSidebarRow(SidebarRow):
 
     def on_saved_search_clicked(self, button):
         saved_search = saved_search_db.get_saved_search_by_id(self.saved_search.saved_search_id) or self.saved_search
-        self.application.show_window(EditSearchCategoryDialog, saved_search=saved_search, parent=self.get_toplevel())
+        self.application.show_window(EditSavedSearchDialog, saved_search=saved_search, parent=self.get_toplevel())
         return True
 
     def __lt__(self, other):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -13,6 +13,7 @@ from lutris.database import games as games_db
 from lutris.database.categories import CATEGORIES_UPDATED
 from lutris.game import GAME_START, GAME_STOPPED, GAME_UPDATED, Game
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
+from lutris.gui.config.edit_search_category import EditSearchCategoryDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
@@ -274,7 +275,10 @@ class CategorySidebarRow(SidebarRow):
         return [("applications-system-symbolic", _("Edit Games"), self.on_category_clicked, "manage-category-games")]
 
     def on_category_clicked(self, button):
-        self.application.show_window(EditCategoryGamesDialog, category=self.category, parent=self.get_toplevel())
+        if self.category.get("search"):
+            self.application.show_window(EditSearchCategoryDialog, category=self.category, parent=self.get_toplevel())
+        else:
+            self.application.show_window(EditCategoryGamesDialog, category=self.category, parent=self.get_toplevel())
         return True
 
     def __lt__(self, other):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -295,17 +295,17 @@ class CategorySidebarRow(SidebarRow):
 
 
 class SavedSearchSidebarRow(SidebarRow):
-    def __init__(self, saved_search, application):
+    def __init__(self, saved_search: saved_search_db.SavedSearch, application):
         super().__init__(
-            saved_search["name"],
+            saved_search.name,
             "saved_search",
-            saved_search["name"],
+            saved_search.name,
             LutrisSidebar.get_sidebar_icon("folder-saved-search-symbolic"),
             application=application,
         )
-        self.category = saved_search
+        self.saved_search = saved_search
 
-        self._sort_name = locale.strxfrm(saved_search["name"])
+        self._sort_name = locale.strxfrm(saved_search.name)
 
     @property
     def sort_key(self):
@@ -318,7 +318,7 @@ class SavedSearchSidebarRow(SidebarRow):
         ]
 
     def on_saved_search_clicked(self, button):
-        saved_search = saved_search_db.get_saved_search_by_id(self.category["id"]) or self.category
+        saved_search = saved_search_db.get_saved_search_by_id(self.saved_search.saved_search_id) or self.saved_search
         self.application.show_window(EditSearchCategoryDialog, saved_search=saved_search, parent=self.get_toplevel())
         return True
 
@@ -635,7 +635,7 @@ class LutrisSidebar(Gtk.ListBox):
         saved_searches = saved_search_db.get_saved_searches()
 
         self.used_categories = {c["name"] for c in categories}
-        self.saved_searches = {s["name"] for s in saved_searches}
+        self.saved_searches = {s.name for s in saved_searches}
         self.active_services = services.get_enabled_services()
         self.installed_runners = [runner.name for runner in runners.get_installed()]
         self.active_platforms = games_db.get_used_platforms()
@@ -678,9 +678,9 @@ class LutrisSidebar(Gtk.ListBox):
                 insert_row(new_category_row)
 
         for saved_search in saved_searches:
-            if saved_search["name"] not in self.saved_search_rows:
+            if saved_search.name not in self.saved_search_rows:
                 new_saved_search_row = SavedSearchSidebarRow(saved_search, application=self.application)
-                self.saved_search_rows[saved_search["name"]] = new_saved_search_row
+                self.saved_search_rows[saved_search.name] = new_saved_search_row
                 insert_row(new_saved_search_row)
 
         self.invalidate_filter()

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -10,6 +10,7 @@ from lutris import runners, services
 from lutris.config import LutrisConfig
 from lutris.database import categories as categories_db
 from lutris.database import games as games_db
+from lutris.database.categories import CATEGORIES_UPDATED
 from lutris.game import GAME_START, GAME_STOPPED, GAME_UPDATED, Game
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
 from lutris.gui.config.runner import RunnerConfigDialog
@@ -362,6 +363,7 @@ class LutrisSidebar(Gtk.ListBox):
         GAME_START.register(self.on_game_start)
         GAME_STOPPED.register(self.on_game_stopped)
         GAME_UPDATED.register(self.update_rows)
+        CATEGORIES_UPDATED.register(self.update_rows)
         SERVICE_LOGIN.register(self.on_service_auth_changed)
         SERVICE_LOGOUT.register(self.on_service_auth_changed)
         SERVICE_GAMES_LOADING.register(self.on_service_games_loading)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -275,10 +275,11 @@ class CategorySidebarRow(SidebarRow):
         return [("applications-system-symbolic", _("Edit Games"), self.on_category_clicked, "manage-category-games")]
 
     def on_category_clicked(self, button):
+        category = categories_db.get_category_by_id(self.category["id"]) or self.category
         if self.category.get("search"):
-            self.application.show_window(EditSearchCategoryDialog, category=self.category, parent=self.get_toplevel())
+            self.application.show_window(EditSearchCategoryDialog, category=category, parent=self.get_toplevel())
         else:
-            self.application.show_window(EditCategoryGamesDialog, category=self.category, parent=self.get_toplevel())
+            self.application.show_window(EditCategoryGamesDialog, category=category, parent=self.get_toplevel())
         return True
 
     def __lt__(self, other):

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -337,10 +337,8 @@ class GameSearch(BaseSearch):
         except ValueError as ex:
             raise InvalidSearchTermError(f"'{duration_text}' is not a valid playtime.") from ex
 
-        def format_predicate():
-            return f"{tag}:{operator}{get_formatted_playtime(duration)}"
-
-        return FunctionPredicate(matcher, formatter=format_predicate)
+        text = f"{tag}:{operator}{get_formatted_playtime(duration)}"
+        return FunctionPredicate(matcher, text)
 
     def get_directory_predicate(self, directory: str) -> SearchPredicate:
         return TextPredicate(directory, lambda c: c.get("directory"), tag="directory")
@@ -372,10 +370,8 @@ class GameSearch(BaseSearch):
             game_id = db_game["id"]
             return game_id in category_game_ids
 
-        def format_predicate():
-            return f"category:{self.quote_token(category)}"
-
-        return MatchPredicate(match_category, formatter=format_predicate, tag="category", value=category)
+        text = f"category:{self.quote_token(category)}"
+        return MatchPredicate(match_category, text=text, tag="category", value=category)
 
     def get_category_flag_predicate(self, category: str, tag: str, in_category: Optional[bool] = True) -> FlagPredicate:
         names = normalized_category_names(category, subname_allowed=True)
@@ -401,10 +397,8 @@ class GameSearch(BaseSearch):
             service = SERVICES.get(game_service)
             return service and service_name in service.name.casefold()
 
-        def format_predicate():
-            return f"source:{service_name}"
-
-        return MatchPredicate(match_service, formatter=format_predicate, tag="source", value=service_name)
+        text = f"source:{service_name}"
+        return MatchPredicate(match_service, text=text, tag="source", value=service_name)
 
     def get_runner_predicate(self, runner_name: str) -> SearchPredicate:
         folded_runner_name = runner_name.casefold()
@@ -421,10 +415,8 @@ class GameSearch(BaseSearch):
             runner_human_name = get_runner_human_name(game_runner)
             return runner_name in runner_human_name.casefold()
 
-        def format_predicate():
-            return f"runner:{self.quote_token(runner_name)}"
-
-        return MatchPredicate(match_runner, formatter=format_predicate, tag="runner", value=runner_name)
+        text = f"runner:{self.quote_token(runner_name)}"
+        return MatchPredicate(match_runner, text=text, tag="runner", value=runner_name)
 
     def get_platform_predicate(self, platform: str) -> SearchPredicate:
         folded_platform = platform.casefold()
@@ -439,10 +431,8 @@ class GameSearch(BaseSearch):
                 return any(matches)
             return False
 
-        def format_predicate():
-            return f"platform:{self.quote_token(platform)}"
-
-        return MatchPredicate(match_platform, formatter=format_predicate, tag="platform", value=platform)
+        text = f"platform:{self.quote_token(platform)}"
+        return MatchPredicate(match_platform, text=text, tag="platform", value=platform)
 
 
 class RunnerSearch(BaseSearch):

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -263,12 +263,6 @@ class GameSearch(BaseSearch):
         # group them at the end.
         flag = read_flag_token(tokens)
 
-        if flag is None:
-            # None represents 'maybe' which performs no test, but overrides
-            # the tests performed outside the search. Useful for 'hidden' and
-            # 'installed' components
-            return TRUE_PREDICATE
-
         if name == "installed":
             return self.get_installed_predicate(flag)
 
@@ -348,7 +342,7 @@ class GameSearch(BaseSearch):
     def get_directory_predicate(self, directory: str) -> SearchPredicate:
         return TextPredicate(directory, lambda c: c.get("directory"), tag="directory")
 
-    def get_installed_predicate(self, installed: bool) -> SearchPredicate:
+    def get_installed_predicate(self, installed: Optional[bool]) -> SearchPredicate:
         if self.service:
 
             def is_installed(db_game):
@@ -359,7 +353,7 @@ class GameSearch(BaseSearch):
 
         return FlagPredicate(installed, lambda db_game: bool(db_game["installed"]), tag="installed")
 
-    def get_categorized_predicate(self, categorized: bool) -> SearchPredicate:
+    def get_categorized_predicate(self, categorized: Optional[bool]) -> SearchPredicate:
         uncategorized_ids = set(get_uncategorized_game_ids())
 
         def is_categorized(db_game):
@@ -367,7 +361,10 @@ class GameSearch(BaseSearch):
 
         return FlagPredicate(categorized, is_categorized, tag="categorized")
 
-    def get_category_predicate(self, category: str, in_category: bool = True) -> SearchPredicate:
+    def get_category_predicate(self, category: str, in_category: Optional[bool] = True) -> SearchPredicate:
+        if in_category is None:
+            return TRUE_PREDICATE
+
         names = normalized_category_names(category, subname_allowed=True)
         category_game_ids = set(get_game_ids_for_categories(names))
 

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -269,10 +269,10 @@ class GameSearch(BaseSearch):
             return self.get_installed_predicate(flag)
 
         if name == "hidden":
-            return self.get_category_predicate(".hidden", in_category=flag)
+            return self.get_category_flag_predicate(".hidden", "hidden", in_category=flag)
 
         if name == "favorite":
-            return self.get_category_predicate("favorite", in_category=flag)
+            return self.get_category_flag_predicate("favorite", "favorite", in_category=flag)
 
         if name == "categorized":
             return self.get_categorized_predicate(flag)
@@ -379,6 +379,16 @@ class GameSearch(BaseSearch):
             return f"category:{self.quote_token(category)}"
 
         return FunctionPredicate(match_category, formatter=format_predicate)
+
+    def get_category_flag_predicate(self, category: str, tag: str, in_category: Optional[bool] = True) -> FlagPredicate:
+        names = normalized_category_names(category, subname_allowed=True)
+        category_game_ids = set(get_game_ids_for_categories(names))
+
+        def is_in_category(db_game):
+            game_id = db_game["id"]
+            return game_id in category_game_ids
+
+        return FlagPredicate(in_category, is_in_category, tag=tag)
 
     def get_service_predicate(self, service_name: str) -> SearchPredicate:
         service_name = service_name.casefold()

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -404,7 +404,7 @@ class GameSearch(BaseSearch):
         def format_predicate():
             return f"source:{service_name}"
 
-        return FunctionPredicate(match_service, formatter=format_predicate)
+        return MatchPredicate(match_service, formatter=format_predicate, tag="source", value=service_name)
 
     def get_runner_predicate(self, runner_name: str) -> SearchPredicate:
         folded_runner_name = runner_name.casefold()
@@ -424,7 +424,7 @@ class GameSearch(BaseSearch):
         def format_predicate():
             return f"runner:{self.quote_token(runner_name)}"
 
-        return FunctionPredicate(match_runner, formatter=format_predicate)
+        return MatchPredicate(match_runner, formatter=format_predicate, tag="runner", value=runner_name)
 
     def get_platform_predicate(self, platform: str) -> SearchPredicate:
         folded_platform = platform.casefold()
@@ -442,7 +442,7 @@ class GameSearch(BaseSearch):
         def format_predicate():
             return f"platform:{self.quote_token(platform)}"
 
-        return FunctionPredicate(match_platform, formatter=format_predicate)
+        return MatchPredicate(match_platform, formatter=format_predicate, tag="platform", value=platform)
 
 
 class RunnerSearch(BaseSearch):

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -225,7 +225,7 @@ class GameSearch(BaseSearch):
         ]
     )
 
-    def __init__(self, text: str, service) -> None:
+    def __init__(self, text: str, service=None) -> None:
         self.service = service
         super().__init__(text)
 

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -9,6 +9,12 @@ class SearchPredicate(ABC):
     def accept(self, candidate: Any) -> bool:
         return True
 
+    def has_flag(self, tag: str) -> bool:
+        return False
+
+    def get_flag(self, tag: str) -> Optional[bool]:
+        return None
+
     def to_child_text(self) -> str:
         return str(self)
 
@@ -61,6 +67,12 @@ class FlagPredicate(SearchPredicate):
             return True
         return self.flag == self.flag_function(candidate)
 
+    def has_flag(self, tag: str) -> bool:
+        return tag == self.tag
+
+    def get_flag(self, tag: str) -> Optional[bool]:
+        return self.flag if self.tag == tag else None
+
     def __str__(self):
         if self.flag is None:
             flag_text = "maybe"
@@ -93,6 +105,18 @@ class AndPredicate(SearchPredicate):
             if not c.accept(candidate):
                 return False
         return True
+
+    def has_flag(self, tag: str) -> bool:
+        for c in self.components:
+            if c.has_flag(tag):
+                return True
+        return False
+
+    def get_flag(self, tag: str) -> Optional[bool]:
+        for c in self.components:
+            if c.has_flag(tag):
+                return c.get_flag(tag)
+        return None
 
     def __str__(self):
         return " ".join(self.components)

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -14,29 +14,48 @@ def format_flag(flag: Optional[bool]) -> str:
 
 
 class SearchPredicate(ABC):
+    """This class is a filter function that also includes formatting and other functionality so
+    it can be edited in the UI."""
+
     @abstractmethod
     def accept(self, candidate: Any) -> bool:
+        """This method tests an object against the predicate."""
         return True
 
     def simplify(self) -> "SearchPredicate":
+        """This method and return a simplified and flattened version of
+        the predicate; the simplified predicate will match the same objects as
+        the original."""
         return self
 
     def without_match(self, tag: str, value: str) -> "SearchPredicate":
+        """Returns a predicate without the MatchPredicate that has the tag and value
+        given. Matches that are negated or the like are not removed."""
         return self
 
     def get_matches(self, tag: str) -> List[str]:
+        """ "Returns all the values for the matches for the tag given; again any
+        negated matches are ignored."""
         return []
 
     def without_flag(self, tag: str) -> "SearchPredicate":
+        """Returns a predicate without the FlagPredicate that has the tag
+        given. Flags that are negated or the like are not removed."""
         return self
 
     def has_flag(self, tag: str) -> bool:
+        """True if the predicate has a FlagPredicate with the tag given;
+        Flags that are negated or the like are ignored."""
         return False
 
     def get_flag(self, tag: str) -> Optional[bool]:
+        """Returns the flag test value for the FlagPredicte with the tag
+        given. None represents 'maybe', not that the flag is missing."""
         return None
 
     def to_child_text(self) -> str:
+        """Returns the text of this predicate as it should be if nested inside a larger
+        predicate; this may be in parentheses where __str__ would not be."""
         return str(self)
 
     @abstractmethod

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -28,9 +28,9 @@ class SearchPredicate(ABC):
         the original."""
         return self
 
-    def without_match(self, tag: str, value: str) -> "SearchPredicate":
+    def without_match(self, tag: str, value: Optional[str] = None) -> "SearchPredicate":
         """Returns a predicate without the MatchPredicate that has the tag and value
-        given. Matches that are negated or the like are not removed."""
+        given (or just the tag). Matches that are negated or the like are not removed."""
         return self
 
     def get_matches(self, tag: str) -> List[str]:
@@ -90,7 +90,10 @@ class MatchPredicate(FunctionPredicate):
     def get_matches(self, tag: str) -> List[str]:
         return [self.value] if self.tag == tag else []
 
-    def without_match(self, tag: str, value: str) -> "SearchPredicate":
+    def without_match(self, tag: str, value: Optional[str] = None) -> "SearchPredicate":
+        if value is None:
+            return TRUE_PREDICATE if self.tag == tag else self
+
         return TRUE_PREDICATE if self.tag == tag and self.value == value else self
 
 
@@ -193,7 +196,7 @@ class AndPredicate(SearchPredicate):
             matches += c.get_matches(tag)
         return matches
 
-    def without_match(self, tag: str, value: str) -> "SearchPredicate":
+    def without_match(self, tag: str, value: Optional[str] = None) -> "SearchPredicate":
         new_components = []
         for c in self.components:
             r = c.without_match(tag, value)

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -64,20 +64,22 @@ class SearchPredicate(ABC):
 
 
 class FunctionPredicate(SearchPredicate):
-    def __init__(self, predicate: Callable[[Any], bool], formatter: Callable[[], str]) -> None:
+    """This is a generate predicate that wraps a function to perform the test."""
+
+    def __init__(self, predicate: Callable[[Any], bool], text: str) -> None:
         self.predicate = predicate
-        self.formatter = formatter
+        self.text = text
 
     def accept(self, candidate: Any) -> bool:
         return self.predicate(candidate)
 
     def __str__(self):
-        return self.formatter()
+        return self.text
 
 
 class MatchPredicate(FunctionPredicate):
-    def __init__(self, predicate: Callable[[Any], bool], formatter: Callable[[], str], tag: str, value: str) -> None:
-        super().__init__(predicate, formatter)
+    def __init__(self, predicate: Callable[[Any], bool], text: str, tag: str, value: str) -> None:
+        super().__init__(predicate, text)
         self.tag = tag
         self.value = value
 

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -1,0 +1,70 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, List, Optional
+
+from lutris.util.strings import strip_accents
+
+
+class SearchPredicate(ABC):
+    @abstractmethod
+    def accept(self, candidate: Any) -> bool:
+        return True
+
+
+class FunctionPredicate(SearchPredicate):
+    def __init__(self, predicate: Callable[[Any], bool]) -> None:
+        self.predicate = predicate
+
+    def accept(self, candidate: Any) -> bool:
+        return self.predicate(candidate)
+
+
+class TextPredicate(SearchPredicate):
+    def __init__(self, match_text: str, text_function: Callable[[Any], Optional[str]]):
+        self.stripped_text = strip_accents(match_text).casefold()
+        self.text_function = text_function
+
+    def accept(self, candidate: Any) -> bool:
+        candidate_text = self.text_function(candidate)
+        if not candidate_text:
+            return False
+
+        candidate_text = strip_accents(candidate_text).casefold()
+        return bool(candidate_text and self.stripped_text in candidate_text)
+
+
+class NotPredicate(SearchPredicate):
+    def __init__(self, to_negate: SearchPredicate) -> None:
+        self.to_negate = to_negate
+
+    def accept(self, candidate: Any) -> bool:
+        return not self.to_negate.accept(candidate)
+
+
+class AndPredicate(SearchPredicate):
+    def __init__(self, components: List[SearchPredicate]) -> None:
+        self.components = components
+
+    def accept(self, candidate: Any) -> bool:
+        for c in self.components:
+            if not c.accept(candidate):
+                return False
+        return True
+
+
+class OrPredicate(SearchPredicate):
+    def __init__(self, components: List[SearchPredicate]) -> None:
+        self.components = components
+
+    def accept(self, candidate: Any) -> bool:
+        for c in self.components:
+            if c.accept(candidate):
+                return True
+        return False
+
+
+class TruePredicate(SearchPredicate):
+    def accept(self, candidate: Any) -> bool:
+        return True
+
+
+TRUE_PREDICATE: SearchPredicate = TruePredicate()

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -32,6 +32,17 @@ class TextPredicate(SearchPredicate):
         return bool(candidate_text and self.stripped_text in candidate_text)
 
 
+class FlagPredicate(SearchPredicate):
+    def __init__(self, flag: Optional[bool], flag_function: Callable[[Any], bool]):
+        self.flag = flag
+        self.flag_function = flag_function
+
+    def accept(self, candidate: Any) -> bool:
+        if self.flag is None:
+            return True
+        return self.flag == self.flag_function(candidate)
+
+
 class NotPredicate(SearchPredicate):
     def __init__(self, to_negate: SearchPredicate) -> None:
         self.to_negate = to_negate

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -18,15 +18,15 @@ class SearchPredicate(ABC):
 
 
 class FunctionPredicate(SearchPredicate):
-    def __init__(self, predicate: Callable[[Any], bool], text: str) -> None:
+    def __init__(self, predicate: Callable[[Any], bool], formatter: Callable[[], str]) -> None:
         self.predicate = predicate
-        self.text = text
+        self.formatter = formatter
 
     def accept(self, candidate: Any) -> bool:
         return self.predicate(candidate)
 
     def __str__(self):
-        return self.text
+        return self.formatter()
 
 
 class TextPredicate(SearchPredicate):

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -680,14 +680,28 @@
           <object class="GtkModelButton">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
-            <property name="receives-default">False</property>
-            <property name="action-name">win.add-game</property>
-            <property name="text" translatable="yes">Add games</property>
+            <property name="receives-default">True</property>
+            <property name="action-name">win.add-search-category</property>
+            <property name="text" translatable="yes">Add Category</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">4</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="action-name">win.add-game</property>
+            <property name="text" translatable="yes">Add Games</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">5</property>
           </packing>
         </child>
         <child>
@@ -701,7 +715,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">6</property>
+            <property name="position">7</property>
           </packing>
         </child>
         <child>
@@ -712,7 +726,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">8</property>
+            <property name="position">9</property>
           </packing>
         </child>
         <child>
@@ -726,7 +740,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">9</property>
+            <property name="position">10</property>
           </packing>
         </child>
         <child>
@@ -740,7 +754,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">10</property>
+            <property name="position">11</property>
           </packing>
         </child>
         <child>
@@ -754,7 +768,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">11</property>
+            <property name="position">12</property>
           </packing>
         </child>
         <child>
@@ -768,7 +782,7 @@
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">12</property>
+            <property name="position">13</property>
           </packing>
         </child>
       </object>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -682,7 +682,7 @@
             <property name="can-focus">True</property>
             <property name="receives-default">True</property>
             <property name="action-name">win.add-search-category</property>
-            <property name="text" translatable="yes">Add Category</property>
+            <property name="text" translatable="yes">Add Saved Search</property>
           </object>
           <packing>
             <property name="expand">False</property>


### PR DESCRIPTION
There seems to be little interest in this, but here it is if you want it. Saved searches!

You create them with a menu command in the hamburger menu:
![Screenshot from 2024-07-17 20-11-44](https://github.com/user-attachments/assets/151d843d-a1bd-4a97-a1b1-74156d463c97)
And there's a dialog to edit the search, rather than typing it in:
![Screenshot from 2024-07-17 19-55-46](https://github.com/user-attachments/assets/a9171f70-29c0-4cb8-a152-1a208f95a303)
And the result appears in the sidebar:
![Screenshot from 2024-07-17 19-56-00](https://github.com/user-attachments/assets/cca44e4d-60de-4ce0-a8f9-82feeee693fd)

They do not appear as a kind of category, because they are not part of the library sync feature, and I expect they won't become so. This should be teachable- categories are attributes of a game, but searches aren't.

The main downside of this PR, I think, is significant complexity. The search predicates aren't functions any more but much more complex objects. That is how searches are editable, but if you are feeling the code is getting out of hand... maybe it's not worth it.