### PR TITLE
adding missing lib imports in lutris.util.http to fix some name errors

### DIFF
--- a/lutris/util/http.py
+++ b/lutris/util/http.py
@@ -11,7 +11,6 @@ from ssl import CertificateError
 from typing import TYPE_CHECKING, Any, Collection, Dict, Generator, Optional
 from http.cookiejar import CookieJar
 from http.client import HTTPResponse
-from typing import Generator
 import certifi
 
 from lutris.settings import PROJECT, SITE_URL, VERSION, read_setting


### PR DESCRIPTION
a quick fix for issue https://github.com/lutris/lutris/issues/6494

runtime NameError crashes occur in release 5.22 when running the flatpak (observed on nixOS unstable with bundled Python 3.13). the module lutris/util/http.py references lib names (threading, CookieJar, HTTPResponse, Generator) used in type annotations and runtime code but does not import them.

What this change does
adds the missing imports to  lutris/util/http.py

import threading
from http.cookiejar import CookieJar
from http.client import HTTPResponse
from typing import Generator

Reproduction
run the flatpak build of Lutris 5.22 you will see tracebacks like:

NameError: name 'threading' is not defined
NameError: name 'CookieJar' is not defined
NameError: name 'HTTPResponse' is not defined

Fix verification
applied the patch to the flatpak bundle on nixOS unstable 26.05 and Lutris starts successfully afterwards.

Conclusion
iam not an expert so take it as a grain of salt with revision