### PR TITLE
Update `StartupWMClass` to the desktop file

### DIFF
--- a/share/applications/net.lutris.Lutris.desktop
+++ b/share/applications/net.lutris.Lutris.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Lutris
-StartupWMClass=Lutris
+StartupWMClass=net.lutris.Lutris
 Comment=Video Game Preservation Platform
 Categories=Game;PackageManager;
 Keywords=gaming;wine;emulator;


### PR DESCRIPTION
According to the information I got, `StartupWMClass` is called `net.lutris.Lutris` now.

This should resolve the edge-cases where icon is not shown in Gnome's dash & maybe in some other desktop environments.