### PR TITLE
Proton: fix proton download everytime Lutris check for updates

### DIFF
--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -311,6 +311,9 @@ class RuntimeComponentUpdater(ComponentUpdater):
     @property
     def local_runtime_path(self) -> str:
         """Return the local path for the runtime folder"""
+        if self.name == "ge-proton":
+            proton_dir = "proton/GE-Proton/"
+            return os.path.join(settings.RUNNER_DIR, proton_dir)
         return os.path.join(settings.RUNTIME_DIR, self.name)
 
     def get_updated_at(self) -> time.struct_time:


### PR DESCRIPTION
Proton is a special case, it's treated like a runtime but it's not a runtime so we must set the runner dir. Additionally it use a custom dir that must be set or local_runtime_path will fail and Lutris will download it again the next time updates are checked.

Test: updated proton, restarted Lutris and manually checked for updates

Fixes lutris/lutris#5714

NOTE: probably not the cleanest thing to do but works fine with minimal changes