### PR TITLE
Ubisoft library connect fix

### DIFF
--- a/lutris/gui/dialogs/webconnect_dialog.py
+++ b/lutris/gui/dialogs/webconnect_dialog.py
@@ -46,6 +46,7 @@ class WebConnectDialog(ModalDialog):
         self.webview.load_uri(service.login_url)
         self.webview.connect("load-changed", self.on_navigation)
         self.webview.connect("create", self.on_webview_popup)
+        self.webview.connect("decide-policy", self.on_decide_policy)
         self.vbox.set_border_width(0)  # pylint: disable=no-member
         self.vbox.pack_start(self.webview, True, True, 0)  # pylint: disable=no-member
 
@@ -73,6 +74,11 @@ class WebConnectDialog(ModalDialog):
         # All inputs are blocked by the the webkit dialog.
         inspector = self.webview.get_inspector()
         inspector.show()
+    
+    def on_decide_policy(self, webview, decision, decision_type):
+        if decision_type == WebKit2.PolicyDecisionType.NAVIGATION_ACTION:
+            decision.use()
+        return True
 
     def on_navigation(self, widget, load_event):
         if load_event == WebKit2.LoadEvent.FINISHED:


### PR DESCRIPTION
This change (Fixes #5501). The issue arises because some policy decisions were handled incorrectly. I asked about this issue here: https://forums.lutris.net/t/cannot-connect-ubisoft-library-to-lutris/21024 and later decided to fix it myself.

The policy decision handler accepts navigation actions, which were previously denied for some reason. This effectively meant that navigating the WebView to connect.ubisoft.com/ready  was impossible, using javascript and even manually with load_uri(). Using the "load-failed" handler I got the following error: "WebKitPolicyError: Frame load interrupted", which is now fixed. I have For Honor installed and it shows up in Lutris under the Games tab, although not under the Ubisoft Connect one.

You could add your own logic for evaluating the uri for navigation, but I find it unnecessary.  It would probably look something like this:
evaluate(decision.get_navigation_action().get_request().get_uri())