### PR TITLE
Updating the mypy Python version check to be 3.10

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -40,7 +40,7 @@ jobs:
       - name: Run mypy analysis
         run: |
           mypy --version
-          mypy . --python-version 3.9
+          mypy . --python-version 3.10
 
   po-checker:
     name: Translation files

--- a/Makefile
+++ b/Makefile
@@ -124,10 +124,10 @@ po-check:
 	@for f in po/*.po; do msgfmt --check "$$f" -o /dev/null; done
 
 mypy:
-	mypy . --install-types --non-interactive 2>&1 | mypy-baseline filter
+	mypy . --python-version 3.10 --install-types --non-interactive 2>&1 | mypy-baseline filter
 
 mypy-reset-baseline:  # Add new typing errors to mypy. Use sparingly.
-	mypy . --install-types --non-interactive 2>&1 | mypy-baseline sync
+	mypy . --python-version 3.10--install-types --non-interactive 2>&1 | mypy-baseline sync
 
 # =============
 # Abbreviations


### PR DESCRIPTION
Both the github workflow action and the Makefile was updated to target Python 3.10. This is to make sure that when locally running `make check`, it matches the result of the workflow.