### PR TITLE
Skip downloading cached files

### DIFF
--- a/lutris/gui/widgets/download_collection_progress_box.py
+++ b/lutris/gui/widgets/download_collection_progress_box.py
@@ -1,3 +1,4 @@
+import os
 import time
 from gettext import gettext as _
 
@@ -107,6 +108,15 @@ class DownloadCollectionProgressBox(Gtk.Box):
             self.cancel_button.set_sensitive(False)
             self.is_complete = True
             self.emit("complete", {})
+            return
+
+        # Check if the file already exists in the cache and skip this download then
+        if os.path.exists(file.dest_file):
+            logger.info("File exists, skipping download: '%s'", file.dest_file)
+            self.num_files_downloaded += 1
+            self.current_size += os.path.getsize(file.dest_file)
+            self._file_download = None
+            self.start()
             return
 
         self.update_download_file_label(file.filename)


### PR DESCRIPTION
Adds a check if an installation file is already existing in the cache and skips downloading it then.

My problem was that the download failed midways and I could not resume it anymore. I always needed to restart the complete download, wait until it retrieved all the already existing files, only to find out that it failed again after some hours. So this was wasting time and energy/bandwidth...

Note that the current approach might cause problems if a cached file is broken/incomplete because it is skipped as well.
This can happen for example if Lutris is started from the command line and the download is aborted by canceling the program directly (if the download is aborted via the GUI, the intermediate file is deleted correctly).