### PR TITLE
Support for PROTON_ENABLE_WAYLAND and PROTON_ENABLE_HDR.

### DIFF
--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -424,18 +424,20 @@ class wine(Runner):
             "default": False,
             "advanced": True,
             "visible": _is_proton_wayland_available,
-            "help": _("Enable Proton's support for the Wayland Display Server."),
+            "help": _(
+                "Enable Proton's support for the Wayland Display Server. Some Proton versions don't support this."
+            ),
         },
         {
             "option": "proton_hdr",
             "section": _("Graphics"),
-            "label": _("Enable HDR"),
+            "label": _("Enable HDR (Experimental)"),
             "type": "bool",
             "default": False,
             "advanced": True,
             "visible": _is_proton_wayland_available,
             "conditional_on": "proton_wayland",
-            "help": _("Enable Proton's support for the High Dynamic Range graphics. Requires Wayland."),
+            "help": _("Enable Proton's support for High Dynamic Range graphics. Requires Wayland."),
         },
         {
             "option": "esync",

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -73,8 +73,13 @@ def _is_pre_proton(_option_key: str, config: LutrisConfig) -> bool:
 
 
 def _is_proton_wayland_available(_option_key: str, config: LutrisConfig) -> bool:
-    version = config.runner_config.get("version")
-    return proton.is_proton_version(version) and not is_display_x11()
+    if not is_display_x11():
+        version = config.runner_config.get("version")
+        versions = proton.get_proton_versions()
+        if version in versions:
+            _wine_path, proton_version, _proton_source = versions[version]
+            return proton_version and proton_version >= 1747214205
+    return False
 
 
 def _get_version_warning(_option_key: str, config: LutrisConfig) -> Optional[str]:


### PR DESCRIPTION
Just some options to enable some new env-vars that have been added in Proton 10.

![image](https://github.com/user-attachments/assets/15570a02-7402-4177-a8ca-3a972c0bc147)

These enable ``PROTON_ENABLE_WAYLAND`` and, if you enable that, you can have ``PROTON_ENABLE_HDR``. They are available only on Wayland. I do not know how to check if HDR support is available, so I just check for Wayland. I suppose HDR is even more experimental here, if it's experimental in gamescope.

These are disabled by default since there are compatibility issues; indeed, one way you can tell that this works is that it breaks the graphics of Doom 2016. They are also considered "Advanced" features.