### PR TITLE
raise error if wine prefix is a broken symlink or unusable

### DIFF
--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -37,6 +37,16 @@ class DirectoryNotFoundError(MisconfigurationError):
         self.directory = directory
 
 
+class SymlinkNotUsableError(MisconfigurationError):
+    """Raise this error if a symlink that is required is not usable."""
+
+    def __init__(self, message=None, link=None, *args, **kwarg):
+        if not message and link:
+            message = message or _("The link {} could not be used.").format(link)
+        super().__init__(message, *args, **kwarg)
+        self.link = link
+
+
 class GameConfigError(MisconfigurationError):
     """Throw this error when the game configuration prevents the game from
     running properly."""

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -6,6 +6,7 @@ import shlex
 import time
 
 from lutris import runtime, settings
+from lutris.exceptions import SymlinkNotUsableError
 from lutris.monitored_command import MonitoredCommand
 from lutris.runners import import_runner
 from lutris.util import linux, system
@@ -108,6 +109,12 @@ def create_prefix(
 
     # Follow symlinks, don't delete existing ones as it would break some setups
     if os.path.islink(prefix):
+        try:
+            _ = os.stat(prefix)
+        except FileNotFoundError:
+            raise SymlinkNotUsableError(
+                message=f"Link {prefix} couldn't be used, please check permissions or broken link.", link=prefix
+            )
         prefix = os.readlink(prefix)
 
     # Avoid issue of 64bit Wine refusing to create win32 prefix

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -6,7 +6,6 @@ import shlex
 import time
 
 from lutris import runtime, settings
-from lutris.exceptions import SymlinkNotUsableError
 from lutris.monitored_command import MonitoredCommand
 from lutris.runners import import_runner
 from lutris.util import linux, system
@@ -109,12 +108,6 @@ def create_prefix(
 
     # Follow symlinks, don't delete existing ones as it would break some setups
     if os.path.islink(prefix):
-        try:
-            _ = os.stat(prefix)
-        except FileNotFoundError:
-            raise SymlinkNotUsableError(
-                message=f"Link {prefix} couldn't be used, please check permissions or broken link.", link=prefix
-            )
         prefix = os.readlink(prefix)
 
     # Avoid issue of 64bit Wine refusing to create win32 prefix

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -16,6 +16,7 @@ from lutris.exceptions import (
     MisconfigurationError,
     MissingExecutableError,
     MissingGameExecutableError,
+    SymlinkNotUsableError,
     UnspecifiedVersionError,
 )
 from lutris.game import Game
@@ -1052,6 +1053,11 @@ class wine(Runner):
 
         prefix_path = self.prefix_path
         if prefix_path:
+            if os.path.islink(prefix_path) and not os.path.exists(prefix_path):
+                raise SymlinkNotUsableError(
+                    message=f"Link {prefix_path} couldn't be used, please check permissions or broken link.",
+                    link=prefix_path,
+                )
             if not system.path_exists(os.path.join(prefix_path, "user.reg")):
                 logger.warning("No valid prefix detected in %s, creating one...", prefix_path)
                 create_prefix(prefix_path, wine_path=self.get_executable(), arch=self.wine_arch, runner=self)

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -16,7 +16,6 @@ from lutris.exceptions import (
     MisconfigurationError,
     MissingExecutableError,
     MissingGameExecutableError,
-    SymlinkNotUsableError,
     UnspecifiedVersionError,
 )
 from lutris.game import Game
@@ -1053,11 +1052,6 @@ class wine(Runner):
 
         prefix_path = self.prefix_path
         if prefix_path:
-            if os.path.islink(prefix_path) and not os.path.exists(prefix_path):
-                raise SymlinkNotUsableError(
-                    message=f"Link {prefix_path} couldn't be used, please check permissions or broken link.",
-                    link=prefix_path,
-                )
             if not system.path_exists(os.path.join(prefix_path, "user.reg")):
                 logger.warning("No valid prefix detected in %s, creating one...", prefix_path)
                 create_prefix(prefix_path, wine_path=self.get_executable(), arch=self.wine_arch, runner=self)


### PR DESCRIPTION
currently, in that case, this is not detected and regular startup is attempted; causing timeout message and lack of feedback via GUI.

This intentionally doesn't try to perform checks regarding the link target itself - could be subject to separate PR if really needed, but I think just the basic check done here would cover already enough situationx where it would be actually useful.

For example in my case I use shared wine prefix, and it sometimes happen the link is broken, because i created it wrongly, or external device it points to is not mounted - and notice that only due to abnormal startup time and message in console.

With this, the error is reported via GUI with no wait time nor risky attempts to start the game anyway.