### PR TITLE
Add libayatana-appindicator based tray icon

### DIFF
--- a/lutris/gui/widgets/status_icon.py
+++ b/lutris/gui/widgets/status_icon.py
@@ -1,4 +1,4 @@
-"""AppIndicator based tray icon"""
+"""AppIndicator/AyatanaAppIndicator based tray icon"""
 
 from gettext import gettext as _
 
@@ -15,7 +15,13 @@ try:
 
     APP_INDICATOR_SUPPORTED = True
 except (ImportError, ValueError):
-    APP_INDICATOR_SUPPORTED = False
+    try:
+        gi.require_version("AyatanaAppIndicator3", "0.1")
+        from gi.repository import AyatanaAppIndicator3 as AppIndicator
+
+        APP_INDICATOR_SUPPORTED = True
+    except (ImportError, ValueError):
+        APP_INDICATOR_SUPPORTED = False
 
 
 def supports_status_icon() -> bool:


### PR DESCRIPTION
Gentoo dropped the libappindicator package from its main repository in favour of libayatana-appindicator which broke the status tray, I simply added a check for libayatana-appindicator if libappindicator is not found.