### PR TITLE
Add Realtime Scheduling option for Gamescope

### DIFF
--- a/lutris/runner_interpreter.py
+++ b/lutris/runner_interpreter.py
@@ -92,6 +92,8 @@ def get_gamescope_args(launch_arguments, system_config):
     launch_arguments.insert(0, "--")
     if system_config.get("gamescope_force_grab_cursor"):
         launch_arguments.insert(0, "--force-grab-cursor")
+    if system_config.get("gamescope_realtime_scheduling"):
+        launch_arguments.insert(0, "--rt")
     if system_config.get("gamescope_fsr_sharpness"):
         launch_arguments.insert(0, system_config["gamescope_fsr_sharpness"])
         launch_arguments.insert(0, "--fsr-sharpness")

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -227,6 +227,21 @@ system_options = [  # pylint: disable=invalid-name
     },
     {
         "section": _("Gamescope"),
+        "option": "gamescope_realtime_scheduling",
+        "type": "bool",
+        "label": _("Realtime Scheduling"),
+        "advanced": True,
+        "default": False,
+        "condition": bool(system.can_find_executable("gamescope")),
+        "help": _(
+            "Use realtime scheduling.\n"
+            "Requires 'CAP_SYS_NICE=eip' capability set on gamescope:\n"
+            "\n"
+            "    <b>sudo setcap 'CAP_SYS_NICE=eip' $(which gamescope)</b>"
+        ),
+    },
+    {
+        "section": _("Gamescope"),
         "option": "gamescope_force_grab_cursor",
         "type": "bool",
         "label": _("Relative Mouse Mode"),


### PR DESCRIPTION
I know one can set `Custom Settings` for `Gamescope` but I think `Realtime Scheduling` is interesting enough to have as a toggleable option.