### PR TITLE
util: rewrite cache_single as class decorator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,13 @@ ignore = []
 
 [[tool.mypy.overrides]]
 module = [
+    "lutris.cache",
     "lutris.exception_backstops",
     "lutris.exceptions",
     "lutris.scanners.default_installers",
     "lutris.services.mame",
     "lutris.settings",
+    "lutris.util",
     "lutris.util.discord.base",
     "lutris.util.retroarch.core_config",
     "lutris.util.settings",

--- a/tests/util/test_init.py
+++ b/tests/util/test_init.py
@@ -1,0 +1,32 @@
+import unittest
+
+from lutris.util import cache_single
+
+
+class TestCacheSingle(unittest.TestCase):
+    def test_no_args(self):
+        call_count = 0
+
+        @cache_single
+        def no_args():
+            nonlocal call_count
+            call_count += 1
+            return call_count
+
+        self.assertEqual(no_args(), 1)
+        self.assertEqual(no_args(), 1)
+
+        no_args.cache_clear()
+        self.assertEqual(no_args(), 2)
+        self.assertEqual(no_args(), 2)
+
+    def test_with_args(self):
+        @cache_single
+        def with_args(return_value):
+            return return_value
+
+        self.assertEqual(with_args(1), 1)
+        self.assertEqual(with_args(2), 2)
+
+        with_args.cache_clear()
+        self.assertEqual(with_args(3), 3)


### PR DESCRIPTION
Why:

* remove type-checking issues
* seems more appropriate than using nonlocal and monkey-patching
  cache_clear()
