### PR TITLE
mypy: enforce strict mode on modules that are already compliant

### DIFF
--- a/lutris/exceptions.py
+++ b/lutris/exceptions.py
@@ -43,7 +43,7 @@ class DirectoryNotFoundError(MisconfigurationError):
 class SymlinkNotUsableError(MisconfigurationError):
     """Raise this error if a symlink that is required is not usable."""
 
-    def __init__(self, message=None, link=None, *args, **kwarg):
+    def __init__(self, message: str = None, link: str = None, *args: Any, **kwarg: Any):
         if not message and link:
             message = message or _("The link {} could not be used.").format(link)
         super().__init__(message, *args, **kwarg)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,25 @@ no_colors = false
 # --ignore: regexes for error messages to ignore
 ignore = []
 
+[[tool.mypy.overrides]]
+module = [
+    "lutris.exceptions",
+]
+# Equivalent to strict = true for per-module config
+# Use strict = true when https://github.com/python/mypy/issues/11401 is fixed
+check_untyped_defs = true
+disallow_any_generics = true
+disallow_incomplete_defs = true
+disallow_subclassing_any = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_untyped_defs = true
+extra_checks = true
+no_implicit_reexport = true
+strict_equality = true
+warn_return_any = true
+warn_unused_ignores = true
+
 [tool.pyright]
 
 typeCheckingMode = "basic"


### PR DESCRIPTION
Since type annotations are desired on the whole codebase, modules that are
mypy-strict-compliant should enforce type annotations on new code.

I only added one module in this PR, but I plan to add all mypy-strict-compliant
modules, if this PR is accepted and merged.
