### PR TITLE
fix Frenh locale utf to utf8 to avoid error message

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -31,7 +31,7 @@ def get_locale_choices():
         (_("Dutch"), "nl_NL.utf8"),
         (_("English"), "en_US.utf8"),
         (_("Finnish"), "fi_FI.utf8"),
-        (_("French"), "fr_FR.utf"),
+        (_("French"), "fr_FR.utf8"),
         (_("Georgian"), "ka_GE.utf8"),
         (_("German"), "de_DE.utf8"),
         (_("Greek"), "el_GR.utf8"),


### PR DESCRIPTION
In get_locale_choices():
French locale setting is set to "fr_FR.utf" while utf8 is used for other languages. When using the French locale in the GUI error appears, despite /etc/locale.gen is OK. Using utf8 fixe the problem and no errors are reported.