### PR TITLE
Allow the melonDS emulator to be launched standalone

### DIFF
--- a/share/lutris/json/melonds.json
+++ b/share/lutris/json/melonds.json
@@ -3,6 +3,7 @@
     "description": "Nintendo DS emulator",
     "platforms": ["Nintendo DS"],
     "runner_executable": "melonds/melonDS",
+    "runnable_alone": true,
     "flatpak_id": "net.kuribo64.melonDS",
     "download_url": "https://melonds.kuribo64.net/downloads/melonDS-appimage-x86_64.zip",
     "game_options": [


### PR DESCRIPTION
This looks like an oversight, as the emulator can be launched without a game.

fixes #6272 