### PR TITLE
Rename the 'sandbox' options to never say 'sandbox'.

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -604,21 +604,22 @@ class wine(Runner):
             {
                 "option": "sandbox",
                 "type": "bool",
-                "section": _("Sandbox"),
-                "label": _("Create a sandbox for Wine folders"),
+                "section": _("Desktop Integration Folder Isolation"),
+                "label": _("Place desktop folders specifically"),
                 "default": True,
                 "advanced": True,
                 "help": _(
                     "Explicitly specify the location for desktop integration folders.\n"
-                    "If turned off, these are placed in '%s'"
+                    "If turned off, these are placed in '%s'.\n"
+                    "These folders include 'Documents', 'Pictures' and others."
                 )
                 % os.path.expanduser("~"),
             },
             {
                 "option": "sandbox_dir",
                 "type": "directory",
-                "section": _("Sandbox"),
-                "label": _("Sandbox directory"),
+                "section": _("Desktop Integration Folder Isolation"),
+                "label": _("Integration folder location"),
                 "warn_if_non_writable_parent": True,
                 "condition": _is_sandboxed,
                 "help": _(


### PR DESCRIPTION
A sandbox is a security thing, and this feature was never that. This is about placing folders like 'Documents' in particular places, instead of in your actual 'Documents' directory.

 'Sandbox' is a very misleading term for this.

So this PR changes it, at shown:
![image](https://github.com/user-attachments/assets/7e94d639-2f30-41e2-a09f-61803d02f99a)

"Desktop Integration Folder Location" is not obvious, but it more suggests "confusion" than "security", so that's an improvement.