### PR TITLE
github actions: fix ruff check

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -68,8 +68,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           make dev
-      - name: Check code style
+      - name: Ruff version
         run: ruff --version
-          ruff check .
+      - name: Check code style
+        run: ruff check .
       - name: Check format
         run: ruff format . --check

--- a/lutris/util/settings.py
+++ b/lutris/util/settings.py
@@ -1,9 +1,9 @@
 import configparser
 import os
+from typing import Any
 
 from lutris.gui.widgets import NotificationSource
 from lutris.util.log import logger
-from typing import Any
 
 
 class SettingsIO:


### PR DESCRIPTION
Currently, `ruff check .` is never run, as it is shadowed by `ruff --version`.
