### PR TITLE
Display Trace-Back and Logs for Errors in the InstallerWindow and ErrorDialog, and provide links to GitHub and Discord.

### DIFF
--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -1,4 +1,3 @@
-import os
 from gettext import gettext as _
 from typing import Dict, Iterable, List
 

--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -8,7 +8,7 @@ from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.gui.widgets.log_text_view import LogTextView
 from lutris.util import linux, system
 from lutris.util.linux import gather_system_info_dict
-from lutris.util.log import LOG_FILENAME
+from lutris.util.log import get_log_contents
 from lutris.util.strings import gtk_safe
 from lutris.util.wine.wine import is_esync_limit_set, is_fsync_supported, is_installed_systemwide
 
@@ -77,13 +77,6 @@ class SystemBox(BaseConfigBox):
         log_buffer = Gtk.TextBuffer()
         log_buffer.set_text(self.get_log_contents())
         return LogTextView(log_buffer)
-
-    def get_log_contents(self):
-        if not os.path.exists(LOG_FILENAME):
-            return ""
-        with open(LOG_FILENAME, encoding="utf-8") as log_file:
-            content = log_file.read()
-        return content
 
     def get_items(self) -> list:
         """Assembles a list of items to display; most items are name-value tuples
@@ -159,6 +152,6 @@ class SystemBox(BaseConfigBox):
         clipboard.set_text(text.strip(), -1)
 
     def on_copy_log_clicked(self, _widget) -> None:
-        text = self.get_log_contents()
+        text = get_log_contents()
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
         clipboard.set_text(text.strip(), -1)

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -18,7 +18,7 @@ from lutris import api, settings
 from lutris.gui.widgets.log_text_view import LogTextView
 from lutris.util import datapath
 from lutris.util.jobs import schedule_at_idle
-from lutris.util.log import logger
+from lutris.util.log import get_log_contents, logger
 from lutris.util.strings import gtk_safe
 
 
@@ -352,7 +352,13 @@ class ErrorDialog(Gtk.MessageDialog):
         formatted = traceback.format_exception(type(error), error, error.__traceback__)
         if include_message:
             formatted = [str(error), ""] + formatted
-        return "\n".join(formatted).strip()
+        text = "\n".join(formatted).strip()
+        log = get_log_contents()
+
+        if log:
+            text = f"{text}\n\nLutris log:\n{log}".strip()
+
+        return text
 
 
 class QuestionDialog(Gtk.MessageDialog):

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -316,7 +316,7 @@ class ErrorDialog(Gtk.MessageDialog):
             content_area.pack_end(details_expander, False, False, 0)
 
             action_area = self.get_action_area()
-            copy_button = Gtk.Button(_("Copy to Clipboard"), visible=True)
+            copy_button = Gtk.Button(_("Copy Details to Clipboard"), visible=True)
             action_area.pack_start(copy_button, False, True, 0)
             action_area.set_child_secondary(copy_button, True)
             copy_button.connect("clicked", self.on_copy_clicked, error)
@@ -331,11 +331,25 @@ class ErrorDialog(Gtk.MessageDialog):
 
     def get_details_expander(self, error: BaseException) -> Gtk.Widget:
         details = self.format_error(error, include_message=False)
+
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
+        label = Gtk.Label(xalign=0.0, wrap=True, margin_left=6, margin_right=6, margin_bottom=6)
+        label.set_markup(
+            _(
+                "You can get support from "
+                "<a href='https://github.com/lutris/lutris'>GitHub</a> or "
+                "<a href='https://discordapp.com/invite/Pnt5CuY'>Discord</a>. "
+                "Make sure to provide the error details;\n"
+                "use the 'Copy Details to Clipboard' button to get them."
+            )
+        )
+        box.pack_start(label, False, False, 0)
+
         expander = Gtk.Expander.new(_("Error details"))
 
         details_box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL)
 
-        details_box.pack_start(Gtk.Separator(margin_top=6), False, False, 0)
+        details_box.pack_start(Gtk.Separator(), False, False, 0)
 
         details_textview = Gtk.TextView(editable=False)
         details_textview.get_buffer().set_text(details)
@@ -344,8 +358,10 @@ class ErrorDialog(Gtk.MessageDialog):
         details_scrolledwindow.add(details_textview)
         details_box.pack_start(details_scrolledwindow, False, False, 0)
         expander.add(details_box)
-        expander.show_all()
-        return expander
+
+        box.pack_start(expander, True, True, 0)
+        box.show_all()
+        return box
 
     @staticmethod
     def format_error(error: BaseException, include_message: bool = True):

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -901,7 +901,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         frame.add(scrolledwindow)
         box.pack_start(frame, True, True, 0)
 
-        copy_button = Gtk.Button(_("Copy to Clipboard"), halign=Gtk.Align.START)
+        copy_button = Gtk.Button(_("Copy Details to Clipboard"), halign=Gtk.Align.START)
         box.pack_end(copy_button, False, True, 0)
         copy_button.connect("clicked", on_copy_clicked)
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -877,7 +877,15 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             clipboard.set_text(text, -1)
 
         box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
-        label = Gtk.Label(_("Error details"), halign=Gtk.Align.START)
+        label = Gtk.Label(xalign=0.0, wrap=True)
+        label.set_markup(
+            _(
+                "An unexpected error has occurred while installing this game. "
+                "Please share the details below with the Lutris team on "
+                "<a href='https://github.com/lutris/lutris'>GitHub</a> or "
+                "<a href='https://discordapp.com/invite/Pnt5CuY'>Discord</a>."
+            )
+        )
         box.pack_start(label, False, False, 0)
         frame = Gtk.Frame(shadow_type=Gtk.ShadowType.ETCHED_IN)
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -30,7 +30,7 @@ from lutris.installer.interpreter import ScriptInterpreter
 from lutris.util import xdgshortcuts
 from lutris.util.jobs import AsyncCall
 from lutris.util.linux import LINUX_SYSTEM
-from lutris.util.log import logger, get_log_contents
+from lutris.util.log import get_log_contents, logger
 from lutris.util.steam import shortcut as steam_shortcut
 from lutris.util.strings import human_size
 from lutris.util.system import is_removeable
@@ -44,8 +44,7 @@ class MarkupLabel(Gtk.Label):
         self.set_alignment(0.5, 0)
 
 
-class InstallerWindow(ModelessDialog, DialogInstallUIDelegate,
-                      ScriptInterpreter.InterpreterUIDelegate):  # pylint: disable=too-many-public-methods
+class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter.InterpreterUIDelegate):  # pylint: disable=too-many-public-methods
     """GUI for the install process.
 
     This window is divided into pages; as you go through the install each page
@@ -865,7 +864,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate,
 
         log = get_log_contents()
         if log:
-            formatted = (formatted + "\n\nLutris log:\n" + log).strip()
+            formatted = f"{formatted}\n\nLutris log:\n{log}".strip()
 
         self.error_details_buffer.set_text(formatted)
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -30,7 +30,7 @@ from lutris.installer.interpreter import ScriptInterpreter
 from lutris.util import xdgshortcuts
 from lutris.util.jobs import AsyncCall
 from lutris.util.linux import LINUX_SYSTEM
-from lutris.util.log import logger
+from lutris.util.log import logger, get_log_contents
 from lutris.util.steam import shortcut as steam_shortcut
 from lutris.util.strings import human_size
 from lutris.util.system import is_removeable
@@ -44,7 +44,8 @@ class MarkupLabel(Gtk.Label):
         self.set_alignment(0.5, 0)
 
 
-class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter.InterpreterUIDelegate):  # pylint: disable=too-many-public-methods
+class InstallerWindow(ModelessDialog, DialogInstallUIDelegate,
+                      ScriptInterpreter.InterpreterUIDelegate):  # pylint: disable=too-many-public-methods
     """GUI for the install process.
 
     This window is divided into pages; as you go through the install each page
@@ -861,6 +862,11 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
 
         formatted = traceback.format_exception(type(error), error, error.__traceback__)
         formatted = "\n".join(formatted).strip()
+
+        log = get_log_contents()
+        if log:
+            formatted = (formatted + "\n\nLutris log:\n" + log).strip()
+
         self.error_details_buffer.set_text(formatted)
 
         self.stack.present_page("error")

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -40,7 +40,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
 
         def report_error(self, error):
             """Called to report an error during installation. The installation will then stop."""
-            logger.exception("Error during installation: %s", error)
+            pass
 
         def report_status(self, status):
             """Called to report the current activity of the installer."""
@@ -334,6 +334,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
                 self._finish_install()
         except Exception as ex:
             # Redirect errors to the delegate, instead of the default ErrorDialog.
+            logger.exception("Error during installation: %s", ex)
             self.interpreter_ui_delegate.report_error(ex)
 
     @staticmethod

--- a/lutris/util/log.py
+++ b/lutris/util/log.py
@@ -35,3 +35,12 @@ console_handler.setFormatter(SIMPLE_FORMATTER)
 logger = logging.getLogger(__name__)
 logger.addHandler(console_handler)
 logger.setLevel(logging.INFO)
+
+
+def get_log_contents():
+    """Returns the entire text of the log file for this run."""
+    if not os.path.exists(LOG_FILENAME):
+        return ""
+    with open(LOG_FILENAME, encoding="utf-8") as log_file:
+        content = log_file.read()
+    return content


### PR DESCRIPTION
When the InstallerWindow displays errors in a page, instead of a separate dialog, we will now show the trace-back and the log:

![Screenshot from 2024-09-02 13-09-10](https://github.com/user-attachments/assets/8475b3d7-207c-4170-9200-ce20d5994a24)

This gives you the trace-back and then the Lutris log (which usually contains the trace-back, but better safe that sorry). The message directs the user to GitHub or Discord, and this way they can easily provide the information we need to help them.

I've also updated the ErrorDialog to include the log in the same way, but no new links in there yet.

The downside here is just that all this tech stuff may be scary for users.  The ErrorDialog hides this stuff initially- you have to ask for it.

Still, I think Linux gamers can handle it, and getting better error feedback from users is worthwhile.