### PR TITLE
Fancy UI for the Invalid Choice Warning

### DIFF
--- a/lutris/gui/config/widget_generator.py
+++ b/lutris/gui/config/widget_generator.py
@@ -404,7 +404,7 @@ class WidgetGenerator(ABC):
         """Generate a combobox (drop-down menu)."""
 
         def populate_combobox_choices():
-            expanded, tooltip_default = expand_combobox_choices()
+            expanded, tooltip_default, _valid_choices = expand_combobox_choices()
             for choice in expanded:
                 liststore.append(choice)
 
@@ -414,6 +414,7 @@ class WidgetGenerator(ABC):
         def expand_combobox_choices():
             expanded = []
             tooltip_default = None
+            valid = []
             has_value = False
             for choice in choices:
                 if isinstance(choice, str):
@@ -423,10 +424,11 @@ class WidgetGenerator(ABC):
                 if choice[1] == default:
                     tooltip_default = choice[0]
                     choice = (_("%s (default)") % choice[0], choice[1])
+                valid.append(choice[1])
                 expanded.append(choice)
             if not has_value and value:
-                expanded.insert(0, (value + " (invalid)", value))
-            return expanded, tooltip_default
+                expanded.insert(0, (value, value))
+            return expanded, tooltip_default, valid
 
         def on_combobox_scroll(widget, _event):
             """Prevents users from accidentally changing configuration values
@@ -468,7 +470,7 @@ class WidgetGenerator(ABC):
 
         combobox.set_id_column(1)
 
-        expanded_choices, _tooltip_default = expand_combobox_choices()
+        expanded_choices, _tooltip_default, valid_choices = expand_combobox_choices()
         if value in [v for _k, v in expanded_choices]:
             combobox.set_active_id(value)
         elif has_entry:
@@ -482,6 +484,17 @@ class WidgetGenerator(ABC):
         combobox.connect("changed", on_combobox_change)
         combobox.connect("scroll-event", on_combobox_scroll)
         combobox.set_valign(Gtk.Align.CENTER)
+
+        def get_invalidity_error(option_key: str, _config: LutrisConfig):
+            v = self.get_setting(option_key)
+            if v in valid_choices:
+                return None
+
+            return _("The setting '%s' is no longer available. You should select another choice.") % v
+
+        if not has_entry and value not in valid_choices:
+            self.underslung_widgets.append(ConfigWarningBox(get_invalidity_error))
+
         return self.build_option_widget(option, combobox)
 
     # ComboBox


### PR DESCRIPTION
It can happen that a config option chosen with a drop-down list become invalid. We've seen this with the GPU setting - change your hardware and your previously selected GPU might not be there anymore. More recently, we changed the name of "GE-Proton (Latest)" to just "ge-proton", which is different enough to cause the same problem.

We had just been appending the text "(invalid)" on the no-longer-available option, but this is not very explanatory, I guess: See #5778. But what if we use more words? Like this:

![Screenshot from 2024-12-09 19-19-12](https://github.com/user-attachments/assets/ae06de6f-b274-4e5a-9bf9-a2d5701c4726)

This is a larger warning box that tries to explain a bit more and provides some guidance to the user about what to do. It will disappear immediately once the user make any other choice in the drop-down list.

~~This is built on a refactoring branch I was working on that factors out shared code between the config boxes and the preferences, so there's a lot more code change that you might expect. It fixes some bugs but adds some too, so this isn't an appropriate fix if you were planning to ship 0.5.19 right away.~~

I've gone ahead and merged the refactoring, since we're not jumping to 0.5.19 quite yet, and so that I can hide the non-Proton compatible options in the UI when a Proton wine is selected. This becomes a much smaller PR with that.

Resolves #5778.