### PR TITLE
Fix for sorting date columns

### DIFF
--- a/lutris/gui/views/list.py
+++ b/lutris/gui/views/list.py
@@ -62,14 +62,13 @@ class GameListView(Gtk.TreeView, GameView):  # type:ignore[misc]
         name_cell = self.set_text_cell()
         name_cell.set_padding(5, 0)
 
-        self.set_column(name_cell, _("Name"), COL_NAME, 200, always_visible=True)
-        self.set_sort_with_column(COL_NAME, COL_SORTNAME)
+        self.set_column(name_cell, _("Name"), COL_NAME, 200, always_visible=True, sort_id=COL_SORTNAME)
         self.set_column(default_text_cell, _("Year"), COL_YEAR, 60)
         self.set_column(default_text_cell, _("Runner"), COL_RUNNER_HUMAN_NAME, 120)
         self.set_column(default_text_cell, _("Platform"), COL_PLATFORM, 120)
-        self.set_column(default_text_cell, _("Last Played"), COL_LASTPLAYED_TEXT, 120)
-        self.set_column(default_text_cell, _("Play Time"), COL_PLAYTIME_TEXT, 100)
-        self.set_column(default_text_cell, _("Installed At"), COL_INSTALLED_AT_TEXT, 120)
+        self.set_column(default_text_cell, _("Last Played"), COL_LASTPLAYED_TEXT, 120, sort_id=COL_LASTPLAYED)
+        self.set_column(default_text_cell, _("Play Time"), COL_PLAYTIME_TEXT, 100, sort_id=COL_PLAYTIME)
+        self.set_column(default_text_cell, _("Installed At"), COL_INSTALLED_AT_TEXT, 120, sort_id=COL_INSTALLED_AT)
 
         self.get_selection().set_mode(Gtk.SelectionMode.MULTIPLE)
 
@@ -82,9 +81,6 @@ class GameListView(Gtk.TreeView, GameView):  # type:ignore[misc]
 
         self.model = game_store.store
         self.set_model(self.model)
-        self.set_sort_with_column(COL_LASTPLAYED_TEXT, COL_LASTPLAYED)
-        self.set_sort_with_column(COL_INSTALLED_AT_TEXT, COL_INSTALLED_AT)
-        self.set_sort_with_column(COL_PLAYTIME_TEXT, COL_PLAYTIME)
 
         if self.media_column:
             size = game_store.service_media.size


### PR DESCRIPTION
I consistently ran into issues with sorting the date columns of "Last Played Time" and "Installed At".
The columns sorted by the displayed date which begins with the time of day.
<img width="185" height="472" alt="image" src="https://github.com/user-attachments/assets/6425e3b0-7986-4593-872a-ce2ed43b64fc" />
<img width="200" height="405" alt="image" src="https://github.com/user-attachments/assets/31aacc7e-234a-4df3-a0cd-2ffefd8a6c47" />


This fixes that issue and sorts by the actual dates instead.
<img width="188" height="366" alt="image" src="https://github.com/user-attachments/assets/75272c22-cba1-49f9-b490-5d57c96ae5d4" />

<img width="194" height="373" alt="image" src="https://github.com/user-attachments/assets/4329f543-58de-4375-b874-a865f16b256a" />


I ran it locally and it works as expected.