### PR TITLE
ruffle: bump to latest available version

### DIFF
--- a/share/lutris/json/ruffle.json
+++ b/share/lutris/json/ruffle.json
@@ -3,7 +3,7 @@
     "description": "Emulates Flash games",
     "platforms": ["Flash"],
     "runner_executable": "ruffle/ruffle",
-    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/nightly-2024-05-22/ruffle-nightly-2024_05_22-linux-x86_64.tar.gz",
+    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/nightly-2025-05-08/ruffle-nightly-2025_05_08-linux-x86_64.tar.gz",
     "game_options": [
         {
             "option": "main_file",


### PR DESCRIPTION
since current one is ~= 1 y.o this seems required