### PR TITLE
Adding Speedtest feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,10 @@ tests/coverage/*
 /flake.nix
 /flake.lock
 
+# direnv
+/.direnv
+.envrc
+
 # meson builddirs
 builddir
 
@@ -38,3 +42,4 @@ env
 
 # glade recovery files
 *.ui~
+

--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -35,6 +35,7 @@ class InstallerFileBox(Gtk.VBox):
         self.set_margin_right(12)
         self.provider = self.installer_file.default_provider
         self.file_provider_widget = None
+        self.spinner_widget = None
         self.add(self.get_widgets())
 
     @property
@@ -113,19 +114,28 @@ class InstallerFileBox(Gtk.VBox):
         combobox.set_active_id(self.provider)
         return combobox
 
-    def replace_file_provider_widget(self):
-        """Replace the file provider label and the source button with the actual widget"""
+    def replace_file_provider_widget(self, processing = False):
+        """
+        Replace the file provider label and the source button with the actual widget.
+        Set processing to True to add a spinner to the widget.
+        """
         self.file_provider_widget.destroy()
+        if self.spinner_widget: self.spinner_widget.destroy()
         widget_box = self.get_children()[0]
         if self.started:
             self.file_provider_widget = self.get_file_provider_widget()
+            self.spinner_widget = self.get_spinner_widget()
             # Also remove the the source button
             for child in widget_box.get_children():
                 child.destroy()
         else:
             self.file_provider_widget = self.get_file_provider_label()
+            self.spinner_widget = self.get_spinner_widget()
+        if processing:
+            widget_box.pack_start(self.spinner_widget, False, False, 0)
         widget_box.pack_start(self.file_provider_widget, True, True, 0)
         widget_box.reorder_child(self.file_provider_widget, 0)
+        widget_box.reorder_child(self.spinner_widget, 1)
         widget_box.show_all()
 
     def on_source_changed(self, combobox):
@@ -179,6 +189,14 @@ class InstallerFileBox(Gtk.VBox):
         combobox = self.get_combobox()
         source_box.pack_start(combobox, False, False, 0)
         return box
+
+    def get_spinner_widget(self, size = 24):
+        """ Returns a standard GTK Spinner"""
+        spinner = Gtk.Spinner()
+        spinner.set_size_request(size, size)
+        spinner.start()
+        spinner.hides_when_stopped = True
+        return spinner
 
     def on_location_changed(self, widget):
         """Open a file picker when the browse button is clicked"""

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -135,6 +135,12 @@ class InstallerFilesBox(Gtk.ListBox):
                         else:
                             file_entry.replace_file_provider_widget(processing = True) # Display Spinner
                             file_entry.installer_file.run_speedtest()
+                            if file_entry.installer_file.speedtest.is_file_completed:
+                                for widget in file_entry.get_children():
+                                    file_entry.remove(widget)
+                                file_entry.provider = "pga"
+                                file_entry.add(file_entry.get_widgets())
+                            else:
+                                domains[file_entry.installer_file.domain] = file_entry.installer_file.speed
                             file_entry.replace_file_provider_widget() # Display Result
-                            domains[file_entry.installer_file.domain] = file_entry.installer_file.speed
         AsyncCall(iter_files, None)

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -2,6 +2,7 @@ from gi.repository import GObject, Gtk
 
 from lutris.gui.installer.file_box import InstallerFileBox
 from lutris.util.log import logger
+from lutris.util.jobs import AsyncCall
 
 
 class InstallerFilesBox(Gtk.ListBox):
@@ -120,3 +121,20 @@ class InstallerFilesBox(Gtk.ListBox):
         for installer_file in self.installer.files:
             files.update(installer_file.get_dest_files_by_id())
         return files
+
+    def speedtest(self):
+        """Begin speedtest on all files sequentially and update the UI"""
+        domains = {}
+        def iter_files():
+            for file_id, file_entry in self.installer_files_boxes.items():
+                if file_id not in self.available_files:
+                    if file_entry.provider == "download":
+                        if file_entry.installer_file.domain in domains: # Makes sure we only run speedtest once per domain
+                            file_entry.installer_file.speed = domains[file_entry.installer_file.domain]
+                            file_entry.replace_file_provider_widget()
+                        else:
+                            file_entry.replace_file_provider_widget(processing = True) # Display Spinner
+                            file_entry.installer_file.run_speedtest()
+                            file_entry.replace_file_provider_widget() # Display Result
+                            domains[file_entry.installer_file.domain] = file_entry.installer_file.speed
+        AsyncCall(iter_files, None)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -124,6 +124,12 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             tooltip=_("Change where Lutris downloads game installer files."),
         )
 
+        self.speedtest_button = self.add_menu_button(
+            _("Run Speedtests"),
+            self.on_speedtest_clicked,
+            tooltip=_("Run a short speedtest on all files available for download"),
+        )
+
         self.source_button = self.add_menu_button(_("View installer source"), self.on_source_clicked)
 
         # Pre-create some UI bits we need to refer to in several places.
@@ -202,6 +208,10 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
     def on_cache_clicked(self, _button):
         """Open the cache configuration dialog"""
         CacheConfigurationDialog(parent=self)
+
+    def on_speedtest_clicked(self, _button):
+        """Begin speedtest on all files sequentially"""
+        self.installer_files_box.speedtest()
 
     def on_response(self, dialog, response: Gtk.ResponseType) -> None:
         if response in (Gtk.ResponseType.CLOSE, Gtk.ResponseType.CANCEL, Gtk.ResponseType.DELETE_EVENT):
@@ -634,7 +644,13 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         logger.debug("Presenting installer files page")
         self.set_status(_("Please review the files needed for the installation then click 'Install'"))
         self.stack.present_page("installer_files")
-        self.display_install_button(self.on_files_confirmed, sensitive=self.installer_files_box.is_ready)
+        self.display_install_button(
+            self.on_files_confirmed, 
+            sensitive=self.installer_files_box.is_ready, 
+            extra_buttons=[self.speedtest_button if self.interpreter.installer.files else None, 
+                           self.source_button
+                           ]
+        )
 
     def present_downloading_files_page(self):
         def on_exit_page():
@@ -1006,10 +1022,10 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         buttons = [self.continue_button] + (extra_buttons or [])
         self.display_buttons(buttons)
 
-    def display_install_button(self, handler, sensitive=True):
+    def display_install_button(self, handler, sensitive=True, extra_buttons=None):
         """Displays the continue button, but labels it 'Install'."""
         self.display_continue_button(
-            handler, continue_button_label=_("_Install"), sensitive=sensitive, extra_buttons=[self.source_button]
+            handler, continue_button_label=_("_Install"), sensitive=sensitive, extra_buttons=extra_buttons or []
         )
 
     def display_cancel_button(self, extra_buttons=None):
@@ -1030,7 +1046,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             self.cancel_button.set_tooltip_text("")
             style_context.remove_class("destructive-action")
 
-        all_buttons = [self.cache_button, self.source_button, self.continue_button]
+        all_buttons = [self.cache_button, self.source_button, self.continue_button, self.speedtest_button]
 
         for b in all_buttons:
             b.set_visible(b in buttons)

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -12,7 +12,6 @@ from lutris.util import system
 from lutris.util.downloader import Downloader
 from lutris.util.log import logger
 from lutris.util.strings import gtk_safe_urls
-from lutris.util.jobs import AsyncCall
 
 
 class InstallerFile:

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -1,7 +1,6 @@
 """Manipulates installer files"""
 
 import os
-import io
 from gettext import gettext as _
 from typing import Optional
 from urllib.parse import urlparse

--- a/lutris/util/downloader.py
+++ b/lutris/util/downloader.py
@@ -1,5 +1,6 @@
 import bisect
 import os
+import io
 import threading
 import time
 from typing import Any
@@ -25,9 +26,9 @@ class Downloader:
     Stop with cancel().
     """
 
-    (INIT, DOWNLOADING, CANCELLED, ERROR, COMPLETED) = list(range(5))
+    (INIT, DOWNLOADING, SPEEDTEST, CANCELLED, ERROR, COMPLETED) = list(range(6))
 
-    def __init__(self, url: str, dest: str, overwrite: bool = False, referer: str = None, cookies: Any = None) -> None:
+    def __init__(self, url: str, dest: str, overwrite: bool = False, referer: str = None, cookies: Any = None, speedtest = False) -> None:
         self.url: str = url
         self.dest: str = dest
         self.cookies = cookies
@@ -35,6 +36,14 @@ class Downloader:
         self.referer = referer
         self.stop_request = None
         self.thread = None
+
+        # Speedtest mode writes to memory for more accurate results and less disk I/O
+        # In this mode the COMPLETED state will be reached once get_speed determines a value, not when the download is complete
+        # To check if a tiny file has been fully downloaded anyway (given 'dest' has been set), file_completed() has to be called
+        self.speedtest = speedtest
+        if speedtest: 
+            self.memfile = io.BytesIO()
+            self.start_time = get_time()
 
         # Read these after a check_progress()
         self.state = self.INIT
@@ -57,13 +66,23 @@ class Downloader:
         return "downloader for %s" % self.url
 
     def start(self):
-        """Start download job."""
-        logger.debug("⬇ %s", self.url)
-        self.state = self.DOWNLOADING
+        """Start download or speedtest job."""
+        if self.speedtest:
+            logger.debug("📶 %s", self.url)
+            self.state = self.SPEEDTEST
+        else:
+            if not self.dest: 
+                logger.exception("Downloader class called in download mode without a destination file, Aborting. URL: %s", self.url)
+                self.state = self.ERROR
+                self.error = "No destination file provided"
+                return
+            logger.debug("⬇ %s", self.url)
+            self.state = self.DOWNLOADING
         self.last_check_time = get_time()
         if self.overwrite and os.path.isfile(self.dest):
             os.remove(self.dest)
-        self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
+        if self.dest: 
+            self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
         self.thread = jobs.AsyncCall(self.async_download, None)
         self.stop_request = self.thread.stop_request
 
@@ -89,7 +108,7 @@ class Downloader:
 
         blocking: if true and still downloading, block until some progress is made.
         :return: progress (between 0.0 and 1.0)"""
-        if blocking and self.state in [self.INIT, self.DOWNLOADING] and self.progress_fraction < 1.0:
+        if blocking and self.state in [self.INIT, self.DOWNLOADING, self.SPEEDTEST] and self.progress_fraction < 1.0:
             self.progress_event.wait()
             self.progress_event.clear()
 
@@ -104,7 +123,7 @@ class Downloader:
         proceeds, if given, and is passed the downloader itself.
 
         Returns True on success, False if cancelled."""
-        while self.state == self.DOWNLOADING:
+        while self.state in [self.DOWNLOADING, self.SPEEDTEST]:
             self.check_progress(blocking=True)
             if progress_callback:
                 progress_callback(self)
@@ -115,13 +134,16 @@ class Downloader:
 
     def cancel(self):
         """Request download stop and remove destination file."""
-        logger.debug("❌ %s", self.url)
+        logger.debug("❌ Cancelled download: %s", self.url)
         self.state = self.CANCELLED
         if self.stop_request:
             self.stop_request.set()
         if self.file_pointer:
             self.file_pointer.close()
             self.file_pointer = None
+        if self.speedtest:
+            self.memfile.close()
+            self.memfile = None
         if os.path.isfile(self.dest):
             os.remove(self.dest)
 
@@ -137,14 +159,28 @@ class Downloader:
             response.raise_for_status()
             self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
             self.progress_event.set()
-            for chunk in response.iter_content(chunk_size=8192):
-                if not self.file_pointer:
-                    break
-                if chunk:
-                    self.downloaded_size += len(chunk)
-                    self.file_pointer.write(chunk)
-                self.progress_event.set()
-            self.on_download_completed()
+
+            if self.state == self.DOWNLOADING:
+                for chunk in response.iter_content(chunk_size=8192):
+                    if not self.file_pointer:
+                        break
+                    if chunk:
+                        self.downloaded_size += len(chunk)
+                        self.file_pointer.write(chunk)
+                    self.progress_event.set()
+                self.on_download_completed()
+
+            elif self.state == self.SPEEDTEST:
+                for chunk in response.iter_content(chunk_size=1024):
+                    if chunk:
+                        self.downloaded_size += len(chunk)
+                        self.memfile.write(chunk)
+                    if get_time() - self.start_time > 1:
+                        self.average_speed = self.downloaded_size / (get_time() - self.start_time)
+                        break
+                    self.progress_event.set()
+                self.on_speedtest_completed(not chunk)
+                
         except Exception as ex:
             logger.exception("Download failed: %s", ex)
             self.on_download_failed(ex)
@@ -163,7 +199,7 @@ class Downloader:
         if self.state == self.CANCELLED:
             return
 
-        logger.debug("Finished downloading %s", self.url)
+        logger.debug("✔⬇ Finished downloading %s", self.url)
         if not self.downloaded_size:
             logger.warning("Downloaded file is empty")
 
@@ -173,6 +209,22 @@ class Downloader:
         self.state = self.COMPLETED
         self.file_pointer.close()
         self.file_pointer = None
+
+    def on_speedtest_completed(self, download_completed = False):
+        if self.state == self.CANCELLED:
+            return
+        
+        logger.debug("✔📶 %s KB/s for %s", f"{(self.average_speed / 1_000):.1f}", self.url)
+        if self.file_pointer and download_completed:
+            self.memfile.close()
+            self.file_pointer.write(self.memfile.getvalue())
+            self.memfile = None
+            self.on_download_completed()
+        self.progress_fraction = 1.0    # Not technically true, but we don't want to show a progress bar for speedtests anyway
+        self.progress_percentage = 100
+        self.progress_event.set()
+        self.state = self.COMPLETED
+
 
     def get_stats(self):
         """Calculate and store download stats."""


### PR DESCRIPTION
Adds a new feature for the Installer Files Page to conduct a quick Speedtest on all domains. This way users can determine if they want to let Lutris download the file from the given source or get it on their own.
If the file gets fully downloaded during the test (within 1.5 seconds) it gets cached to be used during installation. This works independently from an Installer Cache being set or not by the user.

[Example](https://github.com/user-attachments/assets/51265f5a-d2e6-49f2-a6e9-7b26278a2fda)

This is a technically an interim step to another PR I'm working on for Lutris to support multiple sources per file. This is also the reason for io.bytesIO being used in Downloader.py, as I aimed to reduce unnecessary disk I/O during repeated tests and ensure the results are reasonably accurate despite the short period.
Contains https://github.com/lutris/lutris/pull/6044.