### PR TITLE
check hash for download installers

### DIFF
--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -221,6 +221,7 @@ class InstallerFileBox(Gtk.VBox):
     def on_download_complete(self, widget, _data=None):
         """Action called on a completed download."""
         logger.info("Download completed")
+        self.installer_file.check_hash()
         if isinstance(widget, SteamInstaller):
             self.installer_file.dest_file = widget.get_steam_data_path()
         else:

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -223,7 +223,9 @@ class InstallerFile:
         logger.info("Checking hash %s for %s", hash_type, self.dest_file)
         calculated_hash = system.get_file_checksum(self.dest_file, hash_type)
         if calculated_hash != expected_hash:
-            raise ScriptingError(hash_type.capitalize() + _(" checksum mismatch "), f"{expected_hash} != {calculated_hash}")
+            raise ScriptingError(
+                hash_type.capitalize() + _(" checksum mismatch "), f"{expected_hash} != {calculated_hash}"
+            )
 
     @property
     def size(self):

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -220,8 +220,10 @@ class InstallerFile:
         except ValueError as err:
             raise ScriptingError(_("Invalid checksum, expected format (type:hash) "), self.checksum) from err
 
-        if system.get_file_checksum(self.dest_file, hash_type) != expected_hash:
-            raise ScriptingError(hash_type.capitalize() + _(" checksum mismatch "), self.checksum)
+        logger.info("Checking hash %s for %s", hash_type, self.dest_file)
+        calculated_hash = system.get_file_checksum(self.dest_file, hash_type)
+        if calculated_hash != expected_hash:
+            raise ScriptingError(hash_type.capitalize() + _(" checksum mismatch "), f"{expected_hash} != {calculated_hash}")
 
     @property
     def size(self):

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -146,7 +146,7 @@ class InstallerFileCollection:
             if not installer_file.is_ready(provider):
                 return False
         return True
-    
+
     def check_hash(self):
         """Check the hash of all the files (if available)"""
         for installer_file in self.files_list:

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -146,6 +146,11 @@ class InstallerFileCollection:
             if not installer_file.is_ready(provider):
                 return False
         return True
+    
+    def check_hash(self):
+        """Check the hash of all the files (if available)"""
+        for installer_file in self.files_list:
+            installer_file.check_hash()
 
     @property
     def is_cached(self):


### PR DESCRIPTION
Implements #1218 - not sure if this is enough to close it.

Using [6 Days A Sacrifice](https://lutris.net/games/install/3246/view) as example, we add `checksum`:

```yaml
  files:
  - game:
      filename: 6days_se.zip
      url: http://www.g4g.it/files3/2009/FullyRamblomatic_SpecialEditions_www.g4g.it.zip
      checksum: md5:5a546c58dd0323a6dcbc31dfcd90c339
```