### PR TITLE
Don't write empty TryExec to desktop files.

### DIFF
--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -67,7 +67,7 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
     # field code in the Exec key.
     command = f"{lutris_executable} {shlex.quote(url)}".replace("%", "%%")
 
-    try_exec = "" if LINUX_SYSTEM.is_flatpak() else "lutris"
+    try_exec = "" if LINUX_SYSTEM.is_flatpak() else "TryExec=lutris"
 
     launcher_content = dedent(
         """
@@ -77,7 +77,7 @@ def create_launcher(game_slug, game_id, game_name, launch_config_name=None, desk
         Icon={}
         Exec=env LUTRIS_SKIP_INIT=1 {}
         Categories=Game
-        TryExec={}
+        {}
         """.format(game_name, f"lutris_{game_slug}", command, try_exec)
     )
 


### PR DESCRIPTION
Flatpak's lutris generates desktop files with empty `TryExec` (see https://github.com/lutris/lutris/pull/5634). Such files are ignored by application launchers, e.g. rofi. [Freedesktop spec](https://specifications.freedesktop.org/desktop-entry/latest/basic-format.html) doesn't really indicate that empty values should be treated as absent, so to avoid misinterpretation it is better to not add the key at all. 