### PR TITLE
Fix call to get_log_contents() in sysinfo_box.py

### DIFF
--- a/lutris/gui/config/sysinfo_box.py
+++ b/lutris/gui/config/sysinfo_box.py
@@ -74,7 +74,7 @@ class SystemBox(BaseConfigBox):
 
     def get_log_view(self):
         log_buffer = Gtk.TextBuffer()
-        log_buffer.set_text(self.get_log_contents())
+        log_buffer.set_text(get_log_contents())
         return LogTextView(log_buffer)
 
     def get_items(self) -> list:


### PR DESCRIPTION
Fixes a crash in `Preferences` -> `System` when accessing the Lutris logs.

This just fixes the invocation of `get_log_contents()` so it runs correctly and shows the logs as expected.

![image](https://github.com/user-attachments/assets/9f89d23d-3057-42aa-b6a6-57232555b0b6)

Current build gets the error:

```
 [ERROR:2024-09-24 13:22:49,843:exception_backstops]: Error handling signal 'row-selected': 'SystemBox' object has no attribute 'get_log_contents'
```

Current error stack trace:

```
Traceback (most recent call last):

  File "/usr/lib/python3.12/site-packages/lutris/exception_backstops.py", line 76, in error_wrapper
    return handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^

  File "/usr/lib/python3.12/site-packages/lutris/gui/config/preferences_dialog.py", line 91, in on_sidebar_activated
    generator()

  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 73, in populate
    self.log_scrolled_window.add(self.get_log_view())
                                 ^^^^^^^^^^^^^^^^^^^

  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 77, in get_log_view
    log_buffer.set_text(self.get_log_contents())
                        ^^^^^^^^^^^^^^^^^^^^^

AttributeError: 'SystemBox' object has no attribute 'get_log_contents'. Did you mean: 'get_pango_context'?

Lutris log:
[INFO:2024-09-24 13:22:10,213:application]: Starting Lutris 0.5.17
[INFO:2024-09-24 13:22:10,273:startup]: Intel Xe Graphics (8086:9a49 f111:0001 i915) Driver 24.2.3
[ERROR:2024-09-24 13:22:41,925:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/299910/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:41,927:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/360950/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:41,932:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/410970/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:41,936:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/407530/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:41,941:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/399820/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:42,143:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/410990/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:42,144:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/410980/library_600x900.jpg: HTTP Error 404: Not Found
[ERROR:2024-09-24 13:22:42,147:service_media]: Failed to download http://cdn.steamstatic.com/steam/apps/272330/library_600x900.jpg: HTTP Error 404: Not Found
[INFO:2024-09-24 13:22:42,221:shortcut]: Removing Steam shortcut for Mega Man 11 (steam)
[INFO:2024-09-24 13:22:42,228:shortcut]: Removing Steam shortcut for No Man's Sky (steam)
[INFO:2024-09-24 13:22:42,237:shortcut]: Removing Steam shortcut for Puyo Puyo™ Tetris® 2 (steam)
[ERROR:2024-09-24 13:22:49,843:exception_backstops]: Error handling signal 'row-selected': 'SystemBox' object has no attribute 'get_log_contents'
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/lutris/exception_backstops.py", line 76, in error_wrapper
    return handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/preferences_dialog.py", line 91, in on_sidebar_activated
    generator()
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 73, in populate
    self.log_scrolled_window.add(self.get_log_view())
                                 ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 77, in get_log_view
    log_buffer.set_text(self.get_log_contents())
                        ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SystemBox' object has no attribute 'get_log_contents'. Did you mean: 'get_pango_context'?
[ERROR:2024-09-24 13:24:37,801:game]: The game '2048' has no ID, it is not stored in the database.
[ERROR:2024-09-24 13:24:41,543:game]: The game 'AisleRiot Solitaire' has no ID, it is not stored in the database.
[ERROR:2024-09-24 13:24:44,267:game]: The game 'Maelstrom' has no ID, it is not stored in the database.
[INFO:2024-09-24 13:24:57,021:runner]: Runtime disabled by system configuration
[WARNING:2024-09-24 13:25:01,291:game]: Game still running (state: running)
[INFO:2024-09-24 13:25:01,291:game]: Stopping SuperTux 2 (linux)
[WARNING:2024-09-24 13:25:01,292:game]: The game has run for a very short time, did it crash?
[INFO:2024-09-24 13:25:18,021:shortcut]: Removing Steam shortcut for SuperTux 2 (linux)
[ERROR:2024-09-24 13:25:48,668:exception_backstops]: Error handling signal 'row-selected': 'SystemBox' object has no attribute 'get_log_contents'
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/lutris/exception_backstops.py", line 76, in error_wrapper
    return handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/preferences_dialog.py", line 91, in on_sidebar_activated
    generator()
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 73, in populate
    self.log_scrolled_window.add(self.get_log_view())
                                 ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 77, in get_log_view
    log_buffer.set_text(self.get_log_contents())
                        ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SystemBox' object has no attribute 'get_log_contents'. Did you mean: 'get_pango_context'?
[ERROR:2024-09-24 13:28:01,723:exception_backstops]: Error handling signal 'row-selected': 'SystemBox' object has no attribute 'get_log_contents'
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/lutris/exception_backstops.py", line 76, in error_wrapper
    return handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/preferences_dialog.py", line 91, in on_sidebar_activated
    generator()
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 73, in populate
    self.log_scrolled_window.add(self.get_log_view())
                                 ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 77, in get_log_view
    log_buffer.set_text(self.get_log_contents())
                        ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SystemBox' object has no attribute 'get_log_contents'. Did you mean: 'get_pango_context'?
[ERROR:2024-09-24 13:31:45,968:exception_backstops]: Error handling signal 'row-selected': 'SystemBox' object has no attribute 'get_log_contents'
Traceback (most recent call last):
  File "/usr/lib/python3.12/site-packages/lutris/exception_backstops.py", line 76, in error_wrapper
    return handler(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/preferences_dialog.py", line 91, in on_sidebar_activated
    generator()
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 73, in populate
    self.log_scrolled_window.add(self.get_log_view())
                                 ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/site-packages/lutris/gui/config/sysinfo_box.py", line 77, in get_log_view
    log_buffer.set_text(self.get_log_contents())
                        ^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'SystemBox' object has no attribute 'get_log_contents'. Did you mean: 'get_pango_context'?
```