### PR TITLE
Search BIOS files in Lutris RA dir instead of user level RA.

### DIFF
--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -182,7 +182,7 @@ class libretro(Runner):
         """Return the system directory used for storing BIOS and firmwares."""
         system_directory = retro_config["system_directory"]
         if not system_directory or system_directory == "default":
-            system_directory = "~/.config/retroarch/system"
+            system_directory = get_default_config_path("system")
         return os.path.expanduser(system_directory)
 
     def prelaunch(self):
@@ -212,7 +212,7 @@ class libretro(Runner):
             retro_config["rgui_config_directory"] = get_default_config_path("config")
             retro_config["overlay_directory"] = get_default_config_path("overlay")
             retro_config["assets_directory"] = get_default_config_path("assets")
-            retro_config["system_directory"] = "~/.config/retroarch/system"
+            retro_config["system_directory"] = get_default_config_path("system")
             retro_config.save()
         else:
             retro_config = RetroConfig(config_file)

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -123,14 +123,11 @@ class libretro(Runner):
         return ""
 
     def get_core_path(self, core):
-        """Return the path of a core, prioritizing Retroarch cores"""
-        lutris_cores_folder = os.path.join(self.directory, "cores")
-        retroarch_core_folder = os.path.join(os.path.expanduser("~/.config/retroarch/cores"))
+        """Return the path of a core from libretro's runner only"""
+        lutris_cores_folder = get_default_config_path("cores")
         core_filename = "{}_libretro.so".format(core)
-        retroarch_core = os.path.join(retroarch_core_folder, core_filename)
-        if system.path_exists(retroarch_core):
-            return retroarch_core
-        return os.path.join(lutris_cores_folder, core_filename)
+        lutris_core = os.path.join(lutris_cores_folder, core_filename)
+        return lutris_core
 
     def get_version(self, use_default=True):
         return self.game_config["core"]
@@ -254,7 +251,7 @@ class libretro(Runner):
                 required_firmware_filename = retro_config["firmware%d_path" % index]
                 required_firmware_path = os.path.join(system_path, required_firmware_filename)
                 required_firmware_name = required_firmware_filename.split("/")[-1]
-                required_firmware_checksum = checksums.get(required_firmware_filename)
+                required_firmware_checksum = checksums.get(required_firmware_name)
                 if system.path_exists(required_firmware_path):
                     if required_firmware_checksum:
                         checksum = system.get_md5_hash(required_firmware_path)


### PR DESCRIPTION
There are references to ~/.config/retroarch but when the runner is installed, it is created at ~/.local/share/lutris/runners/retroarch

The references cause correct BIOS files under
~/.local/share/lutris/runners/retroarch/system to be skipped.

Due to recent changes, missing firmware won't cause crash, but this still prevent expected behavior (I presume) to avoid interference between Lutris' RA runner setup and a user level setup,and discovery of bios files placed in the runner directory.

before change, with ~/.local/share/lutris/runners/retroarch/system populated (files manually added in system/dc/):

[libretro.prelaunch:269]:Firmware 'dc/dc_boot.bin' not found! [libretro.prelaunch:269]:Firmware 'dc/naomi.zip' not found! [libretro.prelaunch:269]:Firmware 'dc/hod2bios.zip' not found! [libretro.prelaunch:269]:Firmware 'dc/f355dlx.zip' not found! [libretro.prelaunch:269]:Firmware 'dc/f355bios.zip' not found! [libretro.prelaunch:269]:Firmware 'dc/airlbios.zip' not found! [libretro.prelaunch:269]:Firmware 'dc/awbios.zip' not found!

after change, system/ similarly populated:
[libretro.prelaunch:268]:Firmware 'dc/dc_boot.bin' found (No checksum info) [libretro.prelaunch:268]:Firmware 'dc/naomi.zip' found (No checksum info) [libretro.prelaunch:268]:Firmware 'dc/hod2bios.zip' found (No checksum info) [libretro.prelaunch:268]:Firmware 'dc/f355dlx.zip' found (No checksum info) [libretro.prelaunch:268]:Firmware 'dc/f355bios.zip' found (No checksum info) [libretro.prelaunch:268]:Firmware 'dc/airlbios.zip' found (No checksum info) [libretro.prelaunch:268]:Firmware 'dc/awbios.zip' found (No checksum info)

Now BIOS files are detected, if present.

probable fix for issue #5977