### PR TITLE
remove last ruff format error and update workflow to fail on unformatted files

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -45,5 +45,4 @@ jobs:
           ruff --version
           ruff check .
       - name: Check format
-        continue-on-error: true # TODO remove this line when format is applied
         run: ruff format . --check

--- a/lutris/gui/dialogs/webconnect_dialog.py
+++ b/lutris/gui/dialogs/webconnect_dialog.py
@@ -74,7 +74,7 @@ class WebConnectDialog(ModalDialog):
         # All inputs are blocked by the the webkit dialog.
         inspector = self.webview.get_inspector()
         inspector.show()
-    
+
     def on_decide_policy(self, webview, decision, decision_type):
         if decision_type == WebKit2.PolicyDecisionType.NAVIGATION_ACTION:
             decision.use()


### PR DESCRIPTION
I noticed the ruff-format workflow doesn't fail, even tho there are unformatted files.
So I looked into the workflow file, found the TODO and fixed it...