### PR TITLE
add optional support of balanced directories for games config files a…

### DIFF
--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -46,6 +46,8 @@ class ServiceMedia:
     def get_possible_media_paths(self, slug: str) -> List[str]:
         """Returns a list of each path where the media might be found. At most one of these should
         be found, but they are in a priority order - the first is in the preferred format."""
+        if os.environ.get("LUTRIS_BALANCE_ASSETS"):
+            self.file_patterns = [f"{slug[0]}/%s.jpg", f"{slug[0]}/%s.png", "%s.jpg", "%s.png"]
         return [os.path.join(self.dest_path, pattern % slug) for pattern in self.file_patterns]
 
     def trash_media(
@@ -90,7 +92,10 @@ class ServiceMedia:
         """Downloads the banner if not present"""
         if not url:
             return
-        cache_path = os.path.join(self.dest_path, self.get_filename(slug))
+        if os.environ.get("LUTRIS_BALANCE_ASSETS"):
+            cache_path = os.path.join(os.path.join(self.dest_path, slug[0]), self.get_filename(slug))
+        else:
+            cache_path = os.path.join(self.dest_path, self.get_filename(slug))
         if system.path_exists(cache_path, exclude_empty=True):
             return
         if system.path_exists(cache_path):


### PR DESCRIPTION
…nd covers/banners

Add support via environment variable LUTRIS_BALANCE_ASSETS of an additional directory in the storage path of game config files (YAML) and for games coverarts and banners.

When this variable is set, the following happens:

Instead of:
~/.local/share/lutris/games/cyberpunk_2077_goodies_collection-1664997482.yml the following file is read (or created when relevant): ~/.local/share/lutris/games/c/cyberpunk_2077_goodies_collection-1664997482.yml

Instead of:
~/.local/share/lutris/coverart/cyberpunk_2077_goodies_collection.jpg the following file is read (or created when relevant): ~/.local/share/lutris/coverart/c/cyberpunk_2077_goodies_collection.jpg

Intent:
While storing all the YAML and games related covers/banner files in a single directory works perfectly, when reaching high number of games, longer access time and lower perceived reactiveness of the GUI can happen, for example when switching from "Library/Favorites" "Library/Games".

This if of course mitigated when using modern fast storage such as SDD, but however it is possible to obtain slowdowns when dealing with a few thousands+ entries. The problem is notably perceptible when using emulation runners and trying to manage large collections with many thousands of ROM entries.

The proposed changes tries to be as minimal as possible, and non intrusive as it's clearly intended for rather niche use case, and not intending to be a default option: when the LUTRIS_BALANCE_ASSETS env var is not set, behaviour is unchanged.

The modification doesn't fully solve the scaling problem, as it is still possible that a specific directory holds too many files after a certain time, notably due to the prevalence of certain first letters in games titles, depending on the language (i.e, many title starting with letter 'w' en english while much less common in french) BUT
has the advantage of remaining very simple, not adding a new dependancy that could possibly provide more advanced/tunable balancing logic, while increasing a lot the treshold of appearance of the slowness.

Been using this locally for a few years, now proposing it upstream in case this can be of any interest.

Available for any modifications, explanations, tests etc. if needed.

Cheers