### PR TITLE
Migrate the "GE-Proton (Latest)" wine version to "ge-proton"

### DIFF
--- a/lutris/gui/config/widget_generator.py
+++ b/lutris/gui/config/widget_generator.py
@@ -398,11 +398,6 @@ class WidgetGenerator(ABC):
     def _generate_choice(self, option, value, default, has_entry=False):
         """Generate a combobox (drop-down menu)."""
 
-        # Provide seamless transition from old naming scheme to current one.
-        # Not the best place to put this code, I know...
-        if value == "GE-Proton (Latest)":
-            value = "ge-proton"
-
         def populate_combobox_choices():
             expanded, tooltip_default, _valid_choices = expand_combobox_choices()
             for choice in expanded:

--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -3,7 +3,7 @@ import importlib
 from lutris import settings
 from lutris.util.log import logger
 
-MIGRATION_VERSION = 14  # Never decrease this number
+MIGRATION_VERSION = 15  # Never decrease this number
 
 # Replace deprecated migrations with empty lists
 MIGRATIONS = [
@@ -21,6 +21,7 @@ MIGRATIONS = [
     ["retrieve_discord_appids"],
     ["migrate_sortname"],
     ["migrate_hidden_category"],
+    ["migrate_ge_proton"],
 ]
 
 

--- a/lutris/migrations/migrate_ge_proton.py
+++ b/lutris/migrations/migrate_ge_proton.py
@@ -1,0 +1,33 @@
+"""Replace the Wine version 'GE-Proton (Latest)' with 'ge-proton'."""
+
+import os
+
+from lutris import settings
+from lutris.database.games import get_games_by_runner
+from lutris.util.yaml import read_yaml_from_file, write_yaml_to_file
+
+
+def migrate():
+    """Run migration"""
+    try:
+        config_paths = [os.path.join(settings.CONFIG_DIR, "runners/wine.yml")]
+
+        for db_game in get_games_by_runner("wine"):
+            config_filename = db_game.get("configpath")
+            config_paths.append(os.path.join(settings.CONFIG_DIR, "games/%s.yml" % config_filename))
+
+        for config_path in config_paths:
+            try:
+                if os.path.isfile(config_path):
+                    config = read_yaml_from_file(config_path)
+                    wine = config.get("wine")
+                    if wine:
+                        version = wine.get("version")
+                        if version and version.casefold() == "ge-proton (latest)":
+                            wine["version"] = "ge-proton"
+                            write_yaml_to_file(config, filepath=config_path)
+            except Exception as ex:
+                print(f"Failed to convert GE-Proton (Latest) to ge-proton in '{config_path}': {ex}")
+    except Exception as ex:
+        print(f"Failed to convert GE-Proton (Latest) to ge-proton: {ex}")
+        return []

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -727,8 +727,6 @@ class wine(Runner):
             if "wine" in level:
                 runner_version = level["wine"].get("version")
                 if runner_version:
-                    if runner_version == "GE-Proton (Latest)":
-                        return "ge-proton"
                     return runner_version
 
         if default:


### PR DESCRIPTION
I understand we're going with "ge-proton" as the name of the auto-updating Umu Wine version. We're going to use "GE-Proton (Latest)" as the displayed name, but internally it will be "ge-proton".

This PR is a migration to convert the runner settings and all games to that name.