### PR TITLE
Ubuntu: packaging: add AppArmor profile for bwrap

### DIFF
--- a/debian/apparmor-profile
+++ b/debian/apparmor-profile
@@ -1,0 +1,68 @@
+# This profile allows almost everything and only exists to allow
+# bwrap to work on a system with user namespace restrictions
+# being enforced.
+# bwrap is allowed access to user namespaces and capabilities
+# within the user namespace, but its children do not have
+# capabilities, blocking bwrap from being able to be used to
+# arbitrarily by-pass the user namespace restrictions.
+#
+# Note: the bwrap child is stacked against the bwrap profile due to
+# bwraps use of no-new-privs
+
+# disabled by default as it can break some use cases on a system that
+# doesn't have or has disable user namespace restrictions for unconfined
+# use aa-enforce to enable it
+
+abi <abi/4.0>,
+
+include <tunables/global>
+
+profile bwrap /usr/bin/bwrap flags=(attach_disconnected,mediate_deleted) {
+  allow capability,
+  # not allow all, to allow for pix stack
+  # sadly we have to allow  m every where to allow children to work under
+  # stacking.
+  allow file rwlkm /{**,},
+  allow network,
+  allow unix,
+  allow ptrace,
+  allow signal,
+  allow mqueue,
+  allow io_uring,
+  allow userns,
+  allow mount,
+  allow umount,
+  allow pivot_root,
+  allow dbus,
+  allow px /** -> bwrap//&unpriv_bwrap,
+
+  # the local include should not be used without understanding the userns
+  # restriction.
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/bwrap-userns-restrict>
+}
+
+profile unpriv_bwrap flags=(attach_disconnected,mediate_deleted) {
+  # not allow all, to allow for pix stack
+  allow file rwlkm /{**,},
+  allow network,
+  allow unix,
+  allow ptrace,
+  allow signal,
+  allow mqueue,
+  allow io_uring,
+  allow userns,
+  allow mount,
+  allow umount,
+  allow pivot_root,
+  allow dbus,
+
+  allow pix /** -> &unpriv_bwrap,
+
+  audit deny capability,
+
+  # the local include should not be used without understanding the userns
+  # restriction.
+  # Site-specific additions and overrides. See local/README for details.
+  include if exists <local/unpriv_bwrap>
+}

--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Priority: optional
 Maintainer: Mathieu Comandon <mathieucomandon@gmail.com>
 Build-Depends: debhelper-compat (= 12),
                appstream,
+               dh-apparmor,
                dh-sequence-python3,
                meson,
 Rules-Requires-Root: no

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+set -e
+
+# Remove apparmor profile if abi < 4.0
+if [ ! -e /etc/apparmor.d/abi/4.0 ]; then
+    rm -f /etc/apparmor.d/lutris-bwrap-userns-restrict
+    rm -f /etc/apparmor.d/local/lutris-bwrap-userns-restrict
+else
+    if [ -e /etc/apparmor.d/bwrap-userns-restrict ]; then
+        # Ubuntu profile found, remove our custom profile
+        rm -f /etc/apparmor.d/lutris-bwrap-userns-restrict
+        rm -f /etc/apparmor.d/local/lutris-bwrap-userns-restrict
+    else
+        # Restart apparmor and load bwrap profile if abi = 4.0
+        systemctl restart apparmor.service || true
+    fi
+fi

--- a/debian/postrm
+++ b/debian/postrm
@@ -1,0 +1,24 @@
+#!/bin/sh
+
+set -e
+
+if [ -e /etc/apparmor.d/abi/4.0 ]; then
+    if [ ! -e /etc/apparmor.d/bwrap-userns-restrict ]; then
+        # By default only apt purge remove AppArmor profiles, remove
+        # it even with an apt remove and notify user that a reboot is
+        # required.
+        rm -f /etc/apparmor.d/lutris-bwrap-userns-restrict
+        rm -f /etc/apparmor.d/local/lutris-bwrap-userns-restrict
+
+        # Used by unattended-upgrades etc.
+        touch /var/run/reboot-required || true
+
+        if ! grep -Fqsx lutris /run/reboot-required.pkgs; then
+            echo lutris >> /run/reboot-required.pkgs || true
+        fi
+
+        # same thing for the older update-notifier interface
+        [ -x /usr/share/update-notifier/notify-reboot-required ] && \
+            /usr/share/update-notifier/notify-reboot-required || true
+    fi
+fi

--- a/debian/rules
+++ b/debian/rules
@@ -12,3 +12,7 @@ override_dh_auto_configure:
 
 override_dh_builddeb:
 	dh_builddeb -- -Zgzip
+
+execute_after_dh_install:
+	install -m 0644 -D debian/apparmor-profile debian/lutris/etc/apparmor.d/lutris-bwrap-userns-restrict
+	dh_apparmor --profile-name=lutris-bwrap-userns-restrict


### PR DESCRIPTION
Starting with Ubuntu 23.10 Canonical begin to restrict unprivileged user namespaces.[1] After this change AppArmor completely block bwrap, breaking Umu, which stops with the following error:

```
pressure-vessel-wrap[290705]: E: Child process exited with code 1: bwrap: setting up uid map: Permission denied
```

The solution is to add the missing AppArmor profile for bwrap. Ubuntu already has it on apparmor-profiles package, but it's still in testing phase. This commit adds the profile to Lutris package and add the rules during the deb installation.[2] Since it's an experimental profile it may not be perfect or cause some issues on some corner cases, but it's still much more better than leave bwrap completely unconfined or Umu broken for all Ubuntu users on 23.10+.

Note: The profile will break AppArmor with ABI version < 4, for this reason this patch include a postinst script[3] that will remove bwrap profile in case Lutris is installed on an old Ubuntu version or Debian (ABI 3).

Note for packaging: dh-apparmor now is a required build dependency.

Test:
1) Kubuntu 24.10 (Real HW) ABI 4: AppArmor OK (rules applied), Umu works
2) Ubuntu 23.04 (VM) ABI 3: AppArmor OK (rules removed), Umu works
3) Debian 12 (VM) ABI 3: AppArmor OK (rules removed), Umu works

[1] https://ubuntu.com/blog/ubuntu-23-10-restricted-unprivileged-user-namespaces
[2] https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
[3] https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html#summary-of-ways-maintainer-scripts-are-called

EDIT
v2: restart apparmor in postinst if ABI = 4 (load rules without the need of a reboot) and renamed apparmor profile (avoid dpkg conflicts when Ubuntu will move the profile from extra to apparmor.d)