### PR TITLE
Hide various X11-only  settings when not on X11

### DIFF
--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -149,6 +149,13 @@ class ConfigBox(VBox):
                 option_key = option["option"]
                 value = self.config.get(option_key)
 
+                if "visible" in option:
+                    if callable(option["visible"]):
+                        option["visible"] = option["visible"]()
+
+                    if not option["visible"]:
+                        continue
+
                 if callable(option.get("choices")) and option["type"] != "choice_with_search":
                     option["choices"] = option["choices"]()
                 if callable(option.get("condition")):

--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -3,11 +3,11 @@
 from gettext import gettext as _
 
 import gi
-from gi.repository import Gdk, Gtk
+from gi.repository import Gtk
 
 from lutris.database.games import get_games
 from lutris.game import Game
-from lutris.util import cache_single
+from lutris.util.display import is_display_x11
 
 try:
     gi.require_version("AppIndicator3", "0.1")
@@ -18,13 +18,8 @@ except (ImportError, ValueError):
     APP_INDICATOR_SUPPORTED = False
 
 
-@cache_single
-def supports_status_icon():
-    if APP_INDICATOR_SUPPORTED:
-        return True
-
-    display = Gdk.Display.get_default()
-    return "x11" in type(display).__name__.casefold()
+def supports_status_icon() -> bool:
+    return bool(APP_INDICATOR_SUPPORTED or is_display_x11())
 
 
 class LutrisStatusIcon:

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -6,7 +6,7 @@ from gettext import gettext as _
 
 from lutris import runners
 from lutris.util import linux, system
-from lutris.util.display import DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, is_compositing_enabled
+from lutris.util.display import DISPLAY_MANAGER, SCREEN_SAVER_INHIBITOR, is_compositing_enabled, is_display_x11
 from lutris.util.graphics.gpu import GPUS
 
 
@@ -131,6 +131,7 @@ system_options = [  # pylint: disable=invalid-name
         "type": "bool",
         "label": _("Restore resolution on game exit"),
         "default": False,
+        "visible": is_display_x11,
         "advanced": True,
         "help": _(
             "Some games don't restore your screen resolution when \n"
@@ -145,7 +146,8 @@ system_options = [  # pylint: disable=invalid-name
         "type": "bool",
         "default": False,
         "advanced": True,
-        "condition": is_compositing_enabled(),
+        "visible": is_display_x11,
+        "condition": is_compositing_enabled,
         "help": _("Disable desktop effects while game is running, " "reducing stuttering and increasing performance"),
     },
     {
@@ -169,6 +171,7 @@ system_options = [  # pylint: disable=invalid-name
         "label": _("SDL 1.2 Fullscreen Monitor"),
         "choices": get_output_list,
         "default": "off",
+        "visible": is_display_x11,
         "advanced": True,
         "help": _(
             "Hint SDL 1.2 games to use a specific monitor when going "
@@ -183,6 +186,7 @@ system_options = [  # pylint: disable=invalid-name
         "label": _("Turn off monitors except"),
         "choices": get_output_choices,
         "default": "off",
+        "visible": is_display_x11,
         "advanced": True,
         "help": _(
             "Only keep the selected screen active while the game is "
@@ -197,6 +201,7 @@ system_options = [  # pylint: disable=invalid-name
         "type": "choice",
         "label": _("Switch resolution to"),
         "advanced": True,
+        "visible": is_display_x11,
         "choices": get_resolution_choices,
         "default": "off",
         "help": _("Switch to this screen resolution while the game is running."),
@@ -501,6 +506,7 @@ system_options = [  # pylint: disable=invalid-name
             (_("24BPP (16M colors)"), "24bpp"),
         ),
         "default": "off",
+        "visible": is_display_x11,
         "advanced": True,
         "help": _("Run program in Xephyr to support 8BPP and 16BPP color modes"),
     },
@@ -509,6 +515,7 @@ system_options = [  # pylint: disable=invalid-name
         "option": "xephyr_resolution",
         "type": "string",
         "label": _("Xephyr resolution"),
+        "visible": is_display_x11,
         "advanced": True,
         "help": _("Screen resolution of the Xephyr server"),
     },
@@ -518,6 +525,7 @@ system_options = [  # pylint: disable=invalid-name
         "type": "bool",
         "label": _("Xephyr Fullscreen"),
         "default": True,
+        "visible": is_display_x11,
         "advanced": True,
         "help": _("Open Xephyr in fullscreen (at the desktop resolution)"),
     },

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -46,6 +46,13 @@ def get_default_dpi():
     return 96
 
 
+@cache_single
+def is_display_x11():
+    """True if"""
+    display = Gdk.Display.get_default()
+    return "x11" in type(display).__name__.casefold()
+
+
 class DisplayManager:
     """Get display and resolution using GnomeDesktop"""
 


### PR DESCRIPTION
This is in support of #4882; these settings are (I understand) never going to work on Wayland and will eventually disappear. They should disappear for Wayland users right now, since it's just confusing to offer options that don't work. Like so:

![image](https://github.com/user-attachments/assets/77ea35ca-3c83-43e8-a689-4d0c15429acf)

The settings that disappear are:

- Restore resolution on game exit
- Disable desktop effects
- SDL 1.2 Fullscreen Monitor
- Turn off monitors except
- Switch resolution to
- All Xephyr settings

These are the ones mentioned as doomed in #4882, plus 'disable desktop effects'- I'm pretty sure we can't kill the compositor on Wayland, so let's hide that too. "Restore gamma on game exit" is no longer included in Lutris at all, so no need to hide it.

I suspect there are other settings that won't work on Wayland too, but I don't know what they are.

I think this PR is a simple, safe step to take on the road to actually removing all these settings.