### PR TITLE
Added Note field to game configs ENV variable entry

### DIFF
--- a/lutris/gui/config/widget_generator.py
+++ b/lutris/gui/config/widget_generator.py
@@ -2,7 +2,7 @@
 
 import os
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from gettext import gettext as _
 from inspect import Parameter, signature
 from typing import TYPE_CHECKING, Any
@@ -706,22 +706,47 @@ class WidgetGenerator(ABC):
         return self.build_option_widget(option, directory_chooser)
 
     # EditableGrid
-    def _generate_mapping(self, option, value, default):
+    def _generate_mapping(self, option: dict[str, Any], value, default):
         """Adds an editable grid widget"""
 
-        def on_changed(widget):
-            values = dict(widget.get_data())
+        mapping_columns = ["Key", "Value"]
+
+        def on_changed(widget) -> None:
+            values: dict[Any, Any] = {}
+            for data_val in widget.get_data():
+                # If the mapping contains 3 or more columns
+                # then store the values as a mapping of:
+                # key -> { "Value":<value>, <additional_col_name>:<additional_col_val>...]
+                if len(list(data_val)) > 2:
+                    values[data_val[0]] = dict(zip(mapping_columns[1:], data_val[1:]))
+                else:
+                    values[data_val[0]] = data_val[1]
             self.changed.fire(option_key, values)
 
         option_key = option["option"]
         value = value or default or {}
         try:
-            value = list(value.items())
+            value_dict_list: list[dict[Any, Any]] = []
+            for key, val in value.items():
+                value_dict = {}
+                value_dict[mapping_columns[0]] = key
+                if not isinstance(val, dict):
+                    value_dict[mapping_columns[1]] = val
+                else:
+                    value_dict.update(val)
+                value_dict_list.append(value_dict)
+            value = value_dict_list
         except AttributeError:
             logger.error("Invalid value of type %s passed to grid widget: %s", type(value), value)
             value = []
 
-        grid = EditableGrid(value, columns=["Key", "Value"])
+        # Add optional columns to the right of the Key and the Value columns if specified
+        # in the widget options.
+        additional_columns = option.get("additional_columns", [])
+        if isinstance(additional_columns, Iterable):
+            mapping_columns.extend(additional_columns)
+
+        grid = EditableGrid(value, columns=mapping_columns)
         grid.connect("changed", on_changed)
         return self.build_option_widget(option, grid)
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -349,7 +349,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             env["LD_LIBRARY_PATH"] = os.pathsep.join(filter(None, [runtime_ld_library_path, ld_library_path]))
 
         # Apply user overrides at the end
-        env.update(self.system_config.get("env") or {})
+        env.update({key: val.get("Value", "") for key, val in self.system_config.get("env", {}).items()})
 
         return env
 

--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -458,6 +458,7 @@ system_options: list[dict[str, Any]] = [  # pylint: disable=invalid-name
         "option": "env",
         "type": "mapping",
         "label": _("Environment variables"),
+        "additional_columns": ["Notes / Comments"],
         "help": _("Environment variables loaded at run time"),
     },
     {


### PR DESCRIPTION
Updated the Editable Grid class to support optional additional columns that will be serialized with the mapping data that it represents. The option name for the additional_columns is called "additional_columns" and can be specified for a field that has the type of "mapping".

Modified the runner.get_env method to retrieve the ENV value from the "Value" key of the "env" field now.

<img width="926" height="707" alt="image" src="https://github.com/user-attachments/assets/2dd89b5b-74e8-4605-9390-4a4f55321fc6" />


resolves lutris/lutris#6278