### PR TITLE
use icoextract intead of extract-icon, which is outdated

### DIFF
--- a/lutris/util/wine/extract_icon.py
+++ b/lutris/util/wine/extract_icon.py
@@ -1,6 +1,35 @@
+"""
+The MIT License (MIT)
+
+Copyright (c) 2015-2016 Fadhil Mandaga
+Copyright (c) 2019-2025 James Lu <james@overdrivenetworks.com>
+Copyright (c) 2025 Hoang Cao Tri
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
 # pylint: disable=no-member
+import logging
 import struct
 from io import BytesIO
+from typing import List, Tuple
+from PIL import Image
 
 try:
     import pefile
@@ -10,145 +39,160 @@ except ImportError:
     pefile = None
     PEFILE_AVAILABLE = False
 
-from PIL import Image
+GRPICONDIRENTRY_FORMAT = (
+    "GRPICONDIRENTRY",
+    ("B,Width", "B,Height", "B,ColorCount", "B,Reserved", "H,Planes", "H,BitCount", "I,BytesInRes", "H,ID"),
+)
+GRPICONDIR_FORMAT = ("GRPICONDIR", ("H,Reserved", "H,Type", "H,Count"))
 
-# From https://github.com/firodj/extract-icon-py
+logger = logging.getLogger("icoextract")
+logging.basicConfig()
 
 
-class ExtractIcon(object):
-    GRPICONDIRENTRY_format = (
-        "GRPICONDIRENTRY",
-        ("B,Width", "B,Height", "B,ColorCount", "B,Reserved", "H,Planes", "H,BitCount", "I,BytesInRes", "H,ID"),
-    )
-    GRPICONDIR_format = ("GRPICONDIR", ("H,Reserved", "H,Type", "H,Count"))
-    RES_ICON = 1
-    RES_CURSOR = 2
+class IconExtractorError(Exception):
+    """Superclass for exceptions raised by IconExtractor."""
 
-    def __init__(self, filepath):
-        self.pe = pefile.PE(filepath)
 
-    def find_resource_base(self, res_type):
-        if hasattr(self.pe, "DIRECTORY_ENTRY_RESOURCE"):
-            try:
-                rt_base_idx = [entry.id for entry in self.pe.DIRECTORY_ENTRY_RESOURCE.entries].index(
-                    pefile.RESOURCE_TYPE[res_type]
-                )
+class IconNotFoundError(IconExtractorError):
+    """Exception raised when extracting an icon index or resource ID that does not exist."""
 
-                if rt_base_idx is not None:
-                    return self.pe.DIRECTORY_ENTRY_RESOURCE.entries[rt_base_idx]
-            except (ValueError, IndexError):
-                pass  # if the resource is not found or the index is bogus
 
+class NoIconsAvailableError(IconExtractorError):
+    """Exception raised when the input program has no icon resources."""
+
+
+class InvalidIconDefinitionError(IconExtractorError):
+    """Exception raised when the input program has an invalid icon resource."""
+
+
+class IconExtractor:
+    def __init__(self, filename=None, data=None):
+        """
+        Loads an executable from the given `filename` or `data` (raw bytes).
+        As with pefile, if both `filename` and `data` are given, `filename` takes precedence.
+
+        If the executable has contains no icons, this will raise `NoIconsAvailableError`.
+        """
+        # Use fast loading and explicitly load the RESOURCE directory entry. This saves a LOT of time
+        # on larger files
+        self._pe = pefile.PE(name=filename, data=data, fast_load=True)
+        self._pe.parse_data_directories(pefile.DIRECTORY_ENTRY["IMAGE_DIRECTORY_ENTRY_RESOURCE"])
+
+        if not hasattr(self._pe, "DIRECTORY_ENTRY_RESOURCE"):
+            raise NoIconsAvailableError("File has no resources")
+
+        # Reverse the list of entries before making the mapping so that earlier values take precedence
+        # When an executable includes multiple icon resources, we should use only the first one.
+        # pylint: disable=no-member
+        resources = {rsrc.id: rsrc for rsrc in reversed(self._pe.DIRECTORY_ENTRY_RESOURCE.entries)}
+
+        self.groupiconres = resources.get(pefile.RESOURCE_TYPE["RT_GROUP_ICON"])
+        if not self.groupiconres:
+            raise NoIconsAvailableError("File has no group icon resources")
+        self.rticonres = resources.get(pefile.RESOURCE_TYPE["RT_ICON"])
+
+        # Populate resources by ID
+        self._group_icons = {entry.struct.Name: idx for idx, entry in enumerate(self.groupiconres.directory.entries)}
+        self._icons = {
+            icon_entry_list.id: icon_entry_list.directory.entries[0]  # Select first language
+            for icon_entry_list in self.rticonres.directory.entries
+        }
+
+    def _get_icon(self, index: int = 0) -> List[Tuple[pefile.Structure, bytes]]:
+        """
+        Returns the specified group icon in the binary.
+
+        Result is a list of (group icon structure, icon data) tuples.
+        """
+        try:
+            groupicon = self.groupiconres.directory.entries[index]
+        except IndexError:
+            raise IconNotFoundError(f"No icon exists at index {index}") from None
+        resource_id = groupicon.struct.Name
+        icon_lang = None
+        if groupicon.struct.DataIsDirectory:
+            # Select the first language from subfolders as needed.
+            groupicon = groupicon.directory.entries[0]
+            icon_lang = groupicon.struct.Name
+            logger.debug("Picking first language %s", icon_lang)
+
+        # Read the data pointed to by the group icon directory (GRPICONDIR) struct.
+        rva = groupicon.data.struct.OffsetToData
+        grp_icon_data = self._pe.get_data(rva, groupicon.data.struct.Size)
+        file_offset = self._pe.get_offset_from_rva(rva)
+
+        grp_icon_dir = self._pe.__unpack_data__(GRPICONDIR_FORMAT, grp_icon_data, file_offset)
+        logger.debug(
+            "Group icon %d has ID %s and %d images: %s",
+            # pylint: disable=no-member
+            index,
+            resource_id,
+            grp_icon_dir.Count,
+            grp_icon_dir,
+        )
+
+        # pylint: disable=no-member
+        if grp_icon_dir.Reserved:
+            # pylint: disable=no-member
+            raise InvalidIconDefinitionError(
+                "Invalid group icon definition (got Reserved=%s instead of 0)" % hex(grp_icon_dir.Reserved)
+            )
+
+        # For each group icon entry (GRPICONDIRENTRY) that immediately follows, read the struct and look up the
+        # corresponding icon image
+        grp_icons = []
+        icon_offset = grp_icon_dir.sizeof()
+        for grp_icon_index in range(grp_icon_dir.Count):
+            grp_icon = self._pe.__unpack_data__(
+                GRPICONDIRENTRY_FORMAT, grp_icon_data[icon_offset:], file_offset + icon_offset
+            )
+            icon_offset += grp_icon.sizeof()
+            logger.debug("Got group icon entry %d: %s", grp_icon_index, grp_icon)
+
+            icon_entry = self._icons[grp_icon.ID]
+            icon_data = self._pe.get_data(icon_entry.data.struct.OffsetToData, icon_entry.data.struct.Size)
+            logger.debug("Got icon data for ID %d: %s", grp_icon.ID, icon_entry.data.struct)
+            grp_icons.append((grp_icon, icon_data))
+        return grp_icons
+
+    def get_best_icon(self, size=128):
+        """
+        Extract best matching icon closest to specified size
+
+        Returns PIL Image object or None if extraction fails
+        """
+        icons = self._get_icon()
+        best_score = -1
+        icon = None
+
+        for grp_icon, icon_data in icons:
+            width = grp_icon.Width or 256
+            height = grp_icon.Height or 256
+            bit_count = grp_icon.BitCount or 32
+
+            score = (1 << 20) if (width == size and height == size) else (bit_count << 10) + (width * height)
+            if score > best_score:
+                best_score = score
+                icon = (grp_icon, icon_data)
+        if not icon:
+            return None
+
+        # Write minimal ICO header and icon data
+        with BytesIO() as buffer:
+            buffer.write(
+                b"\x00\x00"  # 2 reserved bytes
+                + struct.pack("<HH", 1, 1)  # 0x1 (little endian) specifying that this is an .ICO image
+                +
+                # Elements in ICONDIRENTRY and GRPICONDIRENTRY are all the same
+                # except the last value, which is an ID in GRPICONDIRENTRY and
+                # the offset from the beginning of the file in ICONDIRENTRY.
+                icon[0].__pack__()[:12]  # ICONDIRENTRY
+                + struct.pack("<I", 22)  # Data Offset
+                + icon[1]  # Icon Data
+            )
+            buffer.seek(0)
+            return Image.open(buffer)
         return None
 
-    def find_resource(self, res_type, res_index):
-        rt_base_dir = self.find_resource_base(res_type)
 
-        if not rt_base_dir:
-            return None
-
-        if res_index < 0:
-            try:
-                idx = [entry.id for entry in rt_base_dir.directory.entries].index(-res_index)
-            except:
-                return None
-        else:
-            idx = res_index if res_index < len(rt_base_dir.directory.entries) else None
-
-        if idx is None:
-            return None
-
-        test_res_dir = rt_base_dir.directory.entries[idx]
-        res_dir = test_res_dir
-        if test_res_dir.struct.DataIsDirectory:
-            # another Directory
-            # probably language take the first one
-            res_dir = test_res_dir.directory.entries[0]
-        if res_dir.struct.DataIsDirectory:
-            # Ooooooooooiconoo no !! another Directory !!!
-            return None
-
-        return res_dir
-
-    def get_group_icons(self):
-        rt_base_dir = self.find_resource_base("RT_GROUP_ICON")
-
-        if not rt_base_dir:
-            return []
-
-        groups = []
-        for res_index in range(0, len(rt_base_dir.directory.entries)):
-            grp_icon_dir_entry = self.find_resource("RT_GROUP_ICON", res_index)
-
-            if not grp_icon_dir_entry:
-                continue
-
-            data_rva = grp_icon_dir_entry.data.struct.OffsetToData
-            size = grp_icon_dir_entry.data.struct.Size
-            data = self.pe.get_memory_mapped_image()[data_rva : data_rva + size]
-            file_offset = self.pe.get_offset_from_rva(data_rva)
-
-            grp_icon_dir = pefile.Structure(self.GRPICONDIR_format, file_offset=file_offset)
-            grp_icon_dir.__unpack__(data)
-
-            if grp_icon_dir.Reserved != 0 or grp_icon_dir.Type != self.RES_ICON:
-                continue
-            offset = grp_icon_dir.sizeof()
-
-            entries = []
-            for _idx in range(0, grp_icon_dir.Count):
-                grp_icon = pefile.Structure(self.GRPICONDIRENTRY_format, file_offset=file_offset + offset)
-                grp_icon.__unpack__(data[offset:])
-                offset += grp_icon.sizeof()
-                entries.append(grp_icon)
-
-            groups.append(entries)
-        return groups
-
-    def get_icon(self, index):
-        icon_entry = self.find_resource("RT_ICON", -index)
-        if not icon_entry:
-            return None
-
-        data_rva = icon_entry.data.struct.OffsetToData
-        size = icon_entry.data.struct.Size
-        data = self.pe.get_memory_mapped_image()[data_rva : data_rva + size]
-
-        return data
-
-    def export_raw(self, entries, index=None):
-        if index is not None:
-            entries = entries[index : index + 1]
-
-        ico = struct.pack("<HHH", 0, self.RES_ICON, len(entries))
-        data_offset = None
-        data = []
-        info = []
-        for grp_icon in entries:
-            if data_offset is None:
-                data_offset = len(ico) + ((grp_icon.sizeof() + 2) * len(entries))
-
-            nfo = grp_icon.__pack__()[:-2] + struct.pack("<L", data_offset)
-            info.append(nfo)
-
-            raw_data = self.get_icon(grp_icon.ID)
-            if not raw_data:
-                continue
-
-            data.append(raw_data)
-            data_offset += len(raw_data)
-
-        raw = ico + b"".join(info + data)
-        return raw
-
-    def export(self, entries, index=None):
-        raw = self.export_raw(entries, index)
-        return Image.open(BytesIO(raw))
-
-    def _get_bmp_header(self, data):
-        if data[0:4] == b"\x89PNG":
-            header = b""
-        else:
-            dib_size = struct.unpack("<L", data[0:4])[0]
-            header = b"BM" + struct.pack("<LLL", len(data) + 14, 0, 14 + dib_size)
-        return header
+__all__ = ["IconExtractor", "IconExtractorError", "InvalidIconDefinitionError", "NoIconsAvailableError"]


### PR DESCRIPTION
extract-icon is outdated and cannot handle large .exe files.
```
ERROR    2025-04-10 20:30:07,375 [wine.extract_icon:1351]:Unable to extract icon from /mnt/wind/tmp/HoYoPlay/games/Genshin Impact game/GenshinImpact.exe: 'Data length less than expected header length.'
Traceback (most recent call last):
  File "/home/zebra2711/git/lutris/lutris/runners/wine.py", line 1328, in extract_icon
    groups = extractor.get_group_icons()
  File "/home/zebra2711/git/lutris/lutris/util/wine/extract_icon.py", line 92, in get_group_icons
    grp_icon_dir.__unpack__(data)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/usr/lib/python3.13/site-packages/pefile.py", line 1016, in __unpack__
    raise PEFormatError("Data length less than expected header length.")
pefile.PEFormatError: 'Data length less than expected header length.'
```
refs: https://github.com/jlu5/icoextract.git