### PR TITLE
vk icd files: add xe->intel dict entry to loader_map

### DIFF
--- a/lutris/util/graphics/gpu.py
+++ b/lutris/util/graphics/gpu.py
@@ -183,6 +183,7 @@ class GPU:
             "v3d": "broadcom",
             "virtio-pci": "lvp",
             "i915": "intel",
+            "xe": "intel",
         }
         if self.driver in loader_map:
             loader = loader_map[self.driver]


### PR DESCRIPTION
fixes error message when using intel xe kernel driver (wherein `DRIVER=xe` instead of `DRIVER=i915`)