### PR TITLE
Add a "Show in games" command in the context menu for service games

### DIFF
--- a/lutris/database/services.py
+++ b/lutris/database/services.py
@@ -29,3 +29,23 @@ class ServiceGameCollection:
         if len(results) > 1:
             logger.warning("More than one game found for %s on %s", appid, service)
         return results[0]
+
+    @classmethod
+    def link_service_game(cls, service, appid, lutris_slug):
+        """Updates a service-game to have the corresponding Lutris slug."""
+        sql.db_update(
+            settings.DB_PATH,
+            "service_games",
+            {"lutris_slug": lutris_slug},
+            conditions={"appid": appid, "service": service},
+        )
+
+    @classmethod
+    def link_lutris_game(cls, service, appid, lutris_game_id):
+        """Update a Lutris game to link to a service game."""
+        sql.db_update(
+            settings.DB_PATH,
+            "games",
+            {"service": service, "service_id": appid},
+            conditions={"id": lutris_game_id},
+        )

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -127,6 +127,10 @@ class Game:
         game.slug = service.get_installed_slug(db_game)
         game.runner_name = service.get_installed_runner_name(db_game)
 
+        platforms = service.get_game_platforms(db_game)
+        if len(platforms) == 1:
+            game.platform = platforms[0]
+
         if "service_id" in db_game:
             game.appid = db_game["service_id"]
         elif service:

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -450,8 +450,8 @@ class SingleGameActions(GameActions):
 
 
 class ServiceGameActions(GameActions):
-    """This actions class supports a single service game, which has an idiosyncratic set of
-    actions."""
+    """This actions class supports service games, which has an idiosyncratic set of
+    actions. There can be ordinary games selected as well."""
 
     def __init__(self, games: List[Game], window: Gtk.Window, application=None):
         super().__init__(window, application)
@@ -475,8 +475,12 @@ class ServiceGameActions(GameActions):
             "install": self.is_installable,
             "add": self.is_installable,
             "view": len(self.games) == 1,
-            "show-in-games": True,
+            "show-in-games": self.is_game_unstored,
         }
+
+    @property
+    def is_game_unstored(self):
+        return any(not g.is_db_stored for g in self.get_games())
 
     def on_edit_game_categories(self, *args):
         def on_games_shown(_result, error):
@@ -560,7 +564,7 @@ def get_game_actions(games: List[Game], window: Gtk.Window, application=None) ->
                 return ServiceGameActions([game], window, application)
         elif all(g.is_db_stored for g in games):
             return MultiGameActions(games, window)
-        elif all(not g.is_db_stored for g in games):
+        elif any(not g.is_db_stored for g in games):
             return ServiceGameActions(games, window, application)
 
     # If given no games, or the games are not of a kind we can handle,

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -221,12 +221,10 @@ class BaseService:
         """Match a service game to a lutris game referenced by its slug"""
         if not service_game:
             return
-        sql.db_update(
-            settings.DB_PATH,
-            "service_games",
-            {"lutris_slug": lutris_game["slug"]},
-            conditions={"appid": service_game["appid"], "service": self.id},
-        )
+
+        appid = service_game["appid"]
+        ServiceGameCollection.link_service_game(self.id, appid, lutris_game["slug"])
+
         unmatched_lutris_games = get_games(
             searches={"installer_slug": self.matcher},
             filters={"slug": lutris_game["slug"]},
@@ -234,12 +232,7 @@ class BaseService:
         )
         for game in unmatched_lutris_games:
             logger.debug("Updating unmatched game %s", game)
-            sql.db_update(
-                settings.DB_PATH,
-                "games",
-                {"service": self.id, "service_id": service_game["appid"]},
-                conditions={"id": game["id"]},
-            )
+            ServiceGameCollection.link_lutris_game(self.id, appid, game["id"])
 
     def match_games(self):
         """Matching of service games to lutris games"""


### PR DESCRIPTION
This command creates the (uninstalled) Lutris game, and links the games to each other.

This won't overwrite an existing game; if a game with the right slug is found, we'll just link them. If the existing game already is linked to a service game for some other service, we'll show an error and not change anything.

This command is supported for multi-selection, so you can do it for your whole library. That is a bit dicey if you have the same game from different services- this code won't create two games for the same slug, so you'll have an awkward time adding games one at a time. A more elaborate UI could mitigate this, but I think this simple version is still useful.

The point of all this is to help users categorize games that are just coming from their services. To this end, I've enabled the 'Categories' command for service games, and it prompts you with this:
![image](https://github.com/user-attachments/assets/80fe0f42-3b32-499d-92fb-649186ca8766)
If the user clicks 'Yes', then we add or link the games, and then when that is done we pop the Categories UI as usual.

Resolves #5606.