### PR TITLE
Fix dxvk and UMU logging

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1104,7 +1104,12 @@ class wine(Runner):
         show_debug = self.runner_config.get("show_debug", "-all")
         if show_debug != "inherit":
             env["WINEDEBUG"] = show_debug
-            if show_debug == "-all":
+            env["DXVK_LOG_LEVEL"] = "error"
+            env["UMU_LOG"] = "1"
+            if show_debug == "":
+                env["DXVK_LOG_LEVEL"] = "info"
+                env["UMU_LOG"] = "warning"
+            elif show_debug == "+all":
                 env["DXVK_LOG_LEVEL"] = "debug"
                 env["UMU_LOG"] = "debug"
         env["WINEARCH"] = self.wine_arch

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -1104,9 +1104,9 @@ class wine(Runner):
         show_debug = self.runner_config.get("show_debug", "-all")
         if show_debug != "inherit":
             env["WINEDEBUG"] = show_debug
-        if show_debug == "-all":
-            env["DXVK_LOG_LEVEL"] = "debug"
-            env["UMU_LOG"] = "debug"
+            if show_debug == "-all":
+                env["DXVK_LOG_LEVEL"] = "debug"
+                env["UMU_LOG"] = "debug"
         env["WINEARCH"] = self.wine_arch
         wine_exe = self.get_executable()
         wine_config_version = self.read_version_from_config()


### PR DESCRIPTION
Previously, the `Disabled` option for the `Output debugging info` Runner setting would turn on maximum debug logging for UMU and dxvk. For dxvk, this would result in extremely verbose logs. The other options for the `Output debugging info` setting would incorrectly disable logging for UMU and dxvk.

This PR fixes that and sets appropriate log levels for UMU and dxvk depending on the option selected for `Output debugging info`.