### PR TITLE
Fix Lutris icon not used in KDE switcher on Wayland

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -82,6 +82,7 @@ class Application(Gtk.Application):
         settings.SETTINGS_CHANGED.register(self.on_settings_changed)
 
         GLib.set_application_name(_("Lutris"))
+        GLib.set_prgname("net.lutris.Lutris")
         self.force_updates = False
         self.css_provider = Gtk.CssProvider.new()
         self.window = None


### PR DESCRIPTION
Wayland require the name of the program to be set (must be the same as application_id) or a generic Wayland icon will be used in app switcher instead the Lutris specific one.

Test: tested on Wayland, Lutris icon is used. No changes on X11 (it was already working even without this)

Fixes: lutris/lutris#5729