### PR TITLE
Add 'none' options to the search for services, platforms and runners

### DIFF
--- a/lutris/gui/config/edit_saved_search.py
+++ b/lutris/gui/config/edit_saved_search.py
@@ -179,6 +179,7 @@ class SearchFiltersBox(Gtk.Box):
 
     def _add_service_widget(self, row):
         options = [(s[1]().name, s[0]) for s in services.get_enabled_services().items()]
+        options.append(("(none)", "none"))
 
         self._add_match_widget(
             row, _("Source"), "source", options, predicate_factory=lambda s, v: s.get_service_predicate(v)
@@ -186,6 +187,7 @@ class SearchFiltersBox(Gtk.Box):
 
     def _add_runner_widget(self, row):
         options = [(r.human_name, r.name) for r in runners.get_installed()]
+        options.append(("(none)", "none"))
 
         self._add_match_widget(
             row, _("Runner"), "runner", options, predicate_factory=lambda s, v: s.get_runner_predicate(v)
@@ -193,6 +195,7 @@ class SearchFiltersBox(Gtk.Box):
 
     def _add_platform_widget(self, row):
         options = [(p, p) for p in games_db.get_used_platforms()]
+        options.append(("(none)", "none"))
 
         self._add_match_widget(
             row, _("Platform"), "platform", options, predicate_factory=lambda s, v: s.get_platform_predicate(v)

--- a/lutris/search.py
+++ b/lutris/search.py
@@ -385,53 +385,74 @@ class GameSearch(BaseSearch):
 
     def get_service_predicate(self, service_name: str) -> SearchPredicate:
         service_name = service_name.casefold()
-
-        def match_service(db_game):
-            game_service = db_game.get("service")
-            if not game_service:
-                return False
-
-            if game_service.casefold() == service_name:
-                return True
-
-            service = SERVICES.get(game_service)
-            return service and service_name in service.name.casefold()
-
         text = f"source:{service_name}"
+
+        if service_name == "none":
+
+            def match_service(db_game):
+                game_service = db_game.get("service")
+                return not game_service
+        else:
+
+            def match_service(db_game):
+                game_service = db_game.get("service")
+                if not game_service:
+                    return False
+
+                if game_service.casefold() == service_name:
+                    return True
+
+                service = SERVICES.get(game_service)
+                return service and service_name in service.name.casefold()
+
         return MatchPredicate(match_service, text=text, tag="source", value=service_name)
 
     def get_runner_predicate(self, runner_name: str) -> SearchPredicate:
         folded_runner_name = runner_name.casefold()
-
-        def match_runner(db_game):
-            game_runner = db_game.get("runner")
-
-            if not game_runner:
-                return False
-
-            if game_runner.casefold() == folded_runner_name:
-                return True
-
-            runner_human_name = get_runner_human_name(game_runner)
-            return runner_name in runner_human_name.casefold()
-
         text = f"runner:{self.quote_token(runner_name)}"
+
+        if folded_runner_name == "none":
+
+            def match_runner(db_game):
+                game_runner = db_game.get("runner")
+                return not game_runner
+        else:
+
+            def match_runner(db_game):
+                game_runner = db_game.get("runner")
+
+                if not game_runner:
+                    return False
+
+                if game_runner.casefold() == folded_runner_name:
+                    return True
+
+                runner_human_name = get_runner_human_name(game_runner)
+                return runner_name in runner_human_name.casefold()
+
         return MatchPredicate(match_runner, text=text, tag="runner", value=runner_name)
 
     def get_platform_predicate(self, platform: str) -> SearchPredicate:
         folded_platform = platform.casefold()
-
-        def match_platform(db_game):
-            game_platform = db_game.get("platform")
-            if game_platform:
-                return folded_platform in game_platform.casefold()
-            if self.service:
-                platforms = [p.casefold() for p in self.service.get_game_platforms(db_game)]
-                matches = [p for p in platforms if folded_platform in p]
-                return any(matches)
-            return False
-
         text = f"platform:{self.quote_token(platform)}"
+
+        if folded_platform == "none":
+
+            def match_platform(db_game):
+                game_platform = db_game.get("platform")
+                return not game_platform
+        else:
+
+            def match_platform(db_game):
+                game_platform = db_game.get("platform")
+                if game_platform:
+                    return folded_platform in game_platform.casefold()
+                if self.service:
+                    platforms = [p.casefold() for p in self.service.get_game_platforms(db_game)]
+                    matches = [p for p in platforms if folded_platform in p]
+                    return any(matches)
+                return False
+
         return MatchPredicate(match_platform, text=text, tag="platform", value=platform)
 
 


### PR DESCRIPTION
This one is pretty simple and should be uncontroversial- add "none" as a search option for souces/sevices, platforms and runners. So you can see games that don't have those things. I seem to have a lot of sourceless games for some reason. I don't know how to fix that but now I can see it!

<img width="1282" height="733" alt="image" src="https://github.com/user-attachments/assets/03d82007-f8b0-4648-990c-b311c98d79a1" />

Literally all of those should be GOG games, though I do have a few legitimately sourceless games.