### PR TITLE
Add options to the Ruffle runner

### DIFF
--- a/lutris/runners/json.py
+++ b/lutris/runners/json.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import shlex
 
 from lutris import settings
 from lutris.exceptions import MissingGameExecutableError
@@ -52,6 +53,11 @@ class JsonRunner(Runner):
             elif option["type"] == "string":
                 arguments.append(option["argument"])
                 arguments.append(self.runner_config.get(option["option"]))
+            elif option["type"] == "command_line":
+                arg = option.get("argument")
+                if arg:
+                    arguments.append(arg)
+                arguments += shlex.split(self.runner_config.get(option["option"]))
             else:
                 raise RuntimeError("Unhandled type %s" % option["type"])
         main_file = self.game_config.get(self.entry_point_option)

--- a/share/lutris/json/ruffle.json
+++ b/share/lutris/json/ruffle.json
@@ -71,6 +71,19 @@
             "advanced": true,
             "argument": "--no-gui",
             "help": "Hides the menu bar (the bar at the top of the window)"
+        },
+        {
+            "option": "open_url_mode",
+            "type": "choice",
+            "label": "Open URLs",
+            "choices": [
+                ["Automatic", "off"],
+                ["Allow", "allow"],
+                ["Confirm", "confirm"],
+                ["Deny", "deny"]
+            ],
+            "default": "off",
+            "argument": "--open-url-mode"
         }
     ]
 }

--- a/share/lutris/json/ruffle.json
+++ b/share/lutris/json/ruffle.json
@@ -14,6 +14,11 @@
     ],
     "runner_options": [
         {
+            "option": "args",
+            "type": "command_line",
+            "label": "Arguments"
+        },
+        {
             "option": "fullscreen",
             "type": "bool",
             "default": true,


### PR DESCRIPTION
Pretty minor, but this adds 2 options for the Ruffle runner:
![Screenshot from 2024-10-20 15-09-11](https://github.com/user-attachments/assets/a328d600-6d0c-498b-8c13-c5750d59a072)

'Arguments' is a full command line, which can be used to enter arbitrary options. Might be useful for other runners, but this PR is just for Ruffle. The UI is our existing ``command_line`` option type, which lets you treat it as a file path, which does not make all that much sense here. I put this on the runner options since the options for Ruffle seem to be 'runner level' to me, rather than game level as for the Wine runner.

'Open URLs' is a more basic option to control how to handle Flash games that try to open URLs; the default Automatic option omits the option, so your Ruffle configuration will govern this.

Resolves #5655