### PR TITLE
Fix German translation for GC

### DIFF
--- a/po/de.po
+++ b/po/de.po
@@ -2159,7 +2159,7 @@ msgstr "Dolphin"
 
 #: lutris/runners/dolphin.py:12 lutris/runners/dolphin.py:27
 msgid "Nintendo GameCube"
-msgstr "Nintenndo GameCube"
+msgstr "Nintendo GameCube"
 
 #: lutris/runners/dolphin.py:12 lutris/runners/dolphin.py:27
 msgid "Nintendo Wii"


### PR DESCRIPTION
Fixes spelling of "Nintenndo" in the German translation.
When using a German locale, the UI now shows the correct icon for the GameCube platform and games.

If GC games were already in the library and showing the generic icon, I had to remove and re-add them in lutris to show the correct system icon after applying the change.

<img width="411" height="115" alt="lutris_gc_german" src="https://github.com/user-attachments/assets/cad6cf07-7dc2-4f6c-be4a-c94e732b1679" />
