### PR TITLE
Fixed two minor ScummCM issues related with argument handling

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -565,7 +565,7 @@ class CommandsMixin:
         game_id = arguments.split()[-1]
         arguments = " ".join(arguments.split()[:-1])
         base_dir = os.path.dirname(gog_config_path)
-        return {"game_id": game_id, "path": base_dir, "arguments": arguments}
+        return {"game_id": game_id, "path": base_dir, "args": arguments}
 
     def autosetup_gog_game(self, file_id, silent=False):
         """Automatically guess the best way to install a GOG game by inspecting its contents.

--- a/lutris/runners/scummvm.py
+++ b/lutris/runners/scummvm.py
@@ -544,7 +544,8 @@ class scummvm(Runner):
         args = self.game_config.get("args") or ""
         for arg in split_arguments(args):
             command.append(arg)
-        command.append(self.game_config.get("game_id"))
+        if self.game_config.get("game_id"):
+            command.append(self.game_config.get("game_id"))
         output = {"command": command}
 
         extra_libs = self.get_extra_libs()


### PR DESCRIPTION
This small commit will fix two issues related with argument handling when using the ScummVM runner:

* If the `game_id` is not set, it will avoid adding a `None` in the command line. This is useful if you want to set the ScummVM runner to use `--auto-detect` in their arguments and you don't want to use the `game_id` directly.
* It will correctly set the arguments key name to `args` when the games are imported from a GOG installation. Previously, when using `arguments` as a key in the dictionary returned by `_get_scummvm_arguments` did not had any effect.