### PR TITLE
Fixes #5205

### DIFF
--- a/lutris/gui/dialogs/webconnect_dialog.py
+++ b/lutris/gui/dialogs/webconnect_dialog.py
@@ -41,7 +41,10 @@ class WebConnectDialog(ModalDialog):
         if lutris_locale:
             webview_locales = [lutris_locale.split(".")[0]] + webview_locales
         logger.debug(
-            f"Webview locale fallback order: {webview_locales[0]}{''.join(' -> ' + i for i in webview_locales[1:])}"
+            f"Webview locale fallback order: "
+            f"[Lutris locale]: '{lutris_locale}' -> "
+            f"[env: LANG]: '{environment_locale_lang}' -> "
+            f"[Default]: '{webview_locales[-1]}'"
         )
         self.context.set_preferred_languages(webview_locales)
 

--- a/lutris/gui/dialogs/webconnect_dialog.py
+++ b/lutris/gui/dialogs/webconnect_dialog.py
@@ -2,7 +2,7 @@
 
 import os
 from gettext import gettext as _
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 import gi
 
@@ -32,13 +32,13 @@ class WebConnectDialog(ModalDialog):
         # Set locale
         # Locale fallback routine:
         # Lutris locale -> System environment locale -> US English
-        webview_locales: List = ["en_US"]
-        lutris_config: LutrisConfig = LutrisConfig()
-        environment_lang: Optional[str] = os.environ.get("LANG")
-        if environment_lang is not None and environment_lang != "":
-            webview_locales = [environment_lang.split(".")[0]] + webview_locales
-        lutris_locale: Optional[str] = lutris_config.system_config.get("locale")
-        if lutris_locale is not None and lutris_locale != "":
+        webview_locales = ["en_US"]
+        lutris_config = LutrisConfig()
+        environment_locale_lang = os.environ.get("LANG")
+        if environment_locale_lang:
+            webview_locales = [environment_locale_lang.split(".")[0]] + webview_locales
+        lutris_locale = lutris_config.system_config.get("locale")
+        if lutris_locale:
             webview_locales = [lutris_locale.split(".")[0]] + webview_locales
         logger.debug(
             f"Webview locale fallback order: {webview_locales[0]}{''.join(' -> ' + i for i in webview_locales[1:])}"

--- a/lutris/gui/dialogs/webconnect_dialog.py
+++ b/lutris/gui/dialogs/webconnect_dialog.py
@@ -24,7 +24,10 @@ class WebConnectDialog(ModalDialog):
     def __init__(self, service: "OnlineService", parent=None):
         service.is_login_in_progress = True
 
-        self.context = WebKit2.WebContext.new()
+        self.context: WebKit2.WebContext = WebKit2.WebContext.new()
+
+        # Set locale
+        self.context.set_preferred_languages([os.environ["LANG"].split(".")[0], "en_US"])
 
         if "http_proxy" in os.environ:
             proxy = WebKit2.NetworkProxySettings.new(os.environ["http_proxy"])


### PR DESCRIPTION
Added English fallback locale to prevent EA login screen being displayed in a language that looks like Arabic, when `LANG` was set to an unsupported locale. Tested with `LANG=hu_HU.UTF-8`, EA and Epic Games Launcher logins. #5205 