### PR TITLE
Runner download: properly handle download cancel action

### DIFF
--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -96,8 +96,6 @@ class RunnerBox(Gtk.Box):
 
         if self.runner.is_installed():
             self.emit("runner-installed")
-        else:
-            raise RuntimeError("Runner failed to install")
 
     def on_configure_clicked(self, widget):
         window = self.get_toplevel()

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -521,8 +521,11 @@ class Runner:  # pylint: disable=too-many-public-methods
         if not dest:
             dest = settings.RUNNER_DIR
 
-        install_ui_delegate.download_install_file(url, runner_archive)
-        self.extract(archive=runner_archive, dest=dest, merge_single=merge_single, callback=callback)
+        download_successful = install_ui_delegate.download_install_file(url, runner_archive)
+        if download_successful:
+            self.extract(archive=runner_archive, dest=dest, merge_single=merge_single, callback=callback)
+        else:
+            logger.info("Download canceled by the user.")
 
     def extract(self, archive=None, dest=None, merge_single=None, callback=None):
         if not system.path_exists(archive, exclude_empty=True):


### PR DESCRIPTION
This PR fixes an exception raised when user start a runner download and then press the cancel button (read commit message for details). in addition to what I have already written I have tried to crash Lutris in every way I could think of (malformed urls, decompression of non existent archives, corrupted archives) but I have not been able to do so, Lutris handled all the other exceptions as before