### PR TITLE
Fix tooltips on some Gtk3 themes on X11

### DIFF
--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -679,10 +679,10 @@ class ConfigBox(VBox):
         label = Label(text)
         label.set_use_markup(True)
         label.set_max_width_chars(60)
-        hbox = Gtk.Box()
-        hbox.pack_start(label, False, False, 0)
-        hbox.show_all()
-        tooltip.set_custom(hbox)
+        event_box = Gtk.EventBox()
+        event_box.add(label)
+        event_box.show_all()
+        tooltip.set_custom(event_box)
         return True
 
     def option_changed(self, widget, option_name, value):


### PR DESCRIPTION
As reported in lutris/lutris#4868 , under some circumstances Lutris custom tooltips are completely broken. More specifically this happens only on X11 with KDE 5/6, and only with some themes. I honestly don't know why there are these differences between themes or X11/Wayland, but the problem is caused by the tooltip (which is a Gtk Box) that steal window focus when appear. For this reason I switched tooltips to Gtk EventBox. The advantage of EventBox compared to Box is that EventBox cannot gain focus and ignore hover events unless explicitly configured, so we are 100% sure that tooltips won't interfere with Lutris windows. Please note that this PR has been tested only on KDE on both X11/Wayland in Ubuntu Oracular, even if should work fine on Gnome and other DEs it would be probably better to try it before merge, at least to check if there are aesthetic changes. Last thing, this bug does not seem related to some specific GPU/driver, I can reproduce it on Intel, AMD and NVidia GPUs on X11, and all of them works fine on Wayland.
PS: while i was at it I've also fixed some pylint warns, is the line limit to 100 characters good for you guys or you prefer a different length?

EDIT: I answered myself when I saw ruff check fail, removed the offending changes and ran a format, now ruff it's happy again