### PR TITLE
ruff B011: remove unused "assert False"

### DIFF
--- a/lutris/util/wine/fsync.py
+++ b/lutris/util/wine/fsync.py
@@ -117,8 +117,6 @@ def _get_syscall_nr_from_headers(syscall_name):
             "__NR_" + syscall_name + " not a valid number: " + last_line
         ) from ex
 
-    assert False
-
 
 # Hardcode some of the most commonly used architectures's
 # futex syscall numbers.

--- a/ruff.toml
+++ b/ruff.toml
@@ -15,7 +15,6 @@ ignore = [
     "PERF203", # `try`-`except` within a loop incurs performance overhead
     "RUF015", #  Prefer `next(...)` over single element slice - opinionated, but some cases could be changed
     "PERF102",# When using only the values of a dict use the `values()` method
-    "B011", # Do not `assert False` (`python -O` removes these calls), raise `AssertionError()`
     "RUF005", # Consider iterable unpacking instead of concatenation
     "A003", # Class attribute `id` is shadowing a Python builtin
     "B024", # `DiscordRichPresenceBase` is an abstract base class, but it has no abstract methods


### PR DESCRIPTION
This removes the ruff warning B011.
This code can not be reached, since the code either returns or raises before reaching the `assert False`.
