### PR TITLE
Update lutris to 3.14 python

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,14 +5,17 @@ jobs:
   mypy-checker:
     name: Mypy
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.14"]
     steps:
       - uses: actions/checkout@v4
       - name: Print current dir
         run: pwd
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install Ubuntu dependencies
         run: |
           sudo apt update
@@ -30,18 +33,22 @@ jobs:
   ruff-checker:
     name: Ruff
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.14"]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
+      - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
           make dev
       - name: Check code style
-        run: ruff --version
+        run: |
+          ruff --version
           ruff check .
       - name: Check format
         run: ruff format . --check

--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -37,11 +37,13 @@ class LogWindow(GObject.Object):
         save_button = builder.get_object("save_button")
         save_button.connect("clicked", self.on_save_clicked)
 
-        # Add zoom buttons
+        # Add zoom buttons (may not exist in all UI versions)
         zoom_in_button = builder.get_object("zoom_in_button")
         zoom_out_button = builder.get_object("zoom_out_button")
-        zoom_in_button.connect("clicked", self.on_zoom_in_clicked)
-        zoom_out_button.connect("clicked", self.on_zoom_out_clicked)
+        if zoom_in_button:
+            zoom_in_button.connect("clicked", self.on_zoom_in_clicked)
+        if zoom_out_button:
+            zoom_out_button.connect("clicked", self.on_zoom_out_clicked)
 
         self.window.connect("key-press-event", self.on_key_press_event)
         self.window.show_all()

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -423,7 +423,7 @@ def winetricks(
     if not wine_path or proton.is_umu_path(wine_path):
         winetricks_wine = proton.get_umu_path()
         proton_verb = "waitforexitandrun"
-        working_dir = None
+        winetricks_path, working_dir, env = find_winetricks(env, system_winetricks)
     elif proton.is_proton_path(wine_path):
         proton_verb = "waitforexitandrun"
         protonfixes_path = os.path.join(proton.get_proton_path_by_path(wine_path), "protonfixes")
@@ -462,7 +462,6 @@ def winetricks(
         runner=runner,
         proton_verb=proton_verb,
     )
-
 
 def winecfg(wine_path=None, prefix=None, arch=WINE_DEFAULT_ARCH, config=None, env=None, runner=None, proton_verb=None):
     """Execute winecfg."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.14"
 packages = [
     "lutris",
     "tests",

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ from lutris import __version__ as VERSION
 
 if sys.version_info < (3, 8):
     sys.exit("Python >= 3.8 is required to run Lutris")
+# Python 3.14 is supported and tested
 
 data_files = []
 


### PR DESCRIPTION
Lutris is not working on Fedora 43 due to python 3.14 
With this Pr now it works! not sure if it will be merged but if any edits are needed let me know!