### PR TITLE
add setting to allow override system locale with global options locale

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -426,16 +426,6 @@ system_options = [  # pylint: disable=invalid-name
     },
     {
         "section": _("Game execution"),
-        "option": "override_system_locale",
-        "type": "bool",
-        "default": False,
-        "advanced": True,
-        "conditional_on": "locale",
-        "label": _("Override system locale"),
-        "help": _("Use the locale defined above in priority to any system value, whenever possible."),
-    },
-    {
-        "section": _("Game execution"),
         "option": "prefix_command",
         "type": "string",
         "label": _("Command prefix"),

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -426,6 +426,16 @@ system_options = [  # pylint: disable=invalid-name
     },
     {
         "section": _("Game execution"),
+        "option": "override_system_locale",
+        "type": "bool",
+        "default": False,
+        "advanced": True,
+        "conditional_on": "locale",
+        "label": _("Override system locale"),
+        "help": _("Use the locale defined above in priority to any system value, whenever possible."),
+    },
+    {
+        "section": _("Game execution"),
         "option": "prefix_command",
         "type": "string",
         "label": _("Command prefix"),

--- a/lutris/util/i18n.py
+++ b/lutris/util/i18n.py
@@ -5,12 +5,15 @@ import locale
 from lutris.config import LutrisConfig
 from lutris.util.log import logger
 
+
 def get_locale_override():
     """Get a tuple of overridden user locale and encoding values if set"""
     config = LutrisConfig(level="system")
-    if config.system_config.get('override_system_locale', False) and config.system_config.get('locale'):
-        user_locale, _user_encoding = config.system_config.get('locale').split('.')
-        return (user_locale, _user_encoding.replace('utf8', 'UTF8'))
+    if config.system_config.get(
+        "override_system_locale", False
+    ) and config.system_config.get("locale"):
+        user_locale, _user_encoding = config.system_config.get("locale").split(".")
+        return (user_locale, _user_encoding.replace("utf8", "UTF8"))
     return (None, None)
 
 

--- a/lutris/util/i18n.py
+++ b/lutris/util/i18n.py
@@ -9,9 +9,7 @@ from lutris.util.log import logger
 def get_locale_override():
     """Get a tuple of overridden user locale and encoding values if set"""
     config = LutrisConfig(level="system")
-    if config.system_config.get(
-        "override_system_locale", False
-    ) and config.system_config.get("locale"):
+    if config.system_config.get("override_system_locale", False) and config.system_config.get("locale"):
         user_locale, _user_encoding = config.system_config.get("locale").split(".")
         return (user_locale, _user_encoding.replace("utf8", "UTF8"))
     return (None, None)

--- a/lutris/util/i18n.py
+++ b/lutris/util/i18n.py
@@ -6,21 +6,12 @@ from lutris.config import LutrisConfig
 from lutris.util.log import logger
 
 
-def get_locale_override():
-    """Get a tuple of overridden user locale and encoding values if set"""
-    config = LutrisConfig(level="system")
-    if config.system_config.get("override_system_locale", False) and config.system_config.get("locale"):
-        user_locale, _user_encoding = config.system_config.get("locale").split(".")
-        return (user_locale, _user_encoding.replace("utf8", "UTF8"))
-    return (None, None)
-
-
 def get_user_locale():
-    """Get locale for the user, based on optional override, else try system locale"""
-    user_locale, _user_encoding = get_locale_override()
-    if user_locale:
+    """Get locale for the user, based on global options, else try system locale"""
+    config = LutrisConfig(level="system")
+    if config.system_config.get("locale"):
+        user_locale, _user_encoding = config.system_config.get("locale").split(".")
         return user_locale
-    # No valid locale override, try to use system one
     user_locale, _user_encoding = locale.getlocale()
     if not user_locale:
         logger.error("Unable to get locale")

--- a/lutris/util/i18n.py
+++ b/lutris/util/i18n.py
@@ -2,10 +2,24 @@
 
 import locale
 
+from lutris.config import LutrisConfig
 from lutris.util.log import logger
+
+def get_locale_override():
+    """Get a tuple of overridden user locale and encoding values if set"""
+    config = LutrisConfig(level="system")
+    if config.system_config.get('override_system_locale', False) and config.system_config.get('locale'):
+        user_locale, _user_encoding = config.system_config.get('locale').split('.')
+        return (user_locale, _user_encoding.replace('utf8', 'UTF8'))
+    return (None, None)
 
 
 def get_user_locale():
+    """Get locale for the user, based on optional override, else try system locale"""
+    user_locale, _user_encoding = get_locale_override()
+    if user_locale:
+        return user_locale
+    # No valid locale override, try to use system one
     user_locale, _user_encoding = locale.getlocale()
     if not user_locale:
         logger.error("Unable to get locale")


### PR DESCRIPTION
Add an option in global options, visible in "advanced" mode, that allows to override system locale with the locale set in Lutris global options.

The interest is for people like me needing en_US (or anything else) system locale, but who still appreciate being able to have GOG download localized installer files in their native (or preferred) language, when available.

Not providing anything related to translations of added strings to help review.
Please let me know if any changes are required.
