### PR TITLE
Check for Umu/Proton *only* by version, not by path.

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -22,8 +22,11 @@ from lutris.util import extract, linux, selective_merge, system
 from lutris.util.fileio import EvilConfigParser, MultiOrderedDict
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
-from lutris.util.wine import proton
-from lutris.util.wine.wine import WINE_DEFAULT_ARCH, get_default_wine_version, get_wine_path_for_version
+from lutris.util.wine.wine import (
+    WINE_DEFAULT_ARCH,
+    get_default_wine_version,
+    get_wine_or_umu_path_for_version,
+)
 
 
 class CommandsMixin:
@@ -43,32 +46,20 @@ class CommandsMixin:
         runner = self.get_runner_class(self.installer.runner)()
         version = runner.get_installer_runner_version(self.installer, use_runner_config=False)
         if version:
-            wine_path = get_wine_path_for_version(version)
-            if proton.is_proton_version(version):
-                return proton.get_umu_path(), version
-            else:
-                return wine_path, version
+            return get_wine_or_umu_path_for_version(version), version
 
         # Special case that lets the Wine configuration explicit specify the path
         # to the Wine executable, not just a version number.
         if self.installer.runner == "wine":
             try:
                 config_version, runner_config = wine.get_runner_version_and_config()
-                wine_path = get_wine_path_for_version(config_version, config=runner_config.runner_level["wine"])
-
-                if proton.is_proton_version(wine_path):
-                    return proton.get_umu_path(), config_version
-                else:
-                    return wine_path, config_version
+                wine_path = get_wine_or_umu_path_for_version(config_version, config=runner_config.runner_level["wine"])
+                return wine_path, config_version
             except UnspecifiedVersionError:
                 pass
 
         version = get_default_wine_version()
-        wine_path = get_wine_path_for_version(version)
-        if proton.is_proton_version(wine_path):
-            return proton.get_umu_path(), version
-        else:
-            return wine_path, version
+        return get_wine_or_umu_path_for_version(version), version
 
     def get_runner_class(self, runner_name):
         """Runner the runner class from its name"""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -452,5 +452,5 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
 
     def eject_wine_disc(self):
         """Use Wine to eject a CD, otherwise Wine can have problems detecting disc changes"""
-        wine_path = self.get_wine_path()
-        wine.eject_disc(wine_path, self.target_path)
+        wine_path, version = self.get_wine_path_and_version()
+        wine.eject_disc(wine_path, self.target_path, wine_version=version)

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -59,7 +59,9 @@ def set_regedit(
     os.remove(reg_path)
 
 
-def set_regedit_file(filename, wine_path=None, wine_version=None, prefix=None, arch=WINE_DEFAULT_ARCH, proton_verb=None):
+def set_regedit_file(
+    filename, wine_path=None, wine_version=None, prefix=None, arch=WINE_DEFAULT_ARCH, proton_verb=None
+):
     """Apply a regedit file to the Windows registry."""
     if arch == "win64" and wine_path and system.path_exists(wine_path + "64"):
         # Use wine64 by default if set to a 64bit prefix. Using regular wine
@@ -482,7 +484,16 @@ def winetricks(
     )
 
 
-def winecfg(wine_path=None, wine_version=None, prefix=None, arch=WINE_DEFAULT_ARCH, config=None, env=None, runner=None, proton_verb=None):
+def winecfg(
+    wine_path=None,
+    wine_version=None,
+    prefix=None,
+    arch=WINE_DEFAULT_ARCH,
+    config=None,
+    env=None,
+    runner=None,
+    proton_verb=None,
+):
     """Execute winecfg."""
 
     if not wine_path:
@@ -515,7 +526,9 @@ def eject_disc(wine_path, prefix, wine_version=None, proton_verb=None):
     wineexec("eject", prefix=prefix, wine_path=wine_path, wine_version=wine_version, args="-a", proton_verb=proton_verb)
 
 
-def install_cab_component(cabfile, component, wine_version=None, wine_path=None, prefix=None, arch=None, proton_verb=None):
+def install_cab_component(
+    cabfile, component, wine_version=None, wine_path=None, prefix=None, arch=None, proton_verb=None
+):
     """Install a component from a cabfile in a prefix"""
 
     if proton.is_umu_path(wine_path):
@@ -524,7 +537,14 @@ def install_cab_component(cabfile, component, wine_version=None, wine_path=None,
     files = cab_installer.extract_from_cab(cabfile, component)
     registry_files = cab_installer.get_registry_files(files)
     for registry_file, _arch in registry_files:
-        set_regedit_file(registry_file, wine_path=wine_path, wine_version=wine_version, prefix=prefix, arch=_arch, proton_verb=proton_verb)
+        set_regedit_file(
+            registry_file,
+            wine_path=wine_path,
+            wine_version=wine_version,
+            prefix=prefix,
+            arch=_arch,
+            proton_verb=proton_verb,
+        )
     cab_installer.cleanup()
 
 

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -22,24 +22,6 @@ def is_proton_version(version: str) -> bool:
     return "Proton" in version and "lutris" not in version
 
 
-def is_proton_path(wine_path: Optional[str]) -> bool:
-    """True if the wine-path refers to a Proton Wine installation; these require
-    special handling. The Umu path is considered a Proton-path too."""
-    if not wine_path:
-        return False
-
-    if is_umu_path(wine_path):
-        return True
-
-    # This is janky, but we can at least not trigger Umu because the user's
-    # username contains "Proton" or whatnot.
-    #
-    # This will still activate Umu for paths like
-    #   ~/.local/share/Steam/steamapps/common/Proton - Experimental/
-    relative = system.reverse_expanduser(wine_path)
-    return "Proton" in relative and "lutris" not in relative
-
-
 def is_umu_path(wine_path: Optional[str]) -> bool:
     """True if the path given actually runs Umu; this will run Proton-Wine in turn,
     but can be directed to particular Proton implementation by setting the env-var

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -134,6 +134,22 @@ def get_wine_path_for_version(version: str, config: dict = None) -> str:
     if not version and config:
         version = config["version"]
 
+    return _get_wine_path_for_version(version)
+
+
+def get_wine_or_umu_path_for_version(version: str, config: dict = None) -> str:
+    """Returns the wine path for a version, but if the version is an Umu version then the
+    Umu path is returned instead of finding the Wine path."""
+    if not version and config:
+        version = config["version"]
+
+    if proton.is_proton_version(version):
+        return proton.get_umu_path()
+    else:
+        return _get_wine_path_for_version(version, config)
+
+
+def _get_wine_path_for_version(version: str, config: dict = None) -> str:
     if not version:
         raise UnspecifiedVersionError(_("The Wine version must be specified."))
 


### PR DESCRIPTION
This PR removes the ``is_proton_path()`` jank; it deletes that function altogether.

The only way to decide if a Wine version is Protonic by looking at the version string. This means it is done consistently (or so I hope). At least it does not depend on the version sometimes, and the directory containing Wine sometimes

To do this, there's a new ``wine_version`` argument passed in to almost all of the ``command/wine.py`` commands; this is provided automatically just like ``wine_path`` is. In some cases these commands create a runner, but they now give it an that explicit ``wine_version`` to use instead of the usual configuration stuff.

I've done some testing, but this is substantial enough (and close enough to release) that I'd like some more eyes on it, rather than just merging the fix up front.

But I am convinced that deciding when to use Umu in two different ways that can disagree just *can't* be right. Let's try to get this fixed for 0.5.18.