### PR TITLE
Add a migration to move banners and cover-art from .cache to .local/share

### DIFF
--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -3,7 +3,7 @@ import importlib
 from lutris import settings
 from lutris.util.log import logger
 
-MIGRATION_VERSION = 15  # Never decrease this number
+MIGRATION_VERSION = 16  # Never decrease this number
 
 # Replace deprecated migrations with empty lists
 MIGRATIONS = [
@@ -22,6 +22,7 @@ MIGRATIONS = [
     ["migrate_sortname"],
     ["migrate_hidden_category"],
     ["migrate_ge_proton"],
+    ["migrate_banners_back"],
 ]
 
 

--- a/lutris/migrations/migrate_banners_back.py
+++ b/lutris/migrations/migrate_banners_back.py
@@ -1,0 +1,33 @@
+"""Migrate banners and coverart from .cache/lutris to .local/share/lutris"""
+
+import os
+
+from lutris import settings
+from lutris.util.log import logger
+
+
+def _migrate(dirname):
+    dest_dir = os.path.join(settings.DATA_DIR, dirname)
+    src_dir = os.path.join(settings.CACHE_DIR, dirname)
+
+    try:
+        # init_lutris() creates the new banners directory
+        if os.path.isdir(src_dir) and os.path.isdir(dest_dir):
+            for filename in os.listdir(src_dir):
+                src_file = os.path.join(src_dir, filename)
+                dest_file = os.path.join(dest_dir, filename)
+
+                if not os.path.exists(dest_file):
+                    os.rename(src_file, dest_file)
+                else:
+                    os.unlink(src_file)
+
+            if not os.listdir(src_dir):
+                os.rmdir(src_dir)
+    except OSError as ex:
+        logger.exception("Failed to migrate banners: %s", ex)
+
+
+def migrate():
+    _migrate("banners")
+    _migrate("coverart")

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -34,12 +34,8 @@ RUNNERS_CONFIG_DIR = os.path.join(CONFIG_DIR, "runners")
 
 SHADER_CACHE_DIR = os.path.join(CACHE_DIR, "shaders")
 INSTALLER_CACHE_DIR = os.path.join(CACHE_DIR, "installer")
-BANNER_PATH = os.path.join(CACHE_DIR, "banners")
-if not os.path.exists(BANNER_PATH):
-    BANNER_PATH = os.path.join(DATA_DIR, "banners")
-COVERART_PATH = os.path.join(CACHE_DIR, "coverart")
-if not os.path.exists(COVERART_PATH):
-    COVERART_PATH = os.path.join(DATA_DIR, "coverart")
+BANNER_PATH = os.path.join(DATA_DIR, "banners")
+COVERART_PATH = os.path.join(DATA_DIR, "coverart")
 
 RUNTIME_VERSIONS_PATH = os.path.join(CACHE_DIR, "versions.json")
 ICON_PATH = os.path.join(GLib.get_user_data_dir(), "icons", "hicolor", "128x128", "apps")


### PR DESCRIPTION
v0.5.18 has logic to use ``~/.local/share/lutris`` for banners and coverart instead of ``~/.cache/lutris``- but just continues to use ``~/.cache/lutris`` if those directories are found there. That was a convenience for troubleshooting, but I do not think we want it to be that way forever.

This PR removes that logic and uses only ``~/.local/share`` for these things, and also adds a migration to move your banners and covert art to the current location that 0.5.18 already prefers.

See #5882.