### PR TITLE
Update melonDS to the latest version

### DIFF
--- a/share/lutris/json/melonds.json
+++ b/share/lutris/json/melonds.json
@@ -4,7 +4,7 @@
     "platforms": ["Nintendo DS"],
     "runner_executable": "melonds/melonDS",
     "flatpak_id": "net.kuribo64.melonDS",
-    "download_url": "https://melonds.kuribo64.net/downloads/melonDS-ubuntu-x86_64.zip",
+    "download_url": "https://melonds.kuribo64.net/downloads/melonDS-appimage-x86_64.zip",
     "game_options": [
         {
             "option": "main_file",

--- a/share/lutris/json/melonds.json
+++ b/share/lutris/json/melonds.json
@@ -4,7 +4,7 @@
     "platforms": ["Nintendo DS"],
     "runner_executable": "melonds/melonDS",
     "flatpak_id": "net.kuribo64.melonDS",
-    "download_url": "https://melonds.kuribo64.net/downloads/melonDS_0.9.5_linux_x64.zip",
+    "download_url": "https://melonds.kuribo64.net/downloads/melonDS-ubuntu-x86_64.zip",
     "game_options": [
         {
             "option": "main_file",


### PR DESCRIPTION
melonDS has been updated to 1.0RC so it would be good to point to the new linux package. I *guessing???* that this is a permalink that always points to the newest package though I could be wrong.

There is a pretty major caveat, that being that melonDS now requires a bunch of Qt6 libraries. I'm currently using the latest stable flatpak release of Lutris which doesn't have those. Not sure how this affects the regular packaged version/s of Lutris. It would be nice if somebody could troubleshoot that for me since I'm not experienced enough to deal with it. Thanks!