### PR TITLE
INSTALLERDIR variable

### DIFF
--- a/lutris/installer/__init__.py
+++ b/lutris/installer/__init__.py
@@ -33,6 +33,12 @@ def read_script(filename):
 
 def get_installers(game_slug=None, installer_file=None, revision=None):
     # check if installer is local or online
+
     if system.path_exists(installer_file):
-        return [normalize_installer(i) for i in read_script(installer_file)]
-    return get_game_installers(game_slug=game_slug, revision=revision)
+        installers = [normalize_installer(i) for i in read_script(installer_file)]
+        for installer in installers:
+            installer["_lutris_installer_file"] = installer_file
+    else:
+        installers = get_game_installers(game_slug=game_slug, revision=revision)
+
+    return installers

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -1,6 +1,7 @@
 """Lutris installer class"""
 
 import json
+import os
 from gettext import gettext as _
 
 from lutris.config import LutrisConfig, write_game_config
@@ -40,6 +41,10 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         self.service = self.get_service(initial=service)
         self.service_appid = self.get_appid(installer, initial=appid)
         self.variables = self.script.get("variables", {})
+        try:
+            self.installer_dir = os.path.dirname(installer["_lutris_installer_file"])
+        except:
+            self.installer_dir = None
         self.script_files = [
             InstallerFile(self.game_slug, file_id, file_meta)
             for file_desc in self.script.get("files", [])

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -421,6 +421,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
 
         replacements = {
             "GAMEDIR": self.target_path,
+            "INSTALLERDIR": self.installer.installer_dir,
             "CACHE": self.cache_path,
             "HOME": os.path.expanduser("~"),
             "STEAM_DATA_DIR": steam.steam().steam_data_dir,

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -33,6 +33,20 @@ class TestScriptInterpreter(TestCase):
         self.assertEqual(interpreter.installer.game_name, "Doom")
         self.assertFalse(interpreter.installer.get_errors())
 
+    def test_installer_dir(self):
+        installer = {
+            "_lutris_installer_file": "/tmp/lutris_installer_file.yml",
+            "runner": "linux",
+            "script": {"exe": "doom"},
+            "name": "Doom",
+            "slug": "doom",
+            "game_slug": "doom",
+            "version": "doom-gzdoom",
+        }
+        interpreter = ScriptInterpreter(installer, None)
+        replacements = interpreter._get_string_replacements()
+        assert replacements["INSTALLERDIR"] == "/tmp"
+
     def test_move_requires_src_and_dst(self):
         script = {
             "foo": "bar",


### PR DESCRIPTION
like discussed in issue #6155 : I think this variable would be useful to make installer scripts 'more portable', it makes Lutris aware of where the script is, so it can use it.
This is a prototype usage : 
```
game_slug: nice-game
slug: nice-game
name: Nice Game
runner: wine
version: 1.0.0
script:
  game:
    arch: win32
    exe: $GAMEDIR/drive_c/Games/Game/Launcher.exe
    prefix: $GAMEDIR
  installer:
    - task:
        name: create_prefix
        prefix: $GAMEDIR   
    - task:
        executable: setup.exe
        working_dir: $INSTALLERDIR
        name: wineexec
        prefix: $GAMEDIR
```