### PR TITLE
fix(winetricks): Use regular winetricks for official Proton builds instead of silently failing

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -352,11 +352,10 @@ def wineexec(
     command_parameters = []
     if proton.is_proton_path(wine_path):
         command_parameters.append(proton.get_umu_path())
-        if winetricks_wine and wine_path not in winetricks_wine:
+        if winetricks_wine and wine_path not in winetricks_wine and "winetricks" not in args:
             command_parameters.append("winetricks")
     else:
         command_parameters.append(wine_path)
-
     if executable:
         command_parameters.append(executable)
     command_parameters += split_arguments(args)
@@ -420,26 +419,28 @@ def winetricks(
         silent = False
         app = "--gui"
     args = app
-    if not wine_path or proton.is_umu_path(wine_path):
+
+    if wine_path and proton.is_proton_path(wine_path):
+        protonfixes_path = os.path.join(proton.get_proton_path_by_path(wine_path), "protonfixes")
+    else:
+        protonfixes_path = None
+
+    if protonfixes_path and os.path.exists(protonfixes_path):
+        proton_verb = "waitforexitandrun"
+        working_dir = None
+        winetricks_wine = os.path.join(protonfixes_path, "winetricks")
+        winetricks_path = wine_path
+    elif not wine_path or proton.is_umu_path(wine_path):
         winetricks_wine = proton.get_umu_path()
         winetricks_path = None
         args = "winetricks " + args
         proton_verb = "waitforexitandrun"
         working_dir = None
-    elif proton.is_proton_path(wine_path):
-        proton_verb = "waitforexitandrun"
-        protonfixes_path = os.path.join(proton.get_proton_path_by_path(wine_path), "protonfixes")
-        working_dir = None
-        if os.path.exists(protonfixes_path):
-            winetricks_wine = os.path.join(protonfixes_path, "winetricks")
-            winetricks_path = wine_path
-            if not app:
-                silent = False
-                app = "--gui"
-        else:
-            logger.error("winetricks: Valve official Proton builds do not support winetricks.")
-            return
     else:
+        if protonfixes_path:
+            logger.warning(
+                "winetricks: attempting to run on a Valve official Proton build; this may not work as expected."
+            )
         winetricks_path, working_dir, env = find_winetricks(env, system_winetricks)
         if not runner:
             runner = import_runner("wine")()


### PR DESCRIPTION
I don't known why Lutris wasn't doing this up until then but it's working on my machine. Maybe it's due to a recent update? Using:

```
$HOME/.local/share/lutris/runtime/winetricks
Using winetricks 20250102-next - sha256sum: d00f5634463f5ed00e3af93160e827cb99ab8c647fe7b31848fed806dac50eb5 with wine-10.0 and WINEARCH=win64
```

UMU is also correctly executing winetricks verbs with:

```
WINEPREFIX=… $HOME/.local/share/lutris/runtime/umu/umu-run winetricks
```

However, executing UMU on official Proton builds prefixes within Lutris' code also fails with UMU trying to execute `protonfixes` which doesn't exist in official Proton builds. I suppose it's because UMU behaves differently when `PROTONPATH` environement variable is set.

Anyway, I thing the regular `winetricks` code path should be tried when dealing with official Proton builds. If it fails, it fails but it's still better than the current behavior of not trying at all.

This also shoud solve #5986.