### PR TITLE
tic80: update version and modify runner to adapt to upstream

### DIFF
--- a/share/lutris/json/tic80.json
+++ b/share/lutris/json/tic80.json
@@ -4,7 +4,6 @@
     "platforms": ["TIC-80"],
     "runner_executable": "tic80/tic80",
     "flatpak_id": "com.tic80.TIC_80",
-    "download_url": "https://github.com/nesbox/tic.computer/releases/download/v0.70.6/tic80_0.70.6.tar.gz",
     "game_options": [
         {
             "option": "main_file",
@@ -15,25 +14,32 @@
     ],
     "runner_options": [
         {
-            "option": "surf",
+            "option": "fullscreen",
             "type": "bool",
-            "label": "Start in Surf",
+            "label": "Start in fullscreen",
             "default": false,
-            "argument": "-surf"
+            "argument": "--fullscreen"
+        },    
+        {
+            "option": "software_rendering",
+            "type": "bool",
+            "label": "Software rendering",
+            "default": false,
+            "argument": "--soft"
         },
         {
             "option": "skip",
             "type": "bool",
             "label": "Skip startup animation",
             "default": false,
-            "argument": "-skip"
+            "argument": "--skip"
         },
         {
             "option": "nosound",
             "type": "bool",
             "label": "Start in silent mode",
             "default": false,
-            "argument": "-nosound"
+            "argument": "--volume=0"
         }
     ]
 }


### PR DESCRIPTION
- make options use '--' to adapt upstream change
- removed surf option as no longer supported
- added option to enable software rendering
- added option to enable fullscreen
- adapated "no sound" option to new syntax
- removed standalone binary URL because:
  - it is very outdated, causing compatibility issues with recent cartridges
  - upstream no longer provides tar.gz linux binary asset, only source code and .deb archives
  - flatpak version is updated and allow keeping most of configurations options we used before

For reference, new supported options are:
```
    -h, --help        show this help message and exit
    --skip            skip startup animation
    --volume=<int>    global volume value [0-15]
    --cli             console only output
    --fullscreen      enable fullscreen mode
    --vsync           enable VSYNC
    --soft            use software rendering
    --fs=<str>        path to the file system folder
    --scale=<int>     main window scale
    --cmd=<str>       run commands in the console
```