### PR TITLE
Fixed Dolphin-emu not launching on some distros

### DIFF
--- a/lutris/runners/dolphin.py
+++ b/lutris/runners/dolphin.py
@@ -19,8 +19,9 @@ class dolphin(Runner):
         "libOpenGL.so.0",
     ]
     runnable_alone = True
-    runner_executable = "dolphin/dolphin-emu"
+    runner_executable = "dolphin/Dolphin_Emulator-2512-anylinux-x86_64.AppImage"
     flatpak_id = "org.DolphinEmu.dolphin-emu"
+    download_url = "https://github.com/pkgforge-dev/Dolphin-emu-AppImage/releases/download/2512%402026-01-26_1769467304/Dolphin_Emulator-2512-anylinux-x86_64.AppImage"
     game_options = [
         {
             "option": "main_file",


### PR DESCRIPTION
The Dolphin-emu runner has been updated to use an AppImage
This fixes the dependency issues with libavformat on some Linux distros

fixes #6230 