### PR TITLE
fix : handle escaped double quote in steam account name

### DIFF
--- a/lutris/util/steam/vdfutils.py
+++ b/lutris/util/steam/vdfutils.py
@@ -10,12 +10,14 @@ def vdf_parse(steam_config_file, config):
     while line:
         try:
             line = steam_config_file.readline()
+
         except UnicodeDecodeError:
             logger.error(
                 "Error while reading Steam VDF file %s. Returning %s",
                 steam_config_file,
                 config,
             )
+
             return config
         if not line or line.strip() == "}":
             return config
@@ -24,7 +26,8 @@ def vdf_parse(steam_config_file, config):
             if not nextline:
                 break
             line = line[:-1] + nextline
-
+        if any(k in line for k in ['"AccountName"', '"PersonaName"']):
+            line = line.replace('\\"', '')
         line_elements = line.strip().split('"')
         if len(line_elements) == 3:
             key = line_elements[1]

--- a/lutris/util/steam/vdfutils.py
+++ b/lutris/util/steam/vdfutils.py
@@ -26,7 +26,7 @@ def vdf_parse(steam_config_file, config):
             if not nextline:
                 break
             line = line[:-1] + nextline
-        if any(k in line for k in ['"AccountName"', '"PersonaName"']):
+        if '"PersonaName"' in line:
             line = line.replace('\\"', "")
         line_elements = line.strip().split('"')
         if len(line_elements) == 3:

--- a/lutris/util/steam/vdfutils.py
+++ b/lutris/util/steam/vdfutils.py
@@ -27,7 +27,7 @@ def vdf_parse(steam_config_file, config):
                 break
             line = line[:-1] + nextline
         if any(k in line for k in ['"AccountName"', '"PersonaName"']):
-            line = line.replace('\\"', '')
+            line = line.replace('\\"', "")
         line_elements = line.strip().split('"')
         if len(line_elements) == 3:
             key = line_elements[1]


### PR DESCRIPTION
Simply remove the escaped double quotes if found in AccountName or PersonaName.                                                                                      

Trying to maintain the double quote in final display would need much  more modification in different places, for very little added value.
At least the name is displayed with this changed, instead of '\' as  before.                                                                                           

fixes issue: #5988 