### PR TITLE
feat(util/linux.py): add AOSC OS optenv32 path (/opt/32) to multiarch_lib_folders

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -92,6 +92,7 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
         ("/usr/lib32", "/usr/lib64"),
         ("/lib/i386-linux-gnu", "/lib/x86_64-linux-gnu"),
         ("/usr/lib/i386-linux-gnu", "/usr/lib/x86_64-linux-gnu"),
+        ("/usr/lib", "/opt/32/lib"),
     ]
 
     soundfont_folders = [


### PR DESCRIPTION
AOSC OS is a non-multiarch distribution which ships its 32-bit x86 runtime (under the name optenv32) in /opt/32, and the "native" 64-bit x86-64 runtime in /usr/lib.

Add this path combo to make Lutris work on AOSC OS.