### PR TITLE
fix: evdev ver 1.9.0 InputDevice.fn is dropped

### DIFF
--- a/lutris/util/joypad.py
+++ b/lutris/util/joypad.py
@@ -32,7 +32,7 @@ def get_devices():
 
 def get_joypads():
     """Return a list of tuples with the device and the joypad name"""
-    return [(dev.fn, dev.name) for dev in get_devices()]
+    return [(dev.path, dev.name) for dev in get_devices()]
 
 
 def read_button(device):


### PR DESCRIPTION
With the new python-evdev version 1.9.0 the attribute `InputDevice.fn` was removed.

It was replaced with `InputDevice.path` , so a small change is needed to keep it working with Version 1.9 and later.

The attribute `InputDevice.path` was intruduced with version 1.0

Changelog for Version 1.9.0 :
https://python-evdev.readthedocs.io/en/latest/changelog.html#feb-08-2025

Lutris traceback:
```
'InputDevice' object has no attribute 'fn'
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/lutris/exception_backstops.py", line 29, in wrapper
    result = function(*args, **kwargs)
  File "/usr/lib/python3.13/site-packages/lutris/game.py", line 764, in configure_game
    raise error
  File "/usr/lib/python3.13/site-packages/lutris/util/jobs.py", line 30, in target
    result = self.function(*a, **kw)
  File "/usr/lib/python3.13/site-packages/lutris/runners/wine.py", line 1051, in prelaunch
    prefix_manager.configure_joypads()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/lutris/util/wine/prefix.py", line 358, in configure_joypads
    for _device, joypad_name in joypad.get_joypads():
                                ~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/lutris/util/joypad.py", line 35, in get_joypads
    return [(dev.fn, dev.name) for dev in get_devices()]
             ^^^^^^
AttributeError: 'InputDevice' object has no attribute 'fn'. Did you mean: 'fd'?

Lutris log:
[INFO:2025-02-17 20:19:23,961:application]: Starting Lutris 0.5.18
[INFO:2025-02-17 20:19:24,141:startup]: "card1" is NVIDIA GeForce RTX 3080 (10de:220a 19da:b612 nvidia) Driver 570.86.16
[ERROR:2025-02-17 20:19:24,363:i18n]: Unable to get locale
[ERROR:2025-02-17 20:19:27,228:jobs]: Error while completing task <bound method wine.prelaunch of <lutris.runners.wine.wine object at 0x7f440cb41850>>: <class 'AttributeError'> 'InputDevice' object has no attribute 'fn'
[ERROR:2025-02-17 20:19:27,229:exception_backstops]: Ubisoft Connect (wine) has encountered an error: 'InputDevice' object has no attribute 'fn'
Traceback (most recent call last):
  File "/usr/lib/python3.13/site-packages/lutris/exception_backstops.py", line 29, in wrapper
    result = function(*args, **kwargs)
  File "/usr/lib/python3.13/site-packages/lutris/game.py", line 764, in configure_game
    raise error
  File "/usr/lib/python3.13/site-packages/lutris/util/jobs.py", line 30, in target
    result = self.function(*a, **kw)
  File "/usr/lib/python3.13/site-packages/lutris/runners/wine.py", line 1051, in prelaunch
    prefix_manager.configure_joypads()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/lutris/util/wine/prefix.py", line 358, in configure_joypads
    for _device, joypad_name in joypad.get_joypads():
                                ~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/lutris/util/joypad.py", line 35, in get_joypads
    return [(dev.fn, dev.name) for dev in get_devices()]
             ^^^^^^
AttributeError: 'InputDevice' object has no attribute 'fn'. Did you mean: 'fd'?
[WARNING:2025-02-17 20:19:27,230:game]: The game has run for a very short time, did it crash?
```

error was generated on a Fedora 41
