### PR TITLE
Add service provided release year to itchio and gog

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -454,6 +454,10 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             # we must tolerate them. We treat them all as blank.
             value = value or sort_defaults.get(self.view_sorting, "")
             if self.view_sorting == "year":
+                if self.service:
+                    service_value = self.service.get_game_release_date(item)
+                    if service_value:
+                        value = service_value
                 contains_year = bool(value)
                 if self.view_reverse_order:
                     contains_year = not contains_year
@@ -552,13 +556,17 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def combine_games(service_game, lutris_game):
         """Inject lutris game information into a service game"""
         if lutris_game and service_game["appid"] == lutris_game["service_id"]:
-            for field in ("platform", "runner", "year", "installed_at", "lastplayed", "playtime", "installed"):
+            for field in ("platform", "runner", "installed_at", "lastplayed", "playtime", "installed"):
                 service_game[field] = lutris_game[field]
+            service_game["year"] = service_game["year"] if "year" in service_game else lutris_game["year"]
         return service_game
 
     def get_service_games(self, service_id):
         """Return games for the service indicated."""
         service_games = ServiceGameCollection.get_for_service(service_id)
+        for game in service_games:
+            game["year"] = self.service.get_game_release_year(game)
+
         if service_id == "lutris":
             lutris_games = {g["slug"]: g for g in games_db.get_games()}
         else:

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -410,6 +410,17 @@ class BaseService:
             return ServiceGameCollection.get_game(self.id, game.appid)
         return None
 
+    def get_game_release_date(self, db_game: dict):
+        """Services can implement this method so games that are not in the
+        database can be sorted by release date (Year) based on service data."""
+
+    def get_game_release_year(self, db_game: dict):
+        """Returns game release year
+        Does not have to be rewritten if get_game_release_date returns
+        rfc/iso compatible date (YYYY-MM-DD)"""
+        date = self.get_game_release_date(db_game)
+        return date[:4] if date else ""
+
 
 class OnlineService(BaseService):
     """Base class for online gaming services"""

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -753,3 +753,15 @@ class GOGService(OnlineService):
             if worksOn is not None:
                 return [name for name, works in worksOn.items() if works]
         return []
+
+    def get_game_release_date(self, db_game: dict):
+        details = db_game.get("details")
+        if details:
+            release_date = json.loads(details).get("releaseDate")
+            if release_date is not None:
+                date = release_date.get("date")
+                # GoG stores unknown release dates as a negative date
+                if date is not None and isinstance(date, str) and date[0] != "-":
+                    # Return as YYYY-MM-DD
+                    return date[:10]
+        return ""

--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -789,6 +789,20 @@ class ItchIoService(OnlineService):
             weight |= 0x40
         return weight
 
+    def get_game_release_date(self, db_game: dict):
+        details = db_game.get("details")
+        if details:
+            details = json.loads(details)
+            # Game Release
+            release_date = details.get("created_at")
+            if release_date is None:
+                # Last Update Release
+                release_date = details.get("published_at")
+            if release_date is not None and isinstance(release_date, str):
+                # Return as YYYY-MM-DD
+                return release_date[:10]
+        return ""
+
     def _rfc3999_to_timestamp(self, _s):
         # Python does ootb not fully comply with RFC3999; Cut after seconds
         return datetime.datetime.fromisoformat(_s[: _s.rfind(".")]).timestamp()


### PR DESCRIPTION
One thing that always bothered me is that most games in the services do not have a date making the sort by year often pointless.

This gives services the ability to implement `get_game_release_date` which enables the initial sorting to take the release date into account and to let the release year show up on list view.
(Sorting in list view will only sort by year tho due to how that sorting works)

I implemented this for itchio and gog because I was sure that those already stored the release date in the details field.