### PR TITLE
Correct NameError: name 'threading'/'CookieJar' not defined in util/h…

### DIFF
--- a/lutris/util/http.py
+++ b/lutris/util/http.py
@@ -7,6 +7,9 @@ import ssl
 import urllib.error
 import urllib.parse
 import urllib.request
+import threading
+from http.client import HTTPResponse
+from http.cookiejar import CookieJar
 from ssl import CertificateError
 from typing import TYPE_CHECKING, Any, Collection, Dict, Generator, Optional
 


### PR DESCRIPTION
…ttp.py

(TYPE_CHECKING-only imports)

```
Traceback (most recent call last):
  File "/usr/games/lutris", line 69, in <module>
    from lutris.gui.application import LutrisApplication
  File "/usr/lib/python3/dist-packages/lutris/gui/application.py", line 37, in <module>
    from lutris.api import get_runners, parse_installer_url
  File "/usr/lib/python3/dist-packages/lutris/api.py", line 20, in <module>
    from lutris.util import http, system
  File "/usr/lib/python3/dist-packages/lutris/util/http.py", line 41, in <module>
    class Request:
    ...<160 lines>...
            return ""
  File "/usr/lib/python3/dist-packages/lutris/util/http.py", line 46, in Request
    stop_request: threading.Event = None,
                  ^^^^^^^^^
NameError: name 'threading' is not defined. Did you forget to import 'threading'?
```