### PR TITLE
Sort games by last modified date

### DIFF
--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -138,7 +138,9 @@ def get_games_by_slug(slug):
 
 def add_game(**game_data):
     """Add a game to the database."""
-    game_data["installed_at"] = int(time.time())
+    now = int(time.time())
+    game_data["installed_at"] = now
+    game_data["modified_at"] = now
     if "slug" not in game_data:
         game_data["slug"] = slugify(game_data["name"])
     return sql.db_insert(settings.DB_PATH, "games", game_data)
@@ -177,6 +179,7 @@ def update_existing(**params):
     game_id = get_matching_game(params)
     if game_id:
         params["id"] = game_id
+        params["modified_at"] = int(time.time())
         sql.db_update(settings.DB_PATH, "games", params, {"id": game_id})
         return game_id
     return None

--- a/lutris/database/schema.py
+++ b/lutris/database/schema.py
@@ -33,6 +33,7 @@ DATABASE = {
             "name": "discord_id",
             "type": "TEXT",
         },
+        {"name": "modified_at", "type": "INTEGER"},
     ],
     "service_games": [
         {"name": "id", "type": "INTEGER", "indexed": True},

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -44,6 +44,8 @@ from lutris.gui.views import (
     COL_PLAYTIME_TEXT,
     COL_SORTNAME,
     COL_YEAR,
+    COL_MODIFIED_AT,
+    COL_MODIFIED_AT_TEXT,
 )
 from lutris.gui.views.grid import GameGridView
 from lutris.gui.views.list import GameListView
@@ -444,6 +446,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 return set([COL_INSTALLED_AT, COL_INSTALLED_AT_TEXT])
             elif self.view_sorting == "playtime":
                 return set([COL_PLAYTIME, COL_PLAYTIME_TEXT])
+            elif self.view_sorting == "modified_at":
+                return set([COL_MODIFIED_AT, COL_MODIFIED_AT_TEXT])
 
         return set()
 
@@ -464,6 +468,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             "lastplayed": 0.0,
             "installed_at": 0.0,
             "playtime": 0.0,
+            "modified_at": 0.0,
         }
 
         def get_sort_default(item):
@@ -625,7 +630,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def combine_games(service_game, lutris_game):
         """Inject lutris game information into a service game"""
         if lutris_game and service_game["appid"] == lutris_game["service_id"]:
-            for field in ("platform", "runner", "installed_at", "lastplayed", "playtime", "installed"):
+            for field in ("platform", "runner", "installed_at", "lastplayed", "playtime", "installed", "modified_at"):
                 service_game[field] = lutris_game[field]
             service_game["year"] = service_game["year"] if "year" in service_game else lutris_game["year"]
         return service_game

--- a/lutris/gui/views/__init__.py
+++ b/lutris/gui/views/__init__.py
@@ -17,7 +17,9 @@
     COL_INSTALLED_AT_TEXT,
     COL_PLAYTIME,
     COL_PLAYTIME_TEXT,
-) = list(range(16))
+    COL_MODIFIED_AT,
+    COL_MODIFIED_AT_TEXT,
+) = list(range(18))
 
 COLUMN_NAMES = {
     COL_NAME: "name",
@@ -27,4 +29,5 @@ COLUMN_NAMES = {
     COL_LASTPLAYED_TEXT: "lastplayed",
     COL_INSTALLED_AT_TEXT: "installedat",
     COL_PLAYTIME_TEXT: "playtime",
+    COL_MODIFIED_AT_TEXT: "modifiedat",
 }

--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -24,6 +24,8 @@ from lutris.gui.views import (
     COL_SORTNAME,
     COL_YEAR,
     COLUMN_NAMES,
+    COL_MODIFIED_AT,
+    COL_MODIFIED_AT_TEXT,
 )
 from lutris.gui.views.base import GameView
 from lutris.gui.views.store import sort_func
@@ -70,6 +72,7 @@ class GameListView(Gtk.TreeView, GameView):
         self.set_column(default_text_cell, _("Last Played"), COL_LASTPLAYED_TEXT, 120)
         self.set_column(default_text_cell, _("Play Time"), COL_PLAYTIME_TEXT, 100)
         self.set_column(default_text_cell, _("Installed At"), COL_INSTALLED_AT_TEXT, 120)
+        self.set_column(default_text_cell, _("Modified At"), COL_MODIFIED_AT_TEXT, 120)
 
         self.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
 
@@ -84,6 +87,7 @@ class GameListView(Gtk.TreeView, GameView):
         self.set_model(self.model)
         self.set_sort_with_column(COL_LASTPLAYED_TEXT, COL_LASTPLAYED)
         self.set_sort_with_column(COL_INSTALLED_AT_TEXT, COL_INSTALLED_AT)
+        self.set_sort_with_column(COL_MODIFIED_AT_TEXT, COL_MODIFIED_AT)
         self.set_sort_with_column(COL_PLAYTIME_TEXT, COL_PLAYTIME)
 
         if self.media_column:

--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -29,6 +29,8 @@ from . import (
     COL_SLUG,
     COL_SORTNAME,
     COL_YEAR,
+    COL_MODIFIED_AT,
+    COL_MODIFIED_AT_TEXT,
 )
 
 
@@ -95,6 +97,8 @@ class GameStore(GObject.Object):
             str,
             float,
             str,
+            int,
+            str,
         )
 
     @property
@@ -156,6 +160,8 @@ class GameStore(GObject.Object):
         new_values[COL_INSTALLED_AT_TEXT] = store_item.installed_at_text
         new_values[COL_PLAYTIME] = store_item.playtime
         new_values[COL_PLAYTIME_TEXT] = store_item.playtime_text
+        new_values[COL_MODIFIED_AT] = store_item.modified_at
+        new_values[COL_MODIFIED_AT_TEXT] = store_item.modified_at_text
 
         changed_indices = set()
         for idx, value in new_values.items():
@@ -188,6 +194,8 @@ class GameStore(GObject.Object):
                 store_item.installed_at_text,
                 store_item.playtime,
                 store_item.playtime_text,
+                store_item.modified_at,
+                store_item.modified_at_text,
             )
         )
 

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -153,6 +153,16 @@ class StoreItem:
         return gtk_safe(time.strftime("%X %x", time.localtime(self.installed_at)) if self.installed_at else "")
 
     @property
+    def modified_at(self):
+        """Date when the game was last modified"""
+        return self._get_game_attribute("modified_at")
+
+    @property
+    def modified_at_text(self):
+        """Date when the game was last modified (textual representation)"""
+        return gtk_safe(time.strftime("%X %x", time.localtime(self.modified_at)) if self.modified_at else "")
+
+    @property
     def lastplayed(self):
         """Date of last play"""
         return self._get_game_attribute("lastplayed")

--- a/lutris/migrations/__init__.py
+++ b/lutris/migrations/__init__.py
@@ -3,7 +3,7 @@ import importlib
 from lutris import settings
 from lutris.util.log import logger
 
-MIGRATION_VERSION = 16  # Never decrease this number
+MIGRATION_VERSION = 17  # Never decrease this number
 
 # Replace deprecated migrations with empty lists
 MIGRATIONS = [
@@ -23,6 +23,7 @@ MIGRATIONS = [
     ["migrate_hidden_category"],
     ["migrate_ge_proton"],
     ["migrate_banners_back"],
+    ["migrate_modified_at"],
 ]
 
 

--- a/lutris/migrations/migrate_modified_at.py
+++ b/lutris/migrations/migrate_modified_at.py
@@ -1,0 +1,16 @@
+from lutris import settings
+from lutris.database import sql
+from lutris.database.games import get_games
+from lutris.util.log import logger
+
+
+def migrate():
+    """Add modified at field to all games"""
+    logger.info("Adding modified at field to database")
+    games = get_games()
+    for game in games:
+        if "modified_at" not in game.keys() or game["modified_at"] is None:
+            installed_at = game["installed_at"]
+            slug = game["slug"]
+            logger.info("Using installed at %d as modified at for game %s", installed_at, slug)
+            sql.db_update(settings.DB_PATH, "games", {"modified_at": installed_at}, {"slug": slug})

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -644,13 +644,28 @@
             <property name="can-focus">True</property>
             <property name="receives-default">False</property>
             <property name="action-name">win.view-sorting</property>
+            <property name="action-target">'modified_at'</property>
+            <property name="text" translatable="yes">Modified At</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">8</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkModelButton">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="action-name">win.view-sorting</property>
             <property name="action-target">'playtime'</property>
             <property name="text" translatable="yes">Play Time</property>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">8</property>
+            <property name="position">9</property>
           </packing>
         </child>
       </object>


### PR DESCRIPTION
This PR adds a new field to the `games` DB table called `modified_at`. A new migration initializes this column with values taken from the `installed_at` column. Whenever the game gets modified, `modified_at` will be set to the current time. Finally, the values are exposed in the UI via a new column in the list view and a new sorting option in the grid view.