### PR TITLE
expose runner's env to prelaunch command script

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -569,6 +569,7 @@ class Game:
             logger.warning("Command %s not found", command_array[0])
             return
         env = self.game_runtime_config["env"]
+        env["LUTRIS_RUNNER_SYSTEM_CONFIG"] = json.dumps(self.runner.system_config)
         if wait_for_completion:
             logger.info("Prelauch command: %s, waiting for completion", prelaunch_command)
             # Monitor the prelaunch command and wait until it has finished

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -39,7 +39,7 @@ from lutris.util.graphics.xrandr import turn_off_except
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import LOG_BUFFERS, logger
 from lutris.util.steam.shortcut import remove_shortcut as remove_steam_shortcut
-from lutris.util.system import fix_path_case
+from lutris.util.system import expose_environment, fix_path_case
 from lutris.util.timer import Timer
 from lutris.util.yaml import write_yaml_to_file
 
@@ -569,7 +569,7 @@ class Game:
             logger.warning("Command %s not found", command_array[0])
             return
         env = self.game_runtime_config["env"]
-        env["LUTRIS_RUNNER_SYSTEM_CONFIG"] = json.dumps(self.runner.system_config)
+        env = expose_environment(self.runner, env)
         if wait_for_completion:
             logger.info("Prelauch command: %s, waiting for completion", prelaunch_command)
             # Monitor the prelaunch command and wait until it has finished
@@ -953,12 +953,13 @@ class Game:
         postexit_command = self.runner.system_config.get("postexit_command")
         if postexit_command:
             command_array = shlex.split(postexit_command)
+            env = self.game_runtime_config["env"]
             if system.path_exists(command_array[0]):
                 logger.info("Running post-exit command: %s", postexit_command)
                 postexit_thread = MonitoredCommand(
                     command_array,
                     include_processes=[os.path.basename(postexit_command)],
-                    env=self.game_runtime_config["env"],
+                    env=expose_environment(self.runner, env),
                     cwd=self.resolve_game_path(),
                 )
                 postexit_thread.start()

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -26,7 +26,7 @@ from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 from lutris.util.steam import shortcut as steam_shortcut
 from lutris.util.strings import gtk_safe, slugify
-from lutris.util.system import path_exists
+from lutris.util.system import expose_environment, path_exists
 
 
 class GameActions:
@@ -312,6 +312,7 @@ class SingleGameActions(GameActions):
         if path_exists(manual_command):
             runner = game.runner
             env = runner.get_env()
+            env = expose_environment(runner, env)
             MonitoredCommand(
                 [manual_command], include_processes=[os.path.basename(manual_command)], cwd=game.directory, env=env
             ).start()

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -416,6 +416,51 @@ system_options = [  # pylint: disable=invalid-name
     },
     {
         "section": _("Game execution"),
+        "option": "env_expose_systemconfig",
+        "label": "Expose system config to scripts",
+        "type": "bool",
+        "default": False,
+        "advanced": False,
+        "help": _(
+            "Expose system configuration values"
+            "to the following scripts:"
+            "Manual Script, Pre-launch script, Post-exit script"
+            "as a JSON string available in environment variable:"
+            "LUTRIS_RUNNER_SYSTEM_CONFIG"
+        ),
+    },
+    {
+        "section": _("Game execution"),
+        "option": "env_expose_runnerconfig",
+        "label": "Expose runner config to scripts",
+        "type": "bool",
+        "default": False,
+        "advanced": False,
+        "help": _(
+            "Expose runner's own configuration values"
+            "to the following scripts:"
+            "Manual Script, Pre-launch script, Post-exit script"
+            "as a JSON string available in environment variable:"
+            "LUTRIS_RUNNER_RUNNER_CONFIG"
+        ),
+    },
+    {
+        "section": _("Game execution"),
+        "option": "env_expose_gameconfig",
+        "label": "Expose game config to scripts",
+        "type": "bool",
+        "default": False,
+        "advanced": False,
+        "help": _(
+            "Expose game configuration values"
+            "to the following scripts:"
+            "Manual Script, Pre-launch script, Post-exit script"
+            "as a JSON string available in environment variable:"
+            "LUTRIS_RUNNER_GAME_CONFIG"
+        ),
+    },
+    {
+        "section": _("Game execution"),
         "option": "locale",
         "type": "choice_with_entry",
         "label": _("Locale"),

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -1,6 +1,7 @@
 """System utilities"""
 
 import hashlib
+import json
 import os
 import re
 import shutil
@@ -11,7 +12,7 @@ import subprocess
 import zipfile
 from gettext import gettext as _
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from gi.repository import Gio, GLib
 
@@ -37,6 +38,18 @@ def get_environment():
     """Return a safe to use copy of the system's environment.
     Values starting with BASH_FUNC can cause issues when written in a text file."""
     return {key: value for key, value in os.environ.items() if not key.startswith("BASH_FUNC")}
+
+
+def expose_environment(runner: Any, env: Dict[str, str]):
+    """Expose runner's system, runner, and game config as JSON data to scripts via env vars, if enabled"""
+    for expose in zip(
+        ("env_expose_systemconfig", "env_expose_runnerconfig", "env_expose_gameconfig"),
+        ("LUTRIS_RUNNER_SYSTEM_CONFIG", "LUTRIS_RUNNER_RUNNER_CONFIG", "LUTRIS_RUNNER_GAME_CONFIG"),
+        (runner.system_config, runner.runner_config, runner.game_config),
+    ):
+        if runner.system_config.get(expose[0]):
+            env[expose[1]] = json.dumps(expose[2])
+    return env
 
 
 def execute(


### PR DESCRIPTION
By adding `env' dictionnary passed to the process a new key: LUTRIS_RUNNER_SYSTEM_CONFIG
containing json dump of the the dict: `self.runner.system_config'

Implements feature request: #5550