### PR TITLE
Add a special Wine version to represent the default Umu behavior

### DIFF
--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -78,6 +78,10 @@ class MissingExecutableError(MisconfigurationError):
     """Raised when a program can't be located."""
 
 
+class UndefinedExecutableError(MissingExecutableError):
+    """Raised when a program isn't actually specified, and shouldn't be needed."""
+
+
 class MissingMediaError(LutrisError):
     """Raised when an image file could not be found."""
 

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -31,7 +31,7 @@ class CommandsMixin:
     # pylint: disable=no-member
     installer: LutrisInstaller = NotImplemented
 
-    def get_wine_version(self)->Optional[str]:
+    def get_wine_version(self) -> Optional[str]:
         runner = self.get_runner_class(self.installer.runner)()
         return runner.get_installer_runner_version(self.installer, use_runner_config=False)
 

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -471,5 +471,5 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
 
     def eject_wine_disc(self):
         """Use Wine to eject a CD, otherwise Wine can have problems detecting disc changes"""
-        wine_path = self.get_wine_path()
-        wine.eject_disc(wine_path, self.target_path)
+        wine_path, wine_version = self.get_wine_path_and_version()
+        wine.eject_disc(wine_path, wine_version, self.target_path)

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -136,8 +136,6 @@ def create_prefix(
     if not runner:
         runner = import_runner("wine")(prefix=prefix, wine_arch=arch)
 
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
-
     if not wine_path:
         try:
             wine_path = runner.get_executable()
@@ -166,7 +164,7 @@ def create_prefix(
         wineenv["WINE_SKIP_MONO_INSTALLATION"] = "1"
         overrides["mscoree"] = "disabled"
 
-    if is_proton:
+    if proton.is_proton(wine_path, wine_version):
         # All proton path prefixes are created via Umu; if you aren't using
         # the default Umu, we'll use PROTONPATH to indicate what Proton is
         # to be used.
@@ -214,9 +212,7 @@ def winekill(
     if not env:
         env = {"WINEARCH": arch, "WINEPREFIX": prefix}
 
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
-
-    if is_proton:
+    if proton.is_proton(wine_path, wine_version):
         command = [proton.get_umu_path(), "wineboot", "-k"]
         env["GAMEID"] = proton.DEFAULT_GAMEID
         env["WINEPREFIX"] = prefix
@@ -329,7 +325,7 @@ def wineexec(
     if not runner:
         runner = import_runner("wine")(prefix=prefix, working_dir=working_dir, wine_arch=arch)
 
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
+    is_proton = proton.is_proton(wine_path, wine_version)
 
     if not wine_path:
         wine_path = runner.get_wine_path(version=wine_version)
@@ -457,7 +453,7 @@ def winetricks(
     """Execute winetricks."""
     winetricks_path, working_dir, env = find_winetricks(env, system_winetricks)
 
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
+    is_proton = proton.is_proton(wine_path, wine_version)
 
     if is_proton:
         protonfixes_path = os.path.join(proton.get_proton_path_by_path(wine_path), "protonfixes") if wine_path else None
@@ -517,7 +513,7 @@ def winecfg(
 ):
     """Execute winecfg."""
 
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
+    is_proton = proton.is_proton(wine_path, wine_version)
 
     if not wine_path and not is_proton:
         if wine_version:
@@ -549,9 +545,7 @@ def winecfg(
 def eject_disc(wine_path=None, wine_version=None, prefix=None, proton_verb=None):
     """Use Wine to eject a drive"""
 
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
-
-    if is_proton:
+    if proton.is_proton(wine_path, wine_version):
         proton_verb = "run"
     wineexec("eject", prefix=prefix, wine_path=wine_path, wine_version=wine_version, args="-a", proton_verb=proton_verb)
 
@@ -570,10 +564,9 @@ def install_cab_component(cabfile, component, wine_path=None, prefix=None, arch=
 
 
 def open_wine_terminal(terminal, wine_path=None, wine_version=None, prefix=None, env=None, system_winetricks=False):
-    is_proton = proton.is_proton_version(wine_version) if wine_version else proton.is_proton_path(wine_path)
     winetricks_path, _working_dir, env = find_winetricks(env, system_winetricks)
     path_paths = [os.path.dirname(wine_path)] if wine_path else []
-    if is_proton:
+    if proton.is_proton(wine_path, wine_version):
         proton.update_proton_env(wine_path, env)
         umu_path = proton.get_umu_path()
         path_paths.insert(0, os.path.dirname(umu_path))

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -550,16 +550,31 @@ def eject_disc(wine_path=None, wine_version=None, prefix=None, proton_verb=None)
     wineexec("eject", prefix=prefix, wine_path=wine_path, wine_version=wine_version, args="-a", proton_verb=proton_verb)
 
 
-def install_cab_component(cabfile, component, wine_path=None, prefix=None, arch=None, proton_verb=None):
+def install_cab_component(
+    cabfile, component, wine_path=None, wine_version=None, prefix=None, arch=None, proton_verb=None
+):
     """Install a component from a cabfile in a prefix"""
 
-    if proton.is_proton_path(wine_path):
+    if proton.is_proton(wine_path, wine_version):
         proton_verb = "run"
-    cab_installer = CabInstaller(prefix, wine_path=wine_path, arch=arch)
+        if not wine_path and wine_version:
+            wine_path = proton.get_proton_wine_path(wine_version)
+
+    if not wine_path:
+        raise RuntimeError("CAB components can't be installed without a wine path")
+
+    cab_installer = CabInstaller(prefix, wine_path=wine_path, wine_version=wine_version, arch=arch)
     files = cab_installer.extract_from_cab(cabfile, component)
     registry_files = cab_installer.get_registry_files(files)
     for registry_file, _arch in registry_files:
-        set_regedit_file(registry_file, wine_path=wine_path, prefix=prefix, arch=_arch, proton_verb=proton_verb)
+        set_regedit_file(
+            registry_file,
+            wine_path=wine_path,
+            wine_version=wine_version,
+            prefix=prefix,
+            arch=_arch,
+            proton_verb=proton_verb,
+        )
     cab_installer.cleanup()
 
 

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -957,7 +957,8 @@ class wine(Runner):
         winetricks(
             "",
             prefix=self.prefix_path,
-            wine_path=self.get_executable(),
+            wine_path=self.get_wine_path(),
+            wine_version=self.read_version_from_config(),
             config=self,
             disable_runtime=disable_runtime,
             system_winetricks=system_winetricks,

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -894,7 +894,8 @@ class wine(Runner):
         """Runs a Windows executable using this game's configuration"""
         wineexec(
             executable,
-            wine_path=self.get_executable(),
+            wine_path=self.get_wine_path(),
+            wine_version=self.read_version_from_config(),
             prefix=self.prefix_path,
             working_dir=self.prefix_path,
             config=self,
@@ -939,7 +940,8 @@ class wine(Runner):
         system_winetricks = self.runner_config.get("system_winetricks")
         open_wine_terminal(
             terminal=terminal,
-            wine_path=self.get_executable(),
+            wine_path=self.get_wine_path(),
+            wine_version=self.read_version_from_config(),
             prefix=self.prefix_path,
             env=self.get_env(os_env=True),
             system_winetricks=system_winetricks,
@@ -982,7 +984,8 @@ class wine(Runner):
         winekill(
             self.prefix_path,
             arch=self.wine_arch,
-            wine_path=self.get_executable(),
+            wine_path=self.get_wine_path(),
+            wine_version=self.read_version_from_config(),
             env=self.get_env(),
             initial_pids=self.get_wine_executable_pids(),
         )

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -16,6 +16,7 @@ from lutris.exceptions import (
     MisconfigurationError,
     MissingExecutableError,
     MissingGameExecutableError,
+    UndefinedExecutableError,
     UnspecifiedVersionError,
 )
 from lutris.game import Game
@@ -1179,7 +1180,7 @@ class wine(Runner):
         if self.is_proton_version():
             try:
                 wine_exe = self.get_executable()
-            except MissingExecutableError:
+            except UndefinedExecutableError:
                 wine_exe = None
 
             game_id = proton.get_game_id(game, env)
@@ -1291,7 +1292,7 @@ class wine(Runner):
         version = self.read_version_from_config()
         try:
             wine_exe = self.get_executable()
-        except MissingExecutableError:
+        except UndefinedExecutableError:
             wine_exe = None
 
         winekill(

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -15,6 +15,15 @@ DEFAULT_GAMEID = "umu-default"
 PROTON_DIR: str = os.path.join(settings.RUNNER_DIR, "proton")
 
 
+def is_proton(path: str = None, version: str = None) -> bool:
+    """True if the version indicated specifies a Proton version, or if that is null,
+    if the path is a known Proton path. If both are None, this returns False.
+
+    This is a convenience to check for Proton when you may have either a path or
+    a version. This comes up during install scripts frequently."""
+    return is_proton_version(version) if version else is_proton_path(path)
+
+
 def is_proton_version(version: Optional[str]) -> bool:
     """True if the version indicated specifies a Proton version of Wine; these
     require special handling."""

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -16,12 +16,12 @@ PROTON_DIR: str = os.path.join(settings.RUNNER_DIR, "proton")
 
 
 def is_proton(path: str = None, version: str = None) -> bool:
-    """True if the version indicated specifies a Proton version, or if that is null,
-    if the path is a known Proton path. If both are None, this returns False.
+    """True if the version indicated specifies a Proton version, or if the
+    path is a known Proton path. If both are None, this returns False.
 
     This is a convenience to check for Proton when you may have either a path or
     a version. This comes up during install scripts frequently."""
-    return is_proton_version(version) if version else is_proton_path(path)
+    return is_proton_version(version) or is_proton_path(path)
 
 
 def is_proton_version(version: Optional[str]) -> bool:

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -29,7 +29,7 @@ def is_umu_path(path: str) -> bool:
     return bool(path and (path.endswith("/umu_run.py") or path.endswith("/umu-run")))
 
 
-def is_proton_path(wine_path: str) -> bool:
+def is_proton_path(wine_path: Optional[str]) -> bool:
     """True if the path given actually runs Umu; this will run Proton-Wine in turn,
     but can be directed to particular Proton implementation by setting the env-var
     PROTONPATH, but if this is omitted it will default to the latest Proton it
@@ -37,9 +37,10 @@ def is_proton_path(wine_path: str) -> bool:
 
     This function may be given the wine root directory or a file within such as
     the wine executable and will return true for either."""
-    for candidate_wine_path in get_proton_versions().values():
-        if not candidate_wine_path or system.path_contains(candidate_wine_path, wine_path):
-            return True
+    if wine_path:
+        for candidate_wine_path in get_proton_versions().values():
+            if not candidate_wine_path or system.path_contains(candidate_wine_path, wine_path):
+                return True
     return False
 
 

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -109,7 +109,7 @@ def get_proton_wine_path(version: str) -> str:
         if os.path.exists(wine_path_files):
             return wine_path_files
 
-    raise UndefinedExecutableError("Proton version '%s' is has no wine executable." % version)
+    raise UndefinedExecutableError("Proton version '%s' is has no stable wine path." % version)
 
 
 def get_proton_path_by_path(wine_path: str) -> str:

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -2,11 +2,10 @@
 
 import json
 import os
-from gettext import gettext as _
 from typing import Dict, Generator, List, Optional
 
 from lutris import settings
-from lutris.exceptions import MissingExecutableError
+from lutris.exceptions import MissingExecutableError, UndefinedExecutableError
 from lutris.monitored_command import RUNNING_COMMANDS
 from lutris.util import cache_single, system
 from lutris.util.steam.config import get_steamapps_dirs
@@ -86,7 +85,11 @@ def get_umu_path() -> str:
 
 def get_proton_wine_path(version: str) -> str:
     """Get the wine path for the specified proton version"""
-    wine_path = get_proton_versions().get(version)
+    proton_version = get_proton_versions()
+    if version not in proton_version:
+        raise MissingExecutableError("'%s' is not a known Proton version." % version)
+
+    wine_path = proton_version[version]
     if wine_path:
         wine_path_dist = os.path.join(wine_path, "dist/bin/wine")
         if os.path.exists(wine_path_dist):
@@ -96,7 +99,7 @@ def get_proton_wine_path(version: str) -> str:
         if os.path.exists(wine_path_files):
             return wine_path_files
 
-    raise MissingExecutableError(_("Proton version '%s' is missing its wine executable and can't be used.") % version)
+    raise UndefinedExecutableError("Proton version '%s' is has no wine executable." % version)
 
 
 def get_proton_path_by_path(wine_path: str) -> str:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -36,8 +36,14 @@ except Exception as ex:
     logger.exception("Unable to enumerate system Wine versions: %s", ex)
 
 
-def detect_arch(prefix_path: str = None, wine_path: str = None) -> str:
+def detect_arch(prefix_path: str = None, wine_path: str = None, wine_version: str = None) -> str:
     """Given a Wine prefix path, return its architecture"""
+    if wine_version:
+        if proton.is_proton_version(wine_version):
+            return "win64"
+        if not wine_path:
+            wine_path = get_wine_path_for_version(wine_version)
+
     if wine_path:
         if proton.is_proton_path(wine_path) or system.path_exists(wine_path + "64"):
             return "win64"
@@ -163,7 +169,7 @@ def get_runner_files_dir_for_version(version: str) -> Optional[str]:
         return os.path.join(WINE_DIR, version)
 
 
-def get_wine_path_for_version(version: str, config: dict = None) -> str:
+def get_wine_path_for_version(version: str, config: dict = None) -> Optional[str]:
     """Return the absolute path of a wine executable for a given version,
     or the configured version if you don't ask for a version."""
     if not version and config:
@@ -172,6 +178,8 @@ def get_wine_path_for_version(version: str, config: dict = None) -> str:
     if not version:
         raise UnspecifiedVersionError(_("The Wine version must be specified."))
 
+    if version == "proton":
+        return None
     if version in WINE_PATHS:
         return system.find_required_executable(WINE_PATHS[version])
     if proton.is_proton_version(version):

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -157,7 +157,8 @@ def get_runner_files_dir_for_version(version: str) -> Optional[str]:
     if version in WINE_PATHS:
         return None
     elif proton.is_proton_version(version):
-        return os.path.join(proton.PROTON_DIR, version, "files")
+        version_dir = proton.get_proton_versions()[version]
+        return os.path.join(version_dir, "files") if version_dir else None
     else:
         return os.path.join(WINE_DIR, version)
 


### PR DESCRIPTION
This adds a new fake Wine version ``proton`` (presented as "Proton (Latest)") that has *no* Wine-path. Instead it executes ``umu-run`` with no ``PROTONPATH`` set. Umu will download and use a version of Proton of its choice.

This is *not* the same was "GE-Proton (Latest)"; that's a different version with @GloriousEggroll *extra* special sauce. I'm getting an older Proton version from Umu actually. This PR leaves "GE-Proton (Latest)" as it was.

This involves some bodges to redirect around the things that use the Wine-path so they use ``umu-run`` in some way instead. ~~Hope I got them all;~~ Nope, ``CabInstaller`` doesn't support ``umu-run`` at all and it isn't going to work. That may break some installers (on "Proton (Latest)").

It's all done with ``if`` statements, so there's definitely a call for a cleanup pass on this once we've sorted out how all this works.