### PR TITLE
util/http: fix iter_chunks return type upon request end

### DIFF
--- a/lutris/util/http.py
+++ b/lutris/util/http.py
@@ -148,14 +148,14 @@ class Request:
         while 1:
             if self.stop_request and self.stop_request.is_set():
                 self.content = b""
-                return self
+                return b""
             try:
                 chunk = request.read(self.buffer_size)
             except (socket.timeout, ConnectionResetError) as err:
                 raise HTTPError("Request timed out") from err
             self.downloaded_size += len(chunk)
             if not chunk:
-                return
+                return b""
             yield chunk
 
     def get(self, data=None):


### PR DESCRIPTION
AFAIU, `iter_chunks` should always return some bytes. This change will fix error when adding typing annotations.

This code dates back from d623ba04511ab25f09f3cc78a5b8129f9c8ed8ff, when the generator did not exist.