### PR TITLE
Use real MangoHud with Gamescope but skip both for steam runner

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -58,9 +58,15 @@ def get_launch_parameters(runner, gameplay_info):
     # Gamescope
     has_gamescope = system_config.get("gamescope") and system.can_find_executable("gamescope")
     if has_gamescope:
-        launch_arguments = get_gamescope_args(launch_arguments, system_config)
-        if system_config.get("gamescope_hdr"):
-            env["DXVK_HDR"] = "1"
+        if runner.name == "steam":
+            logger.info(
+                "Do not enable Gamescope for Steam games in Lutris. "
+                "Edit the launch options in Steam and set them to 'gamescope %%command%%'"
+            )
+        else:
+            launch_arguments = get_gamescope_args(launch_arguments, system_config)
+            if system_config.get("gamescope_hdr"):
+                env["DXVK_HDR"] = "1"
 
     # MangoHud
     if system_config.get("mangohud") and system.can_find_executable("mangohud"):


### PR DESCRIPTION
Launching `mangohud lutris` and within `Lutris` enabling `Gamescope` yields no errors in my system (tested with more than 70 games) unlike the current implementation of `MangoHud` in `Lutris`.

Hence, this PR changes how `MangoHud` is set in the launch arguments so it can be combined with `Gamescope` instead of using `gamescope --mangoapp`, which if it behaved exactly the same way as the real `MangoHud` it could be a non issue, but the fact is the output is not the same, AFAIK it cannot be configured and it misses very interesting options available with the real `MangoHud`.

At the same time it disables setting `Gamescope` with the `steam runner` which at least in my system does not work and needs to be set within `Steam`, unlike `MangoHud` which can be launched as `mangohud steam-native` with no issues. Anyhow, I think it is less confusing this way, having both `MangoHud` and `Gamescope` not settable for the `steam runner`.

```
Vulkan support: YES
Esync support: YES
Fsync support: YES
Wine installed: YES
Gamescope: YES
Mangohud: YES
Gamemode: NO
Steam: YES
In Flatpak: NO

[System]
OS: Arch Linux rolling n/a
Arch: x86_64
Kernel: 6.12.3-z790i-1-1
Lutris Version: 0.5.18
Desktop: KDE
Display Server: wayland

[CPU]
Vendor: GenuineIntel
Model: 13th Gen Intel(R) Core(TM) i9-13900K
Physical cores: 24
Logical cores: 32

[Memory]
RAM: 62.5 GB
Swap: 0.0 GB

[Graphics]
Vendor: NVIDIA Corporation
OpenGL Renderer: NVIDIA GeForce RTX 4080 SUPER/PCIe/SSE2
OpenGL Version: 4.6.0 NVIDIA 565.77
OpenGL Core: 4.6.0 NVIDIA 565.77
OpenGL ES: OpenGL ES 3.2 NVIDIA 565.77
Vulkan Version: 1.4.303
Vulkan Drivers: NVIDIA GeForce RTX 4080 SUPER (1.3.289)
```