### PR TITLE
Move fluidsynth as optional command

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -32,11 +32,11 @@ SYSTEM_COMPONENTS = {
         "lspci",
         "ldconfig",
         "wine",
-        "fluidsynth",
     ],
     "OPTIONAL_COMMANDS": [
         "lsi-steam",
         "nvidia-smi",
+        "fluidsynth",
     ],
     "TERMINALS": [
         "xterm",


### PR DESCRIPTION
Apparently this is used for ScummVM?

I don't have this program and keeps warning every time I start Lutris:

> 2024-11-14 20:22:13,904: Command 'fluidsynth' not found on your system