### PR TITLE
modify find_windows_game_executable() to be also compatible with newe…

### DIFF
--- a/lutris/util/game_finder.py
+++ b/lutris/util/game_finder.py
@@ -89,9 +89,11 @@ def find_windows_game_executable(path):
             file_type = magic.from_file(abspath)
             if "MS Windows shortcut" in file_type:
                 candidates["link"] = abspath
-            elif "PE32+ executable (GUI) x86-64" in file_type:
+            elif all([_ in file_type for _ in ("PE32+ executable", "(GUI)", "x86-64")]):
                 candidates["64bit"] = abspath
-            elif "PE32 executable (GUI) Intel 80386" in file_type:
+            elif all([_ in file_type for _ in ("PE32 executable", "(GUI)")]) and any(
+                [_ in file_type for _ in ("Intel i386", "Intel 80386")]
+            ):
                 candidates["32bit"] = abspath
         if candidates:
             return candidates.get("link") or candidates.get("64bit") or candidates.get("32bit")


### PR DESCRIPTION
…st format

Format returned has changed, maybe related to difference between libc 2.40 and 2.41 (not 100% sure, but seems like it) and causes the function to not detect win executable ending in empty 'exe' field in YAML file.

Problem identified on Arch current using:
    GNU C Library (GNU libc) stable release version 2.41
as well as on Fedora Workstation 42, using the same version

Not impacting on Ubuntu 24.10 using:
    GNU C Library (Ubuntu GLIBC 2.40-1ubuntu3.1) stable release version 2.40.

Examples of differing outputs:
---
Arch, Fedora 42 - win32 exe file:
 - 'PE32 executable for MS Windows 4.00 (GUI), Intel i386, 5 sections

Ubuntu 24.10 - win32 exe file:
 - PE32 executable (GUI) Intel 80386

Arch, Fedora 42 - win64 exe file:
 - PE32+ executable for MS Windows 5.02 (GUI), x86-64, 7 sections

Ubuntu 24.10 - win64 exe file:
 - PE32+ executable (GUI) x86-64, for MS Windows, 7 sections

The modified code matches substrings, instead of whole string, and should hopefully be more resilient in case of future format changes.

Tested on tested the above 3 OS, with the itch.io source and win32 and win64 games.