### PR TITLE
Add --application-id parameter to Ryujinx runner

### DIFF
--- a/lutris/runners/ryujinx.py
+++ b/lutris/runners/ryujinx.py
@@ -24,7 +24,13 @@ class ryujinx(Runner):
             "type": "file",
             "label": _("NSP file"),
             "help": _("The game data, commonly called a ROM image."),
-        }
+        },
+        {
+            "option": "application_id",
+            "type": "string",
+            "label": _("Application ID"),
+            "help": _("Select which app to launch for a multi-game XCI image"),
+        },
     ]
     runner_options = [
         {
@@ -56,6 +62,10 @@ class ryujinx(Runner):
         rom = self.game_config.get("main_file") or ""
         if not system.path_exists(rom):
             raise MissingGameExecutableError(filename=rom)
+
+        if app_id := self.game_config.get("application_id"):
+            arguments.append("--application-id")
+            arguments.append(app_id)
         arguments.append(rom)
         return {"command": arguments}
 


### PR DESCRIPTION
The Ryujinx runner supports specifying an --application-id parameter to select a specific game to launch when using a multi game XCI file.

https://git.ryujinx.app/ryubing/ryujinx/-/commit/6fbf279faca30ffd2ef33394463b98809ccaf127

fixes #6270