### PR TITLE
Fix typo for update_advanced_switch_visibility

### DIFF
--- a/lutris/gui/config/game_common.py
+++ b/lutris/gui/config/game_common.py
@@ -546,7 +546,7 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):  # type:
         self.header_bar_widgets = [self.cancel_button, self.save_button, switch_box]
 
         if self.notebook:
-            self.update_advanced_switch_visibilty(self.notebook.get_current_page())
+            self.update_advanced_switch_visibility(self.notebook.get_current_page())
 
     def on_search_entry_changed(self, entry):
         """Callback for the search input keypresses"""


### PR DESCRIPTION
The `update_advanced_switch_visibility` call in game_common.py:build_header_bar would fail if it was ever called with a non-None `self.notebook` member (currently self.notebook just happens to be `None`) so it no exceptions occur.