### PR TITLE
Change gamescope HDR envar to right one

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -82,7 +82,7 @@ def get_launch_parameters(runner, gameplay_info):
     if has_gamescope:
         launch_arguments = get_gamescope_args(launch_arguments, system_config)
         if system_config.get("gamescope_hdr"):
-            env["ENABLE_HDR_WSI"] = "1"
+            env["DXVK_HDR"] = "1"
 
     return launch_arguments, env
 


### PR DESCRIPTION
"ENABLE_HDR_WSI=1" is an environment variable for native Wayland clients that don't support either "xx-color-management" or "frog-color-management" so they would use a Vulkan layer instead. Gamescope does support "frog-color-management" but it should get HDR data from game which in turn requires "DXVK_HDR=1".