### PR TITLE
Fix TypeError in force_stop_game on Python 3.13

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -808,7 +808,8 @@ class Game:
         # If force_stop_game fails, wait a few seconds and try SIGKILL on any survivors
 
         def force_stop_game():
-            self.runner.force_stop_game(self.get_stop_pids())
+            pids = [str(pid) for pid in self.get_stop_pids()]
+            self.runner.force_stop_game(pids)
             return not self.get_stop_pids()
 
         def force_stop_game_cb(all_dead, error):


### PR DESCRIPTION
On Python 3.13, `force_stop_game` crashes because it tries to join a list of integers, but the runner expects strings.

I added a list comprehension to cast the PIDs to strings. I verified this locally and the crash is gone.

(Note: Epic Games processes still tend to hang around after this, but that seems to be a separate issue—this fix just resolves the Python crash so the stop command actually executes.)

Traceback:

```python
Error while completing task <function Game.force_stop.<locals>.force_stop_game at 0x7fa095d78720>: <class 'TypeError'> sequence item 0: expected str instance, int found
  File "/usr/lib/python3.13/site-packages/lutris/util/jobs.py", line 30, in target
    result = self.function(*a, **kw)
  File "/usr/lib/python3.13/site-packages/lutris/game.py", line 811, in force_stop_game
    self.runner.force_stop_game(self.get_stop_pids())