### PR TITLE
Add the ability to create new runners in the Lutris UI

### DIFF
--- a/lutris/gui/config/add_runner_config_box.py
+++ b/lutris/gui/config/add_runner_config_box.py
@@ -1,0 +1,43 @@
+"""Add, remove and configure runners"""
+
+from gettext import gettext as _
+
+from gi.repository import GObject, Gtk
+
+from lutris.gui.config.create_runner_config_dialog import EditRunnerConfigDialog
+
+
+class AddRunnerConfigBox(Gtk.Box):
+    """Create New Runner Section"""
+
+    __gsignals__ = {"show-created": (GObject.SIGNAL_RUN_FIRST, None, (Gtk.Window,))}
+
+    def __init__(self, **kwargs):
+        super().__init__(orientation=Gtk.Orientation.VERTICAL, margin=12, spacing=6, **kwargs)
+
+        self.label = Gtk.Label(visible=True)
+        self.label.set_markup(f"<b>{_('Add runner config')}</b>")
+        self.label.set_yalign(0.5)
+        self.pack_start(self.label, True, True, 0)
+
+        self.description_label = Gtk.Label(visible=True)
+        self.description_label.set_markup(_("Create a new runner config for Lutris"))
+        self.description_label.set_line_wrap(True)
+        self.description_label.set_yalign(0.5)
+        self.pack_start(self.description_label, True, True, 0)
+
+        self.add_runner_config_button = Gtk.Button.new_from_icon_name("list-add-symbolic", Gtk.IconSize.BUTTON)
+        self.add_runner_config_button.connect("clicked", self.on_add_runner_config)
+        self.add_runner_config_button.set_tooltip_text(_("Create Runner config"))
+        self.add_runner_config_button.get_style_context().add_class("circular")
+        self.add_runner_config_button.show()
+        self.pack_start(self.add_runner_config_button, False, False, 0)
+
+    def on_add_runner_config(self, widget):
+        try:
+            window = self.get_toplevel()
+            application = window.get_application()
+            create_runner_dialog = application.show_window(EditRunnerConfigDialog, parent=window)
+            self.emit("show-created", create_runner_dialog)
+        except RuntimeError as e:
+            raise RuntimeError("Cannot open create runner window") from e

--- a/lutris/gui/config/create_runner_config_dialog.py
+++ b/lutris/gui/config/create_runner_config_dialog.py
@@ -1,0 +1,385 @@
+import json
+from collections.abc import Callable
+from enum import Enum
+from gettext import gettext as _
+from pathlib import Path
+from typing import Any, Type
+
+from gi.repository import GObject, Gtk
+
+from lutris.gui.config.runner_config_boxes import (
+    BaseRunnerConfigBox,
+    GameOptionsBox,
+    RunnerGeneralBox,
+    RunnerOptionsBox,
+    SystemOptionsOverrideBox,
+)
+from lutris.gui.dialogs import ErrorDialog, SavableModelessDialog
+from lutris.gui.dialogs.delegates import DialogInstallUIDelegate
+from lutris.gui.widgets.common import Label, VBox
+from lutris.gui.widgets.utils import open_uri
+from lutris.runners import inject_runners
+from lutris.runners.json import SETTING_JSON_RUNNER_DIR, JsonRunner
+from lutris.runners.model import ModelRunner
+from lutris.runners.model_validator import validate, validate_runner_name
+from lutris.runners.runner import Runner
+from lutris.runners.yaml import SETTING_YAML_RUNNER_DIR, YamlRunner
+from lutris.util.yaml import write_yaml_to_file
+
+
+class RunnerConfigCreator:
+    def __init__(
+        self,
+        label: str = "",
+        tooltip: str = "",
+        widget_class: Type[BaseRunnerConfigBox] | None = None,
+        icon_name: str = "",
+        from_dict_override: Callable[[BaseRunnerConfigBox, dict[str, Any]], bool] | None = None,
+        to_dict_override: Callable[[BaseRunnerConfigBox, dict[str, Any]], bool] | None = None,
+    ) -> None:
+        self.label: str = label
+        self.tooltip: str = tooltip
+        self.icon_name: str = icon_name
+        self.widget_class: Type[BaseRunnerConfigBox] | None = widget_class
+
+        from_dict_functor: Callable[[BaseRunnerConfigBox, dict[str, Any]], bool] | None = None
+        if from_dict_override:
+            from_dict_functor = from_dict_override
+        elif self.widget_class:
+            # extract the from_dict callable from the base widget class
+            from_dict_functor = self.widget_class.from_dict
+
+        to_dict_functor: Callable[[BaseRunnerConfigBox, dict[str, Any]], bool] | None = None
+        if to_dict_override:
+            to_dict_functor = to_dict_override
+        elif self.widget_class:
+            # extract the to_dict callable to the base widget class
+            to_dict_functor = self.widget_class.to_dict
+
+        def to_dict_wrapper(output_dict: dict[str, Any], input_config_box: BaseRunnerConfigBox) -> bool:
+            if to_dict_functor:
+                return to_dict_functor(input_config_box, output_dict)
+            return True
+
+        def from_dict_wrapper(output_config_box: BaseRunnerConfigBox, input_dict: dict[str, Any]) -> bool:
+            if from_dict_functor:
+                return from_dict_functor(output_config_box, input_dict)
+            return True
+
+        self.to_dict: Callable[[dict[str, Any], BaseRunnerConfigBox], bool] = to_dict_wrapper
+        self.from_dict: Callable[[BaseRunnerConfigBox, dict[str, Any]], bool] = from_dict_wrapper
+
+
+RUNNER_CONFIG_SCHEMA = {
+    "general": RunnerConfigCreator(
+        label=_("General Settings"),
+        tooltip=_("General settings for the runner"),
+        widget_class=RunnerGeneralBox,
+        icon_name="emblem-system-symbolic",
+    ),
+    "game_options": RunnerConfigCreator(
+        label=_("Game Options"),
+        tooltip=_("Specify the game options for the config"),
+        widget_class=GameOptionsBox,
+        icon_name="emblem-system-symbolic",
+    ),
+    "runner_options": RunnerConfigCreator(
+        label=_("Runner Options"),
+        tooltip=_("Specify the runner options for the config"),
+        widget_class=RunnerOptionsBox,
+        icon_name="emblem-system-symbolic",
+    ),
+    "system_options_override": RunnerConfigCreator(
+        label=_("System Options Override"),
+        tooltip=_("Overrides for the System Options panel in the runner configuration"),
+        widget_class=SystemOptionsOverrideBox,
+        icon_name="emblem-system-symbolic",
+    ),
+}
+
+
+class CreateRunnerBox(VBox):
+    """Box for creating a runner"""
+
+    COL_SIDEBAR_BUTTON = 0
+
+    def __init__(self, **kwargs) -> None:
+        super().__init__(**kwargs)
+
+        sidebar = Gtk.ListBox(visible=True)
+        sidebar.connect("row-activated", self._on_sidebar_activated)
+
+        self.stack = Gtk.Stack(visible=True)
+        self.stack.set_vhomogeneous(False)
+        self.stack.set_interpolate_size(True)
+
+        toplevel_box = Gtk.HBox(visible=True)
+        toplevel_box.pack_start(sidebar, False, False, 0)
+        toplevel_box.add(self.stack)
+
+        self.config_boxes: dict[str, BaseRunnerConfigBox] = {}
+        for runner_field, config_creator in RUNNER_CONFIG_SCHEMA.items():
+            if not callable(config_creator.widget_class):
+                continue
+
+            stack_id = f"{runner_field}-stack"
+            self.config_boxes[runner_field] = config_creator.widget_class(dict_key=runner_field, visible=True)
+            self.stack.add_named(self.config_boxes[runner_field], stack_id)
+            sidebar.add(
+                self._get_sidebar_button(
+                    text=_(config_creator.label),
+                    tooltip=config_creator.tooltip,
+                    icon_name=config_creator.icon_name,
+                )
+            )
+
+        self.pack_start(toplevel_box, True, True, 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Populate the runner dict with the values from each runner config widget"""
+        runner_dict: dict[Any, Any] = {}
+        for runner_field, runner_schema in RUNNER_CONFIG_SCHEMA.items():
+            runner_schema.to_dict(runner_dict, self.config_boxes[runner_field])
+
+        return runner_dict
+
+    def from_dict(self, runner_dict: dict[str, Any]) -> bool:
+        """Update the widget values using the runner config dict"""
+        loaded_no_errors = True
+        for runner_field, runner_schema in RUNNER_CONFIG_SCHEMA.items():
+            runner_box_widget = self.config_boxes.get(runner_field)
+            if not runner_box_widget:
+                continue
+            if not runner_schema.from_dict(runner_box_widget, runner_dict):
+                # Continue loading the other fields into the UI even if a previous field
+                # has failed
+                loaded_no_errors = False
+
+        return loaded_no_errors
+
+    def _on_sidebar_activated(self, _sidebar, row: Gtk.ListBoxRow) -> None:
+        row_index = row.get_index()
+        self.stack.set_visible_child(self.stack.get_children()[row_index])
+
+    def _get_sidebar_button(self, text: str, tooltip: str, icon_name: str) -> Gtk.HBox:
+        hbox = Gtk.HBox(visible=True)
+        hbox.set_margin_top(12)
+        hbox.set_margin_bottom(12)
+        hbox.set_tooltip_text(tooltip)
+
+        icon = Gtk.Image.new_from_icon_name(icon_name, Gtk.IconSize.MENU)
+        icon.show()
+        hbox.pack_start(icon, False, False, 6)
+
+        label = Gtk.Label(label=text, visible=True)
+        label.set_yalign(0.5)
+        hbox.pack_start(label, False, False, 0)
+        return hbox
+
+
+class RunnerConfigEditMode(Enum):
+    CREATE = 0
+    UPDATE = 1
+
+
+class RunnerConfigFileFormats(str, Enum):
+    JSON = "json"
+    YAML = "yml"
+
+
+class RunnerNameEntry(Gtk.Entry, Gtk.Editable):  # type:ignore[misc]
+    def do_insert_text(self, new_text, length, position):
+        """Filter inserted characters to only accept alphanumeric and dashes
+        Do not allow backslashes or forward slashes to prevent upward path traverseral
+        """
+        new_text = "".join([c for c in new_text if c.isalnum() or c == "-"])
+        length = len(new_text)
+        self.get_buffer().insert_text(position, new_text, length)
+        return position + length
+
+
+class EditRunnerConfigDialog(SavableModelessDialog, DialogInstallUIDelegate):  # type:ignore[misc]
+    """Allow creation of a runner config JSON"""
+
+    __gsignals__ = {"runner-saved": (GObject.SIGNAL_RUN_FIRST, None, (str,))}
+
+    def __init__(
+        self, parent: Gtk.Widget | None = None, edit_mode=RunnerConfigEditMode.CREATE, runner: Runner | None = None
+    ):
+        super().__init__(_("Create New Runner Config"), parent=parent)  # type:ignore[arg-type]
+
+        label = Label(_("Runner File Prefix"))
+        self._create_runner_box = CreateRunnerBox()
+
+        self._runner_name_entry = RunnerNameEntry(visible=True)
+        self._runner_name_entry.set_tooltip_text(
+            _("The prefix used to name the runner file for the runner in the form of <runner-file-prefix>.(json|yml)")
+        )
+        self._runner_name_entry.connect("changed", self._on_runner_name_changed)
+
+        runner_fileformat_box = self._get_runner_format_box()
+
+        # Only allow editing the runner name when creating a new runner
+        # Existing runners cannot have their runner name changed as the save location would change
+        # Also prevent changing the file format type as well
+        if edit_mode == RunnerConfigEditMode.UPDATE:
+            if isinstance(runner, ModelRunner):
+                self._runner_name_entry.set_sensitive(False)
+                self.from_dict(runner.to_dict(), runner.name)
+                self._runner_format_dropdown.set_active_id(
+                    RunnerConfigFileFormats.JSON if isinstance(runner, JsonRunner) else RunnerConfigFileFormats.YAML
+                )
+                self._runner_format_dropdown.set_sensitive(False)
+
+        self.save_button.set_sensitive(bool(self._runner_name_entry.get_text()))
+
+        name_box = Gtk.Box(visible=True, spacing=12, margin_start=12, margin_end=12)
+        name_box.pack_start(label, False, False, 0)
+        name_box.pack_start(self._runner_name_entry, True, True, 0)
+
+        self.get_content_area().pack_start(name_box, False, False, 0)
+        self.get_content_area().pack_start(runner_fileformat_box, False, False, 0)
+        self.get_content_area().pack_start(self._create_runner_box, True, True, 0)
+
+        self.show_all()
+
+    def _get_runner_format_box(self):
+        box = Gtk.Box(visible=True, spacing=12, margin_start=12, margin_end=12)
+        label = Label(_("Runner Format Type"))
+
+        fileformat_liststore = Gtk.ListStore(str, str)
+        for fileformat in RunnerConfigFileFormats:
+            fileformat_liststore.append((fileformat.name, fileformat.value))
+
+        self._runner_format_dropdown = Gtk.ComboBox.new_with_model(fileformat_liststore)
+        self._runner_format_dropdown.set_tooltip_text(_("The file format to used when saving the runner"))
+        self._runner_format_dropdown.connect("changed", self._on_runner_name_changed)
+        self._runner_format_dropdown.set_id_column(1)  # Contains the widget_type key used to create UI elements
+        self._runner_format_dropdown.set_active_id(RunnerConfigFileFormats.YAML)
+
+        cell = Gtk.CellRendererText()
+        self._runner_format_dropdown.pack_start(cell, True)
+        self._runner_format_dropdown.add_attribute(cell, "text", 0)
+
+        open_dir_button = Gtk.Button.new_from_icon_name(
+            "folder-symbolic",
+            Gtk.IconSize.BUTTON,
+        )
+        open_dir_button.show()
+        open_dir_button.set_tooltip_text(_("Open runner location in file browser"))
+
+        open_dir_button.connect("clicked", self._open_in_file_browser, self)
+
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._runner_format_dropdown, True, True, 0)
+        box.pack_start(open_dir_button, False, False, 0)
+
+        return box
+
+    def _open_in_file_browser(self, _open_dir_button: Gtk.Button, _gparam):
+        if self._runner_format_dropdown.get_active_id() == RunnerConfigFileFormats.YAML:
+            SETTING_YAML_RUNNER_DIR.mkdir(parents=True, exist_ok=True)
+            open_uri(str(SETTING_YAML_RUNNER_DIR))
+        elif self._runner_format_dropdown.get_active_id() == RunnerConfigFileFormats.JSON:
+            SETTING_JSON_RUNNER_DIR.mkdir(parents=True, exist_ok=True)
+            open_uri(str(SETTING_JSON_RUNNER_DIR))
+
+    def _on_runner_name_changed(self, _format_dropdown: Gtk.ComboBox):
+        self.save_button.set_sensitive(bool(self._runner_name_entry.get_text()))
+
+    def _inject_runner(self, runner_config_path: Path):
+        runner_name = self._runner_name_entry.get_text()
+
+        runner_format = self._runner_format_dropdown.get_active_id()
+        if runner_format == RunnerConfigFileFormats.JSON:
+            new_runner = type(runner_name, (JsonRunner,), {"json_path": runner_config_path})
+        else:
+            new_runner = type(runner_name, (YamlRunner,), {"yaml_path": runner_config_path})
+        inject_runners(runners={runner_name: new_runner})
+        return new_runner
+
+    def to_dict(self) -> dict[str, Any]:
+        """Populate the runner dict with the values from the runner config dialog"""
+        runner_dict = self._create_runner_box.to_dict()
+        # Set the "name" key to the name in the runner name entry box
+        runner_dict["name"] = self._runner_name_entry.get_text()
+        return runner_dict
+
+    def from_dict(self, runner_dict: dict[str, Any], runner_name_fallback: str) -> bool:
+        """Update the dialog values using the runner config dict
+        The runner_name_fallback string is used if the runner dictionary does not
+        contain a name key
+        """
+        runner_name: str = runner_dict.get("name", runner_name_fallback)
+        self._runner_name_entry.set_text(runner_name)
+        return self._create_runner_box.from_dict(runner_dict)
+
+    def on_save(self, _save_button: Gtk.Button):
+        runner_dict: dict[str, Any] = self.to_dict()
+        runner_name = self._runner_name_entry.get_text()
+        runner_format = self._runner_format_dropdown.get_active_id()
+
+        validate_result = validate(runner_dict)
+        if validate_result.get_errors():
+            error_string = "\n".join([f"{error.key_path}: {error.message}" for error in validate_result.get_errors()])
+            ErrorDialog(
+                error=_("Cannot save new runner '%s'\n%s") % (runner_name, error_string),
+                parent=self,
+            )
+            return
+
+        runner_name_validate_result = validate_runner_name(runner_name)
+        if runner_name_validate_result.get_errors():
+            error_string = "\n".join(
+                [f"{error.key_path}: {error.message}" for error in runner_name_validate_result.get_errors()]
+            )
+            ErrorDialog(
+                error=_("Cannot save new runner '%s'\n%s") % (runner_name, error_string),
+                parent=self,
+            )
+            return
+
+        if runner_format == RunnerConfigFileFormats.JSON:
+            runner_config_path = (SETTING_JSON_RUNNER_DIR / f"{runner_name}.{runner_format}").resolve()
+            if not runner_config_path.is_relative_to(SETTING_JSON_RUNNER_DIR):
+                ErrorDialog(
+                    error=_(
+                        "Cannot save new runner '%s' to path '%s'\n"
+                        "Runner name cannot contain '.' and the path must be relative to '%s'"
+                    )
+                    % (runner_name, runner_config_path, SETTING_JSON_RUNNER_DIR),
+                    parent=self,
+                )
+                return
+
+        elif runner_format == RunnerConfigFileFormats.YAML:
+            runner_config_path = (SETTING_YAML_RUNNER_DIR / f"{runner_name}.{runner_format}").resolve()
+            if not runner_config_path.is_relative_to(SETTING_YAML_RUNNER_DIR):
+                ErrorDialog(
+                    error=_(
+                        "Cannot save new runner '%s' to path '%s'\n"
+                        "Runner name cannot contain '.' and the path must be relative to '%s'"
+                        % (runner_name, runner_config_path, SETTING_YAML_RUNNER_DIR)
+                    ),
+                    parent=self,
+                )
+                return
+
+        runner_config_path = Path()
+        if runner_format == RunnerConfigFileFormats.JSON:
+            # Make json directory runner directory if it doesn't exist
+            SETTING_JSON_RUNNER_DIR.mkdir(parents=True, exist_ok=True)
+            runner_config_path = SETTING_JSON_RUNNER_DIR / f"{runner_name}.{runner_format}"
+            with runner_config_path.open("w", encoding="utf-8") as runner_file:
+                json.dump(runner_dict, runner_file, indent=4)
+                runner_file.write("\n")
+        elif runner_format == RunnerConfigFileFormats.YAML:
+            SETTING_YAML_RUNNER_DIR.mkdir(parents=True, exist_ok=True)
+            runner_config_path = SETTING_YAML_RUNNER_DIR / f"{runner_name}.{runner_format}"
+            write_yaml_to_file(config=runner_dict, filepath=str(runner_config_path))
+
+        # Injects the runner into the list of addon runners
+        if self._inject_runner(runner_config_path):
+            self.emit("runner-saved", runner_name)
+
+        self.destroy()

--- a/lutris/gui/config/runner_box.py
+++ b/lutris/gui/config/runner_box.py
@@ -1,12 +1,16 @@
 from gettext import gettext as _
+from pathlib import Path
 
 from gi.repository import GObject, Gtk
 
 from lutris import runners
+from lutris.gui.config.create_runner_config_dialog import EditRunnerConfigDialog, RunnerConfigEditMode
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.dialogs import QuestionDialog
 from lutris.gui.dialogs.runner_install import RunnerInstallDialog
 from lutris.gui.widgets.scaled_image import ScaledImage
+from lutris.runners.json import SETTING_JSON_RUNNER_DIR
+from lutris.runners.yaml import SETTING_YAML_RUNNER_DIR
 from lutris.util.log import logger
 
 
@@ -54,14 +58,34 @@ class RunnerBox(Gtk.Box):
         self.configure_button.set_valign(Gtk.Align.CENTER)
         self.configure_button.set_margin_right(12)
         self.configure_button.connect("clicked", self.on_configure_clicked)
-        self.pack_start(self.configure_button, False, False, 0)
         if not self.runner.is_installed():
             self.runner_label_box.set_sensitive(False)
         self.configure_button.show()
         self.action_alignment = Gtk.Alignment.new(0.5, 0.5, 0, 0)
         self.action_alignment.show()
         self.action_alignment.add(self.get_action_button())
+        self.edit_button = Gtk.Button.new_from_icon_name("document-edit-symbolic", Gtk.IconSize.BUTTON)
+
+        self.edit_button.set_valign(Gtk.Align.CENTER)
+        self.edit_button.set_margin_right(12)
+
+        self.edit_button.connect("clicked", self.on_edit_clicked)
+        self.pack_start(self.edit_button, False, False, 0)
+        self.pack_start(self.configure_button, False, False, 0)
         self.pack_start(self.action_alignment, False, False, 0)
+
+        # Provide a button to edit the runner if it is existing in the user writable runner directory
+        if hasattr(self.runner, "file_path"):
+            runner_file_path = Path(self.runner.file_path)
+            if (
+                runner_file_path
+                and runner_file_path.exists()
+                and (
+                    runner_file_path.is_relative_to(SETTING_JSON_RUNNER_DIR)
+                    or runner_file_path.is_relative_to(SETTING_YAML_RUNNER_DIR)
+                )
+            ):
+                self.edit_button.show()
 
     def get_action_button(self):
         """Return a install or remove button"""
@@ -101,6 +125,17 @@ class RunnerBox(Gtk.Box):
         window = self.get_toplevel()
         application = window.get_application()
         application.show_window(RunnerConfigDialog, runner=self.runner, parent=window)
+
+    def on_edit_clicked(self, widget):
+        window = self.get_toplevel()
+        application = window.get_application()
+        create_dialog_window = application.show_window(
+            EditRunnerConfigDialog, runner=self.runner, parent=window, edit_mode=RunnerConfigEditMode.UPDATE
+        )
+        create_dialog_window.connect("runner-saved", self.on_runner_saved)
+
+    def on_runner_saved(self, widget, runner_name):
+        self.runner = runners.import_runner(runner_name)()
 
     def on_remove_clicked(self, widget):
         dialog = QuestionDialog(

--- a/lutris/gui/config/runner_config_boxes.py
+++ b/lutris/gui/config/runner_config_boxes.py
@@ -1,0 +1,1173 @@
+from abc import abstractmethod
+from collections.abc import Iterable
+from gettext import gettext as _
+from sys import float_info
+from typing import Any
+
+from gi.repository import Gdk, Gio, GObject, Gtk
+
+from lutris.gui.widgets.common import EditableGrid, Label, VBox
+from lutris.runners.model import DEFAULT_ENTRY_POINT_OPTION
+
+WIDGET_TYPES = {
+    "label": "UI label",
+    "string": "Text Field",
+    "bool": "Radio Button",
+    "range": "Spin Box",
+    "choice": "Combo Box",
+    "choice_with_entry": "Combo Box with text entry",
+    "choice_with_search": "Combo Box with filtering",
+    "file": "File Chooser with Text Entry",
+    "multiple_file": "Multi File Chooser",
+    "directory": "Directory Chooser",
+    "mapping": "Editable Grid (Key -> Value map)",
+    "command_line": "File Chooser with text entry and shell quoting ",
+}
+CHOICE_WIDGET_TYPES = {"choice", "choice_with_entry", "choice_with_search"}
+RANGE_WIDGET_TYPES = {
+    "range",
+}
+FILE_CHOOSER_WIDGET_TYPES = {"file", "multiple_file", "command_line"}
+DEFAULT_WIDGET_TYPE = "string"
+
+ICON_NAME_STATE_LIST = [("changes-prevent-symbolic", False), ("changes-allow-symbolic", True)]
+
+
+class IconToggleButton(Gtk.Button):
+    """
+    Button that swaps between multiple icons when clicked
+    """
+
+    __gsignals__ = {"index-changed": (GObject.SIGNAL_RUN_FIRST, None, (bool,))}
+
+    def __init__(self, icon_name_states=ICON_NAME_STATE_LIST, init_index=0, **kwargs):
+        super().__init__(**kwargs)
+        self._icon_name_states = icon_name_states
+        self._index = init_index % len(self._icon_name_states)
+
+        self._image = Gtk.Image.new_from_icon_name(self._icon_name_states[self._index][0], Gtk.IconSize.BUTTON)
+        self.set_image(self._image)
+
+        def increment_index(button):
+            self.index = (self._index + 1) % len(self._icon_name_states)
+
+        self.connect("clicked", increment_index)
+
+        self.set_tooltip_text(_("If locked, this field will not be saved to option object when writing the JSON file"))
+
+    @property
+    def index(self) -> int:
+        return self._index
+
+    @index.setter
+    def index(self, value):
+        self._index = value
+        self._image.set_from_icon_name(self._icon_name_states[self._index][0], Gtk.IconSize.BUTTON)
+        self.emit("index-changed", self._icon_name_states[self._index][1])
+
+    def get_active(self) -> bool:
+        return self._icon_name_states[self._index][1]
+
+
+class BaseRunnerConfigBox(VBox):
+    __gsignals__ = {"changed": (GObject.SIGNAL_RUN_FIRST, None, ())}
+    # Dictionary key where settings should be saved to
+    dict_key: str
+
+    def __init__(self, *, dict_key: str, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.dict_key = dict_key
+
+    @abstractmethod
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Serialize Box fields to dict for use with saving to a file"""
+        raise NotImplementedError()
+
+    @abstractmethod
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Read Box fields from dict for use with loading config settings"""
+        raise NotImplementedError()
+
+
+class OptionBox(BaseRunnerConfigBox):
+    DEFAULT_ADVANCED_STATE = False
+    DEFAULT_VISIBLE_STATE = True
+    DEFAULT_WARN_IF_NON_WRITABLE_PARENT = True
+
+    def __init__(self, *, dict_key: str, **kwargs) -> None:
+        super().__init__(dict_key=dict_key, **kwargs)
+        self.set_margin_top(0)
+
+        self._option_entry = Gtk.Entry()
+        self._option_box = self._get_option_box()
+
+        self._type_id = ""
+        self._type_dropdown: Gtk.ComboBox = Gtk.ComboBox.new_with_model(self._get_type_liststore())
+        self._type_box = self._get_type_box()
+
+        self._section_entry = Gtk.Entry()
+        self._section_box = self._get_section_box()
+
+        self._label_entry = Gtk.Entry()
+        self._label_box = self._get_label_box()
+
+        self._argument_entry = Gtk.Entry()
+        self._argument_box = self._get_argument_box()
+
+        self._help_entry = Gtk.Entry()
+        self._help_box = self._get_help_box()
+
+        self._default_entry: Gtk.Entry | Gtk.Switch = Gtk.Entry()
+        self._default_box = self._get_default_box()
+
+        self._advanced_enabled_button = IconToggleButton()
+        self._advanced_entry = Gtk.Switch(active=OptionBox.DEFAULT_ADVANCED_STATE, valign=Gtk.Align.CENTER)
+        self._advanced_entry.set_sensitive(False)
+        self._advanced_box = self._get_advanced_box()
+
+        self._choice_grid = EditableGrid(data={}, columns=["Key", "Value"])
+        self._choices_box = self._get_choices_box()
+
+        self._min_entry = Gtk.SpinButton()
+        self._min_box = self._get_min_box()
+
+        self._max_entry = Gtk.SpinButton()
+        self._max_box = self._get_max_box()
+
+        self._visible_enabled_button = IconToggleButton()
+        self._visible_entry = Gtk.Switch(active=OptionBox.DEFAULT_VISIBLE_STATE, valign=Gtk.Align.CENTER)
+        self._visible_entry.set_sensitive(False)
+        self._visible_box = self._get_visible_box()
+
+        self._conditional_on_entry = Gtk.Entry()
+        self._conditional_on_box = self._get_conditional_on_box()
+
+        self._warn_if_non_writable_parent_enabled_button = IconToggleButton()
+        self._warn_if_non_writable_parent_entry = Gtk.Switch(
+            active=OptionBox.DEFAULT_WARN_IF_NON_WRITABLE_PARENT, valign=Gtk.Align.CENTER
+        )
+        self._warn_if_non_writable_parent_entry.set_sensitive(False)
+        self._warn_if_non_writable_parent_box = self._get_warn_if_non_writable_parent_box()
+
+        self.pack_start(self._option_box, False, False, 6)
+        self.pack_start(self._label_box, False, False, 6)
+        self.pack_start(self._section_box, False, False, 6)
+        self.pack_start(self._argument_box, False, False, 6)
+        self.pack_start(self._help_box, False, False, 6)
+        self.pack_start(self._type_box, False, False, 6)
+        self.pack_start(self._default_box, False, False, 6)
+        self.pack_start(self._choices_box, False, False, 6)
+        self.pack_start(self._min_box, False, False, 6)
+        self.pack_start(self._max_box, False, False, 6)
+        self.pack_start(self._advanced_box, False, False, 6)
+        self.pack_start(self._visible_box, False, False, 6)
+        self.pack_start(self._conditional_on_box, False, False, 6)
+        self.pack_start(self._warn_if_non_writable_parent_box, False, False, 6)
+
+        self._option_box.show_all()
+        self.show_all()
+        self.update_widgets()
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Convert the contents of the widget to a dictionary for serialization"""
+        options_dict: dict[str, Any] = {}
+        if option := self._option_entry.get_text():
+            options_dict["option"] = option
+        if type_val := self._type_dropdown.get_active_id():
+            options_dict["type"] = type_val
+        if section := self._section_entry.get_text():
+            options_dict["section"] = section
+        if label := self._label_entry.get_text():
+            options_dict["label"] = label
+        if argument := self._argument_entry.get_text():
+            options_dict["argument"] = argument
+        if help_val := self._help_entry.get_text():
+            options_dict["help"] = help_val
+
+        default = self._default_entry
+        if isinstance(default, Gtk.Entry):
+            options_dict["default"] = default.get_text()
+        elif isinstance(default, Gtk.Switch):
+            options_dict["default"] = default.get_active()
+
+        # Editable Grid should return a list of tuples of size 2
+        if (choices := self._choice_grid.get_data()) and self._type_dropdown.get_active_id() in CHOICE_WIDGET_TYPES:
+            options_dict["choices"] = {choice[0]: choice[1] for choice in choices}
+
+        # Serialize the "advanced" value if either the enabled button is active
+        # or the state is different than the default
+        if (
+            self._advanced_enabled_button.get_active()
+            or self._advanced_entry.get_active() != OptionBox.DEFAULT_ADVANCED_STATE
+        ):
+            options_dict["advanced"] = self._advanced_entry.get_active()
+
+        if (min_val := self._min_entry.get_text()) and self._type_dropdown.get_active_id() in RANGE_WIDGET_TYPES:
+            options_dict["min"] = float(min_val)
+
+        if (max_val := self._max_entry.get_text()) and self._type_dropdown.get_active_id() in RANGE_WIDGET_TYPES:
+            options_dict["max"] = float(max_val)
+
+        # Serialize the "visible" value if either the enabled button is active
+        # or the state is different than the default
+        if (
+            self._visible_enabled_button.get_active()
+            or self._visible_entry.get_active() != OptionBox.DEFAULT_VISIBLE_STATE
+        ):
+            options_dict["visible"] = self._visible_entry.get_active()
+
+        if conditional_on := self._conditional_on_entry.get_text():
+            options_dict["conditional_on"] = conditional_on
+
+        # Serialize the "warn if parent directory is not writable" value if either the enabled button is active
+        # or the state is different than the default
+        if (
+            self._warn_if_non_writable_parent_enabled_button.get_active()
+            or self._warn_if_non_writable_parent_entry.get_active() != OptionBox.DEFAULT_WARN_IF_NON_WRITABLE_PARENT
+        ):
+            options_dict["warn_if_non_writable_parent"] = self._warn_if_non_writable_parent_entry.get_active()
+
+        output_dict[self.dict_key] = options_dict
+        return True
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Populate widget entries from dictionary"""
+
+        option_dict: dict[str, Any] | None = input_dict
+        if not option_dict:
+            return False
+
+        self._option_entry.set_text(option_dict.get("option", ""))
+        self._type_dropdown.set_active_id(option_dict.get("type", DEFAULT_WIDGET_TYPE))
+        self._section_entry.set_text(option_dict.get("section", ""))
+        self._label_entry.set_text(option_dict.get("label", ""))
+        self._argument_entry.set_text(option_dict.get("argument", ""))
+        self._help_entry.set_text(option_dict.get("help", ""))
+
+        default = option_dict.get("default", "")
+        if isinstance(self._default_entry, Gtk.Entry):
+            self._default_entry.set_text(default)
+        elif isinstance(self._default_entry, Gtk.Switch):
+            self._default_entry.set_active(default)
+
+        self._advanced_entry.set_active(option_dict.get("advanced", False))
+
+        self._choice_grid.liststore.clear()
+        choices = option_dict.get("choices", [])
+        if isinstance(choices, dict):
+            for key, value in choices.items():
+                self._choice_grid.liststore.append((key, value))
+        elif isinstance(choices, list):
+            for choice in choices:
+                # Add each choice array element that has exactly 2 entries
+                if isinstance(choice, list) and len(choice) == 2:
+                    self._choice_grid.liststore.append(choice)
+
+        self._min_entry.set_text(str(option_dict.get("min", "")))
+        self._max_entry.set_text(str(option_dict.get("max", "")))
+        self._visible_entry.set_active(option_dict.get("visible", True))
+        self._conditional_on_entry.set_text(option_dict.get("conditional_on", ""))
+
+        if "warn_if_non_writable_parent" in option_dict:
+            self._warn_if_non_writable_parent_enabled_button.index = 1
+            self._warn_if_non_writable_parent_entry.set_active(option_dict["warn_if_non_writable_parent"])
+        else:
+            # disable the warn if non writable parent field if the dictionary doesn't have the key at all
+            self._warn_if_non_writable_parent_enabled_button.index = 0
+
+        return True
+
+    def update_widgets(self):
+        """Update widget visibility when a change event occurs"""
+        self._update_choices_visibility()
+        self._update_range_visibility()
+
+    def connect_option_name_changed(self, callable, *args):
+        """Supply a callable to connect to the changed event of the Option field
+        This can be used by an expander or label to update its text as the option is modified
+        """
+        self._option_entry.connect("changed", callable, *args)
+
+    # "option" methods
+    def _get_option_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Option"))
+        box.pack_start(label, False, False, 0)
+
+        self._option_entry.set_max_length(150)
+        self._option_entry.set_tooltip_text(_("Name of option to set for field"))
+        self._option_entry.connect("changed", self._on_option_changed)
+        box.pack_start(self._option_entry, True, True, 0)
+        return box
+
+    def _on_option_changed(self, widget):
+        self.emit("changed")
+
+    # "type" methods
+    def _get_type_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Type"))
+
+        self._type_dropdown.set_id_column(1)  # Contains the widget_type key used to create UI elements
+        self._type_dropdown.set_active_id(DEFAULT_WIDGET_TYPE)
+        self._type_id = self._type_dropdown.get_active_id()
+        self._type_dropdown.connect("changed", self._on_type_changed)
+
+        cell = Gtk.CellRendererText()
+        self._type_dropdown.pack_start(cell, True)
+        self._type_dropdown.add_attribute(cell, "text", 0)
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._type_dropdown, True, True, 0)
+
+        return box
+
+    def _on_type_changed(self, widget: Gtk.ComboBox):
+        """Action called when type drop down is changed."""
+        new_type = widget.get_active_id()
+        old_type = self._type_id
+        self._update_default_box(new_type=new_type, old_type=old_type)
+        self.update_widgets()
+        self._type_id = new_type
+        self.emit("changed")
+
+    @staticmethod
+    def _get_type_liststore():
+        """Build a ListStore with available types."""
+        type_liststore = Gtk.ListStore(str, str)
+        type_liststore.append((_("Select a type for the option field"), ""))
+
+        for widget_type, widget_desc in WIDGET_TYPES.items():
+            type_liststore.append((f"{widget_type} ({widget_desc})", widget_type))
+        return type_liststore
+
+    # "section" methods
+    def _get_section_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Section"))
+        box.pack_start(label, False, False, 0)
+
+        self._section_entry.set_max_length(150)
+        self._section_entry.set_tooltip_text(_("Creates frame box around option if non-empty"))
+        self._section_entry.connect("changed", self._on_section_changed)
+        box.pack_start(self._section_entry, True, True, 0)
+        return box
+
+    def _on_section_changed(self, widget):
+        self.emit("changed")
+
+    # "label" methods
+    def _get_label_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Label"))
+        box.pack_start(label, False, False, 0)
+
+        self._label_entry.set_max_length(150)
+        self._label_entry.set_tooltip_text(_("Human readable label for option"))
+        self._label_entry.connect("changed", self._on_label_changed)
+        box.pack_start(self._label_entry, True, True, 0)
+        return box
+
+    def _on_label_changed(self, widget):
+        self.emit("changed")
+
+    # "argument" methods
+    def _get_argument_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Argument"))
+        box.pack_start(label, False, False, 0)
+
+        self._argument_entry.set_max_length(150)
+        self._argument_entry.set_tooltip_text(
+            _("Argument key provided with launching the game when option has a value")
+        )
+        self._argument_entry.connect("changed", self._on_argument_changed)
+        box.pack_start(self._argument_entry, True, True, 0)
+        return box
+
+    def _on_argument_changed(self, widget):
+        self.emit("changed")
+
+    # "help" methods
+    def _get_help_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Help"))
+        box.pack_start(label, False, False, 0)
+
+        self._help_entry.set_max_length(150)
+        self._help_entry.set_tooltip_text(_("Help text provided when hovering above the option"))
+        self._help_entry.connect("changed", self._on_help_changed)
+        box.pack_start(self._help_entry, True, True, 0)
+        return box
+
+    def _on_help_changed(self, widget):
+        self.emit("changed")
+
+    # "default" methods
+    def _get_default_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Default"))
+        self._default_entry.set_tooltip_text(_("Default value for this option"))
+        self._default_entry.connect("changed", self._on_default_changed)
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._default_entry, True, True, 0)
+
+        return box
+
+    def _update_default_box(self, new_type, old_type):
+        if new_type == old_type:
+            return
+
+        if new_type == "bool":
+            if not isinstance(self._default_entry, Gtk.Switch):
+                if self._default_entry:
+                    self._default_entry.destroy()
+                self._default_entry = Gtk.Switch(active=False, valign=Gtk.Align.CENTER, visible=True)
+                self._default_entry.set_tooltip_text(_("Default value for this option"))
+                self._default_entry.connect("notify::active", self._on_default_changed)
+                self._default_box.pack_start(
+                    self._default_entry, False, False, 0
+                )  # Don't expand Switch button for styling
+        else:
+            if not isinstance(self._default_entry, Gtk.Entry):
+                if self._default_entry:
+                    self._default_entry.destroy()
+                self._default_entry = Gtk.Entry(visible=True)
+                self._default_entry.set_max_length(150)
+                self._default_entry.set_tooltip_text(_("Default value for this option"))
+                self._default_entry.connect("changed", self._on_default_changed)
+                self._default_box.pack_start(self._default_entry, True, True, 0)  # Expand text entry for usability
+
+    def _on_default_changed(self, widget, gparam=None):
+        self.emit("changed")
+
+    # "Advanced" methods
+    def _get_advanced_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Advanced"))
+
+        self._advanced_entry.connect("notify::active", self._on_advanced_changed)
+        self._advanced_entry.set_tooltip_text(_("If set, the option is only shown when the Advanced setting is active"))
+
+        def toggle_sensitivity(widget, state):
+            self._advanced_entry.set_sensitive(state)
+
+        # toggle sensitivity of widget when the enabled button selected index changes
+        self._advanced_enabled_button.connect("index-changed", toggle_sensitivity)
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._advanced_entry, False, False, 0)
+        box.pack_end(self._advanced_enabled_button, False, False, 0)
+        return box
+
+    def _on_advanced_changed(self, switch, gparam):
+        self.emit("changed")
+
+    # "choices" methods
+    def _get_choices_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Choices"))
+
+        # Add placeholder text for the key value columns
+        for treeview_column in self._choice_grid.treeview.get_columns():
+            for cell_renderer in treeview_column.get_cells():
+                cell_renderer.set_property("placeholder-text", (_("<blank>")))
+        self._choice_grid.connect("changed", self._on_choices_changed)
+
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._choice_grid, True, True, 0)  # expand but don't fill to keep the buttons proportioned
+
+        return box
+
+    def _update_choices_visibility(self):
+        if not (self._choices_box and self._type_dropdown):
+            return
+
+        if self._type_dropdown.get_active_id() in CHOICE_WIDGET_TYPES:
+            self._choices_box.set_visible(True)
+            self._choices_box.set_no_show_all(False)
+        else:
+            self._choices_box.set_visible(False)
+            self._choices_box.set_no_show_all(True)
+
+    def _on_choices_changed(self, widget):
+        self.emit("changed")
+
+    # "min" methods
+    def _get_min_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Min"))
+        box.pack_start(label, False, False, 0)
+
+        adjustment = Gtk.Adjustment(0.0, -float_info.max, float_info.max, 1, 0, 0)
+        self._min_entry.set_adjustment(adjustment)
+        self._min_entry.set_tooltip_text(
+            _("Set minimum value for a Spin Box. Only applicable when the option type is 'range'")
+        )
+        self._min_entry.connect("changed", self._on_min_changed)
+        box.pack_start(self._min_entry, True, True, 0)
+        return box
+
+    def _on_min_changed(self, widget):
+        self.emit("changed")
+
+    # "max" methods
+    def _get_max_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Max"))
+        box.pack_start(label, False, False, 0)
+
+        adjustment = Gtk.Adjustment(0.0, -float_info.max, float_info.max, 1, 0, 0)
+        self._max_entry.set_adjustment(adjustment)
+        self._max_entry.set_tooltip_text(
+            _("Set maximum value for a Spin Box. Only applicable when the option type is 'range'")
+        )
+        self._max_entry.connect("changed", self._on_max_changed)
+        box.pack_start(self._max_entry, True, True, 0)
+        return box
+
+    def _on_max_changed(self, widget):
+        self.emit("changed")
+
+    # "range" methods
+    # combines min and max fields
+    def _update_range_visibility(self):
+        if not (self._min_box and self._max_box and self._type_dropdown):
+            return
+
+        if self._type_dropdown.get_active_id() in RANGE_WIDGET_TYPES:
+            self._min_box.set_visible(True)
+            self._min_box.set_no_show_all(False)
+            self._max_box.set_visible(True)
+            self._max_box.set_no_show_all(False)
+        else:
+            self._min_box.set_visible(False)
+            self._min_box.set_no_show_all(True)
+            self._max_box.set_visible(False)
+            self._max_box.set_no_show_all(True)
+
+    # "visible" methods
+    def _get_visible_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Visible"))
+
+        self._visible_entry.connect("notify::active", self._on_visible_changed)
+        self._visible_entry.set_tooltip_text(_("When set to false option will not appear in UI"))
+
+        def toggle_sensitivity(widget, state):
+            self._visible_entry.set_sensitive(state)
+
+        # toggle sensitivity of widget when the enabled button selected index changes
+        self._visible_enabled_button.connect("index-changed", toggle_sensitivity)
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._visible_entry, False, False, 0)
+        box.pack_end(self._visible_enabled_button, False, False, 0)
+        return box
+
+    def _on_visible_changed(self, switch, gparam):
+        self.emit("changed")
+
+    # "conditional_on" methods
+    def _get_conditional_on_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Conditional On"))
+        box.pack_start(label, False, False, 0)
+
+        self._conditional_on_entry.set_max_length(150)
+        self._conditional_on_entry.set_tooltip_text(
+            _(
+                "Enables this control based on the boolean value of the referenced option in this field."
+                " If the referenced option doesn't exist, the control will be disabled"
+            )
+        )
+        self._conditional_on_entry.connect("changed", self._on_conditional_on_changed)
+        box.pack_start(self._conditional_on_entry, True, True, 0)
+        return box
+
+    def _on_conditional_on_changed(self, widget):
+        self.emit("changed")
+
+    # "Warn if non writable parent" methods
+    def _get_warn_if_non_writable_parent_box(self):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_("Warn if non-writable parent"))
+
+        self._warn_if_non_writable_parent_entry.connect("notify::active", self._on_warn_if_non_writable_parent_changed)
+        self._warn_if_non_writable_parent_entry.set_tooltip_text(
+            _("Triggers a warning if the parent directory for a File Chooser option is not writable")
+        )
+
+        def toggle_sensitivity(widget, state):
+            self._warn_if_non_writable_parent_entry.set_sensitive(state)
+
+        # toggle sensitivity of widget when the enabled button selected index changes
+        self._warn_if_non_writable_parent_enabled_button.connect("index-changed", toggle_sensitivity)
+
+        box.pack_start(label, False, False, 0)
+        box.pack_start(self._warn_if_non_writable_parent_entry, False, False, 0)
+        box.pack_end(self._warn_if_non_writable_parent_enabled_button, False, False, 0)
+        return box
+
+    def _on_warn_if_non_writable_parent_changed(self, switch, gparam):
+        self.emit("changed")
+
+
+class BaseConfigListBox(BaseRunnerConfigBox):
+    def __init__(self, data, derived_widget_type: type[OptionBox], *, dict_key: str, **kwargs):
+        super().__init__(dict_key=dict_key, **kwargs)
+
+        self._widget_type = derived_widget_type
+
+        self._buttons = []
+        self._add_button = Gtk.Button.new_from_icon_name("list-add-symbolic", Gtk.IconSize.BUTTON)
+        self._add_button.set_visible(True)
+        self._buttons.append(self._add_button)
+        self._add_button.connect("clicked", self._on_add)
+
+        self._list_box = Gtk.ListBox(visible=True, selection_mode=Gtk.SelectionMode.NONE)
+
+        scrollable_window = Gtk.ScrolledWindow(visible=True)
+        scrollable_window.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        scrollable_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrollable_window.set_size_request(400, -1)
+        scrollable_window.add(self._list_box)
+
+        button_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, visible=True)
+        for button in self._buttons:
+            button_box.pack_start(button, False, False, 0)
+        self.pack_start(button_box, False, False, 0)
+        self.pack_start(scrollable_window, True, True, 0)
+
+        self._remove_widget = None
+        action_id = "remove"
+        remove_action = Gio.SimpleAction.new(name=action_id)
+        remove_action.connect("activate", self._on_delete_row)
+        option_action_group = Gio.SimpleActionGroup()
+        option_action_group.insert(remove_action)
+        self.insert_action_group("option", option_action_group)
+
+        menu = Gio.Menu()
+        menu.append(_("Remove"), f"option.{action_id}")
+        self._popup_menu = Gtk.Popover.new_from_model(relative_to=None, model=menu)
+
+        self.show_all()
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Convert the contents of the widget to a list for serialization"""
+
+        # Hierarchy layout for the list box is as follows
+        # <list box>
+        #   <list_row 1>
+        #     <hbox>
+        #       <delete button/>
+        #       <event_box>
+        #         <expander>
+        #           <option widget>
+        #   <list_row 2>
+        #   ...
+        #   <list_row N>
+        convert_no_errors = True
+        output_list: list[Any] = []
+        for list_box_row in self._list_box.get_children():
+            hbox = list_box_row.get_children()[0]  # type: ignore
+            event_box = hbox.get_children()[1]
+            expander = event_box.get_children()[0]
+            option_widget: OptionBox = expander.get_children()[0]
+            option_entry: dict[str, Any] = {}
+            if option_widget.to_dict(option_entry):
+                output_list.append(option_entry[option_widget.dict_key])
+            else:
+                convert_no_errors = False
+
+        output_dict[self.dict_key] = output_list
+        return convert_no_errors
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Populate widget entry from list"""
+        values: list[Any] | None = input_dict.get(self.dict_key)
+        if values is None:
+            return False
+
+        # Clear out any existing row widgets from the list before populating
+        self._list_box.foreach(lambda row: self._list_box.remove(row))
+
+        for i, value in enumerate(values):
+            option_widget = self._widget_type(dict_key=f"{self.dict_key}.{i}")
+            if option_widget.from_dict(value):
+                self.add_widget(option_widget)
+
+        return True
+
+    def add_widget(self, new_widget: OptionBox) -> Gtk.Expander:
+        """Adds the widget as a new row in the list box
+        A newly created expander which wraps the new widget is returned
+        """
+
+        expander = Gtk.Expander(visible=True)
+        expander.set_expanded(True)
+
+        delete_button = Gtk.Button.new_from_icon_name("edit-delete-symbolic", Gtk.IconSize.BUTTON)
+        delete_button.set_visible(True)
+
+        list_box_row = Gtk.ListBoxRow(visible=True)
+        delete_button.connect("clicked", self._on_delete, list_box_row)
+
+        # Used to handle the button press-event for descendent widgets
+        event_box = Gtk.EventBox(visible=True)
+        event_box.connect("button-press-event", self._list_box_popup_menu, list_box_row)
+
+        hbox = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, visible=True)
+
+        event_box.add(expander)
+        expander.add(new_widget)
+        hbox.pack_start(delete_button, False, False, 0)
+        hbox.pack_start(event_box, True, True, 0)
+        list_box_row.add(hbox)
+        self._list_box.add(list_box_row)
+
+        return expander
+
+    def _on_add(self, widget):
+        dict_key_name = f"{self.dict_key}.{len(self._list_box.get_children())}"
+        self.add_widget(self._widget_type(dict_key=dict_key_name))
+        self.emit("changed")
+
+    def _on_delete(self, widget, list_bow_row):
+        if list_bow_row in self._list_box.get_children():
+            self._list_box.remove(list_bow_row)
+            self.emit("changed")
+
+    def _list_box_popup_menu(self, widget, event: Gdk.EventButton, list_box_row):
+        """Create popup menu that can be remove list box rows"""
+        if event.button != Gdk.BUTTON_SECONDARY:
+            return
+
+        self._remove_widget = list_box_row
+
+        click_rect = Gdk.Rectangle()
+        click_rect.x = int(event.x)
+        click_rect.y = int(event.y)
+        self._popup_menu.set_relative_to(widget)
+        self._popup_menu.set_pointing_to(click_rect)
+        self._popup_menu.popup()
+
+    def _on_delete_row(self, action, parameter):
+        if self._remove_widget:
+            list_box_row = self._remove_widget
+            self._remove_widget = None
+            self._on_delete(None, list_box_row)
+
+
+class EditableOptionList(BaseConfigListBox):
+    """Override of BaseConfigListBox which adds support for listening
+    for the 'changed' signal of the UI element representing the "option" key
+    The "option" key is the required key for game_options, runner_options, system_options_override elements
+    """
+
+    def add_widget(self, new_widget: OptionBox) -> Gtk.Expander:
+        expander = super().add_widget(new_widget)
+
+        def on_option_name_changed(option_name_widget):
+            expander.set_label(option_name_widget.get_text())
+
+        new_widget.connect_option_name_changed(on_option_name_changed)
+
+        return expander
+
+
+class GameOptionsBox(EditableOptionList):
+    """Stores list of Game Options UI elements"""
+
+    def __init__(self, *, dict_key: str = "game_options", **kwargs) -> None:
+        super().__init__(data={}, derived_widget_type=OptionBox, dict_key=dict_key, **kwargs)
+
+        # Add a row for the DEFAULT_ENTRY_POINT_OPTION on initialization of the game options.
+        # The game options requires at an option that matches the "entry_point_option" field
+        # so it is added to reduce the boilerplate user
+        entry_point_widget = self._widget_type(dict_key=f"{dict_key}.0")
+        self.add_widget(entry_point_widget)
+        entry_point_widget._option_entry.set_text(DEFAULT_ENTRY_POINT_OPTION)
+        entry_point_widget._type_dropdown.set_active_id("file")
+        entry_point_widget._label_entry.set_text("ROM/ISO/exe file")
+
+
+class RunnerOptionsBox(EditableOptionList):
+    """Stores list of Runner Options UI elements"""
+
+    def __init__(self, *, dict_key: str = "runner_options", **kwargs) -> None:
+        super().__init__(data={}, derived_widget_type=OptionBox, dict_key=dict_key, **kwargs)
+
+
+class SystemOptionsOverrideBox(EditableOptionList):
+    """Stores list of System Options Overrides"""
+
+    def __init__(self, *, dict_key: str = "system_options_override", **kwargs) -> None:
+        super().__init__(data={}, derived_widget_type=OptionBox, dict_key=dict_key, **kwargs)
+
+
+class BaseConfigTextBox(BaseRunnerConfigBox):
+    def __init__(self, *, dict_key: str, label: str, tooltip: str = "", **kwargs) -> None:
+        super().__init__(dict_key=dict_key, **kwargs)
+        self._text_entry = Gtk.Entry()
+        self._text_box = self._get_text_box(label, tooltip)
+        self.pack_start(self._text_box, False, False, 0)
+        self.show_all()
+
+    def _get_text_box(self, label, tooltip=""):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label = Label(_(label))
+        box.pack_start(label, False, False, 0)
+
+        self._text_entry.set_max_length(500)
+        self._text_entry.set_tooltip_text(_(tooltip))
+        self._text_entry.connect("changed", self._on_text_changed)
+        box.pack_start(self._text_entry, True, True, 0)
+        return box
+
+    def _on_text_changed(self, widget):
+        self.emit("changed")
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Convert the contents of the widget to a string for serialization"""
+        output_string = ""
+        if _text := self._text_entry.get_text():
+            output_string = _text
+
+        output_dict[self.dict_key] = output_string
+        return True
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Populate widget entry from string"""
+        text_string: str | None = input_dict.get(self.dict_key)
+        if text_string is None:
+            return False
+        self._text_entry.set_text(text_string)
+        return True
+
+
+class HumanNameBox(BaseConfigTextBox):
+    def __init__(self, *, dict_key: str = "human_name", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Human Name"),
+            tooltip=_("(Required) Human readable name for the runner"),
+            **kwargs,
+        )
+
+
+class DescriptionBox(BaseConfigTextBox):
+    def __init__(self, *, dict_key: str = "description", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key, label=_("Description"), tooltip=_("(Optional) Description of the runner"), **kwargs
+        )
+
+
+class RunnerExecutableBox(BaseConfigTextBox):
+    def __init__(self, *, dict_key: str = "runner_executable", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Runner Executable"),
+            tooltip=_("(Required) Path to the runner executable"),
+            **kwargs,
+        )
+
+
+class FlatpakIdBox(BaseConfigTextBox):
+    def __init__(self, *, dict_key: str = "flatpak_id", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Flatpak ID"),
+            tooltip=_("(Optional) ID of flatpak app which can be used to install the runner"),
+            **kwargs,
+        )
+
+
+class DownloadUrlBox(BaseConfigTextBox):
+    def __init__(self, *, dict_key: str = "download_url", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Download URL"),
+            tooltip=_("(Optional) URL where runner can be downloaded by Lutris"),
+            **kwargs,
+        )
+
+
+class EntryPointOptionBox(BaseConfigTextBox):
+    def __init__(self, *, dict_key: str = "entry_point_option", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Entry Point Option"),
+            tooltip=_(
+                "(Required) Name for the primary field in the 'game_options'"
+                + " that is passed to the runner arguments for execution"
+            ),
+            **kwargs,
+        )
+        self._text_entry.set_text(DEFAULT_ENTRY_POINT_OPTION)
+
+
+class BaseConfigSwitchBox(BaseRunnerConfigBox):
+    def __init__(self, *, dict_key: str, label: str, tooltip: str = "", initial_value: bool = False, **kwargs) -> None:
+        super().__init__(dict_key=dict_key, **kwargs)
+        self._switch_entry = Gtk.Switch(active=initial_value)
+        self._switch_box = self._get_switch_box(label, tooltip)
+        self.pack_start(self._switch_box, False, False, 0)
+        self.show_all()
+
+    def _get_switch_box(self, label: str, tooltip: str = ""):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label_widget = Label(_(label))
+        box.pack_start(label_widget, False, False, 0)
+
+        self._switch_entry.set_tooltip_text(_(tooltip))
+        self._switch_entry.connect("notify::active", self._on_switch_active)
+        box.pack_start(self._switch_entry, False, False, 0)
+        return box
+
+    def _on_switch_active(self, widget: Gtk.Widget, gparam):
+        self.emit("changed")
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Convert the contents of the widget to a boolean for serialization"""
+        output_dict[self.dict_key] = self._switch_entry.get_active()
+        return True
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Populate widget entries from a boolean"""
+        switch_state: bool | None = input_dict.get(self.dict_key)
+        if switch_state is None:
+            return False
+        self._switch_entry.set_active(switch_state)
+        return True
+
+
+class RunnableAloneBox(BaseConfigSwitchBox):
+    def __init__(self, *, dict_key: str = "runnable_alone", **kwargs):
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Runnable Alone"),
+            tooltip=_("If set, the runner can be opened standalone in the sidebar"),
+            initial_value=True,
+            **kwargs,
+        )
+
+
+class BaseConfigGridBox(BaseRunnerConfigBox):
+    def __init__(self, *, dict_key: str, label: str, tooltip: str = "", **kwargs):
+        super().__init__(dict_key=dict_key, **kwargs)
+        self._grid_entry = EditableGrid(data={}, columns=("key", "value"))
+        self._grid_box = self._get_grid_box(label, tooltip)
+        self.pack_start(self._grid_box, False, False, 0)
+        self.show_all()
+
+    def _get_grid_box(self, label: str, tooltip: str = ""):
+        box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6, margin_end=12, margin_start=12)
+        label_widget = Label(_(label))
+        box.pack_start(label_widget, False, False, 0)
+
+        self._grid_entry.set_tooltip_text(_(tooltip))
+        for i, treeview_column in enumerate(self._grid_entry.treeview.get_columns()):
+            for cell_renderer in treeview_column.get_cells():
+                cell_renderer.set_property("placeholder-text", (_("<blank>")))
+                cell_renderer.connect("edited", self._on_cell_edited, i)
+
+        box.pack_start(self._grid_entry, True, True, 0)
+        return box
+
+    def _on_cell_edited(self, widget: Gtk.Widget, path, _text, field):
+        self.emit("changed")
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Convert the contents of the widget to a list of dict for serialization"""
+        grid_dict: dict[str, Any] = {}
+        if grid_rows := self._grid_entry.get_data():
+            grid_dict = dict(grid_rows)
+
+        output_dict[self.dict_key] = grid_dict
+
+        return True
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Populate widget entry from dict"""
+        grid_values: dict[str, str] | list[str] | str | None = input_dict.get(self.dict_key)
+        if not isinstance(grid_values, Iterable):
+            return False
+
+        self._grid_entry.liststore.clear()
+        if isinstance(grid_values, dict):
+            for key, value in grid_values.items():
+                self._grid_entry.liststore.append((key, value))
+        elif isinstance(grid_values, list):
+            for key in grid_values:
+                self._grid_entry.liststore.append((key, key))
+        else:
+            key = str(grid_values)
+            self._grid_entry.liststore.append((key, key))
+        return True
+
+
+class PlatformsBox(BaseConfigGridBox):
+    def __init__(self, *, dict_key: str = "platforms", **kwargs) -> None:
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Platforms"),
+            tooltip=_("(Required at least 1) Platforms supported by the runner"),
+            **kwargs,
+        )
+
+    def _on_cell_edited(self, widget: Gtk.Widget, path, _text, field):
+        # Default the second column to the same as the first column if empty
+        if field == 0 and not self._grid_entry.liststore[path][1]:
+            self._grid_entry.liststore[path][1] = self._grid_entry.liststore[path][0].strip()
+        super()._on_cell_edited(widget, path, _text, field)
+
+
+class EnvBox(BaseConfigGridBox):
+    def __init__(self, *, dict_key="env", **kwargs):
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Environment Variables"),
+            tooltip=_("(Optional) Environment Variables to set when invoking the runner"),
+            **kwargs,
+        )
+
+
+class BaseConfigComboBox(BaseRunnerConfigBox):
+    def __init__(self, *, dict_key: str, label: str, tooltip: str = "", **kwargs):
+        super().__init__(dict_key=dict_key, **kwargs)
+        self._combo_dropdown = Gtk.ComboBox.new_with_model(self._get_combo_liststore())
+        self._combo_box = self._get_combo_box(label, tooltip)
+        self.pack_start(self._combo_box, False, False, 0)
+        self.show_all()
+
+    def _get_combo_box(self, label: str, tooltip: str):
+        box = Gtk.Box(spacing=6, margin_end=12, margin_start=12)
+        label_widget = Label(_(label))
+
+        self._combo_dropdown.set_id_column(1)
+        self._combo_dropdown.set_tooltip_text(_(tooltip))
+        self._set_default_active_id()
+        self._combo_dropdown.connect("changed", self._on_dropdown_changed)
+
+        cell = Gtk.CellRendererText()
+        self._combo_dropdown.pack_start(cell, True)
+        self._combo_dropdown.add_attribute(cell, "text", 0)
+        box.pack_start(label_widget, False, False, 0)
+        box.pack_start(self._combo_dropdown, True, True, 0)
+        return box
+
+    def _on_dropdown_changed(self, widget: Gtk.ComboBox):
+        """Action called when combo dropdown is changed."""
+        self.emit("changed")
+
+    @staticmethod
+    @abstractmethod
+    def _get_combo_liststore():
+        """Build a ListStore of string key to string value options for the combo box.
+        Must be Overriden to allow Combo Box options to be available for widget
+        """
+        raise NotImplementedError()
+
+    def _set_default_active_id(self):
+        """Used to set the default entry for the  combo box.
+        This is optional to override, if not then will default to index 0
+        """
+        self._combo_dropdown.set_active(0)
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        """Convert the contents of the widget to a string for serialization"""
+        output_string = ""
+        if combo_val := self._combo_dropdown.get_active_id():
+            output_string = combo_val
+
+        output_dict[self.dict_key] = output_string
+        return True
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        """Populate widget entry from string if is an available option in the combo box"""
+        text_string: str | None = input_dict.get(self.dict_key)
+        if text_string is None:
+            return False
+
+        return self._combo_dropdown.set_active_id(text_string)
+
+
+class WorkingDirectoryBox(BaseConfigComboBox):
+    def __init__(self, *, dict_key: str = "working_dir", **kwargs):
+        super().__init__(
+            dict_key=dict_key,
+            label=_("Working Directory"),
+            tooltip=_(
+                "(Optional) Default working directory when launching runner.\n"
+                'Only value supported at this time "runner"\n"runner" -> Set the working directory to the directory'
+                "of the runner executable"
+            ),
+            **kwargs,
+        )
+
+    @staticmethod
+    def _get_combo_liststore():
+        """Adds an entry to select "runner" working directory value
+        This allows a runner to use the directory containing the runner executable if not overridden.
+        """
+        combo_liststore = Gtk.ListStore(str, str)
+        combo_liststore.append((_("Don't set the default working directory"), ""))
+        combo_liststore.append((_("Use the runner executable directory as the default working directory"), "runner"))
+
+        return combo_liststore
+
+
+class RunnerGeneralBox(BaseRunnerConfigBox):
+    """
+    Box which aggregates the widgets for the runner config text and switch widgets
+    """
+
+    def __init__(self, *, dict_key: str = "general_settings", **kwargs):
+        super().__init__(
+            dict_key=dict_key,
+            **kwargs,
+        )
+        self.set_tooltip_text(_("General Settings for configuring a runner"))
+
+        scroll_box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL, spacing=6, margin_start=12, margin_end=12, margin_top=12
+        )
+        scrollable_window = Gtk.ScrolledWindow(visible=True)
+        scrollable_window.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        scrollable_window.set_policy(Gtk.PolicyType.NEVER, Gtk.PolicyType.AUTOMATIC)
+        scrollable_window.set_size_request(400, 720)
+        scrollable_window.add(scroll_box)
+
+        label_widget = Label(_("General Settings"))
+        scroll_box.pack_start(label_widget, False, False, 0)
+
+        self._child_config_boxes: list[BaseRunnerConfigBox] = [
+            HumanNameBox(),
+            DescriptionBox(),
+            PlatformsBox(),
+            EntryPointOptionBox(),
+            RunnerExecutableBox(),
+            DownloadUrlBox(),
+            FlatpakIdBox(),
+            RunnableAloneBox(),
+            EnvBox(),
+            WorkingDirectoryBox(),
+        ]
+        for config_box in self._child_config_boxes:
+            scroll_box.pack_start(config_box, False, False, 0)
+
+        self.pack_start(scrollable_window, False, False, 0)
+
+    def to_dict(self, output_dict: dict[str, Any]) -> bool:
+        convert_no_errors = True
+        for config_box in self._child_config_boxes:
+            if not config_box.to_dict(output_dict):
+                convert_no_errors = False
+
+        return convert_no_errors
+
+    def from_dict(self, input_dict: dict[str, Any]) -> bool:
+        convert_no_errors = True
+        for config_box in self._child_config_boxes:
+            if not config_box.from_dict(input_dict):
+                convert_no_errors = False
+
+        return convert_no_errors

--- a/lutris/runners/json.py
+++ b/lutris/runners/json.py
@@ -1,104 +1,61 @@
 """Base class and utilities for JSON based runners"""
 
 import json
-import os
-import shlex
+from pathlib import Path
+from typing import Any
 
 from lutris import settings
-from lutris.exceptions import MissingGameExecutableError
-from lutris.runners.runner import Runner
-from lutris.util import datapath, system
+from lutris.runners.model import ModelRunner
+from lutris.util import datapath
+
+SETTING_JSON_RUNNER_DIR = Path(settings.RUNNER_DIR) / "json"
 
 JSON_RUNNER_DIRS = [
-    os.path.join(datapath.get(), "json"),
-    os.path.join(settings.RUNNER_DIR, "json"),
+    Path(datapath.get()) / "json",
+    SETTING_JSON_RUNNER_DIR,
 ]
 
 
-class JsonRunner(Runner):
-    json_path = None
+class JsonRunner(ModelRunner):
+    json_path: Path | None = None
 
-    def __init__(self, config=None):
-        super().__init__(config)
-        if not self.json_path:
-            raise RuntimeError("Create subclasses of JsonRunner with the json_path attribute set")
-        with open(self.json_path, encoding="utf-8") as json_file:
-            self._json_data = json.load(json_file)
+    def __init__(
+        self,
+        config=None,
+        *,
+        dict_data: dict[str, Any] | None = None,
+    ):
+        if not self.json_path and not isinstance(dict_data, dict):
+            raise RuntimeError(
+                "Create subclasses of JsonRunner with the json_path attribute set,"
+                " or supply the `dict_data` argument with a dictionary"
+            )
 
-        self.game_options = self._json_data["game_options"]
-        self.runner_options = self._json_data.get("runner_options", [])
-        self.runner_name = self._json_data.get("name", "")
-        self.human_name = self._json_data["human_name"]
-        self.description = self._json_data["description"]
-        platforms = self._json_data.get("platforms", {})
-        self.platform_dict = (
-            self._json_data["platforms"]
-            if isinstance(platforms, dict)
-            else {platform: platform for platform in platforms}
-        )
-        self.runner_executable = self._json_data["runner_executable"]
-        self.system_options_override = self._json_data.get("system_options_override", [])
-        self.entry_point_option = self._json_data.get("entry_point_option", "main_file")
-        self.download_url = self._json_data.get("download_url")
-        self.runnable_alone = self._json_data.get("runnable_alone")
-        self.flatpak_id = self._json_data.get("flatpak_id")
+        json_data: dict[str, Any] = {}
+        if self.json_path:
+            with open(self.json_path, encoding="utf-8") as json_file:
+                json_data = json.load(json_file)
+        else:
+            json_data = dict_data if dict_data else {}
+        super().__init__(dict_data=json_data, config=config)
 
-    def play(self):
-        """Return a launchable command constructed from the options"""
-        arguments = self.get_command()
-        for option in self.runner_options:
-            if option["option"] not in self.runner_config:
-                continue
-            if option["type"] == "bool":
-                if self.runner_config.get(option["option"]):
-                    arguments.append(option["argument"])
-            elif option["type"] == "choice":
-                if self.runner_config.get(option["option"]) != "off":
-                    arguments.append(option["argument"])
-                    arguments.append(self.runner_config.get(option["option"]))
-            elif option["type"] == "string":
-                arguments.append(option["argument"])
-                arguments.append(self.runner_config.get(option["option"]))
-            elif option["type"] == "command_line":
-                arg = option.get("argument")
-                if arg:
-                    arguments.append(arg)
-                arguments += shlex.split(self.runner_config.get(option["option"]))
-            else:
-                raise RuntimeError("Unhandled type %s" % option["type"])
-
-        # Prepend the option flag before for entry_point_option value
-        for option in self.game_options:
-            if self.entry_point_option != option["option"]:
-                continue
-            if "argument" in option:
-                arguments.append(option["argument"])
-
-        main_file = self.game_config.get(self.entry_point_option)
-        if not system.path_exists(main_file):
-            raise MissingGameExecutableError(filename=main_file)
-        arguments.append(main_file)
-        result = {"command": arguments}
-        if self._json_data.get("env"):
-            result["env"] = self._json_data["env"]
-        if self._json_data.get("working_dir") == "runner":
-            result["working_dir"] = os.path.dirname(os.path.join(settings.RUNNER_DIR, self.runner_executable_path))
-        return result
+    @property
+    def file_path(self):
+        return self.json_path
 
 
 def load_json_runners():
     json_runners = {}
     for json_dir in JSON_RUNNER_DIRS:
-        if not os.path.exists(json_dir):
+        if not json_dir.exists():
             continue
-        for json_path in os.listdir(json_dir):
-            if not json_path.endswith(".json"):
+        for json_path in json_dir.iterdir():
+            if json_path.suffix not in [".json"]:
                 continue
-            json_full_path = os.path.join(json_dir, json_path)
             json_data = {}
-            with open(json_full_path, encoding="utf-8") as json_file:
+            with open(json_path, encoding="utf-8") as json_file:
                 json_data = json.load(json_file)
-            runner_name = json_data.get("name") or json_path[:-5]
-            runner_class = type(runner_name, (JsonRunner,), {"json_path": json_full_path})
+            runner_name = json_data.get("name") or json_path.stem
+            runner_class = type(runner_name, (JsonRunner,), {"json_path": json_dir / json_path})
             json_runners[runner_name] = runner_class
     return json_runners

--- a/lutris/runners/model.py
+++ b/lutris/runners/model.py
@@ -1,0 +1,177 @@
+"""Base class and utilities for JSON based runners"""
+
+import shlex
+from pathlib import Path
+from typing import Any, Callable
+
+from lutris.exceptions import MissingGameExecutableError
+from lutris.runners.runner import Runner
+from lutris.util import system
+
+FILE_BASED_ENTRY_POINTS = set(["exe", "main_file", "iso", "rom", "disk-a", "path", "files"])
+DEFAULT_ENTRY_POINT_OPTION = "main_file"
+
+AppendFunction = Callable[[list[str], Any, dict[str, Any]], None]
+
+
+def _append_args_string(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    if option_value := config.get(option_key):
+        option_arg = option_dict.get("argument")
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.append(option_value)
+
+
+def _append_args_bool(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    value = config.get(option_key)
+    option_arg = option_dict.get("argument")
+    if value and isinstance(option_arg, str) and len(option_arg) > 0:
+        arguments.append(option_arg)
+
+
+def _append_args_choice(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    value = config.get(option_key)
+    if isinstance(value, str) and value == "off":
+        return
+    if value is not None:
+        option_arg = option_dict.get("argument")
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.append(value)
+
+
+def _append_args_multi_string(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    if option_values := shlex.split(str(config.get(option_key))):
+        option_arg = option_dict.get("argument")
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.extend(option_values)
+
+
+def _append_args_mapping(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    option_arg = option_dict.get("argument")
+    option_value = config.get(option_key)
+    if not isinstance(option_value, dict):
+        return
+    for name, value in option_value.items():
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.append(f"{name}={value}")
+
+
+_argument_append_funcs: dict[str, AppendFunction] = {
+    # adds arguments from the supplied option dictionary to the arguments list
+    "label": lambda _1, _2, _3: None,
+    "string": _append_args_string,
+    "bool": _append_args_bool,
+    "range": _append_args_string,
+    "choice": _append_args_choice,
+    "choice_with_entry": _append_args_choice,
+    "choice_with_search": _append_args_choice,
+    "file": _append_args_string,
+    "multiple_file": _append_args_multi_string,
+    "directory": _append_args_string,
+    "mapping": _append_args_mapping,
+    "command_line": _append_args_multi_string,
+}
+
+
+def append_args(
+    arguments: list[str],
+    options_dict_list: list[dict[str, Any]],
+    config: dict[str, Any],
+):
+    for option_dict in options_dict_list:
+        option_key = option_dict.get("option")
+        if option_key not in config:
+            continue
+
+        option_type = option_dict.get("type")
+        if append_func := _argument_append_funcs.get(str(option_type)):
+            append_func(arguments, option_dict, config)
+        else:
+            raise RuntimeError(f"Unhandled option type {option_dict.get('type')}")
+
+
+class ModelRunner(Runner):
+    def __init__(self, dict_data: dict[str, Any] | None = None, config=None):
+        super().__init__(config)
+        if dict_data:
+            self.from_dict(dict_data)
+
+    def from_dict(self, dict_data: dict[str, Any]):
+        self.game_options = dict_data.get("game_options", [])
+        self.runner_options = dict_data.get("runner_options", [])
+        self.runner_name = dict_data.get("name", "")
+        self.human_name = dict_data.get("human_name", "")
+        self.description = dict_data.get("description", "")
+        platform_dict = dict_data.get("platforms", [])
+        self.platform_dict = (
+            platform_dict if isinstance(platform_dict, dict) else {platform: platform for platform in platform_dict}
+        )
+        self.runner_executable = dict_data.get("runner_executable", "")
+        self.system_options_override = dict_data.get("system_options_override", [])
+        self.entry_point_option = dict_data.get("entry_point_option", DEFAULT_ENTRY_POINT_OPTION)
+        self.download_url = dict_data.get("download_url", "")
+        self.runnable_alone = dict_data.get("runnable_alone", True)
+        self.flatpak_id = dict_data.get("flatpak_id", "")
+        self.env = dict_data.get("env", {})
+        self.launch_working_dir = dict_data.get("working_dir", "")
+
+    def to_dict(self) -> dict[str, Any]:
+        output_dict_data: dict[str, Any] = {}
+        output_dict_data["name"] = self.runner_name
+        output_dict_data["human_name"] = self.human_name
+        output_dict_data["description"] = self.description
+        output_dict_data["platforms"] = self.platform_dict
+        output_dict_data["runner_executable"] = self.runner_executable
+        output_dict_data["runnable_alone"] = self.runnable_alone
+        output_dict_data["flatpak_id"] = self.flatpak_id
+        output_dict_data["download_url"] = self.download_url
+        output_dict_data["entry_point_option"] = self.entry_point_option
+        output_dict_data["game_options"] = self.game_options
+        output_dict_data["runner_options"] = self.runner_options
+        output_dict_data["system_options_override"] = self.system_options_override
+        output_dict_data["env"] = self.env
+        output_dict_data["working_dir"] = self.launch_working_dir
+
+        return output_dict_data
+
+    def get_platform(self):
+        """Queries the platform from either a list, dict"""
+        if not self.platform_dict:
+            return ""
+        selected_platform = self.game_config.get("platform")
+        for lutris_platform, runner_platform in self.platform_dict.items():
+            if selected_platform == runner_platform:
+                return lutris_platform
+        return next(iter(self.platform_dict.keys()))
+
+    def play(self) -> dict[str, Any]:
+        """Runs the game"""
+        entry_point_value = self.game_config.get(self.entry_point_option, "")
+        if self.entry_point_option in FILE_BASED_ENTRY_POINTS and not system.path_exists(entry_point_value):
+            raise MissingGameExecutableError(filename=entry_point_value)
+
+        arguments = self.get_command()
+
+        # Append the runner arguments first, and game arguments afterwards
+        append_args(arguments, self.runner_options, self.runner_config)
+        append_args(arguments, self.game_options, self.game_config)
+
+        result: dict[str, Any] = {"command": arguments}
+        if self.env:
+            result["env"] = self.env
+        if self.launch_working_dir == "runner":
+            result["working_dir"] = str(Path(self.get_executable()).parent)
+        return result
+
+    @property
+    def file_path(self) -> Path | None:
+        """Override to specify file path to the runner definition if applicable"""
+        return None

--- a/lutris/runners/model_validator.py
+++ b/lutris/runners/model_validator.py
@@ -1,0 +1,417 @@
+"""Base class and utilities for JSON based runners"""
+
+from enum import Enum
+from gettext import gettext as _
+from typing import Any
+
+from lutris.runners.model import DEFAULT_ENTRY_POINT_OPTION
+
+REQUIRED_OPTION_KEYS = {"option", "type", "label"}
+CHOICE_TYPES = {"choice", "choice_with_entry", "choice_with_search"}
+RANGE_TYPE_REQUIRED_KEYS = {"min", "max"}
+
+
+class RunnerDefinitionCategory(str, Enum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class RunnerDefinitionMessage:
+    def __init__(self, key_path, message, category=RunnerDefinitionCategory.ERROR) -> None:
+        self.key_path: str = key_path
+        self.message: str = message
+        self.category = category
+
+
+class RunnerDefinitionMessages:
+    def __init__(
+        self,
+    ) -> None:
+        self.runner_messages: list[RunnerDefinitionMessage] = []
+
+    def get_all(self) -> list[RunnerDefinitionMessage]:
+        return self.runner_messages
+
+    def get_errors(self) -> list[RunnerDefinitionMessage]:
+        return list(filter(lambda msg: msg.category == RunnerDefinitionCategory.ERROR, self.runner_messages))
+
+    def get_warnings(self) -> list[RunnerDefinitionMessage]:
+        return list(filter(lambda msg: msg.category == RunnerDefinitionCategory.WARNING, self.runner_messages))
+
+    def has_errors(self) -> bool:
+        for runner_message in self.runner_messages:
+            if runner_message.category == RunnerDefinitionCategory.ERROR:
+                return True
+        return False
+
+
+def validate_runner_name(runner_name: str) -> RunnerDefinitionMessages:
+    """Validate the runner name only contains alphanumeric characters and underscore
+    [0-9A-Za-z\\-]
+    """
+    error_list = RunnerDefinitionMessages()
+    if runner_name == "":
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path="name", message=_("Runner name cannot be empty"))
+        )
+    else:
+        for c in runner_name:
+            if not (c.isalnum() and c.islower()) and c != "-":
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path="name",
+                        message=_(
+                            "Runner name '%s' contains invalid character '%s'.\nIt must be alphanumeric lower case"
+                        )
+                        % (runner_name, c),
+                    )
+                )
+                break
+    return error_list
+
+
+def validate(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the dictionary contains the required fields to use as a valid Runner"""
+
+    error_list = RunnerDefinitionMessages()
+
+    error_list.runner_messages.extend(validate_runner_name_from_dict(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_human_name(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_description(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_platforms(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_runner_executable(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_runnable_alone(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_flatpak_id(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_download_url(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_entry_point_option(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_game_options(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_runner_options(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_system_options_override(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_envs(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_working_dir(data_dict).runner_messages)
+
+    return error_list
+
+
+def _validate_string_non_empty(data_dict: dict[str, Any], key: str) -> RunnerDefinitionMessages:
+    """Verify key exist and is non empty.
+    i.e The key is required
+    """
+    error_list = RunnerDefinitionMessages()
+    if key not in data_dict:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must exist") % key)
+        )
+    else:
+        try:
+            str_value = str(data_dict[key])
+            if str_value == "":
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must be non-empty") % key)
+                )
+        except Exception as ex:
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=key, message=_("Error `%s` not convertible to string: %s") % (key, str(ex))
+                )
+            )
+
+    return error_list
+
+
+def _validate_string_non_empty_if_exist(data_dict: dict[str, Any], key: str) -> RunnerDefinitionMessages:
+    """Verify key is non empty if it exist.
+    i.e The key is optional
+    """
+    error_list = RunnerDefinitionMessages()
+    if key not in data_dict:
+        return error_list
+
+    try:
+        str_value = str(data_dict[key])
+        if str_value == "":
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=key,
+                    message=_("Field `%s` must be non-empty") % key,
+                    category=RunnerDefinitionCategory.WARNING,
+                )
+            )
+    except Exception as ex:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key,
+                message=_("Error `%s` not convertible to string: %s") % (key, str(ex)),
+                category=RunnerDefinitionCategory.WARNING,
+            )
+        )
+    return error_list
+
+
+def _validate_bool_if_exist(data_dict: dict[str, Any], key: str) -> RunnerDefinitionMessages:
+    """Verify key is convertible to boolean if it exist."""
+    error_list = RunnerDefinitionMessages()
+    if key not in data_dict:
+        return error_list
+    try:
+        bool(data_dict[key])
+    except Exception as ex:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key,
+                message=_("Error `%s` not convertible to bool: %s") % (str(key), str(ex)),
+                category=RunnerDefinitionCategory.WARNING,
+            )
+        )
+    return error_list
+
+
+def validate_runner_name_from_dict(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner  name is valid"""
+    error_list = _validate_string_non_empty(data_dict, "name")
+    if not error_list.get_errors():
+        error_list.runner_messages.extend(validate_runner_name(data_dict["name"]).runner_messages)
+    return error_list
+
+
+def validate_human_name(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner human name is valid"""
+    return _validate_string_non_empty(data_dict, "human_name")
+
+
+def validate_description(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner description is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "description")
+
+
+def validate_platforms(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner platform list is valid"""
+    error_list = RunnerDefinitionMessages()
+
+    key = "platforms"
+    if key not in data_dict:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must exist") % key)
+        )
+    else:
+        platforms = data_dict[key]
+        if isinstance(platforms, dict):
+            if len(platforms) == 0:
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path=key, message=_("`%s` dict must contain at least one string element") % key
+                    )
+                )
+            else:
+                for index, platform_name in enumerate(platforms.values()):
+                    if platform_name == "":
+                        key_prefix = f"{key}.{index}"
+                        error_list.runner_messages.append(
+                            RunnerDefinitionMessage(
+                                key_path=key, message=_("`%s` dict string entry cannot be empty") % key_prefix
+                            )
+                        )
+        elif isinstance(platforms, list):
+            if len(platforms) == 0:
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path=key, message=_("`%s` list must contain at least one string element") % key
+                    )
+                )
+            else:
+                for index, platform_name in enumerate(platforms):
+                    if platform_name == "":
+                        key_prefix = f"{key}.{index}"
+                        error_list.runner_messages.append(
+                            RunnerDefinitionMessage(
+                                key_path=key, message=_("`%s` list string entry cannot be empty") % key_prefix
+                            )
+                        )
+        elif isinstance(platforms, str):
+            platform_name = platforms
+            if platform_name == "":
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(key_path=key, message=_("`%s` string field cannot be empty") % key)
+                )
+    return error_list
+
+
+def validate_runner_executable(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner executable is valid"""
+    return _validate_string_non_empty(data_dict, "runner_executable")
+
+
+def validate_runnable_alone(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runnable alone option is is valid"""
+    return _validate_bool_if_exist(data_dict, "runnable_alone")
+
+
+def validate_download_url(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the download url is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "download_url")
+
+
+def validate_flatpak_id(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the download url is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "flatpak_id")
+
+
+def validate_entry_point_option(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the entry_point_option is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "entry_point_option")
+
+
+def _validate_option(option_dict: dict[str, Any], key_prefix="") -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+
+    error_list.runner_messages.extend(
+        [
+            RunnerDefinitionMessage(
+                key_path=f"{key_prefix}{'.' if key_prefix else ''}{key}",
+                message=_("Option is missing required key '%s'") % key,
+            )
+            for key in REQUIRED_OPTION_KEYS
+            if key not in option_dict
+        ]
+    )
+    widget_type = option_dict.get("type", "")
+    if widget_type in CHOICE_TYPES:
+        if not option_dict.get("choices", []):
+            key = "choices"
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=f"{key_prefix}{'.' if key_prefix else ''}{key}",
+                    message=_(
+                        "'choices' key is required for widget type %s with a least one element."
+                        ' Ex. `"choices": [ {"option1": "value1"}, {"option2": "value2"} ]`'
+                    )
+                    % widget_type,
+                )
+            )
+
+    if widget_type == "range":
+        error_list.runner_messages.extend(
+            [
+                RunnerDefinitionMessage(
+                    key_path=f"{key_prefix}{'.' if key_prefix else ''}{key}",
+                    message=_("'%s' key is required for widget type '%s'") % (key, widget_type),
+                )
+                for key in RANGE_TYPE_REQUIRED_KEYS
+                if key not in option_dict
+            ]
+        )
+
+    return error_list
+
+
+def _validate_options(option_list: list[dict[str, Any]], prefix="") -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+    for index, option in enumerate(option_list):
+        error_list.runner_messages.extend(
+            _validate_option(option, key_prefix=f"{prefix}{'.' if prefix else ''}{index}").runner_messages
+        )
+    return error_list
+
+
+def validate_game_options(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies game option field is list and contains at least one entry
+    The entry point option must exist as option in order to allow the user to specify the game
+    """
+    error_list = RunnerDefinitionMessages()
+
+    key = "game_options"
+    if key not in data_dict:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must exist") % key)
+        )
+    else:
+        game_options = data_dict[key]
+        # Need the entry point to verify the game_options field contains an option for it
+        entry_point_option = data_dict.get("entry_point_option", DEFAULT_ENTRY_POINT_OPTION)
+        if not isinstance(game_options, list):
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(key_path=key, message=_("`%s` must be a list") % key)
+            )
+        elif len(game_options) == 0:
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(key_path=key, message=_("`%s` list must contain at least one element") % key)
+            )
+        elif len([option for option in game_options if option.get("option", "") == entry_point_option]) != 1:
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=key,
+                    message=_("`%s` require exactly one 'option' for the entry point field: %s")
+                    % (key, entry_point_option),
+                )
+            )
+        else:
+            error_list.runner_messages.extend(_validate_options(game_options, prefix=key).runner_messages)
+
+    return error_list
+
+
+def validate_runner_options(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+
+    key = "runner_options"
+    if key not in data_dict:
+        return error_list
+
+    runner_options = data_dict[key]
+    if not isinstance(runner_options, list):
+        error_list.runner_messages.append(RunnerDefinitionMessage(key_path=key, message=_("`%s` must be a list") % key))
+    else:
+        error_list.runner_messages.extend(_validate_options(runner_options, prefix=key).runner_messages)
+
+    return error_list
+
+
+def validate_system_options_override(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+
+    key = "system_options_override"
+    if key not in data_dict:
+        return error_list
+
+    system_options_override = data_dict[key]
+    if not isinstance(system_options_override, list):
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key, message=_("`%s` must be a list") % key, category=RunnerDefinitionCategory.WARNING
+            )
+        )
+    else:
+        for index, option_override in enumerate(system_options_override):
+            if "option" not in option_override:
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path=key,
+                        message=_("`%s` element:%d must contain an 'option' in order to override system option")
+                        % (key, index),
+                        category=RunnerDefinitionCategory.WARNING,
+                    )
+                )
+    return error_list
+
+
+def validate_envs(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies environment variable dict is valid if it exist"""
+    error_list = RunnerDefinitionMessages()
+
+    key = "env"
+    if key not in data_dict:
+        return error_list
+
+    env_dict = data_dict[key]
+    if not isinstance(env_dict, dict):
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key, message=_("`%s` must be a dictionary") % key, category=RunnerDefinitionCategory.WARNING
+            )
+        )
+    return error_list
+
+
+def validate_working_dir(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies working directory is valid if it exist"""
+    return _validate_string_non_empty_if_exist(data_dict, "working_dir")

--- a/lutris/runners/yaml.py
+++ b/lutris/runners/yaml.py
@@ -1,0 +1,58 @@
+"""Base class and utilities for YAML based runners"""
+
+from pathlib import Path
+from typing import Any
+
+from lutris import settings
+from lutris.runners.model import ModelRunner
+from lutris.util import datapath
+from lutris.util.yaml import read_yaml_from_file
+
+SETTING_YAML_RUNNER_DIR = Path(settings.RUNNER_DIR) / "yaml"
+
+YAML_RUNNER_DIRS = [
+    Path(datapath.get()) / "yaml",
+    SETTING_YAML_RUNNER_DIR,
+]
+
+
+class YamlRunner(ModelRunner):
+    yaml_path: Path | None = None
+
+    def __init__(
+        self,
+        config=None,
+        *,
+        dict_data: dict[str, Any] | None = None,
+    ):
+        if not self.yaml_path and not isinstance(dict_data, dict):
+            raise RuntimeError(
+                f"Create subclasses of {self.__class__.__name__} with the yaml_path attribute set,"
+                " or supply the `dict_data` argument with a dictionary"
+            )
+
+        yaml_data: dict[str, Any] = {}
+        if self.yaml_path:
+            yaml_data = read_yaml_from_file(str(self.yaml_path))
+        else:
+            yaml_data = dict_data if dict_data else {}
+        super().__init__(dict_data=yaml_data, config=config)
+
+    @property
+    def file_path(self):
+        return self.yaml_path
+
+
+def load_yaml_runners():
+    yaml_runners = {}
+    for yaml_dir in YAML_RUNNER_DIRS:
+        if not yaml_dir.exists():
+            continue
+        for yaml_path in yaml_dir.iterdir():
+            if yaml_path.suffix not in [".yml", ".yaml"]:
+                continue
+            yaml_data = read_yaml_from_file(str(yaml_path))
+            runner_name = yaml_data.get("name") or yaml_path.stem
+            runner_class = type(runner_name, (YamlRunner,), {"yaml_path": yaml_dir / yaml_path})
+            yaml_runners[runner_name] = runner_class
+    return yaml_runners

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -17,6 +17,7 @@ from lutris.database.games import get_games
 from lutris.database.schema import syncdb
 from lutris.game import Game
 from lutris.runners.json import load_json_runners
+from lutris.runners.yaml import load_yaml_runners
 from lutris.services import DEFAULT_SERVICES
 from lutris.util.graphics import vkquery
 from lutris.util.graphics.gpu import preload_gpus
@@ -161,6 +162,7 @@ def run_all_checks(async_ops: bool = True) -> None:
 def init_lutris():
     """Run full initialization of Lutris"""
     runners.inject_runners(load_json_runners())
+    runners.inject_runners(load_yaml_runners())
     init_dirs()
     try:
         syncdb()

--- a/share/lutris/yaml/eden.yml
+++ b/share/lutris/yaml/eden.yml
@@ -1,0 +1,16 @@
+description: Nintendo Switch emulator
+download_url: https://stable.eden-emu.dev/v0.2.0/Eden-Linux-v0.2.0-amd64-gcc-standard.AppImage
+entry_point_option: main_file
+game_options:
+- default: ''
+  default_path: game_path
+  help: The Application image to run in emulator.
+  label: ROM/ISO/exe file
+  option: main_file
+  type: file
+human_name: Eden
+name: eden
+platforms:
+  Nintendo Switch: Nintendo Switch
+runnable_alone: true
+runner_executable: Eden-Linux-v0.2.0-amd64-gcc-standard.AppImage

--- a/tests/runners/_test_json.py
+++ b/tests/runners/_test_json.py
@@ -1,0 +1,29 @@
+import unittest
+
+from lutris.runners import json
+from lutris.runners.model_validator import validate
+
+
+class TestJsonRunner(unittest.TestCase):
+    def setUp(self):
+        self.runners = [runner_class() for runner_class in json.load_json_runners().values()]
+        self.runners = []
+
+    def test_validate_installed_runners(self):
+        for runner in self.runners:
+            with self.subTest(runner.name):
+                runner_messages = validate(runner.to_dict())
+                error_messages = list(runner_messages.get_errors())
+                self.assertEqual(
+                    len(error_messages),
+                    0,
+                    f"Validation failed for runner at path '{runner.file_path}':\nErrors:\n"
+                    f"{
+                        '\n'.join(
+                            [
+                                f'{runner_message.key_path}: {runner_message.message}'
+                                for runner_message in error_messages
+                            ]
+                        )
+                    }",
+                )

--- a/tests/runners/_test_model.py
+++ b/tests/runners/_test_model.py
@@ -1,0 +1,595 @@
+import unittest
+from copy import deepcopy
+from typing import Any, NamedTuple
+from unittest.mock import MagicMock, patch
+
+from lutris.exceptions import MissingGameExecutableError
+from lutris.runners.model import (
+    DEFAULT_ENTRY_POINT_OPTION,
+    ModelRunner,
+)
+
+TEST_RUNNER_DICT = {
+    "name": "model-runner",
+    "human_name": "ModelRunner",
+    "description": "Model Description",
+    "platforms": ["Windows", "Linux"],
+    "download_url": "https://lutris.net",
+    "flatpak_id": "net.lutris.model.test",
+    "runnable_alone": False,
+    "entry_point_option": "rom",
+    "runner_executable": "model-runner",
+    "game_options": [{"option": "rom", "type": "file", "label": "Path to Game", "help": "help text"}],
+    "runner_options": [
+        {
+            "option": "fullscreen",
+            "type": "bool",
+            "label": "Fullscreen",
+            "default": True,
+            "argument": "--fullscreen",
+            "help": "Start Game in fullscreen mode.",
+        }
+    ],
+    "system_options_override": [{"option": "disable_runtime", "default": True}],
+    "env": {"SDL_VIDEODRIVER": "x11"},
+    "working_dir": "runner",
+}
+
+
+TEST_OPTION_TYPES_DICT_TEMPLATE = {
+    "name": "model-runner",
+    "human_name": "ModelRunner",
+    "description": "Model Description",
+    "platforms": ["Windows", "Linux"],
+    "download_url": "https://lutris.net",
+    "flatpak_id": "net.lutris.model.test",
+    "runnable_alone": False,
+    "entry_point_option": "rom",
+    "runner_executable": "model-runner",
+    "game_options": [{"option": "rom", "type": "file", "label": "Path to Game", "help": "help text"}],
+    "runner_options": [],
+    "system_options_override": [{"option": "disable_runtime", "default": True}],
+    "env": {"SDL_VIDEODRIVER": "x11"},
+    "working_dir": "runner",
+}
+
+
+TEST_REQUIRED_STRING_KEYS = {
+    "human_name",
+    "runner_executable",
+}
+
+
+class OptionConfigParams(NamedTuple):
+    runner_config: dict[str, Any]
+    expected_command_args: list[str | bool | int | float]
+    expected_result: bool
+
+
+class OptionTestParams(NamedTuple):
+    option_dict: dict[str, Any]
+    option_configs: list[OptionConfigParams]
+
+
+TEST_OPTIONAL_STRING_KEYS = {"description", "flatpak_id", "download_url", "entry_point_option"}
+
+
+TEST_OPTION_TYPES_PARAMS: list[OptionTestParams] = [
+    OptionTestParams(
+        {
+            "option": "bool_argument",
+            "type": "bool",
+            "label": "Bool",
+            "default": True,
+            "argument": "--bool",
+        },
+        [
+            OptionConfigParams({"bool_argument": True}, ["--bool"], True),
+            OptionConfigParams({"bool_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "bool_no_argument",
+            "type": "bool",
+            "label": "Bool",
+            "default": False,
+        },
+        [
+            OptionConfigParams({"bool_no_argument": True}, [], True),
+            OptionConfigParams({"bool_no_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "bool_empty_argument",
+            "type": "bool",
+            "label": "Bool",
+            "default": True,
+            "argument": "",
+        },
+        [
+            OptionConfigParams({"bool_empty_argument": True}, [], True),
+            OptionConfigParams({"bool_empty_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "label",
+            "type": "label",
+            "label": "This is a Note",
+        },
+        [
+            OptionConfigParams({"label": "Could be any type"}, [], True),
+            OptionConfigParams({"label": False}, [], True),
+            OptionConfigParams({"label": 42}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "string_argument", "type": "string", "argument": "--string"},
+        [
+            OptionConfigParams({"string_argument": "True"}, ["--string", "True"], True),
+            OptionConfigParams({"string_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "string_no_argument",
+            "type": "string",
+        },
+        [
+            OptionConfigParams({"string_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"string_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "string_with_empty_argument", "type": "string", "argument": ""},
+        [
+            OptionConfigParams({"string_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"string_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "range_argument", "type": "range", "argument": "--range"},
+        [
+            OptionConfigParams({"range_argument": "True"}, ["--range", "True"], True),
+            OptionConfigParams({"range_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "range_no_argument",
+            "type": "range",
+        },
+        [
+            OptionConfigParams({"range_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"range_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "range_with_empty_argument", "type": "range", "argument": ""},
+        [
+            OptionConfigParams({"range_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"range_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "file_argument", "type": "file", "argument": "--file"},
+        [
+            OptionConfigParams({"file_argument": "True"}, ["--file", "True"], True),
+            OptionConfigParams({"file_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "file_no_argument",
+            "type": "file",
+        },
+        [
+            OptionConfigParams({"file_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"file_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "file_with_empty_argument", "type": "file", "argument": ""},
+        [
+            OptionConfigParams({"file_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"file_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "directory_argument", "type": "directory", "argument": "--directory"},
+        [
+            OptionConfigParams({"directory_argument": "True"}, ["--directory", "True"], True),
+            OptionConfigParams({"directory_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "directory_no_argument",
+            "type": "directory",
+        },
+        [
+            OptionConfigParams({"directory_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"directory_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "directory_with_empty_argument", "type": "directory", "argument": ""},
+        [
+            OptionConfigParams({"directory_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"directory_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "multiple_file_argument", "type": "multiple_file", "argument": "--multiple-file"},
+        [
+            OptionConfigParams({"multiple_file_argument": "True"}, ["--multiple-file", "True"], True),
+            OptionConfigParams({"multiple_file_argument": "True False"}, ["--multiple-file", "True", "False"], True),
+            OptionConfigParams({"multiple_file_argument": '"True False"'}, ["--multiple-file", "True False"], True),
+            OptionConfigParams({"multiple_file_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "multiple_file_no_argument",
+            "type": "multiple_file",
+        },
+        [
+            OptionConfigParams({"multiple_file_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"multiple_file_no_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"multiple_file_no_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"multiple_file_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "multiple_file_with_empty_argument", "type": "multiple_file", "argument": ""},
+        [
+            OptionConfigParams({"multiple_file_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"multiple_file_with_empty_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"multiple_file_with_empty_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"multiple_file_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "command_line_argument", "type": "command_line", "argument": "--command-line"},
+        [
+            OptionConfigParams({"command_line_argument": "True"}, ["--command-line", "True"], True),
+            OptionConfigParams({"command_line_argument": "True False"}, ["--command-line", "True", "False"], True),
+            OptionConfigParams({"command_line_argument": '"True False"'}, ["--command-line", "True False"], True),
+            OptionConfigParams({"command_line_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "command_line_no_argument",
+            "type": "command_line",
+        },
+        [
+            OptionConfigParams({"command_line_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"command_line_no_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"command_line_no_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"command_line_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "command_line_with_empty_argument", "type": "command_line", "argument": ""},
+        [
+            OptionConfigParams({"command_line_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"command_line_with_empty_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"command_line_with_empty_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"command_line_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "mapping_argument", "type": "mapping", "argument": "--mapping"},
+        [
+            OptionConfigParams(
+                {"mapping_argument": {"foo": "True", "bar": 1}}, ["--mapping", "foo=True", "--mapping", "bar=1"], True
+            ),
+            OptionConfigParams({"mapping_argument": "NotADictShouldNotAddArguments"}, [], True),
+            OptionConfigParams({"mapping_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "mapping_no_argument",
+            "type": "mapping",
+        },
+        [
+            OptionConfigParams({"mapping_no_argument": {"foo": "True", "bar": 1}}, ["foo=True", "bar=1"], True),
+            OptionConfigParams({"mapping_no_argument": "NotADictShouldNotAddArguments"}, [], True),
+            OptionConfigParams({"mapping_no_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "mapping_empty_argument", "type": "mapping", "argument": ""},
+        [
+            OptionConfigParams({"mapping_empty_argument": {"foo": "True", "bar": 1}}, ["foo=True", "bar=1"], True),
+            OptionConfigParams({"mapping_empty_argument": "NotADictShouldNotAddArguments"}, [], True),
+            OptionConfigParams({"mapping_empty_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_argument", "type": "choice", "argument": "--choice"},
+        [
+            OptionConfigParams({"choice_argument": "True"}, ["--choice", "True"], True),
+            OptionConfigParams({"choice_argument": 7}, ["--choice", 7], True),
+            OptionConfigParams({"choice_argument": False}, ["--choice", False], True),
+            OptionConfigParams({"choice_argument": 14.0}, ["--choice", 14.0], True),
+            # Having an empty string choice make sense for selecting from a drop-down
+            OptionConfigParams({"choice_argument": ""}, ["--choice", ""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_no_argument", "type": "choice"},
+        [
+            OptionConfigParams({"choice_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_no_argument": 7}, [7], True),
+            OptionConfigParams({"choice_no_argument": False}, [False], True),
+            OptionConfigParams({"choice_no_argument": 14.0}, [14.0], True),
+            # Having an empty string choice make sense for selecting from a drop-down
+            OptionConfigParams({"choice_no_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_no_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_empty_argument", "type": "choice", "argument": ""},
+        [
+            OptionConfigParams({"choice_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_empty_argument": 7}, [7], True),
+            OptionConfigParams({"choice_empty_argument": False}, [False], True),
+            OptionConfigParams({"choice_empty_argument": 14.0}, [14.0], True),
+            # Having an empty string choice make sense for selecting from a drop-down
+            OptionConfigParams({"choice_empty_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_empty_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_entry_argument", "type": "choice_with_entry", "argument": "choice-with-entry"},
+        [
+            OptionConfigParams({"choice_with_entry_argument": "True"}, ["choice-with-entry", "True"], True),
+            OptionConfigParams({"choice_with_entry_argument": 7}, ["choice-with-entry", 7], True),
+            OptionConfigParams({"choice_with_entry_argument": False}, ["choice-with-entry", False], True),
+            OptionConfigParams({"choice_with_entry_argument": 14.0}, ["choice-with-entry", 14.0], True),
+            # Having an empty string choice_with_entry make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_entry_argument": ""}, ["choice-with-entry", ""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_entry_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_entry_no_argument", "type": "choice_with_entry"},
+        [
+            OptionConfigParams({"choice_with_entry_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_entry_no_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_entry_no_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_entry_no_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_entry make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_entry_no_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_entry_no_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_entry_empty_argument", "type": "choice_with_entry", "argument": ""},
+        [
+            OptionConfigParams({"choice_with_entry_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_entry_empty_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_entry_empty_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_entry_empty_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_entry make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_entry_empty_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_entry_empty_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_search_argument", "type": "choice_with_search", "argument": "choice-with-search"},
+        [
+            OptionConfigParams({"choice_with_search_argument": "True"}, ["choice-with-search", "True"], True),
+            OptionConfigParams({"choice_with_search_argument": 7}, ["choice-with-search", 7], True),
+            OptionConfigParams({"choice_with_search_argument": False}, ["choice-with-search", False], True),
+            OptionConfigParams({"choice_with_search_argument": 14.0}, ["choice-with-search", 14.0], True),
+            # Having an empty string choice_with_search make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_search_argument": ""}, ["choice-with-search", ""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_search_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_search_no_argument", "type": "choice_with_search"},
+        [
+            OptionConfigParams({"choice_with_search_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_search_no_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_search_no_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_search_no_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_search make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_search_no_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_search_no_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_search_empty_argument", "type": "choice_with_search", "argument": ""},
+        [
+            OptionConfigParams({"choice_with_search_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_search_empty_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_search_empty_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_search_empty_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_search make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_search_empty_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_search_empty_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+]
+
+
+def generate_runner_dict_for_option_test(test_param: OptionTestParams) -> dict[str, Any]:
+    test_dict = TEST_OPTION_TYPES_DICT_TEMPLATE.copy()
+    test_dict["runner_options"] = [test_param.option_dict]
+    return test_dict
+
+
+class TestModelRunner(unittest.TestCase):
+    def setUp(self):
+        self.runner = ModelRunner()
+
+    def test_create_model_runner(self):
+        self.assertEqual(self.runner.entry_point_option, DEFAULT_ENTRY_POINT_OPTION)
+
+    def test_init_from_dict(self):
+        test_dict_with_array_platforms = TEST_RUNNER_DICT
+        test_dict_with_dict_platforms = TEST_RUNNER_DICT.copy()
+        test_dict_with_dict_platforms["platforms"] = {
+            platform: platform for platform in TEST_RUNNER_DICT.get("platforms", [])
+        }
+        # The runner dict should be saved out with the "platforms" key pointing to a dict
+        expected_dict = test_dict_with_dict_platforms
+
+        # Test with the "platforms" key set to an array
+        self.runner.from_dict(test_dict_with_array_platforms)
+        output_dict = self.runner.to_dict()
+        self.assertDictEqual(output_dict, expected_dict)
+
+        # Test with the "platforms" key set to a dict
+        self.runner.from_dict(test_dict_with_dict_platforms)
+        output_dict = self.runner.to_dict()
+        self.assertDictEqual(output_dict, expected_dict)
+
+    # model.play test
+    @patch("lutris.runners.runner.Runner.get_executable")
+    @patch("os.path.isfile")
+    @patch("lutris.util.system.path_exists")
+    def test_play_valid_game_succeeds(self, mock_path_exists, mock_isfile, mock_get_executable):
+        rom_name = "good_game"
+        mock_path_exists.return_value = True
+        mock_isfile.return_value = True
+        mock_config = MagicMock()
+        mock_config.game_config = {"rom": rom_name}
+        mock_config.runner_config = {"fullscreen": True}
+
+        mock_get_executable.return_value = "/path/to/model-runner"
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        expected = {
+            "command": self.runner.get_command() + ["--fullscreen", rom_name],
+            "env": {"SDL_VIDEODRIVER": "x11"},
+            "working_dir": "/path/to",
+        }
+        self.assertDictEqual(self.runner.play(), expected)
+
+    @patch("os.path.isfile")
+    @patch("lutris.util.system.path_exists")
+    def test_play_missing_game_fails(self, mock_path_exists, mock_isfile):
+        rom_name = "good_game"
+        mock_path_exists.return_value = False
+        mock_isfile.return_value = True
+        mock_config = MagicMock()
+        mock_config.game_config = {"rom": rom_name}
+        mock_config.runner_config = {"fullscreen": True}
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        with self.assertRaises(MissingGameExecutableError):
+            self.runner.play()
+
+    @patch("lutris.runners.runner.Runner.get_executable")
+    @patch("os.path.isfile")
+    @patch("lutris.util.system.path_exists")
+    def test_play_for_all_option_types(self, mock_path_exists, mock_isfile, mock_get_executable):
+        for test_param in TEST_OPTION_TYPES_PARAMS:
+            test_dict = generate_runner_dict_for_option_test(test_param)
+            option_name = test_param.option_dict["option"]
+            for runner_config, expected_commang_args, _ in test_param.option_configs:
+                with self.subTest(
+                    f"Testing play for option {option_name}", option=option_name, runner_config=runner_config
+                ):
+                    rom_name = "good_game"
+                    mock_path_exists.return_value = True
+                    mock_isfile.return_value = True
+                    mock_config = MagicMock()
+                    mock_config.game_config = {"rom": rom_name}
+                    mock_config.runner_config = runner_config
+
+                    mock_get_executable.return_value = "/path/to/model-runner"
+
+                    self.runner.from_dict(test_dict)
+                    self.runner.config = mock_config
+                    expected = {
+                        "command": self.runner.get_command() + expected_commang_args + ["good_game"],
+                        "env": {"SDL_VIDEODRIVER": "x11"},
+                        "working_dir": "/path/to",
+                    }
+                    play_dict = self.runner.play()
+                    self.assertDictEqual(play_dict, expected)
+
+    ## get_platform tests
+    def test_get_platform_with_with_platform_key_succeeds(self):
+        mock_config = MagicMock()
+        mock_config.game_config = {"platform": "Linux"}
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        self.assertEqual(self.runner.get_platform(), "Linux")
+
+    def test_get_platform_with_without_platform_key_returns_first_key(self):
+        mock_config = MagicMock()
+        mock_config.game_config = {}
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        self.assertEqual(self.runner.get_platform(), TEST_RUNNER_DICT["platforms"][0])
+
+    def test_get_platform_succeeds_if_platforms_key_is_dict(self):
+        mock_config = MagicMock()
+        mock_config.game_config = {"platform": "Pocket Challenge V2"}
+
+        valid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        valid_runner_dict["platforms"] = {
+            "Bandai WonderSwan Color": "WonderSwan Color",
+            "Benesse Pocket Challenge V2": "Pocket Challenge V2",
+        }
+        self.runner.from_dict(valid_runner_dict)
+        self.runner.config = mock_config
+        self.assertEqual(self.runner.get_platform(), "Benesse Pocket Challenge V2")

--- a/tests/runners/_test_model_validator.py
+++ b/tests/runners/_test_model_validator.py
@@ -1,0 +1,293 @@
+import unittest
+from copy import deepcopy
+from typing import Any
+
+from lutris.runners.model import (
+    ModelRunner,
+)
+from lutris.runners.model_validator import (
+    RANGE_TYPE_REQUIRED_KEYS,
+    REQUIRED_OPTION_KEYS,
+    RunnerDefinitionCategory,
+    validate,
+    validate_runner_name,
+)
+
+TEST_RUNNER_DICT = {
+    "name": "model-runner",
+    "human_name": "ModelRunner",
+    "description": "Model Description",
+    "platforms": ["Windows", "Linux"],
+    "download_url": "https://lutris.net",
+    "flatpak_id": "net.lutris.model.test",
+    "runnable_alone": False,
+    "entry_point_option": "rom",
+    "runner_executable": "model-runner",
+    "game_options": [{"option": "rom", "type": "file", "label": "Path to Game", "help": "help text"}],
+    "runner_options": [
+        {
+            "option": "fullscreen",
+            "type": "bool",
+            "label": "Fullscreen",
+            "default": True,
+            "argument": "--fullscreen",
+            "help": "Start Game in fullscreen mode.",
+        }
+    ],
+    "system_options_override": [{"option": "disable_runtime", "default": True}],
+    "env": {"SDL_VIDEODRIVER": "x11"},
+    "working_dir": "runner",
+}
+
+TEST_REQUIRED_STRING_KEYS = {
+    "name",
+    "human_name",
+    "runner_executable",
+}
+
+TEST_OPTIONAL_STRING_KEYS = {"description", "flatpak_id", "download_url", "entry_point_option", "working_dir"}
+
+
+class TestModelValidator(unittest.TestCase):
+    def setUp(self):
+        self.runner = ModelRunner()
+
+    def test_validate_runner_name_succeeds(self):
+        runner_messages = validate_runner_name("thisisavalidrunnername")
+        self.assertEqual(len(runner_messages.get_all()), 0)
+        runner_messages = validate_runner_name("this-is-valid-as-well")
+        self.assertEqual(len(runner_messages.get_all()), 0)
+
+    def test_validate_runner_name_with_uppercase_alpha_fails(self):
+        runner_messages = validate_runner_name("ThisIsNotAValidRunnerName")
+        self.assertGreater(len(runner_messages.get_all()), 0)
+
+    def test_validate_runner_name_with_non_alphanumeric_fails(self):
+        runner_messages = validate_runner_name("inv@lid")
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        runner_messages = validate_runner_name("../../etc/cron.d/evil")
+        self.assertGreater(len(runner_messages.get_all()), 0)
+
+    ## Config option validation
+    def test_validate_good_config_succeeds(self):
+        valid_runner_dict = TEST_RUNNER_DICT
+        runner_messages = validate(valid_runner_dict)
+        self.assertEqual(len(runner_messages.get_all()), 0)
+
+    ### Game Options validation
+    def test_validate_bad_config_no_game_option_for_entry_point_fails(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["entry_point_option"] = "iso"
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("require exactly one 'option' for the entry point", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_game_options_missing(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        del invalid_runner_dict["game_options"]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("must exist", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_game_options_not_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["game_options"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("must be a list", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_game_options_empty_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["game_options"] = []
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("list must contain at least one element", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### Runner Options validation
+    def test_validate_bad_config_runner_options_not_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["runner_options"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "runner_options")
+        self.assertIn("must be a list", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### System Options Override validation
+    def test_validate_bad_config_system_options_override_not_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["system_options_override"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "system_options_override")
+        self.assertIn("must be a list", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)
+
+    def test_validate_bad_config_system_options_override_missing_option_field(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["system_options_override"] = [{"default": True}]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "system_options_override")
+        self.assertIn("must contain an 'option'", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)
+
+    ### Individual option validation
+    def test_validate_bad_config_option_required_keys_missing(self) -> None:
+        for required_key in REQUIRED_OPTION_KEYS:
+            with self.subTest(required_key):
+                invalid_runner_dict: dict[str, Any] = deepcopy(TEST_RUNNER_DICT)
+                del invalid_runner_dict["runner_options"][0][required_key]
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, f"runner_options.0.{required_key}")
+                self.assertIn("Option is missing required key", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_option_type_choice_missing_choices_field(self) -> None:
+        invalid_runner_dict: dict[str, Any] = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["runner_options"][0]["type"] = "choice"
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "runner_options.0.choices")
+        self.assertIn("'choices' key is required for widget type", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_option_type_range_missing_required_keys(self) -> None:
+        for range_req_key in RANGE_TYPE_REQUIRED_KEYS:
+            with self.subTest(range_req_key):
+                invalid_runner_dict: dict[str, Any] = deepcopy(TEST_RUNNER_DICT)
+                invalid_runner_dict["runner_options"][0]["type"] = "range"
+                # Add all the required range keys and then delete the key that is passed in to this method
+                for add_keys in RANGE_TYPE_REQUIRED_KEYS:
+                    invalid_runner_dict["runner_options"][0][add_keys] = 0
+                del invalid_runner_dict["runner_options"][0][range_req_key]
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, f"runner_options.0.{range_req_key}")
+                self.assertIn("key is required for widget type 'range'", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### "name" field validation
+    def test_validate_runner_name_fails_sanitation_requirements(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["name"] = "../DangerousPath/That/CanJump/OutsideOf/Sandbox"
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "name")
+        self.assertIn("contains invalid character", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### Strings validation - human_name, description, runner_executable, flatpak_id, download_url, entry_point_option
+    def test_validate_bad_config_required_string_keys_missing(self):
+        for string_key in TEST_REQUIRED_STRING_KEYS:
+            with self.subTest(string_key):
+                invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+                del invalid_runner_dict[string_key]
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, string_key)
+                self.assertIn("must exist", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_required_string_keys_empty(self):
+        for string_key in TEST_REQUIRED_STRING_KEYS:
+            with self.subTest(string_key):
+                invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+                invalid_runner_dict[string_key] = ""
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, string_key)
+                self.assertIn("must be non-empty", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_optional_string_keys_empty(self):
+        for string_key in TEST_OPTIONAL_STRING_KEYS:
+            with self.subTest(string_key):
+                invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+                invalid_runner_dict[string_key] = ""
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, string_key)
+                self.assertIn("must be non-empty", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)
+
+    ### Platforms validation
+    def test_validate_bad_config_platforms_key_is_missing(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        del invalid_runner_dict["platforms"]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("must exist", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_empty_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = []
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("list must contain at least one string element", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_empty_dict(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("dict must contain at least one string element", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_empty_string(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = ""
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("string field cannot be empty", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_list_contains_empty_string(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = [""]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("list string entry cannot be empty", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_dict_contains_empty_string(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = {"Windows": ""}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("dict string entry cannot be empty", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### Runnable Alone Validation (i.e The runner can be invoked without a game argument)
+    def test_validate_good_config_runnable_alone_is_convertible_to_bool(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["runnable_alone"] = 1
+        runner_messages = validate(invalid_runner_dict)
+        self.assertEqual(len(runner_messages.get_all()), 0)
+
+    # env Grid validation
+    def test_validate_bad_config_env_key_is_dict_not_dict(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["env"] = []
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "env")
+        self.assertIn("must be a dictionary", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)

--- a/tests/runners/_test_yaml.py
+++ b/tests/runners/_test_yaml.py
@@ -1,0 +1,28 @@
+import unittest
+
+from lutris.runners import yaml
+from lutris.runners.model_validator import validate
+
+
+class TestYamlRunner(unittest.TestCase):
+    def setUp(self):
+        self.runners = [runner_class() for runner_class in yaml.load_yaml_runners().values()]
+
+    def test_validate_installed_runners(self):
+        for runner in self.runners:
+            with self.subTest(runner.name):
+                runner_messages = validate(runner.to_dict())
+                error_messages = list(runner_messages.get_errors())
+                self.assertEqual(
+                    len(error_messages),
+                    0,
+                    f"Validation failed for runner at path '{runner.file_path}':\nErrors:\n"
+                    f"{
+                        '\n'.join(
+                            [
+                                f'{runner_message.key_path}: {runner_message.message}'
+                                for runner_message in error_messages
+                            ]
+                        )
+                    }",
+                )


### PR DESCRIPTION
## Main Feature
A new "Add runner config" section had been added to the bottom of Runners stack in the Preferences menu which allows the user to open a dialog to create a runner: 

Added the "Create New Runner Config" dialog which allows users to create a new Lutris runner and configure each section of it (human_name, platform, game_options. runner_options, etc...).
The dialog validates that the values entered by the user can be used as valid JSON format for the runner.
Once the dialog the dialog is saved, the runner configuration is then immediately available within with the "Runners" stack in the preferences dialog for use.
Furthermore any runner configuration that resides in the "$XDG_DATA_HOME/lutris/runners/json/" directory can now be edited in the "Runners" stack section of the Preferences menu.

Refactored the JSON Runner to be built upon a ModelRunner base class which abstracts the definition of a runner to a dictionary structure.
The JSON runner now just marshals to/from dictionary stored in the ModelRunner base class.
Validation methods for the runner definition has been added to the ModelRunner which validates whether a supplied dict can be used for runner configuration.

e76d0bf5bacc1f51d51382c2c023481ec4b6a095

### Add Support to use YAML based runners
Runners created using YAML in addition to JSON. It uses the same "ModelRunner" backend that the JSON runner uses to marshal to/from a python dict.
A dropdown option has been added to Runner Creation Dialog to choose between JSON or YAML format when saving a newly created runner.
Once a runner is created, it's file format can't be changed to prevent users from creating multiple of the same runner by inadvertently changing the File Format option.
However it may be desirable in the future to allow changing the file format as that would allow conversion of runners between formats.

YAML runners are saved in a directory parallel to JSON runners.
i.e `$XDG_CONFIG_HOME/lutris/runners/yaml` for user created runners
Shared runners that come with lutris should be put in the source code directory of `share/lutris/yaml`

c8ee30051d3dcd4c3bc5e24d116868f456db6650

### Added POC yaml runner using the UI runner creation dialog
Used the UI runner creation dialog to create the eden runner.
83b6bbf0d3ef8bb7591a0c794673493fe526f60d

https://private-user-images.githubusercontent.com/52703/522629998-73a533e3-27dd-4cf3-bba1-408165d54789.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzEzODM1OTcsIm5iZiI6MTc3MTM4MzI5NywicGF0aCI6Ii81MjcwMy81MjI2Mjk5OTgtNzNhNTMzZTMtMjdkZC00Y2YzLWJiYTEtNDA4MTY1ZDU0Nzg5Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjE4VDAyNTQ1N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWIzOWRhNTgxYTQ1Y2JlY2QyZTAzYmQ2NTYyYTYzNDhlNzZkZWUyMmQxNDBmNGRlNTFjNTg4NTkxMTUwYTcwMDImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.gwQrPGicrrqGN_OXs0sNkImkHAJn3U9d59BB-ePnKG8

https://private-user-images.githubusercontent.com/52703/522631206-9befe6a4-519f-4817-9477-c89c76a850d4.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzEzODM1OTcsIm5iZiI6MTc3MTM4MzI5NywicGF0aCI6Ii81MjcwMy81MjI2MzEyMDYtOWJlZmU2YTQtNTE5Zi00ODE3LTk0NzctYzg5Yzc2YTg1MGQ0Lm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjE4VDAyNTQ1N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPThkNWUwMmRjMjMzMDg4YzBkOThkMjM2YTRlZjJiYmI3ZWMyM2YzYThmZjgxYmNlOWZjODc4MmM4NjNhOGM0ZGUmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.2eE0zs0PLhTZnFS5L7wMlH4sUiCAAOYJ141T57Ij3j8

https://private-user-images.githubusercontent.com/52703/550297283-f06b4e60-38b7-48f5-b3bd-83593f8bb2e2.mp4?jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3NzEzODM1OTcsIm5iZiI6MTc3MTM4MzI5NywicGF0aCI6Ii81MjcwMy81NTAyOTcyODMtZjA2YjRlNjAtMzhiNy00OGY1LWIzYmQtODM1OTNmOGJiMmUyLm1wND9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNjAyMTglMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjYwMjE4VDAyNTQ1N1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWViM2I2NzRhYWM3ZWUyYmYxYTJhNWIxMmZmYjA4Njk1YzA2ZDcwNmY1OTU4NmE0YmUwZjcxYjdkZjNlMzBjNGImWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.u9sPg27qR6k4zfZOAwZkm3gEYjIW1If70JxmWhdcA0A

[YAML Example with Field Validation](https://github.com/user-attachments/assets/e1d5f84e-3b26-4f00-a6d6-d6386afab93d)

resolves #6274
