### PR TITLE
Return of the Saved Searches!

### DIFF
--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -36,16 +36,16 @@ class SearchFiltersBox(Gtk.Box):
         self.set_margin_end(20)
         self.set_spacing(10)
 
-        self.name_entry = self._add_entry_box(_("Name"), self.saved_search.name)
+        # self.name_entry = self._add_entry_box(_("Name"), self.saved_search.name)
         self.search_entry = search_entry or self._add_entry_box(_("Search"), self.search)
         self.search_entry.connect("changed", self.on_search_entry_changed)
 
         self.predicate_widget_functions: Dict[str, Callable[[SearchPredicate], None]] = {}
         self.updating_predicate_widgets = False
 
-        predicates_box = Gtk.Box(Gtk.Orientation.HORIZONTAL)
+        predicates_box = Gtk.Box(Gtk.Orientation.HORIZONTAL, spacing=6)
 
-        self.flags_grid = Gtk.Grid(row_spacing=6, column_spacing=6, margin=6)
+        self.flags_grid = Gtk.Grid(row_spacing=6, column_spacing=6)
         self._add_flag_widgets()
 
         categories_scrolled_window = Gtk.ScrolledWindow(visible=True)

--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -19,7 +19,7 @@ from lutris.search_predicate import AndPredicate, SearchPredicate, format_flag
 class SearchFiltersBox(Gtk.Box):
     """A widget to edit dynamic categories"""
 
-    def __init__(self, saved_search: SavedSearch) -> None:
+    def __init__(self, saved_search: SavedSearch, search_entry: Gtk.SearchEntry = None) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
         self.saved_search = copy(saved_search)
         self.original_search = copy(saved_search)
@@ -37,7 +37,7 @@ class SearchFiltersBox(Gtk.Box):
         self.set_spacing(10)
 
         self.name_entry = self._add_entry_box(_("Name"), self.saved_search.name)
-        self.search_entry = self._add_entry_box(_("Search"), self.search)
+        self.search_entry = search_entry or self._add_entry_box(_("Search"), self.search)
         self.search_entry.connect("changed", self.on_search_entry_changed)
 
         self.predicate_widget_functions: Dict[str, Callable[[SearchPredicate], None]] = {}

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -71,6 +71,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     sidebar_scrolled: Gtk.ScrolledWindow = GtkTemplate.Child()
     game_revealer: Gtk.Revealer = GtkTemplate.Child()
     search_entry: Gtk.SearchEntry = GtkTemplate.Child()
+    search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
+    search_box: Gtk.Box = GtkTemplate.Child()
     zoom_adjustment: Gtk.Adjustment = GtkTemplate.Child()
     blank_overlay: Gtk.Alignment = GtkTemplate.Child()
     viewtype_icon: Gtk.Image = GtkTemplate.Child()
@@ -81,8 +83,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     turn_on_library_sync_label: Gtk.Label = GtkTemplate.Child()
     version_notification_revealer: Gtk.Revealer = GtkTemplate.Child()
     version_notification_label: Gtk.Revealer = GtkTemplate.Child()
-    search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
-    search_box: Gtk.Box = GtkTemplate.Child()
     show_hidden_games_button: Gtk.ModelButton = GtkTemplate.Child()
 
     def __init__(self, application, **kwargs) -> None:
@@ -159,7 +159,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
         search = self.get_game_search()
         new_search = saved_searches_db.SavedSearch(0, "", str(search))
-        filter_box = SearchFiltersBox(saved_search=new_search)
+        filter_box = SearchFiltersBox(saved_search=new_search, search_entry=self.search_entry)
         filter_box.show()
         self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_box)
         self.search_filters_button.set_popover(self.filter_popover)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -157,14 +157,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.revealer_box = Gtk.HBox(visible=True)
         self.game_revealer.add(self.revealer_box)
 
-        search = self.get_game_search()
-        new_search = saved_searches_db.SavedSearch(0, "", str(search))
-        filter_box = SearchFiltersBox(saved_search=new_search, search_entry=self.search_entry)
-        filter_box.set_size_request(600, -1)
-        filter_box.show()
-        self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_box)
-        self.search_filters_button.set_popover(self.filter_popover)
-
         self.update_action_state()
         self.update_notification()
 
@@ -343,8 +335,19 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             self.sidebar.hidden_row.show()
             self.sidebar.selected_category = hidden_category
 
-    def on_open_search_filters(self, action, value):
-        self.filter_popover.popup()
+    def on_open_search_filters(self, _action, _value):
+        def on_filter_popover_closed(_popover):
+            self.search_filters_button.set_active(False)
+
+        if self.search_filters_button.get_active():
+            search = self.get_game_search()
+            new_search = saved_searches_db.SavedSearch(0, "", str(search))
+            filter_box = SearchFiltersBox(saved_search=new_search, search_entry=self.search_entry)
+            filter_box.set_size_request(600, -1)
+            filter_box.show()
+            filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_filters_button)
+            filter_popover.connect("closed", on_filter_popover_closed)
+            filter_popover.popup()
 
     @property
     def current_view_type(self):

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -160,6 +160,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         search = self.get_game_search()
         new_search = saved_searches_db.SavedSearch(0, "", str(search))
         filter_box = SearchFiltersBox(saved_search=new_search, search_entry=self.search_entry)
+        filter_box.set_size_request(600, -1)
         filter_box.show()
         self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_box)
         self.search_filters_button.set_popover(self.filter_popover)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -81,7 +81,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     turn_on_library_sync_label: Gtk.Label = GtkTemplate.Child()
     version_notification_revealer: Gtk.Revealer = GtkTemplate.Child()
     version_notification_label: Gtk.Revealer = GtkTemplate.Child()
-    # search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
+    search_filters_button: Gtk.MenuButton = GtkTemplate.Child()
     search_box: Gtk.Box = GtkTemplate.Child()
     show_hidden_games_button: Gtk.ModelButton = GtkTemplate.Child()
 
@@ -161,8 +161,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         new_search = saved_searches_db.SavedSearch(0, "", str(search))
         filter_box = SearchFiltersBox(saved_search=new_search)
         filter_box.show()
-        # self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_box)
-        # self.search_filters_button.set_popover(self.filter_popover)
+        self.filter_popover = Gtk.Popover(child=filter_box, can_focus=False, relative_to=self.search_box)
+        self.search_filters_button.set_popover(self.filter_popover)
 
         self.update_action_state()
         self.update_notification()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -39,7 +39,7 @@ from lutris.gui.views.store import GameStore
 from lutris.gui.widgets.game_bar import GameBar
 from lutris.gui.widgets.gi_composites import GtkTemplate
 from lutris.gui.widgets.sidebar import LutrisSidebar
-from lutris.gui.widgets.utils import load_icon_theme, open_uri
+from lutris.gui.widgets.utils import has_stock_icon, load_icon_theme, open_uri
 from lutris.runtime import ComponentUpdater, RuntimeUpdater
 from lutris.search import GameSearch
 from lutris.search_predicate import NotPredicate
@@ -131,6 +131,15 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             self.maximize()
         self.init_template()
         self._init_actions()
+
+        # Since system-search-symbolic is already *right there* we'll try to pick some
+        # other icon for the button that shows the search popover.
+        fallback_filter_icons_names = ["filter-symbolic", "edit-find-replace-symbolic", "system-search-symbolic"]
+        filter_button_image = self.search_filters_button.get_child()
+        for n in fallback_filter_icons_names:
+            if has_stock_icon(n):
+                filter_button_image.set_from_icon_name(n, Gtk.IconSize.BUTTON)
+                break
 
         # Setup Drag and drop
         self.drag_dest_set(Gtk.DestDefaults.ALL, [], Gdk.DragAction.COPY)

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -336,7 +336,7 @@
               </packing>
             </child>
             <child>
-              <object class="GtkMenuButton" id="search_filters_button">
+              <object class="GtkToggleButton" id="search_filters_button">
                 <property name="visible">True</property>
                 <property name="can-focus">True</property>
                 <property name="receives-default">True</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -305,7 +305,6 @@
           <object class="GtkBox" id="search_box">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="spacing">6</property>
             <child>
               <object class="GtkSearchEntry" id="search_entry">
                 <property name="visible">True</property>
@@ -357,6 +356,9 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <style>
+              <class name="linked"/>
+            </style>
           </object>
           <packing>
             <property name="position">1</property>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -305,6 +305,7 @@
           <object class="GtkBox" id="search_box">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="spacing">6</property>
             <child>
               <object class="GtkSearchEntry" id="search_entry">
                 <property name="visible">True</property>
@@ -330,9 +331,30 @@
                 <signal name="search-changed" handler="on_search_entry_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkMenuButton" id="search_filters_button">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="action-name">win.open-search-filters</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">system-search-symbolic</property>
+                    <property name="use-fallback">True</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
               </packing>
             </child>
           </object>

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -345,7 +345,6 @@
                   <object class="GtkImage">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
-                    <property name="icon-name">system-search-symbolic</property>
                     <property name="use-fallback">True</property>
                   </object>
                 </child>


### PR DESCRIPTION
Well, 0.5.18 is taking a while, so I figured I'd take the leftover code for saved searches and glue it all together. It really didn't take that much glue. Here's what the search UI looks like:
![Screenshot from 2024-11-13 17-31-15](https://github.com/user-attachments/assets/a168512a-2521-4c87-864f-b2440907e92e)
A linked button looks like part of the search box. Click it and there's a pop-over:
![Screenshot from 2024-11-13 17-32-06](https://github.com/user-attachments/assets/a2bf0993-0154-44e6-b25e-7e3b0c2d2e16)
The search text is still in the same box, and you can edit it by using the pop-overs controls. It updates immediately and is reflected quickly in the view behind. But notice you can enter a name. That tag button is the save button- these are supposed to be 'dynamic categories' now so that seems appropriate. Click that and here's where you go:
![Screenshot from 2024-11-13 17-32-18](https://github.com/user-attachments/assets/8cf3aa45-afe2-4abf-b9d4-e28b983e425e)
We reset the search but switch to the newly saved category. The saved search has an edit button on that is pretty much identical to the work from the previous PR, #5536.

One concern you may have is the icon in the pop-over button. @strycore's effort used ``filter-symbolic`` here. My icon theme hasn't got this icon (and it's ugly and its mother dresses it funny) so I picked some fallbacks. You are seeing ``edit-find-replace-symbolic`` here.

But ``filter-symbolic`` is preferred if you do have it; here's what it looks like with the Breeze icon theme:
![Screenshot from 2024-11-13 17-32-56](https://github.com/user-attachments/assets/35288c4f-a522-4b3b-bbec-2ad5671c736d)
Not a fan, but I would never question maximum leader within earshot.