### PR TITLE
Small Tweaks to Desktop/Application Launcher entries

### DIFF
--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -65,6 +65,8 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
     # field code in the Exec key.
     command = f"{lutris_executable} {shlex.quote(url)}".replace("%", "%%")
 
+    try_exec = "" if LINUX_SYSTEM.is_flatpak() else "lutris"
+
     launcher_content = dedent(
         """
         [Desktop Entry]
@@ -73,7 +75,8 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
         Icon={}
         Exec=env LUTRIS_SKIP_INIT=1 {}
         Categories=Game
-        """.format(game_name, f"lutris_{game_slug}", command)
+        TryExec={}
+        """.format(game_name, f"lutris_{game_slug}", command, try_exec)
     )
 
     launcher_filename = get_xdg_basename(game_slug, game_id)

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -86,7 +86,7 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
         tmp_launcher.close()
     os.chmod(
         tmp_launcher_path,
-        stat.S_IREAD | stat.S_IWRITE | stat.S_IEXEC | stat.S_IRGRP | stat.S_IWGRP | stat.S_IXGRP,
+        stat.S_IREAD | stat.S_IWRITE | stat.S_IRGRP | stat.S_IWGRP,
     )
 
     if desktop:


### PR DESCRIPTION
This incorporates two small changes:

1. Use the `TryExec` key for generated Desktop Entries
2. Remove the executable bit from Desktop Entries, since it is not required.

---

## 1. `TryExec` key
Generated desktop entries are non-functional when Lutris is not installed (e.g. after user uninstalls Lutris or reinstalls their OS).
We can use `TryExec` to hide such entries. Upon reinstallation of Lutris they will automatically be shown again with no further action by users.

> [`TryExec`](https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html)
>
> Path to an executable file on disk used to determine if the program is actually installed. If the path is not an absolute path, the file is looked up in the $PATH environment variable. If the file is not present or if it is not executable, the entry may be ignored (not be used in menus, for example).

Note this only takes a single executable as a value. For that reason it is not possible to use this key for Flatpaks. The presence of `flatpak` does not guarantee the Lutris Flatpak actually being installed.
The use of `flatpak run net.lutris.Lutris` validates in `desktop-file-validate`, however KDE at least does not show the entry.

An empty value also validates and doesn't hide the entry, so leaving it for Flatpaks appears fine.

## 2. Executable bit
Desktop entries don't need to be executable since they are not actually executed by the application launcher, but rather metadata for an installed binary.

Executing a desktop files also merely results in a lot of junk output on the terminal.

Additionally, any permission that is not required should not be granted, see Principle of least Privilege.