### PR TITLE
Validate where commands run by scripts are defined

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -435,6 +435,10 @@ class CommandsMixin:
             data[key] = value
 
         task = import_task(runner_name, task_name)
+
+        if not task:
+            raise ScriptingError(_("Task '%s' is not defined for runner '%s'") % (task_name, runner_name))
+
         command = task(**data)
         if isinstance(command, MonitoredCommand):
             # Monitor thread and continue when task has executed

--- a/lutris/runners/__init__.py
+++ b/lutris/runners/__init__.py
@@ -75,6 +75,15 @@ def get_runner_module(runner_name: str) -> ModuleType:
     return module
 
 
+def get_runner_command_module(runner_name: str) -> ModuleType:
+    if not is_valid_runner_name(runner_name):
+        raise InvalidRunnerError("Invalid runner name '%s'" % runner_name)
+    module = __import__("lutris.runners.commands.%s" % runner_name, globals(), locals(), [runner_name], 0)
+    if not module:
+        raise InvalidRunnerError("No runner commands exist for '%s'." % runner_name)
+    return module
+
+
 def import_runner(runner_name: str) -> type["Runner"]:
     """Dynamically import a runner class."""
     if runner_name in ADDON_RUNNERS:
@@ -84,10 +93,17 @@ def import_runner(runner_name: str) -> type["Runner"]:
     return cast(type["Runner"], getattr(runner_module, runner_name))
 
 
-def import_task(runner: str, task: str) -> Callable[..., Any]:
-    """Return a runner task."""
-    runner_module = get_runner_module(runner)
-    return cast(Callable[..., Any], getattr(runner_module, task))
+def import_task(runner: str, task: str) -> Callable[..., Any] | None:
+    """Return a runner command task, and verifies that it is defined exactly by
+    the command module, not something it imports."""
+    try:
+        runner_module = get_runner_command_module(runner)
+        func = getattr(runner_module, task)
+        if func.__module__ == runner_module.__name__:
+            return cast(Callable[..., Any], func)
+        return None
+    except (AttributeError, InvalidRunnerError):
+        return None
 
 
 def get_installed(sort: bool = True) -> list["Runner"]:

--- a/lutris/runners/commands/dosbox.py
+++ b/lutris/runners/commands/dosbox.py
@@ -9,6 +9,9 @@ from lutris.runners import import_runner
 from lutris.util import system
 from lutris.util.log import logger
 
+# These functions are called by name by installer scripts using the 'task' action;
+# they can't safely be removed even if Lutris does not call them.
+
 
 def dosexec(config_file=None, executable=None, args=None, close_on_exit=True, working_dir=None):
     """Execute Dosbox with given config_file."""

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -30,6 +30,9 @@ from lutris.util.wine.wine import (
     is_prefix_directory,
 )
 
+# These functions are called by name by installer scripts using the 'task' action;
+# they can't safely be removed even if Lutris does not call them.
+
 if TYPE_CHECKING:
     from lutris.runners.wine import wine
 


### PR DESCRIPTION
This PR ensures that any command run via the 'task' action is defined *directly* by the ``lutris.runners.commands.<runner name>`` module for that runner- not by the ``lutris.runners.<runner name>`` module, and not anything imported into one of these modules either.

I've gone over all this and I *believe* the only functions that could have been called improperly were the ones imported into ``lutris.runners.command.wine``, and these are:
1. ``detect_arch``
2. ``get_overrides_env``
3. ``get_real_executable``
4. ``is_installed_systemwide``
5. ``is_prefix_directory``

I believe these are harmless, and since they are all queries and the value returned is just discarded by the 'task' action, they are also useless to an installer, so we can just block them. This PR does that.

But it would be all too easy to add an function to a command or runner module (or to just import one) that would be inappropriate. I know we're installing software, and a malicious installer can just install malware outright without any tricks- but it would be better not to let installers depend on functions they shouldn't.

Plus, I've been looking at #6470 and it was way too painful to figure out if ``kill_pid`` might have been called by an installer this way. I don't think it's possible, but I'd like to be able to just check the two ``commands`` modules and call it a day.

Well, you can still access public methods on ``ScriptInterpreter`` (including its base classes) as before- this PR does not touch that.