### PR TITLE
Stop pointing winetricks to wine in open_wine_terminal

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -535,7 +535,7 @@ def open_wine_terminal(terminal, wine_path, prefix, env, system_winetricks):
         "winecfg": wine_command + "cfg",
         "wineserver": wine_command + "server",
         "wineboot": wine_command + "boot",
-        "winetricks": wine_command,
+        "winetricks": winetricks_path,
     }
     env["WINEPREFIX"] = prefix
     # Ensure scripts you run see the desired version of WINE too


### PR DESCRIPTION
When the user runs `winetricks`, they should get winetricks, not wine.

Fixes bug introduced in 4a62275daa55b6c6ecc76592dd34f61e0e41523f