### PR TITLE
Update .gitignore to enable direnv usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ tests/coverage/*
 /flake.nix
 /flake.lock
 
+# direnv
+/.direnv
+.envrc
+
 # meson builddirs
 builddir
 


### PR DESCRIPTION
Adds .envrc and .direnv to enable easier use of the direnv tool.

direnv tool allows for easier management of both workfolder-specific environment variables as well as virtual environments, especially when used in conjunction with miniconda.