### PR TITLE
feat: add buttons to zoom log text

### DIFF
--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -4,7 +4,7 @@ import os
 from datetime import datetime
 from gettext import gettext as _
 
-from gi.repository import Gdk, GObject, Gtk
+from gi.repository import Gdk, GObject, Gtk, Pango
 
 from lutris.gui.dialogs import FileDialog
 from lutris.gui.widgets.log_text_view import LogTextView
@@ -37,6 +37,12 @@ class LogWindow(GObject.Object):
         save_button = builder.get_object("save_button")
         save_button.connect("clicked", self.on_save_clicked)
 
+        # Add zoom buttons
+        zoom_in_button = builder.get_object("zoom_in_button")
+        zoom_out_button = builder.get_object("zoom_out_button")
+        zoom_in_button.connect("clicked", self.on_zoom_in_clicked)
+        zoom_out_button.connect("clicked", self.on_zoom_out_clicked)
+
         self.window.connect("key-press-event", self.on_key_press_event)
         self.window.show_all()
 
@@ -62,3 +68,17 @@ class LogWindow(GObject.Object):
         text = self.buffer.get_text(self.buffer.get_start_iter(), self.buffer.get_end_iter(), True)
         with open(log_path, "w", encoding="utf-8") as log_file:
             log_file.write(text)
+
+    def on_zoom_in_clicked(self, _button):
+        """Increase font size"""
+        font = self.logtextview.get_style_context().get_font(Gtk.StateFlags.NORMAL)
+        size = font.get_size() / Pango.SCALE
+        if size < 48:  # Maximum size
+            self.logtextview.override_font(Pango.FontDescription(f"monospace {size + 1}"))
+
+    def on_zoom_out_clicked(self, _button):
+        """Decrease font size"""
+        font = self.logtextview.get_style_context().get_font(Gtk.StateFlags.NORMAL)
+        size = font.get_size() / Pango.SCALE
+        if size > 6:  # Minimum size
+            self.logtextview.override_font(Pango.FontDescription(f"monospace {size - 1}"))

--- a/share/lutris/ui/log-window.ui
+++ b/share/lutris/ui/log-window.ui
@@ -37,6 +37,45 @@
           </object>
         </child>
         <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">6</property>
+            <child>
+              <object class="GtkButton" id="zoom_out_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Decrease text size</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="icon_name">zoom-out-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="zoom_in_button">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="tooltip_text" translatable="yes">Increase text size</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="icon_name">zoom-in-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child>
           <object class="GtkButton" id="save_button">
             <property name="label">gtk-save</property>
             <property name="visible">True</property>
@@ -46,7 +85,7 @@
             <property name="always-show-image">True</property>
           </object>
           <packing>
-            <property name="position">1</property>
+            <property name="pack-type">end</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
The log text can be quite small and present an accessibility issue. This change will implement buttons that allow users to zoom in and out for better readability.

| Before | After |
|--------|--------|
| ![lutris-logs-before](https://github.com/user-attachments/assets/6bf5a1aa-a0bf-46e1-a832-ddd149567866) | ![lutris-logs-after](https://github.com/user-attachments/assets/e5a7e8ad-3a54-4b98-ad1e-8737be776919) |

[lutris-logs.webm](https://github.com/user-attachments/assets/7b957d58-5d90-41d9-8565-deadc593717f)