### PR TITLE
Convert saved searches to advanced search / dynamic collections

### DIFF
--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -11,7 +11,7 @@ from lutris.database import games as games_db
 from lutris.database import saved_searches
 from lutris.database.saved_searches import SavedSearch
 from lutris.exceptions import InvalidSearchTermError
-from lutris.gui.dialogs import QuestionDialog
+from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
 from lutris.search import FLAG_TEXTS, GameSearch
 from lutris.search_predicate import AndPredicate, SearchPredicate, format_flag
 
@@ -278,3 +278,20 @@ class SearchFiltersBox(Gtk.Box):
             self.saved_search.update()
 
         self.destroy()
+
+
+class EditSavedSearchDialog(SavableModelessDialog):
+    """A dialog to edit saved searches."""
+
+    def __init__(self, parent, saved_search: SavedSearch) -> None:
+        filter_box = SearchFiltersBox(saved_search)
+        self.saved_search = saved_search
+        if not self.saved_search.name:
+            self.saved_search.name = "New Dynamic Category"
+        title = _("Configure %s") % self.saved_search.name
+        super().__init__(title, parent=parent, border_width=10)
+        self.set_default_size(600, -1)
+
+        self.vbox.set_homogeneous(False)
+        self.vbox.set_spacing(10)
+        self.vbox.pack_start(filter_box, True, True, 0)

--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -11,15 +11,16 @@ from lutris.database import games as games_db
 from lutris.database import saved_searches
 from lutris.database.saved_searches import SavedSearch
 from lutris.exceptions import InvalidSearchTermError
-from lutris.gui.dialogs import QuestionDialog, SavableModelessDialog
+from lutris.gui.dialogs import QuestionDialog
 from lutris.search import FLAG_TEXTS, GameSearch
 from lutris.search_predicate import AndPredicate, SearchPredicate, format_flag
 
 
-class EditSavedSearchDialog(SavableModelessDialog):
-    """A dialog to edit dynamic categories"""
+class SearchFiltersBox(Gtk.Box):
+    """A widget to edit dynamic categories"""
 
-    def __init__(self, parent, saved_search: SavedSearch) -> None:
+    def __init__(self, saved_search: SavedSearch) -> None:
+        super().__init__()
         self.saved_search = copy(saved_search)
         self.original_search = copy(saved_search)
 
@@ -27,13 +28,9 @@ class EditSavedSearchDialog(SavableModelessDialog):
             self.saved_search.name = "New Dynamic Category"
 
         self.search = self.saved_search.search
-        title = _("Advanced search")
 
-        super().__init__(title, parent=parent, border_width=10)
-        self.set_default_size(600, -1)
-
-        self.vbox.set_homogeneous(False)
-        self.vbox.set_spacing(10)
+        self.set_homogeneous(False)
+        self.set_spacing(10)
 
         self.name_entry = self._add_entry_box(_("Name"), self.saved_search.name)
         self.search_entry = self._add_entry_box(_("Search"), self.search)
@@ -64,13 +61,13 @@ class EditSavedSearchDialog(SavableModelessDialog):
 
         predicates_box.pack_start(self.flags_grid, False, False, 0)
         predicates_box.pack_start(categories_frame_box, True, True, 0)
-        self.vbox.pack_start(predicates_box, True, True, 0)
+        self.pack_start(predicates_box, True, True, 0)
 
         self.show_all()
 
-        delete_button = self.add_styled_button(Gtk.STOCK_DELETE, Gtk.ResponseType.NONE, css_class="destructive-action")
-        delete_button.connect("clicked", self.on_delete_clicked)
-        delete_button.show() if self.saved_search.saved_search_id else delete_button.hide()
+        # delete_button = self.add_styled_button(Gtk.STOCK_DELETE, Gtk.ResponseType.NONE, css_class="destructive-action")
+        # delete_button.connect("clicked", self.on_delete_clicked)
+        # delete_button.show() if self.saved_search.saved_search_id else delete_button.hide()
 
     def _add_entry_box(self, label: str, text: str) -> Gtk.Entry:
         hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6)
@@ -81,7 +78,7 @@ class EditSavedSearchDialog(SavableModelessDialog):
         entry.set_text(text)
         hbox.pack_start(entry_label, False, False, 0)
         hbox.pack_start(entry, True, True, 0)
-        self.vbox.pack_start(hbox, False, False, 0)
+        self.pack_start(hbox, False, False, 0)
         return entry
 
     def on_search_entry_changed(self, _widget):

--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -30,6 +30,10 @@ class SearchFiltersBox(Gtk.Box):
         self.search = self.saved_search.search
 
         self.set_homogeneous(False)
+        self.set_margin_top(20)
+        self.set_margin_bottom(20)
+        self.set_margin_start(20)
+        self.set_margin_end(20)
         self.set_spacing(10)
 
         self.name_entry = self._add_entry_box(_("Name"), self.saved_search.name)
@@ -235,7 +239,7 @@ class SearchFiltersBox(Gtk.Box):
         combobox.set_id_column(1)
         combobox.set_halign(Gtk.Align.START)
         combobox.set_valign(Gtk.Align.CENTER)
-        combobox.set_size_request(300, -1)
+        combobox.set_size_request(240, -1)
         renderer_text = Gtk.CellRendererText()
         combobox.pack_start(renderer_text, True)
         combobox.add_attribute(renderer_text, "text", 0)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -323,7 +323,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.sidebar.selected_category = "category", ".hidden"
 
     def on_open_search_filters(self, action, value):
-        self.filter_popover.popdown()
+        self.filter_popover.popup()
 
     @property
     def current_view_type(self):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -78,7 +78,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     turn_on_library_sync_label: Gtk.Label = GtkTemplate.Child()
     version_notification_revealer: Gtk.Revealer = GtkTemplate.Child()
     version_notification_label: Gtk.Revealer = GtkTemplate.Child()
-    search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
+    # search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
+    search_box: Gtk.Box = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs) -> None:
         width = int(settings.read_setting("width") or self.default_width)
@@ -156,8 +157,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         new_search = saved_searches_db.SavedSearch(0, "", str(search))
         filter_box = SearchFiltersBox(saved_search=new_search)
         filter_box.show()
-        self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_filters_button)
-        self.search_filters_button.set_popover(self.filter_popover)
+        # self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_box)
+        # self.search_filters_button.set_popover(self.filter_popover)
 
         self.update_action_state()
         self.update_notification()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -27,7 +27,7 @@ from lutris.exceptions import EsyncLimitError, InvalidSearchTermError
 from lutris.game import GAME_INSTALLED, GAME_STOPPED, GAME_UNHANDLED_ERROR, GAME_UPDATED, Game
 from lutris.gui import dialogs
 from lutris.gui.addgameswindow import AddGamesWindow
-from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
+from lutris.gui.config.edit_saved_search import SearchFiltersBox
 from lutris.gui.config.preferences_dialog import PreferencesDialog
 from lutris.gui.dialogs import ClientLoginDialog, ErrorDialog, QuestionDialog, get_error_handler, register_error_handler
 from lutris.gui.dialogs.delegates import DialogInstallUIDelegate, DialogLaunchUIDelegate
@@ -78,6 +78,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     turn_on_library_sync_label: Gtk.Label = GtkTemplate.Child()
     version_notification_revealer: Gtk.Revealer = GtkTemplate.Child()
     version_notification_label: Gtk.Revealer = GtkTemplate.Child()
+    search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs) -> None:
         width = int(settings.read_setting("width") or self.default_width)
@@ -226,7 +227,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 enabled=lambda: self.is_show_hidden_sensitive,
                 accel="<Primary>h",
             ),
-            "add-search-category": Action(self.on_add_search_category),
+            "open-search-filters": Action(self.on_open_search_filters),
             "open-forums": Action(lambda *x: open_uri("https://forums.lutris.net/")),
             "open-discord": Action(lambda *x: open_uri("https://discord.gg/Pnt5CuY")),
             "donate": Action(lambda *x: open_uri("https://lutris.net/donate")),
@@ -314,11 +315,13 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.sidebar.hidden_row.show()
         self.sidebar.selected_category = "category", ".hidden"
 
-    def on_add_search_category(self, action, value):
+    def on_open_search_filters(self, action, value):
         search = self.get_game_search()
         new_search = saved_searches_db.SavedSearch(0, "", str(search))
-        dlg = EditSavedSearchDialog(saved_search=new_search, parent=self)
-        dlg.show()
+        filter_box = SearchFiltersBox(saved_search=new_search)
+        popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_filters_button)
+        self.search_filters_button.set_popover(popover)
+        popover.popdown()
 
     @property
     def current_view_type(self):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -152,6 +152,13 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.revealer_box = Gtk.HBox(visible=True)
         self.game_revealer.add(self.revealer_box)
 
+        search = self.get_game_search()
+        new_search = saved_searches_db.SavedSearch(0, "", str(search))
+        filter_box = SearchFiltersBox(saved_search=new_search)
+        filter_box.show()
+        self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_filters_button)
+        self.search_filters_button.set_popover(self.filter_popover)
+
         self.update_action_state()
         self.update_notification()
 
@@ -316,12 +323,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.sidebar.selected_category = "category", ".hidden"
 
     def on_open_search_filters(self, action, value):
-        search = self.get_game_search()
-        new_search = saved_searches_db.SavedSearch(0, "", str(search))
-        filter_box = SearchFiltersBox(saved_search=new_search)
-        popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_filters_button)
-        self.search_filters_button.set_popover(popover)
-        popover.popdown()
+        self.filter_popover.popdown()
 
     @property
     def current_view_type(self):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -15,8 +15,7 @@ from lutris.database.categories import CATEGORIES_UPDATED
 from lutris.database.saved_searches import SAVED_SEARCHES_UPDATED
 from lutris.game import GAME_START, GAME_STOPPED, GAME_UPDATED, Game
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
-
-# from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
+from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
@@ -319,8 +318,8 @@ class SavedSearchSidebarRow(SidebarRow):
         ]
 
     def on_saved_search_clicked(self, button):
-        # saved_search = saved_search_db.get_saved_search_by_id(self.saved_search.saved_search_id) or self.saved_search
-        # self.application.show_window(EditSavedSearchDialog, saved_search=saved_search, parent=self.get_toplevel())
+        saved_search = saved_search_db.get_saved_search_by_id(self.saved_search.saved_search_id) or self.saved_search
+        self.application.show_window(EditSavedSearchDialog, saved_search=saved_search, parent=self.get_toplevel())
         return True
 
     def __lt__(self, other):

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -15,7 +15,8 @@ from lutris.database.categories import CATEGORIES_UPDATED
 from lutris.database.saved_searches import SAVED_SEARCHES_UPDATED
 from lutris.game import GAME_START, GAME_STOPPED, GAME_UPDATED, Game
 from lutris.gui.config.edit_category_games import EditCategoryGamesDialog
-from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
+
+# from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
@@ -318,8 +319,8 @@ class SavedSearchSidebarRow(SidebarRow):
         ]
 
     def on_saved_search_clicked(self, button):
-        saved_search = saved_search_db.get_saved_search_by_id(self.saved_search.saved_search_id) or self.saved_search
-        self.application.show_window(EditSavedSearchDialog, saved_search=saved_search, parent=self.get_toplevel())
+        # saved_search = saved_search_db.get_saved_search_by_id(self.saved_search.saved_search_id) or self.saved_search
+        # self.application.show_window(EditSavedSearchDialog, saved_search=saved_search, parent=self.get_toplevel())
         return True
 
     def __lt__(self, other):

--- a/lutris/search_predicate.py
+++ b/lutris/search_predicate.py
@@ -3,14 +3,11 @@ from typing import Any, Callable, Dict, List, Optional
 
 from lutris.util.strings import strip_accents
 
-FLAG_TEXTS: Dict[str, Optional[bool]] = {"true": True, "yes": True, "false": False, "no": False, "maybe": None}
+FLAG_TEXTS: Dict[str, Optional[bool]] = {"true": True, "yes": True, "false": False, "no": False}
 
 
 def format_flag(flag: Optional[bool]) -> str:
-    if flag is None:
-        return "maybe"
-    else:
-        return "yes" if flag else "no"
+    return "yes" if flag else "no"
 
 
 class SearchPredicate(ABC):
@@ -50,7 +47,7 @@ class SearchPredicate(ABC):
 
     def get_flag(self, tag: str) -> Optional[bool]:
         """Returns the flag test value for the FlagPredicte with the tag
-        given. None represents 'maybe', not that the flag is missing."""
+        given."""
         return None
 
     def to_child_text(self) -> str:
@@ -98,8 +95,7 @@ class MatchPredicate(FunctionPredicate):
 
 
 class FlagPredicate(SearchPredicate):
-    """This is a predicate to match a boolean property, with the special feature that it can
-    match 'maybe' which actually matching anything. This odd setting is useful to override
+    """This is a predicate to match a boolean property. This odd setting is useful to override
     the default filtering Lutris provides, like filtering out hidden games."""
 
     def __init__(self, flag: Optional[bool], flag_function: Callable[[Any], bool], tag: str):

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -452,24 +452,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkMenuButton" id="search_filters_button">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="action-name">win.open-search-filters</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">filter-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">1</property>
-              </packing>
+              <placeholder/>
             </child>
           </object>
           <packing>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -302,57 +302,7 @@
         <property name="can-focus">False</property>
         <property name="show-close-button">True</property>
         <child type="title">
-          <object class="GtkSearchEntry" id="search_entry">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="tooltip-markup" translatable="yes">Enter the name of a game to search for, or use search terms:
-
-&lt;b&gt;installed:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only installed games.
-&lt;b&gt;hidden:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only hidden games.
-&lt;b&gt;favorite:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only favorite games.
-&lt;b&gt;categorized:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;		Only games in a category.
-&lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in category &lt;i&gt;x&lt;/i&gt;.
-&lt;b&gt;source:&lt;/b&gt;&lt;i&gt;steam&lt;/i&gt;			Only Steam games
-&lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
-&lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games
-&lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.
-&lt;b&gt;lastplayed:&lt;/b&gt;&lt;i&gt;&amp;lt;2 days&lt;/i&gt;	Only games played in the last 2 days.
-&lt;b&gt;directory:&lt;/b&gt;&lt;i&gt;game/dir&lt;/i&gt;	Only games at the path.</property>
-            <property name="halign">center</property>
-            <property name="valign">center</property>
-            <property name="width-chars">30</property>
-            <property name="placeholder-text" translatable="yes">Search games</property>
-            <signal name="key-press-event" handler="on_search_entry_key_press" swapped="no"/>
-            <signal name="search-changed" handler="on_search_entry_changed" swapped="no"/>
-          </object>
-        </child>
-        <child>
-          <object class="GtkBox" id="left_header_box">
-            <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="spacing">6</property>
-            <child>
-              <object class="GtkButton">
-                <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">False</property>
-                <property name="tooltip-text" translatable="yes">Add Game</property>
-                <property name="action-name">win.add-game</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">list-add-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-          </object>
+          <placeholder/>
         </child>
         <child>
           <object class="GtkBox" id="right_header_box">
@@ -434,7 +384,96 @@
           </object>
           <packing>
             <property name="pack-type">end</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="left_header_box">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Add Game</property>
+                <property name="action-name">win.add-game</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">list-add-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
             <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="search_box">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <child>
+              <object class="GtkSearchEntry" id="search_entry">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-markup" translatable="yes">Enter the name of a game to search for, or use search terms:
+
+&lt;b&gt;installed:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only installed games.
+&lt;b&gt;hidden:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only hidden games.
+&lt;b&gt;favorite:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;			Only favorite games.
+&lt;b&gt;categorized:&lt;/b&gt;&lt;i&gt;true&lt;/i&gt;		Only games in a category.
+&lt;b&gt;category:&lt;/b&gt;&lt;i&gt;x&lt;/i&gt;			Only games in category &lt;i&gt;x&lt;/i&gt;.
+&lt;b&gt;source:&lt;/b&gt;&lt;i&gt;steam&lt;/i&gt;			Only Steam games
+&lt;b&gt;runner:&lt;/b&gt;&lt;i&gt;wine&lt;/i&gt;			Only Wine games
+&lt;b&gt;platform:&lt;/b&gt;&lt;i&gt;windows&lt;/i&gt;	Only Windows games
+&lt;b&gt;playtime:&lt;/b&gt;&lt;i&gt;&amp;gt;2 hours&lt;/i&gt;	Only games played for more than 2 hours.
+&lt;b&gt;lastplayed:&lt;/b&gt;&lt;i&gt;&amp;lt;2 days&lt;/i&gt;	Only games played in the last 2 days.
+&lt;b&gt;directory:&lt;/b&gt;&lt;i&gt;game/dir&lt;/i&gt;	Only games at the path.</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="width-chars">30</property>
+                <property name="placeholder-text" translatable="yes">Search games</property>
+                <signal name="key-press-event" handler="on_search_entry_key_press" swapped="no"/>
+                <signal name="search-changed" handler="on_search_entry_changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="search_filters_button">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="action-name">win.open-search-filters</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">filter-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -632,7 +671,7 @@
         <property name="orientation">vertical</property>
         <property name="spacing">3</property>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="show_installed_only">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="receives-default">False</property>
@@ -647,7 +686,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="show_side_panel">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="receives-default">False</property>
@@ -662,7 +701,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="show_hidden_games">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
             <property name="receives-default">False</property>
@@ -677,21 +716,10 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
-            <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
-            <property name="action-name">win.add-search-category</property>
-            <property name="text" translatable="yes">Add Saved Search</property>
-          </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">True</property>
-            <property name="position">3</property>
-          </packing>
+          <placeholder/>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="add_game">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
@@ -705,7 +733,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="preferences">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
@@ -730,7 +758,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="open_discord">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
@@ -744,7 +772,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="open_forums">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
@@ -758,7 +786,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="donate">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
@@ -772,7 +800,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkModelButton">
+          <object class="GtkModelButton" id="about">
             <property name="visible">True</property>
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>


### PR DESCRIPTION
It's cool that we're now able to do more advanced search but I'd like to adjust the recent saved searches: 

- to have a more general purpose, making it easier to do advanced search without saving the search
- to be more discoverable. Having the advanced search in the search bar is where users will expect this feature to be. Users will have a hard time finding / figuring what is "Add saved search" in a menu
- to be more clear and concise by removing terms like "omit from search" and "maybe", which may be confusing to the user.

The goal is to have something that works in a similar fashion as the Steam advanced filters. 

![image](https://github.com/user-attachments/assets/2812245c-7932-48b7-9713-117753453669)

Creating a Dynamic Collection is proposed but it's not the main feature of this dialog. The main feature is just searching.


TODO:

- [ ] Show advanced search when a dropdown on the right hand side of the search bar is clicked.
- [ ] Remove "Add Saved search" from menu
- [ ] Maybe simplify the UI more, some of those Yes/No dropdowns could be checkboxes?
- [ ] Move the action buttons from the dialog to the box widget so we don't depend on  being in the dialog
- [ ] Show the dynamic categories with the other categories but add an icon next to it. 
- [ ] Center the search on the dialog and try to group the 2 entry + menu button widgets