### PR TITLE
add --fullscreen parameter to melonDS runner

### DIFF
--- a/share/lutris/json/melonds.json
+++ b/share/lutris/json/melonds.json
@@ -15,6 +15,15 @@
             "default_path": "game_path"
         }
     ],
+    "runner_options": [
+        {
+            "option": "fullscreen",
+            "type": "bool",
+            "default": true,
+            "label": "Fullscreen",
+            "argument": "--fullscreen"
+        }
+    ],
     "system_options_override": [
         {
             "option": "disable_runtime",


### PR DESCRIPTION
The melonDS emulator does support --fullscreen  parameter. This change enable to set this parameter using runner settings