### PR TITLE
Make it possible to build on bookworm and ubuntu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         "evdev",
         "lxml",
         "pillow",
-        "PyGObject",
+        "PyGObject == 3.50.0",
         "pypresence",
         "PyYAML",
         "requests",


### PR DESCRIPTION
    * PyGObject > 3.50.0 has a dependency on girepository-2.0 But it's only available on unstable OS versions. Pinned to 3.50.0 instead.