### PR TITLE
refactor proton/umu detection and usage

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -21,7 +21,6 @@ from lutris.util import extract, linux, selective_merge, system
 from lutris.util.fileio import EvilConfigParser, MultiOrderedDict
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
-from lutris.util.wine import proton
 from lutris.util.wine.wine import WINE_DEFAULT_ARCH, get_default_wine_version, get_wine_path_for_version
 
 
@@ -38,10 +37,7 @@ class CommandsMixin:
         version = runner.get_installer_runner_version(self.installer, use_runner_config=False)
         if version:
             wine_path = get_wine_path_for_version(version)
-            if proton.is_proton_path(wine_path):
-                return proton.get_umu_path()
-            else:
-                return wine_path
+            return wine_path
 
         # Special case that lets the Wine configuration explicit specify the path
         # to the Wine executable, not just a version number.
@@ -49,20 +45,13 @@ class CommandsMixin:
             try:
                 config_version, runner_config = wine.get_runner_version_and_config()
                 wine_path = get_wine_path_for_version(config_version, config=runner_config.runner_level["wine"])
-
-                if proton.is_proton_path(wine_path):
-                    return proton.get_umu_path()
-                else:
-                    return wine_path
+                return wine_path
             except UnspecifiedVersionError:
                 pass
 
         version = get_default_wine_version()
         wine_path = get_wine_path_for_version(version)
-        if proton.is_proton_path(wine_path):
-            return proton.get_umu_path()
-        else:
-            return wine_path
+        return wine_path
 
     def get_runner_class(self, runner_name):
         """Runner the runner class from its name"""

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -737,9 +737,9 @@ class wine(Runner):
         """
         if version is None:
             version = self.read_version_from_config()
-        if version == proton.GE_PROTON_LATEST:
-            return proton.get_umu_path()
 
+        if proton.is_proton_version(version):
+            return proton.get_proton_wine_path(version)
         try:
             wine_path = self.get_path_for_version(version)
             if system.path_exists(wine_path):
@@ -987,7 +987,7 @@ class wine(Runner):
                     if (
                         value
                         and key in ("Desktop", "WineDesktop")
-                        and ("wine-ge" in self.get_executable().lower() or "proton" in self.get_executable().lower())
+                        and ("wine-ge" in self.get_executable().lower() or "umu" in self.get_executable().lower())
                     ):
                         logger.warning("Wine Virtual Desktop can't be used with Wine-GE and Proton")
                         value = None
@@ -1153,9 +1153,8 @@ class wine(Runner):
             exe = self.get_executable()
             if WINE_DIR:
                 wine_path = os.path.dirname(os.path.dirname(exe))
-            for proton_path in proton.get_proton_paths():
-                if proton_path in exe:
-                    wine_path = os.path.dirname(os.path.dirname(exe))
+            if "umu" in exe:
+                wine_path = proton.get_umu_path()
         except MisconfigurationError:
             wine_path = None
 

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -38,10 +38,11 @@ except Exception as ex:
 
 def detect_arch(prefix_path: str = None, wine_path: str = None) -> str:
     """Given a Wine prefix path, return its architecture"""
+    if wine_path:
+        if proton.is_proton_path(wine_path) or system.path_exists(wine_path + "64"):
+            return "win64"
     if prefix_path and is_prefix_directory(prefix_path):
         return detect_prefix_arch(prefix_path)
-    if wine_path and system.path_exists(wine_path + "64"):
-        return "win64"
     return "win32"
 
 
@@ -140,7 +141,7 @@ def get_wine_path_for_version(version: str, config: dict = None) -> str:
     if version in WINE_PATHS:
         return system.find_required_executable(WINE_PATHS[version])
     if proton.is_proton_version(version):
-        return proton.get_proton_bin_for_version(version)
+        return proton.get_proton_wine_path(version)
     if version == "custom":
         if config is None:
             raise RuntimeError("Custom wine paths are only supported when a configuration is available.")


### PR DESCRIPTION
complete refactor to allow UMU:
1. full detection of proton path and wine executable as well as proton version
2. full winetricks support
3. full wine program support (winecfg, regedit, wineconsole, etc)
4. full installations for wine games using UMU
5. we do -not- replace the wine executable with umu in get_executable. Instead we safely get the proper wine executable from the proton path and use updated is_proton_path to determine if it's proton, then if so we perform an umu swap in only 5 locations -- 

runners/wine.py `get_command`:
```
    def get_command(self) -> List[str]:
        command = super().get_command()
        if command:
            exe = command[0]

            if proton.is_proton_path(exe) and not proton.is_umu_path(exe):
                command[0] = proton.get_umu_path()
```
runners/commands/wine.py `createprefix`:
```
    if proton.is_proton_path(wine_path):
        # All proton path prefixes are created via Umu; if you aren't using
        # the default Umu, we'll use PROTONPATH to indicate what Proton is
        # to be used.
        wineenv["PROTON_VERB"] = "run"

        proton.update_proton_env(wine_path, wineenv)

        command = MonitoredCommand([proton.get_umu_path(), "createprefix"], env=wineenv)
        command.start()
    else:
        wineboot_path = os.path.join(os.path.dirname(wine_path), "wineboot")
```

runners/commands/wine.py `winekill`:
```
def winekill(prefix, arch=WINE_DEFAULT_ARCH, wine_path=None, env=None, initial_pids=None, runner=None):
    """Kill processes in Wine prefix."""

    initial_pids = initial_pids or []
    steam_data_dir = os.path.expanduser("~/.local/share/Steam/compatibilitytools.d")
    if not env:
        env = {"WINEARCH": arch, "WINEPREFIX": prefix}
    if proton.is_proton_path(wine_path):
        command = [proton.get_umu_path(), "wineboot", "-k"]
```

runners/commands/wine.py `wineexec`:
```
    command_parameters = []
    if proton.is_proton_path(wine_path):
        command_parameters.append(proton.get_umu_path())
        if winetricks_wine is not "" and wine_path not in winetricks_wine:
            command_parameters.append("winetricks")
    else:
        command_parameters.append(wine_path)
```

runners/commands/wine.py `open_wine_terminal`:
```
def open_wine_terminal(terminal, wine_path, prefix, env, system_winetricks):
    winetricks_path, _working_dir, env = find_winetricks(env, system_winetricks)
    if proton.is_proton_path(wine_path):
        wine_path = proton.get_umu_path() + " wine"
        env["PROTON_VERB"] = "waitforexitandrun"
        proton.update_proton_env(wine_path, env)

    aliases = {
        "wine": wine_path,
        "winecfg": wine_path + "cfg",
        "wineserver": wine_path + "server",
        "wineboot": wine_path + "boot",
        "winetricks": winetricks_path,
    }
```


Basically, wineexec, and functions that use wine but do not call wineexec directly. `open_wine_terminal` is the only one we modify the actual wine_path, the rest wine_path is completely untouched.