### PR TITLE
Fix typo in Dutch translation for Lutris website

### DIFF
--- a/po/nl.po
+++ b/po/nl.po
@@ -414,7 +414,7 @@ msgstr ""
 
 #: lutris/gui/addgameswindow.py:26
 msgid "Search the Lutris website for installers"
-msgstr "Zoeken naar installatiewizards op Litrus-website"
+msgstr "Zoeken naar installatiewizards op Lutris-website"
 
 #: lutris/gui/addgameswindow.py:27
 msgid "Query our website for community installers"


### PR DESCRIPTION
Litrus => Lutris 

(was there for almost 3 years)