### PR TITLE
feat: Optimize GOG download speeds with parallel connections and resume support

### DIFF
--- a/lutris/gui/widgets/download_collection_progress_box.py
+++ b/lutris/gui/widgets/download_collection_progress_box.py
@@ -5,6 +5,7 @@ from gettext import gettext as _
 from gi.repository import GObject, Gtk, Pango
 
 from lutris.gui.dialogs import display_error
+from lutris.util.download_cache import CacheState, create_cache_lock, update_cache_lock
 from lutris.util.downloader import Downloader
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
@@ -12,6 +13,23 @@ from lutris.util.strings import gtk_safe, human_size
 
 # Same reason as Downloader
 get_time = time.monotonic
+
+# Maximum number of file downloads running at the same time.  Keeping
+# this at 2 ("prefetch-one") eliminates the cold-start gap between
+# files without overloading the CDN (GOGDownloader already opens 4
+# Range connections per file).
+MAX_CONCURRENT_FILES = 2
+
+
+class _ActiveDownload:
+    """Tracks one active file download and its retry state."""
+
+    __slots__ = ("downloader", "file", "num_retries")
+
+    def __init__(self, file, downloader):
+        self.file = file
+        self.downloader = downloader
+        self.num_retries = 0
 
 
 class DownloadCollectionProgressBox(Gtk.Box):
@@ -31,18 +49,25 @@ class DownloadCollectionProgressBox(Gtk.Box):
         self.downloader = downloader
         self.is_complete = False
         self._file_queue = file_collection.files_list.copy()
-        self._file_download = None  # file being downloaded
         self.title = file_collection.human_url
         self.num_files_downloaded = 0
         self.num_files_to_download = file_collection.num_files
-        self.num_retries = 0
         self.full_size = file_collection.full_size
-        self.current_size = 0
         self.time_left = "00:00:00"
         self.time_left_check_time = 0
         self.last_size = 0
         self.avg_speed = 0
         self.speed_list = []
+
+        # --- Concurrent download state ---
+        # List of _ActiveDownload objects currently downloading.
+        self._active_downloads: list[_ActiveDownload] = []
+        # Cumulative bytes for files that have already completed.
+        self._completed_sizes: dict[str, int] = {}
+
+        # Legacy compat: kept for the single-downloader callers that
+        # pass a ``downloader`` kwarg (e.g. on_retry_clicked).
+        self.num_retries = 0
 
         top_box = Gtk.Box()
         self.main_label = Gtk.Label(self.title)
@@ -85,60 +110,138 @@ class DownloadCollectionProgressBox(Gtk.Box):
         self.show_all()
         self.cancel_button.hide()
 
-    def update_download_file_label(self, file_name):
-        """Update file label to file being downloaded"""
-        self.file_name_label.set_text(file_name)
+    # ------------------------------------------------------------------
+    # Downloader creation helper
+    # ------------------------------------------------------------------
 
-    def get_next_file_from_queue(self):
-        """Returns the file to download; if there isn't one this will pull the next one
-        from the queue and return that. If there are none there, this returns None."""
-        if not self._file_download:
-            if not self._file_queue:
-                return None
+    def _create_downloader(self, file):
+        """Create a Downloader (or subclass) for *file* and return it.
 
-            self._file_download = self._file_queue.pop()
-            self.num_retries = 0
-
-        return self._file_download
-
-    def start(self) -> None:
-        """Start downloading a file."""
-        file = self.get_next_file_from_queue()
-        if not file:
-            self.cancel_button.set_sensitive(False)
-            self.is_complete = True
-            self.emit("complete", {})
-            return
-
-        # Check if the file already exists in the cache and skip this download then
-        if os.path.exists(file.dest_file):
-            logger.info("File exists, skipping download: '%s'", file.dest_file)
-            self.num_files_downloaded += 1
-            self.current_size += os.path.getsize(file.dest_file)
-            self._file_download = None
-            self.start()
-            return
-
-        # Use a temporary file to avoid problems with partially downloaded files
+        Handles `downloader_class` look-up, ``.tmp`` path creation and
+        cache-lock creation.  Returns ``None`` on failure.
+        """
         tmp_path = file.dest_file + ".tmp"
         file.tmp_file = tmp_path
         if os.path.exists(tmp_path):
             os.remove(tmp_path)
 
-        self.update_download_file_label(file.filename)
-        if not self.downloader:
-            try:
-                self.downloader = Downloader(file.url, file.tmp_file, referer=file.referer, overwrite=True)
-            except RuntimeError as ex:
-                display_error(ex, parent=self.get_toplevel())
-                self.emit("cancel")
-                return
+        try:
+            downloader_cls = getattr(file, "downloader_class", None) or Downloader
+            dl = downloader_cls(file.url, file.tmp_file, referer=file.referer, overwrite=True)
+        except RuntimeError as ex:
+            display_error(ex, parent=self.get_toplevel())
+            return None
 
+        create_cache_lock(file.dest_file, CacheState.DOWNLOADING)
+        return dl
+
+    # ------------------------------------------------------------------
+    # File-label helpers
+    # ------------------------------------------------------------------
+
+    def _update_active_file_labels(self):
+        """Set the file-name label to the names of all active downloads."""
+        names = [ad.file.filename for ad in self._active_downloads]
+        self.file_name_label.set_text(", ".join(names) if names else "")
+
+    # ------------------------------------------------------------------
+    # Queue helpers
+    # ------------------------------------------------------------------
+
+    def _pop_next_downloadable_file(self):
+        """Pop and return the next file from the queue, skipping cached files.
+
+        Returns ``None`` when the queue is empty.
+        """
+        while self._file_queue:
+            file = self._file_queue.pop()
+            if os.path.exists(file.dest_file):
+                logger.info("File exists, skipping download: '%s'", file.dest_file)
+                self.num_files_downloaded += 1
+                size = os.path.getsize(file.dest_file)
+                self._completed_sizes[file.dest_file] = size
+                continue
+            return file
+        return None
+
+    # ------------------------------------------------------------------
+    # Start / prefetch
+    # ------------------------------------------------------------------
+
+    def _start_one(self, file):
+        """Create a downloader for *file*, add to active list, and start it.
+
+        Returns the ``_ActiveDownload`` on success, ``None`` on failure.
+        """
+        dl = self._create_downloader(file)
+        if dl is None:
+            self.emit("cancel")
+            return None
+        ad = _ActiveDownload(file, dl)
+        self._active_downloads.append(ad)
+        dl.start()
+        return ad
+
+    def _start_prefetch(self):
+        """If there is room and files remain, start the next download."""
+        if len(self._active_downloads) >= MAX_CONCURRENT_FILES:
+            return
+        file = self._pop_next_downloadable_file()
+        if file is None:
+            return
+        self._start_one(file)
+        self._update_active_file_labels()
+
+    def start(self) -> None:
+        """Start downloading files from the collection.
+
+        Launches up to ``MAX_CONCURRENT_FILES`` downloads immediately.
+        """
+        # If an external caller already supplied a downloader
+        # (e.g. on_retry_clicked), honour it as the primary.
+        if self.downloader:
+            file = self._file_queue.pop() if self._file_queue else None
+            if file is None:
+                self.cancel_button.set_sensitive(False)
+                self.is_complete = True
+                self.emit("complete", {})
+                return
+            file.tmp_file = self.downloader.dest
+            ad = _ActiveDownload(file, self.downloader)
+            self._active_downloads.append(ad)
+            self._update_active_file_labels()
+            create_cache_lock(file.dest_file, CacheState.DOWNLOADING)
+            schedule_repeating_at_idle(self._progress, interval_seconds=0.5)
+            self.cancel_button.show()
+            self.cancel_button.set_sensitive(True)
+            if self.downloader.state != self.downloader.DOWNLOADING:
+                self.downloader.start()
+            self._start_prefetch()
+            return
+
+        # Normal path: start first file, then prefetch
+        file = self._pop_next_downloadable_file()
+        if file is None:
+            self.cancel_button.set_sensitive(False)
+            self.is_complete = True
+            self.emit("complete", {})
+            return
+
+        ad = self._start_one(file)
+        if ad is None:
+            return  # error already emitted
+
+        self._update_active_file_labels()
         schedule_repeating_at_idle(self._progress, interval_seconds=0.5)
         self.cancel_button.show()
         self.cancel_button.set_sensitive(True)
-        if not self.downloader.state == self.downloader.DOWNLOADING:
-            self.downloader.start()
+
+        # Prefetch the next file immediately
+        self._start_prefetch()
+
+    # ------------------------------------------------------------------
+    # Retry helpers
+    # ------------------------------------------------------------------
 
     def set_retry_button(self):
         """Transform the cancel button into a retry button"""
@@ -153,35 +256,97 @@ class DownloadCollectionProgressBox(Gtk.Box):
         button.set_label(_("Cancel"))
         button.disconnect(self.cancel_cb_id)
         self.cancel_cb_id = button.connect("clicked", self.on_cancel_clicked)
-        self.downloader.reset()
+        if self.downloader:
+            self.downloader.reset()
+        self._active_downloads.clear()
         self.start()
 
+    # ------------------------------------------------------------------
+    # Cancel
+    # ------------------------------------------------------------------
+
     def on_cancel_clicked(self, _widget=None):
-        """Cancel the current download."""
+        """Cancel all active downloads."""
         logger.debug("Download cancel requested")
-        if self.downloader:
-            self.downloader.cancel()
+        for ad in self._active_downloads:
+            ad.downloader.cancel()
+        self._active_downloads.clear()
+        self.downloader = None
         self.cancel_button.set_sensitive(False)
         self.emit("cancel")
 
+    # ------------------------------------------------------------------
+    # Aggregate progress helpers
+    # ------------------------------------------------------------------
+
+    def _aggregate_downloaded_size(self):
+        """Return total bytes downloaded (completed + active)."""
+        completed = sum(self._completed_sizes.values())
+        active = sum(ad.downloader.downloaded_size for ad in self._active_downloads)
+        return completed + active
+
+    # ------------------------------------------------------------------
+    # Progress polling
+    # ------------------------------------------------------------------
+
     def _progress(self) -> bool:
-        """Show download progress of current file."""
-        if self.downloader.state in [self.downloader.CANCELLED, self.downloader.ERROR]:
-            self.progressbar.set_fraction(0)
-            if self.downloader.state == self.downloader.CANCELLED:
+        """Periodic callback: check active downloads, update UI."""
+        if not self._active_downloads:
+            return False  # nothing to poll
+
+        # ---- Handle error / cancelled states on each active download ----
+        finished = []
+        for ad in self._active_downloads:
+            state = ad.downloader.state
+            if state == ad.downloader.CANCELLED:
+                self.progressbar.set_fraction(0)
                 self._set_text(_("Download interrupted"))
+                self._cancel_all()
                 self.emit("cancel")
-            else:
-                if self.num_retries > self.max_retries:
-                    self._set_text(str(self.downloader.error)[:80])
-                    self.emit("error", self.downloader.error)
+                return False
+
+            if state == ad.downloader.ERROR:
+                if ad.num_retries >= self.max_retries:
+                    # Exhausted retries — fail entire collection
+                    self._set_text(str(ad.downloader.error)[:80])
+                    self._cancel_all()
+                    self.emit("error", ad.downloader.error)
                     return False
-                self.num_retries += 1
-                if self.downloader:
-                    self.downloader.reset()
-                    self.start()
-            return False
-        downloaded_size = self.current_size + self.downloader.downloaded_size
+                # Retry this one download independently
+                ad.num_retries += 1
+                logger.debug(
+                    "Retrying file %s (attempt %d/%d)",
+                    ad.file.filename,
+                    ad.num_retries,
+                    self.max_retries,
+                )
+                ad.downloader.reset()
+                ad.downloader = self._create_downloader(ad.file)
+                if ad.downloader is None:
+                    self._cancel_all()
+                    self.emit("cancel")
+                    return False
+                ad.downloader.start()
+                continue
+
+            if state == ad.downloader.COMPLETED:
+                finished.append(ad)
+
+        # ---- Process completions ----
+        for ad in finished:
+            self.num_files_downloaded += 1
+            self._completed_sizes[ad.file.dest_file] = ad.downloader.downloaded_size
+            os.rename(ad.file.tmp_file, ad.file.dest_file)
+            update_cache_lock(ad.file.dest_file, CacheState.DOWNLOADED)
+            self._active_downloads.remove(ad)
+
+        # If files finished, maybe start more prefetch downloads
+        if finished:
+            self._start_prefetch()
+            self._update_active_file_labels()
+
+        # ---- Update aggregate progress ----
+        downloaded_size = self._aggregate_downloaded_size()
         progress = 0
         if self.full_size > 0:
             progress = min(downloaded_size / self.full_size, 1)
@@ -195,29 +360,28 @@ class DownloadCollectionProgressBox(Gtk.Box):
             time=self.time_left,
         )
         self._set_text(progress_text)
-        if self.downloader.state == self.downloader.COMPLETED:
-            self.num_files_downloaded += 1
-            self.current_size += self.downloader.downloaded_size
-            os.rename(self._file_download.tmp_file, self._file_download.dest_file)
-            # set file to None to get next one
-            self._file_download = None
+
+        # ---- Check if all done ----
+        if not self._active_downloads and not self._file_queue:
+            self.cancel_button.set_sensitive(False)
+            self.is_complete = True
             self.downloader = None
-            # start the downloader to a new file or finish
-            self.start()
+            self.emit("complete", {})
             return False
+
         return True
 
+    # ------------------------------------------------------------------
+    # Speed / ETA (aggregate)
+    # ------------------------------------------------------------------
+
     def update_speed_and_time(self):
-        """Update time left and average speed."""
+        """Update time left and average speed using aggregate throughput."""
         elapsed_time = get_time() - self.time_left_check_time
         if elapsed_time < 1:  # Minimum delay
             return
 
-        if not self.downloader:
-            self.time_left = "???"
-            return
-
-        downloaded_size = self.current_size + self.downloader.downloaded_size
+        downloaded_size = self._aggregate_downloaded_size()
         elapsed_size = downloaded_size - self.last_size
         self.last_size = downloaded_size
 
@@ -237,6 +401,18 @@ class DownloadCollectionProgressBox(Gtk.Box):
         hours, minutes = divmod(minutes, 60)
         self.time_left_check_time = get_time()
         self.time_left = "%d:%02d:%02d" % (hours, minutes, seconds)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _cancel_all(self):
+        """Cancel every active download without emitting a signal."""
+        for ad in self._active_downloads:
+            ad.downloader.cancel()
+        self._active_downloads.clear()
+        self.downloader = None
+        self.cancel_button.set_sensitive(False)
 
     def _set_text(self, text):
         markup = "<span size='10000'>{}</span>".format(gtk_safe(text))

--- a/lutris/gui/widgets/download_progress_box.py
+++ b/lutris/gui/widgets/download_progress_box.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from gi.repository import GObject, Gtk, Pango
 
 from lutris.gui.dialogs import display_error
+from lutris.util.download_cache import CacheState, create_cache_lock, update_cache_lock
 from lutris.util.downloader import Downloader
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
@@ -98,6 +99,7 @@ class DownloadProgressBox(Gtk.Box):
             self.emit("cancel")
             return None
 
+        create_cache_lock(self.dest, CacheState.DOWNLOADING)
         schedule_repeating_at_idle(self._progress, interval_seconds=0.5)
         self.cancel_button.show()
         self.cancel_button.set_sensitive(True)
@@ -150,6 +152,7 @@ class DownloadProgressBox(Gtk.Box):
         self._set_text(progress_text)
         if downloader.state == downloader.COMPLETED:
             os.rename(self.temp, self.dest)
+            update_cache_lock(self.dest, CacheState.DOWNLOADED)
             self.cancel_button.set_sensitive(False)
             self.is_complete = True
             self.emit("complete", {})

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -88,10 +88,23 @@ class InstallerFile:
 
     @property
     def downloader(self) -> Optional[Downloader]:
+        """Return custom downloader instance, if one was provided."""
         if callable(self._downloader):
             self._downloader = self._downloader(self)
 
         return self._downloader
+
+    @property
+    def downloader_class(self):
+        """Return custom downloader class from file metadata.
+
+        Services can specify a 'downloader_class' in _file_meta to use
+        a specialized downloader (e.g., GOGDownloader for parallel downloads)
+        instead of the default Downloader.
+        """
+        if isinstance(self._file_meta, dict):
+            return self._file_meta.get("downloader_class")
+        return None
 
     @property
     def checksum(self):

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -294,6 +294,9 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
 
         os.makedirs(self.cache_path, exist_ok=True)
 
+        # Mark cached files as being installed
+        self._update_cache_locks_state("installing")
+
         self._iter_commands()
 
     def _iter_commands(self, result=None, exception=None):
@@ -368,6 +371,9 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         game_id = self.installer.save()
         path = None
 
+        # Mark cached files as successfully installed so cleanup can remove them
+        self._update_cache_locks_state("installed")
+
         if path and AUTO_EXE_PREFIX not in path and not os.path.isfile(path) and self.installer.runner != "web":
             status = (
                 _(
@@ -383,9 +389,41 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         self.interpreter_ui_delegate.report_finished(game_id, status)
 
     def cleanup(self):
-        """Clean up install dir after a successful install"""
+        """Clean up install dir after a successful install.
+
+        Uses cache-aware deletion that preserves downloaded files
+        if installation hasn't completed successfully. This prevents
+        re-downloading large game files after failed installations.
+        """
         os.chdir(os.path.expanduser("~"))
-        system.delete_folder(self.cache_path)
+        from lutris.util.download_cache import safe_delete_folder
+
+        safe_delete_folder(self.cache_path)
+
+    def _update_cache_locks_state(self, state_name: str) -> None:
+        """Update cache lock state for all files in the cache directory.
+
+        Args:
+            state_name: One of 'downloading', 'downloaded', 'installing',
+                       'installed', 'failed'.
+        """
+        from lutris.util.download_cache import CacheState, update_cache_lock
+
+        try:
+            state = CacheState(state_name)
+        except ValueError:
+            logger.warning("Invalid cache state: %s", state_name)
+            return
+
+        if not os.path.isdir(self.cache_path):
+            return
+
+        for root, _dirs, files in os.walk(self.cache_path):
+            for name in files:
+                if name.endswith((".cache_lock", ".tmp")):
+                    continue
+                file_path = os.path.join(root, name)
+                update_cache_lock(file_path, state)
 
     def revert(self, remove_game_dir=True, completion_function=None, error_function=None):
         """Revert installation in case of an error. Since winekill can be slow,
@@ -394,6 +432,9 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         logger.info("Cancelling installation of %s", self.installer.game_name)
 
         self.cancelled = True
+
+        # Mark cached files as failed so they're preserved for retry
+        self._update_cache_locks_state("failed")
 
         def on_complete(_result, error):
             if error:

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -21,6 +21,7 @@ from lutris.services.base import SERVICE_LOGIN, OnlineService
 from lutris.services.service_game import ServiceGame
 from lutris.services.service_media import ServiceMedia
 from lutris.util import i18n, system
+from lutris.util.gog_downloader import GOGDownloader
 from lutris.util.http import HTTPError, Request, UnauthorizedAccessError
 from lutris.util.log import logger
 from lutris.util.strings import human_size, slugify
@@ -540,6 +541,7 @@ class GOGService(OnlineService):
                         "alternate_filenames": installer_file["alternate_filenames"],
                         "checksum_url": installer_file.get("checksum_url"),
                         "total_size": installer_file["total_size"],
+                        "downloader_class": GOGDownloader,
                     },
                 )
             )

--- a/lutris/util/download_cache.py
+++ b/lutris/util/download_cache.py
@@ -1,0 +1,253 @@
+"""Download cache protection module.
+
+Provides mechanisms to protect downloaded installer files from being
+deleted before installation completes. This is critical for large game
+downloads (e.g., 40GB+ GOG games) where re-downloading after a failed
+installation is extremely time-consuming.
+
+The module introduces a "cache lock" system:
+- When a download starts, a lock file is created alongside the download
+- The lock tracks download state (downloading, completed, installed)
+- Cleanup routines check the lock before deleting cached files
+- Failed installations preserve cached files for retry
+"""
+
+import json
+import os
+import time
+from enum import Enum
+from typing import Optional
+
+from lutris.util.log import logger
+
+
+class CacheState(Enum):
+    """State of a cached download file."""
+
+    DOWNLOADING = "downloading"
+    DOWNLOADED = "downloaded"  # Download complete, not yet installed
+    INSTALLING = "installing"  # Installation in progress
+    INSTALLED = "installed"  # Installation successful, safe to clean
+    FAILED = "failed"  # Installation failed, preserve for retry
+
+
+def _lock_path(file_path: str) -> str:
+    """Return the path to the lock file for a cached download."""
+    return file_path + ".cache_lock"
+
+
+def create_cache_lock(file_path: str, state: CacheState = CacheState.DOWNLOADING) -> None:
+    """Create a cache lock file to protect a download from premature deletion.
+
+    Args:
+        file_path: Path to the downloaded file being protected.
+        state: Initial state of the cached file.
+    """
+    lock_file = _lock_path(file_path)
+    lock_data = {
+        "state": state.value,
+        "created_at": time.time(),
+        "updated_at": time.time(),
+        "file_path": file_path,
+    }
+    try:
+        lock_dir = os.path.dirname(lock_file)
+        os.makedirs(lock_dir, exist_ok=True)
+        with open(lock_file, "w", encoding="utf-8") as f:
+            json.dump(lock_data, f, indent=2)
+    except OSError as ex:
+        logger.warning("Failed to create cache lock for %s: %s", file_path, ex)
+
+
+def update_cache_lock(file_path: str, state: CacheState) -> None:
+    """Update the state of an existing cache lock.
+
+    Args:
+        file_path: Path to the downloaded file.
+        state: New state to set.
+    """
+    lock_file = _lock_path(file_path)
+    try:
+        lock_data = {}
+        if os.path.exists(lock_file):
+            with open(lock_file, "r", encoding="utf-8") as f:
+                lock_data = json.load(f)
+        lock_data["state"] = state.value
+        lock_data["updated_at"] = time.time()
+        with open(lock_file, "w", encoding="utf-8") as f:
+            json.dump(lock_data, f, indent=2)
+    except (OSError, json.JSONDecodeError) as ex:
+        logger.warning("Failed to update cache lock for %s: %s", file_path, ex)
+
+
+def get_cache_state(file_path: str) -> Optional[CacheState]:
+    """Read the current state from a cache lock file.
+
+    Args:
+        file_path: Path to the downloaded file.
+
+    Returns:
+        The CacheState if a lock exists, None otherwise.
+    """
+    lock_file = _lock_path(file_path)
+    if not os.path.exists(lock_file):
+        return None
+    try:
+        with open(lock_file, "r", encoding="utf-8") as f:
+            lock_data = json.load(f)
+        return CacheState(lock_data.get("state", "downloading"))
+    except (OSError, json.JSONDecodeError, ValueError) as ex:
+        logger.warning("Failed to read cache lock for %s: %s", file_path, ex)
+        return None
+
+
+def remove_cache_lock(file_path: str) -> None:
+    """Remove the cache lock file for a download.
+
+    Args:
+        file_path: Path to the downloaded file.
+    """
+    lock_file = _lock_path(file_path)
+    try:
+        if os.path.exists(lock_file):
+            os.remove(lock_file)
+    except OSError as ex:
+        logger.warning("Failed to remove cache lock for %s: %s", file_path, ex)
+
+
+def is_safe_to_delete(file_path: str) -> bool:
+    """Check if a cached file is safe to delete.
+
+    A file is safe to delete if:
+    - No cache lock exists (legacy behavior, always safe)
+    - The cache lock state is INSTALLED (installation succeeded)
+    - The cache lock is older than 7 days and in FAILED state (stale)
+
+    A file is NOT safe to delete if:
+    - State is DOWNLOADING (download in progress)
+    - State is DOWNLOADED (download complete, waiting for install)
+    - State is INSTALLING (installation in progress)
+    - State is FAILED and less than 7 days old (preserve for retry)
+
+    Args:
+        file_path: Path to the cached file.
+
+    Returns:
+        True if the file can be safely deleted, False otherwise.
+    """
+    state = get_cache_state(file_path)
+
+    # No lock = legacy behavior, allow deletion
+    if state is None:
+        return True
+
+    # Installation succeeded, safe to clean up
+    if state == CacheState.INSTALLED:
+        return True
+
+    # Active states - never delete
+    if state in (CacheState.DOWNLOADING, CacheState.DOWNLOADING, CacheState.INSTALLING):
+        logger.info(
+            "Cache protection: preserving %s (state: %s)",
+            os.path.basename(file_path),
+            state.value,
+        )
+        return False
+
+    # Downloaded but not yet installed - preserve
+    if state == CacheState.DOWNLOADED:
+        logger.info(
+            "Cache protection: preserving downloaded file %s for installation",
+            os.path.basename(file_path),
+        )
+        return False
+
+    # Failed installation - preserve for 7 days for retry
+    if state == CacheState.FAILED:
+        lock_file = _lock_path(file_path)
+        try:
+            with open(lock_file, "r", encoding="utf-8") as f:
+                lock_data = json.load(f)
+            updated_at = lock_data.get("updated_at", 0)
+            days_old = (time.time() - updated_at) / 86400
+            if days_old < 7:
+                logger.info(
+                    "Cache protection: preserving failed install file %s (%.1f days old, expires in %.1f days)",
+                    os.path.basename(file_path),
+                    days_old,
+                    7 - days_old,
+                )
+                return False
+            logger.info(
+                "Cache protection: allowing cleanup of stale failed file %s (%.1f days old)",
+                os.path.basename(file_path),
+                days_old,
+            )
+        except (OSError, json.JSONDecodeError):
+            pass
+        return True
+
+    # Unknown state - allow deletion
+    return True
+
+
+def safe_delete_folder(folder_path: str) -> bool:
+    """Delete a folder, but only remove files that are safe to delete.
+
+    This is a drop-in replacement for system.delete_folder() that
+    respects cache locks. Files with active cache locks are preserved.
+
+    Args:
+        folder_path: Path to the folder to clean up.
+
+    Returns:
+        True if the folder was fully cleaned (all files removed),
+        False if some files were preserved due to cache locks.
+    """
+    if not os.path.isdir(folder_path):
+        return True
+
+    preserved_files = []
+
+    for root, dirs, files in os.walk(folder_path, topdown=False):
+        for name in files:
+            file_path = os.path.join(root, name)
+
+            # Skip lock files themselves - they'll be cleaned with their data files
+            if file_path.endswith(".cache_lock"):
+                continue
+
+            if is_safe_to_delete(file_path):
+                try:
+                    os.remove(file_path)
+                    remove_cache_lock(file_path)
+                except OSError as ex:
+                    logger.warning("Failed to remove %s: %s", file_path, ex)
+            else:
+                preserved_files.append(file_path)
+
+        # Only remove directories if they're empty
+        for name in dirs:
+            dir_path = os.path.join(root, name)
+            try:
+                if not os.listdir(dir_path):
+                    os.rmdir(dir_path)
+            except OSError:
+                pass  # Directory not empty, skip
+
+    if preserved_files:
+        logger.info(
+            "Cache protection: preserved %d file(s) in %s for retry",
+            len(preserved_files),
+            folder_path,
+        )
+        return False
+
+    # If all files were removed, remove the folder itself
+    try:
+        if os.path.isdir(folder_path) and not os.listdir(folder_path):
+            os.rmdir(folder_path)
+    except OSError:
+        pass
+
+    return True

--- a/lutris/util/download_progress.py
+++ b/lutris/util/download_progress.py
@@ -1,0 +1,234 @@
+"""Persistent download progress tracking for resumable downloads.
+
+Stores completed byte ranges on disk so that large GOG downloads can
+resume after interruptions — hibernation, crashes, network errors, or
+Lutris restarts — without re-downloading already-completed portions.
+
+The progress is stored as a JSON `.progress` file alongside the
+download destination. Each file tracks the URL, total file size,
+the planned byte ranges, and which ranges have completed. On
+successful download completion the progress file is removed.
+
+Writes are atomic (write-to-temp + rename) so that a crash during
+a progress update never corrupts the file.
+"""
+
+import json
+import os
+import tempfile
+import time
+from typing import Any, Dict, List, Tuple
+
+from lutris.util.log import logger
+
+
+class DownloadProgress:
+    """Tracks byte-range download progress persistently on disk.
+
+    Create one instance per download destination. The instance manages
+    a `<dest>.progress` sidecar file that records which byte ranges
+    have been flushed to disk. Workers call :meth:`mark_range_complete`
+    after each range finishes; the orchestrator calls :meth:`cleanup`
+    once the full file is verified.
+
+    Thread-safety: :meth:`mark_range_complete` uses a file-level
+    atomic-replace strategy. Multiple threads may call it concurrently
+    as long as they pass non-overlapping (start, end) pairs, which is
+    guaranteed by the range-splitting logic in GOGDownloader.
+    """
+
+    PROGRESS_SUFFIX = ".progress"
+
+    def __init__(self, dest_path: str) -> None:
+        self.dest_path: str = dest_path
+        self.progress_path: str = dest_path + self.PROGRESS_SUFFIX
+        self._data: Dict[str, Any] = {}
+
+    # ------------------------------------------------------------------
+    # Factory / lifecycle
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def progress_path_for(dest_path: str) -> str:
+        """Return the progress file path for a given download destination."""
+        return dest_path + DownloadProgress.PROGRESS_SUFFIX
+
+    def create(
+        self,
+        url: str,
+        file_size: int,
+        ranges: List[Tuple[int, int]],
+    ) -> None:
+        """Create a fresh progress file for a new download.
+
+        Args:
+            url: The download URL (informational; may change between sessions
+                 for CDN URLs so is not used for compatibility checks).
+            file_size: Total expected file size in bytes.
+            ranges: List of ``(start, end)`` inclusive byte-range tuples
+                    that will be downloaded in parallel.
+        """
+        self._data = {
+            "url": url,
+            "file_size": file_size,
+            "total_ranges": [[s, e] for s, e in ranges],
+            "completed_ranges": [],
+            "created_at": time.time(),
+            "updated_at": time.time(),
+        }
+        self._save()
+
+    def load(self) -> bool:
+        """Load existing progress from disk.
+
+        Returns:
+            ``True`` if a valid progress file was found and loaded,
+            ``False`` otherwise (missing, corrupt, or incomplete).
+        """
+        if not os.path.exists(self.progress_path):
+            return False
+        try:
+            with open(self.progress_path, "r", encoding="utf-8") as f:
+                self._data = json.load(f)
+            required = ("url", "file_size", "total_ranges", "completed_ranges")
+            if not all(k in self._data for k in required):
+                logger.warning(
+                    "Progress file missing required fields: %s",
+                    self.progress_path,
+                )
+                return False
+            return True
+        except (OSError, json.JSONDecodeError, ValueError) as ex:
+            logger.warning(
+                "Failed to load progress file %s: %s",
+                self.progress_path,
+                ex,
+            )
+            return False
+
+    # ------------------------------------------------------------------
+    # Progress updates
+    # ------------------------------------------------------------------
+
+    def mark_range_complete(self, start: int, end: int) -> None:
+        """Record a completed byte range and persist to disk.
+
+        This is called by each download worker after it has finished
+        writing its assigned range to the destination file.
+
+        Args:
+            start: Inclusive start byte offset.
+            end: Inclusive end byte offset.
+        """
+        completed = self._data.get("completed_ranges", [])
+        pair = [start, end]
+        if pair not in completed:
+            completed.append(pair)
+            self._data["completed_ranges"] = completed
+            self._data["updated_at"] = time.time()
+            self._save()
+
+    # ------------------------------------------------------------------
+    # Query helpers
+    # ------------------------------------------------------------------
+
+    def get_remaining_ranges(self) -> List[Tuple[int, int]]:
+        """Return byte ranges that have not yet been downloaded.
+
+        Returns:
+            List of ``(start, end)`` tuples for ranges still pending.
+        """
+        total = [tuple(r) for r in self._data.get("total_ranges", [])]
+        completed = {tuple(r) for r in self._data.get("completed_ranges", [])}
+        return [r for r in total if r not in completed]
+
+    def get_completed_size(self) -> int:
+        """Return total bytes across all completed ranges."""
+        total = 0
+        for start, end in self._data.get("completed_ranges", []):
+            total += end - start + 1
+        return total
+
+    @property
+    def url(self) -> str:
+        """The URL stored in the progress file (informational)."""
+        return self._data.get("url", "")
+
+    @property
+    def file_size(self) -> int:
+        """Expected total file size in bytes."""
+        return self._data.get("file_size", 0)
+
+    @property
+    def completed_ranges(self) -> List[Tuple[int, int]]:
+        """List of completed ``(start, end)`` range tuples."""
+        return [tuple(r) for r in self._data.get("completed_ranges", [])]
+
+    @property
+    def total_ranges(self) -> List[Tuple[int, int]]:
+        """List of all planned ``(start, end)`` range tuples."""
+        return [tuple(r) for r in self._data.get("total_ranges", [])]
+
+    def is_compatible(self, file_size: int) -> bool:
+        """Check whether existing progress can be reused for the current download.
+
+        Compatibility is determined solely by file size — CDN URLs
+        frequently rotate across sessions, so the URL is not compared.
+
+        Args:
+            file_size: The file size reported by the current server probe.
+
+        Returns:
+            ``True`` if the progress file's file size matches and is > 0.
+        """
+        return self.file_size == file_size and file_size > 0
+
+    # ------------------------------------------------------------------
+    # Cleanup
+    # ------------------------------------------------------------------
+
+    def cleanup(self) -> None:
+        """Remove the progress file (called on successful completion)."""
+        try:
+            if os.path.exists(self.progress_path):
+                os.remove(self.progress_path)
+                logger.debug("Removed download progress file: %s", self.progress_path)
+        except OSError as ex:
+            logger.warning(
+                "Failed to remove progress file %s: %s",
+                self.progress_path,
+                ex,
+            )
+        self._data = {}
+
+    # ------------------------------------------------------------------
+    # Persistence (atomic writes)
+    # ------------------------------------------------------------------
+
+    def _save(self) -> None:
+        """Atomically write progress data to disk.
+
+        Uses write-to-temp + ``os.replace`` so that a crash mid-write
+        never leaves a corrupted progress file.
+        """
+        try:
+            dir_path = os.path.dirname(self.progress_path) or "."
+            os.makedirs(dir_path, exist_ok=True)
+            fd, tmp_path = tempfile.mkstemp(dir=dir_path, suffix=".progress.tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    json.dump(self._data, f, indent=2)
+                os.replace(tmp_path, self.progress_path)
+            except Exception:
+                # Clean up temp file on failure
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except OSError as ex:
+            logger.warning(
+                "Failed to save progress file %s: %s",
+                self.progress_path,
+                ex,
+            )

--- a/lutris/util/downloader.py
+++ b/lutris/util/downloader.py
@@ -16,6 +16,25 @@ from lutris.util.log import logger
 # download speeds.
 get_time = time.monotonic
 
+# Default chunk size for downloads (512KB).
+# Previously 8KB which caused excessive syscall overhead.
+# 512KB matches heroic-gogdl and provides good throughput
+# while keeping memory usage reasonable.
+DEFAULT_CHUNK_SIZE = 1024 * 512  # 512KB
+
+
+class DownloadStallError(Exception):
+    """Raised when a download connection stalls below the speed threshold.
+
+    Carries diagnostic information about the stall for logging and retry
+    decisions.
+    """
+
+    def __init__(self, throughput: float, duration: float) -> None:
+        self.throughput = throughput  # bytes/second at time of detection
+        self.duration = duration  # seconds the connection was below threshold
+        super().__init__("Download stalled: %.1f B/s for %.1f seconds" % (throughput, duration))
+
 
 class Downloader:
     """Non-blocking downloader.
@@ -27,6 +46,12 @@ class Downloader:
 
     (INIT, DOWNLOADING, CANCELLED, ERROR, COMPLETED) = list(range(5))
 
+    # Stall detection thresholds (matches lgogdownloader defaults)
+    LOW_SPEED_LIMIT = 200  # bytes/second
+    LOW_SPEED_TIME = 30  # seconds below threshold before triggering
+    RETRY_ATTEMPTS = 3
+    RETRY_DELAY = 2  # seconds between retries
+
     def __init__(
         self,
         url: str,
@@ -35,6 +60,8 @@ class Downloader:
         referer: Optional[str] = None,
         cookies: Any = None,
         headers: Dict[str, str] = None,
+        session: Optional[requests.Session] = None,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
         self.url: str = url
         self.dest: str = dest
@@ -42,6 +69,8 @@ class Downloader:
         self.headers = headers
         self.overwrite: bool = overwrite
         self.referer = referer
+        self.session = session
+        self.chunk_size = chunk_size
         self.stop_request = None
         self.thread = None
 
@@ -61,6 +90,52 @@ class Downloader:
         self.time_left_check_time = 0
         self.file_pointer = None
         self.progress_event = threading.Event()
+
+        # Stall detection state
+        self._stall_start: Optional[float] = None  # monotonic time when speed first dropped
+        self._stall_bytes_at_start: int = 0  # downloaded_size when stall window started
+
+    def _reset_stall_state(self) -> None:
+        """Reset stall detection tracking (call at start of each download attempt)."""
+        self._stall_start = None
+        self._stall_bytes_at_start = 0
+
+    def _check_stall(self, bytes_received_total: int) -> None:
+        """Check if download has stalled and raise DownloadStallError if so.
+
+        Tracks a rolling throughput window. When throughput drops below
+        LOW_SPEED_LIMIT for longer than LOW_SPEED_TIME, raises
+        DownloadStallError to trigger a retry.
+
+        Args:
+            bytes_received_total: Total bytes received so far in this
+                download stream (not self.downloaded_size, which may be
+                shared across workers).
+        """
+        now = get_time()
+
+        if self._stall_start is None:
+            # Not currently in a stall window — start one
+            self._stall_start = now
+            self._stall_bytes_at_start = bytes_received_total
+            return
+
+        elapsed = now - self._stall_start
+        if elapsed <= 0:
+            return
+
+        bytes_in_window = bytes_received_total - self._stall_bytes_at_start
+        throughput = bytes_in_window / elapsed
+
+        if throughput >= self.LOW_SPEED_LIMIT:
+            # Speed is good — reset the window
+            self._stall_start = now
+            self._stall_bytes_at_start = bytes_received_total
+            return
+
+        # Speed is below threshold — check if we've exceeded the time limit
+        if elapsed >= self.LOW_SPEED_TIME:
+            raise DownloadStallError(throughput=throughput, duration=elapsed)
 
     def __repr__(self):
         return "downloader for %s" % self.url
@@ -135,31 +210,129 @@ class Downloader:
             os.remove(self.dest)
 
     def async_download(self):
-        try:
-            headers = requests.utils.default_headers()
-            headers["User-Agent"] = "Lutris/%s" % __version__
-            if self.referer:
-                headers["Referer"] = self.referer
-            if self.headers:
-                for key, value in self.headers.items():
-                    headers[key] = value
-            response = requests.get(self.url, headers=headers, stream=True, timeout=30, cookies=self.cookies)
-            if response.status_code != 200:
-                logger.info("%s returned a %s error", self.url, response.status_code)
-            response.raise_for_status()
-            self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
-            self.progress_event.set()
-            for chunk in response.iter_content(chunk_size=8192):
-                if not self.file_pointer:
+        """Execute download with stall detection and retry logic.
+
+        Retries up to RETRY_ATTEMPTS times on stalls and transient errors.
+        Non-retryable errors (HTTP 4xx except 408/429) fail immediately.
+        """
+        last_error = None
+        for attempt in range(self.RETRY_ATTEMPTS):
+            try:
+                self._do_download()
+                self.on_download_completed()
+                return  # Success
+            except DownloadStallError as ex:
+                last_error = ex
+                if self.stop_request and self.stop_request.is_set():
                     break
-                if chunk:
-                    self.downloaded_size += len(chunk)
-                    self.file_pointer.write(chunk)
-                self.progress_event.set()
-            self.on_download_completed()
-        except Exception as ex:
-            logger.exception("Download failed: %s", ex)
-            self.on_download_failed(ex)
+                logger.warning(
+                    "Download stall detected (attempt %d/%d): %s — retrying in %ds",
+                    attempt + 1,
+                    self.RETRY_ATTEMPTS,
+                    ex,
+                    self.RETRY_DELAY,
+                )
+                time.sleep(self.RETRY_DELAY)
+                self._prepare_retry()
+            except requests.HTTPError as ex:
+                last_error = ex
+                if self._is_retryable_http_error(ex):
+                    if self.stop_request and self.stop_request.is_set():
+                        break
+                    logger.warning(
+                        "Transient HTTP error (attempt %d/%d): %s — retrying in %ds",
+                        attempt + 1,
+                        self.RETRY_ATTEMPTS,
+                        ex,
+                        self.RETRY_DELAY,
+                    )
+                    time.sleep(self.RETRY_DELAY)
+                    self._prepare_retry()
+                else:
+                    # Non-retryable (4xx client errors like 404, 403)
+                    logger.error("Non-retryable HTTP error: %s", ex)
+                    self.on_download_failed(ex)
+                    return
+            except Exception as ex:
+                last_error = ex
+                if self.stop_request and self.stop_request.is_set():
+                    break
+                if attempt < self.RETRY_ATTEMPTS - 1:
+                    logger.warning(
+                        "Download error (attempt %d/%d): %s — retrying in %ds",
+                        attempt + 1,
+                        self.RETRY_ATTEMPTS,
+                        ex,
+                        self.RETRY_DELAY,
+                    )
+                    time.sleep(self.RETRY_DELAY)
+                    self._prepare_retry()
+                else:
+                    logger.exception("Download failed after %d attempts: %s", self.RETRY_ATTEMPTS, ex)
+                    self.on_download_failed(ex)
+                    return
+
+        # All retries exhausted
+        if last_error:
+            logger.error("Download failed after %d attempts: %s", self.RETRY_ATTEMPTS, last_error)
+            self.on_download_failed(last_error)
+
+    def _do_download(self):
+        """Perform a single download attempt with stall detection."""
+        headers = requests.utils.default_headers()
+        headers["User-Agent"] = "Lutris/%s" % __version__
+        if self.referer:
+            headers["Referer"] = self.referer
+        if self.headers:
+            for key, value in self.headers.items():
+                headers[key] = value
+
+        # Use provided session for connection pooling, or fall back to plain requests
+        requester = self.session if self.session else requests
+        response = requester.get(self.url, headers=headers, stream=True, timeout=30, cookies=self.cookies)
+        if response.status_code != 200:
+            logger.info("%s returned a %s error", self.url, response.status_code)
+        response.raise_for_status()
+        self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
+        self.progress_event.set()
+
+        self._reset_stall_state()
+        stream_bytes = 0
+
+        for chunk in response.iter_content(chunk_size=self.chunk_size):
+            if not self.file_pointer:
+                break
+            if self.stop_request and self.stop_request.is_set():
+                break
+            if chunk:
+                stream_bytes += len(chunk)
+                self.downloaded_size += len(chunk)
+                self.file_pointer.write(chunk)
+                self._check_stall(stream_bytes)
+            self.progress_event.set()
+
+    def _prepare_retry(self):
+        """Prepare state for a retry attempt.
+
+        Resets stall tracking and restarts the file from the beginning.
+        """
+        self._reset_stall_state()
+        self.downloaded_size = 0
+        if self.file_pointer:
+            self.file_pointer.close()
+        self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
+
+    @staticmethod
+    def _is_retryable_http_error(error: requests.HTTPError) -> bool:
+        """Check if an HTTP error is transient and worth retrying.
+
+        Retries on server errors (5xx), timeouts (408), and rate limits (429).
+        Client errors like 404, 403 are not retried.
+        """
+        if error.response is None:
+            return True  # No response means connection-level failure
+        status = error.response.status_code
+        return status >= 500 or status in (408, 429)
 
     def on_download_failed(self, error: Exception):
         # Cancelling closes the file, which can result in an

--- a/lutris/util/gog_downloader.py
+++ b/lutris/util/gog_downloader.py
@@ -1,0 +1,544 @@
+"""Multi-connection parallel downloader for GOG game files.
+
+Uses HTTP Range requests to download different byte ranges of a file
+simultaneously across multiple threads, significantly improving download
+speeds for large GOG installer files.
+
+This downloader is a drop-in replacement for the standard Downloader class,
+maintaining API compatibility with DownloadProgressBox and
+DownloadCollectionProgressBox.
+"""
+
+import os
+import queue
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+from requests.adapters import HTTPAdapter
+
+from lutris import __version__
+from lutris.util import jobs
+from lutris.util.download_progress import DownloadProgress
+from lutris.util.downloader import DEFAULT_CHUNK_SIZE, Downloader, get_time
+from lutris.util.log import logger
+
+
+class GOGDownloader(Downloader):
+    """Multi-connection parallel downloader optimized for GOG CDN downloads.
+
+    Downloads large files using multiple simultaneous HTTP Range requests,
+    each writing to a different region of the output file. Falls back to
+    single-stream download if the server doesn't support Range requests
+    or the file is too small to benefit from parallelism.
+
+    Designed to be API-compatible with Downloader so it works seamlessly
+    with DownloadProgressBox and DownloadCollectionProgressBox.
+    """
+
+    DEFAULT_WORKERS = 4
+    MIN_CHUNK_SIZE = 5 * 1024 * 1024  # 5MB minimum per worker
+    RETRY_ATTEMPTS = 3
+    RETRY_DELAY = 2  # seconds between retries
+
+    def __init__(
+        self,
+        url: str,
+        dest: str,
+        overwrite: bool = False,
+        referer: Optional[str] = None,
+        cookies: Any = None,
+        headers: Dict[str, str] = None,
+        session: Optional[requests.Session] = None,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
+        num_workers: int = DEFAULT_WORKERS,
+    ) -> None:
+        super().__init__(
+            url=url,
+            dest=dest,
+            overwrite=overwrite,
+            referer=referer,
+            cookies=cookies,
+            headers=headers,
+            session=session,
+            chunk_size=chunk_size,
+        )
+        self.num_workers = max(1, num_workers)
+        self._download_lock = threading.Lock()
+        self._progress: Optional[DownloadProgress] = None
+        # Pipelining: bounded queue decouples download I/O from disk writes
+        self._write_queue: queue.Queue = queue.Queue(maxsize=64)
+        self._writer_error: Optional[Exception] = None
+        self._writer_error_event = threading.Event()
+        # Create a dedicated session with connection pooling sized for our workers
+        self._parallel_session = requests.Session()
+        adapter = HTTPAdapter(pool_maxsize=self.num_workers + 2)
+        self._parallel_session.mount("https://", adapter)
+        self._parallel_session.mount("http://", adapter)
+        self._parallel_session.headers["User-Agent"] = "Lutris/%s" % __version__
+
+    def __repr__(self):
+        return "GOG parallel downloader (%d workers) for %s" % (self.num_workers, self.url)
+
+    def start(self):
+        """Start parallel download job.
+
+        If a previous download was interrupted (hibernate, crash, network
+        error), the progress file and partial destination file are detected
+        and the download resumes from the last completed byte ranges
+        instead of starting over.
+        """
+        logger.debug("⬇ GOG parallel (%d workers): %s", self.num_workers, self.url)
+        self.state = self.DOWNLOADING
+        self.last_check_time = get_time()
+
+        # Check for resumable progress before deleting anything
+        can_resume = False
+        if os.path.isfile(self.dest):
+            progress = DownloadProgress(self.dest)
+            if progress.load() and progress.get_remaining_ranges():
+                can_resume = True
+                logger.info(
+                    "GOG download: found resumable progress for %s "
+                    "(%d/%d ranges complete, %d bytes already downloaded)",
+                    os.path.basename(self.dest),
+                    len(progress.completed_ranges),
+                    len(progress.total_ranges),
+                    progress.get_completed_size(),
+                )
+
+        if not can_resume and self.overwrite and os.path.isfile(self.dest):
+            os.remove(self.dest)
+            # Also clean stale progress files
+            progress_path = DownloadProgress.progress_path_for(self.dest)
+            if os.path.isfile(progress_path):
+                os.remove(progress_path)
+
+        # Workers manage their own file I/O - no shared file_pointer needed
+        self.file_pointer = None
+        self.thread = jobs.AsyncCall(self.async_download, None)
+        self.stop_request = self.thread.stop_request
+
+    def cancel(self):
+        """Request download stop and remove destination file.
+
+        Explicit user cancellation removes both the partial file and
+        the progress file so the next attempt starts fresh.
+        """
+        logger.debug("❌ GOG parallel: %s", self.url)
+        self.state = self.CANCELLED
+        if self.stop_request:
+            self.stop_request.set()
+        # No shared file_pointer to close - workers handle their own
+        if os.path.isfile(self.dest):
+            os.remove(self.dest)
+        # Clean up progress file on explicit cancel
+        if self._progress:
+            self._progress.cleanup()
+            self._progress = None
+
+    def on_download_completed(self):
+        """Mark download as complete and clean up progress file."""
+        if self.state == self.CANCELLED:
+            return
+        logger.debug("✅ GOG parallel download finished: %s", self.url)
+        if not self.downloaded_size:
+            logger.warning("Downloaded file is empty")
+        if not self.full_size:
+            self.progress_fraction = 1.0
+            self.progress_percentage = 100
+        self.state = self.COMPLETED
+        # No shared file_pointer to close
+        # Remove progress file — download is complete
+        if self._progress:
+            self._progress.cleanup()
+            self._progress = None
+
+    def _build_request_headers(self) -> Dict[str, str]:
+        """Build HTTP headers for download requests."""
+        headers: Dict[str, str] = dict(requests.utils.default_headers())
+        headers["User-Agent"] = "Lutris/%s" % __version__
+        if self.referer:
+            headers["Referer"] = self.referer
+        if self.headers:
+            headers.update(self.headers)
+        return headers
+
+    def _calculate_ranges(self, file_size: int) -> List[Tuple[int, int]]:
+        """Split file into byte ranges for parallel download.
+
+        Returns a list of (start, end) tuples representing inclusive byte ranges.
+        """
+        chunk_size = file_size // self.num_workers
+        ranges = []
+        for i in range(self.num_workers):
+            start = i * chunk_size
+            end = file_size - 1 if i == self.num_workers - 1 else (i + 1) * chunk_size - 1
+            ranges.append((start, end))
+        return ranges
+
+    def _writer_loop(self) -> None:
+        """Dedicated writer thread: dequeues chunks and writes to disk.
+
+        Consumes (offset, data, range_start, range_end) tuples from the
+        write queue. A None sentinel signals the writer to exit.
+
+        All disk I/O and progress tracking happens here, keeping download
+        workers free from disk latency.
+        """
+        try:
+            with open(self.dest, "r+b") as f:
+                while True:
+                    if self.stop_request and self.stop_request.is_set():
+                        # Drain remaining items on cancel
+                        break
+                    try:
+                        item = self._write_queue.get(timeout=0.5)
+                    except queue.Empty:
+                        continue
+
+                    if item is None:
+                        # Sentinel — all downloads complete
+                        break
+
+                    offset, data, range_start, range_end = item
+                    f.seek(offset)
+                    f.write(data)
+                    with self._download_lock:
+                        self.downloaded_size += len(data)
+                    self.progress_event.set()
+
+                    # If this write completes a range, mark it in progress file
+                    if range_end is not None and offset + len(data) >= range_end + 1:
+                        if self._progress:
+                            self._progress.mark_range_complete(range_start, range_end)
+        except Exception as ex:
+            logger.error("Writer thread failed: %s", ex)
+            self._writer_error = ex
+            self._writer_error_event.set()
+
+    def async_download(self):
+        """Execute multi-connection parallel download with resume support.
+
+        On each invocation the method:
+        1. Probes the server for the final URL, file size, and Range support.
+        2. Checks for an existing ``.progress`` file alongside the
+           destination.  If one is found and the file size matches, the
+           download resumes from only the remaining byte ranges.
+        3. Pre-allocates (or reuses) the destination file and launches
+           parallel workers for the outstanding ranges.
+        4. On success the progress file is removed.  On failure or
+           interruption (hibernate, crash) the progress file and partial
+           destination are preserved for the next attempt.
+        """
+        try:
+            headers = self._build_request_headers()
+
+            # Step 1: Resolve URL (follow redirects) and check capabilities
+            final_url, file_size, supports_range = self._probe_server(headers)
+            self.full_size = file_size
+
+            # Fall back to single-stream if Range not supported or file too small
+            if not supports_range or file_size < self.MIN_CHUNK_SIZE * 2:
+                logger.info(
+                    "GOG download: falling back to single-stream (range=%s, size=%d bytes)",
+                    supports_range,
+                    file_size,
+                )
+                self._single_stream_download(final_url, headers)
+                return
+
+            self.progress_event.set()  # Signal that size is known
+
+            # Step 2: Check for resumable progress
+            self._progress = DownloadProgress(self.dest)
+            ranges_to_download = None
+
+            if self._progress.load() and self._progress.is_compatible(file_size):
+                remaining = self._progress.get_remaining_ranges()
+                if remaining:
+                    already_done = self._progress.get_completed_size()
+                    logger.info(
+                        "GOG download: resuming — %d/%d ranges done, %d bytes already on disk, %d bytes remaining",
+                        len(self._progress.completed_ranges),
+                        len(self._progress.total_ranges),
+                        already_done,
+                        file_size - already_done,
+                    )
+                    # Credit previously-downloaded bytes to progress tracking
+                    with self._download_lock:
+                        self.downloaded_size = already_done
+                    ranges_to_download = remaining
+                else:
+                    # All ranges already complete — verify file exists & size
+                    if os.path.isfile(self.dest) and os.path.getsize(self.dest) == file_size:
+                        logger.info(
+                            "GOG download: all ranges already complete, skipping download of %s",
+                            os.path.basename(self.dest),
+                        )
+                        with self._download_lock:
+                            self.downloaded_size = file_size
+                        self.on_download_completed()
+                        return
+
+            # Step 3: Compute ranges (fresh or from progress)
+            if ranges_to_download is None:
+                # Fresh download — pre-allocate output file
+                with open(self.dest, "wb") as f:
+                    f.truncate(file_size)
+                all_ranges = self._calculate_ranges(file_size)
+                self._progress.create(final_url, file_size, all_ranges)
+                ranges_to_download = all_ranges
+            else:
+                # Resuming — verify dest file exists and has correct size
+                if not os.path.isfile(self.dest) or os.path.getsize(self.dest) != file_size:
+                    logger.warning("GOG download: dest file missing or wrong size during resume, starting fresh")
+                    with open(self.dest, "wb") as f:
+                        f.truncate(file_size)
+                    all_ranges = self._calculate_ranges(file_size)
+                    self._progress.create(final_url, file_size, all_ranges)
+                    ranges_to_download = all_ranges
+                    with self._download_lock:
+                        self.downloaded_size = 0
+
+            total_remaining = sum(e - s + 1 for s, e in ranges_to_download)
+            logger.info(
+                "GOG parallel download: %d workers, %d ranges to download, %d MB remaining of %d MB total",
+                self.num_workers,
+                len(ranges_to_download),
+                total_remaining // (1024 * 1024),
+                file_size // (1024 * 1024),
+            )
+
+            # Step 4: Download chunks in parallel with pipelined writes
+            # Reset writer error state
+            self._writer_error = None
+            self._writer_error_event.clear()
+
+            # Start dedicated writer thread
+            writer_thread = threading.Thread(target=self._writer_loop, name="GOGDownloader-writer", daemon=True)
+            writer_thread.start()
+
+            errors = []
+            try:
+                with ThreadPoolExecutor(max_workers=self.num_workers) as executor:
+                    future_to_range = {}
+                    for start, end in ranges_to_download:
+                        future = executor.submit(self._download_range, final_url, headers, start, end)
+                        future_to_range[future] = (start, end)
+
+                    for future in as_completed(future_to_range):
+                        try:
+                            future.result()
+                        except Exception as ex:
+                            rng = future_to_range[future]
+                            logger.error("Worker failed for range %d-%d: %s", rng[0], rng[1], ex)
+                            errors.append(ex)
+                            # Signal other workers to stop
+                            if self.stop_request:
+                                self.stop_request.set()
+            finally:
+                # Signal writer thread to exit and wait for it
+                self._write_queue.put(None)
+                writer_thread.join(timeout=30)
+
+            # Check for writer errors
+            if self._writer_error:
+                raise self._writer_error
+
+            if errors:
+                raise errors[0]
+
+            self.on_download_completed()
+        except Exception as ex:
+            logger.exception("GOG parallel download failed: %s", ex)
+            self.on_download_failed(ex)
+
+    def _probe_server(self, headers: dict) -> Tuple[str, int, bool]:
+        """Probe the server to determine final URL, file size, and Range support.
+
+        Uses a HEAD request to follow redirects (e.g., GOG API → CDN URL),
+        get Content-Length, and check Accept-Ranges header.
+
+        Returns:
+            Tuple of (final_url, file_size, supports_range)
+        """
+        resp = self._parallel_session.head(
+            self.url, headers=headers, allow_redirects=True, timeout=30, cookies=self.cookies
+        )
+        resp.raise_for_status()
+
+        final_url = resp.url
+        file_size = int(resp.headers.get("Content-Length", 0))
+        accept_ranges = resp.headers.get("Accept-Ranges", "")
+        supports_range = "bytes" in accept_ranges.lower()
+
+        # Some servers don't advertise Accept-Ranges but still support it.
+        # If we got a Content-Length, try a small Range request to verify.
+        if file_size and not supports_range:
+            supports_range = self._test_range_support(final_url, headers)
+
+        logger.debug(
+            "GOG probe: url=%s, size=%d, range=%s",
+            final_url[:80],
+            file_size,
+            supports_range,
+        )
+        return final_url, file_size, supports_range
+
+    def _test_range_support(self, url: str, headers: dict) -> bool:
+        """Test if server actually supports Range requests with a small probe."""
+        try:
+            test_headers = dict(headers)
+            test_headers["Range"] = "bytes=0-0"
+            resp = self._parallel_session.get(url, headers=test_headers, stream=True, timeout=10, cookies=self.cookies)
+            resp.close()
+            return resp.status_code == 206
+        except Exception:
+            return False
+
+    def _download_range(self, url: str, headers: dict, start: int, end: int) -> None:
+        """Download a specific byte range and enqueue data for the writer thread.
+
+        Each worker downloads its assigned byte range and puts chunks into
+        the write queue for the dedicated writer thread. Workers never
+        perform file I/O directly, keeping them free from disk latency.
+
+        Retries up to RETRY_ATTEMPTS times with exponential backoff.
+        """
+        for attempt in range(self.RETRY_ATTEMPTS):
+            try:
+                range_headers = dict(headers)
+                range_headers["Range"] = "bytes=%d-%d" % (start, end)
+
+                response = self._parallel_session.get(
+                    url,
+                    headers=range_headers,
+                    stream=True,
+                    timeout=30,
+                    cookies=self.cookies,
+                )
+
+                if response.status_code not in (200, 206):
+                    raise requests.HTTPError(
+                        "HTTP %d for range %d-%d" % (response.status_code, start, end),
+                        response=response,
+                    )
+
+                # If server returned 200 (ignoring Range), only write our portion
+                if response.status_code == 200:
+                    logger.warning(
+                        "Server ignored Range header, reading full response for range %d-%d",
+                        start,
+                        end,
+                    )
+                    self._write_from_full_response(response, start, end)
+                    return
+
+                # Normal 206 Partial Content response — enqueue for writer
+                self._reset_stall_state()
+                stream_bytes = 0
+                current_offset = start
+                range_size = end - start + 1
+
+                for chunk in response.iter_content(chunk_size=self.chunk_size):
+                    if self.stop_request and self.stop_request.is_set():
+                        return
+                    if self._writer_error_event.is_set():
+                        return  # Writer failed, stop downloading
+                    if chunk:
+                        stream_bytes += len(chunk)
+                        # Mark the last chunk of this range so writer knows when to
+                        # record the range as complete
+                        is_last_chunk = stream_bytes >= range_size
+                        range_end_marker = end if is_last_chunk else None
+                        self._write_queue.put((current_offset, chunk, start, range_end_marker))
+                        current_offset += len(chunk)
+                        self._check_stall(stream_bytes)
+
+                return  # Success
+
+            except Exception as ex:
+                if self.stop_request and self.stop_request.is_set():
+                    return  # Cancelled, don't retry
+                if attempt < self.RETRY_ATTEMPTS - 1:
+                    wait = self.RETRY_DELAY * (attempt + 1)
+                    logger.warning(
+                        "GOG range %d-%d attempt %d/%d failed: %s, retrying in %ds...",
+                        start,
+                        end,
+                        attempt + 1,
+                        self.RETRY_ATTEMPTS,
+                        ex,
+                        wait,
+                    )
+                    time.sleep(wait)
+                else:
+                    raise
+
+    def _write_from_full_response(self, response: requests.Response, start: int, end: int) -> None:
+        """Handle the case where server returns 200 instead of 206.
+
+        Read the full response but only enqueue our byte range portion.
+        This is a fallback for non-compliant servers.
+        """
+        bytes_read = 0
+        current_offset = start
+        range_size = end - start + 1
+        enqueued_bytes = 0
+
+        for chunk in response.iter_content(chunk_size=self.chunk_size):
+            if self.stop_request and self.stop_request.is_set():
+                return
+            if self._writer_error_event.is_set():
+                return
+            if not chunk:
+                continue
+
+            # Only write the portion that falls within our range
+            chunk_start = bytes_read
+            chunk_end = bytes_read + len(chunk)
+
+            if chunk_end <= start:
+                # Before our range, skip
+                bytes_read += len(chunk)
+                continue
+            elif chunk_start >= end + 1:
+                # Past our range, done
+                break
+            else:
+                # Calculate the slice of this chunk we need
+                slice_start = max(0, start - chunk_start)
+                slice_end = min(len(chunk), end + 1 - chunk_start)
+                data = chunk[slice_start:slice_end]
+                enqueued_bytes += len(data)
+                is_last = enqueued_bytes >= range_size
+                self._write_queue.put((current_offset, data, start, end if is_last else None))
+                current_offset += len(data)
+
+            bytes_read += len(chunk)
+            if bytes_read >= end + 1:
+                break
+
+    def _single_stream_download(self, url: str, headers: dict) -> None:
+        """Fallback single-stream download when Range requests aren't supported.
+
+        Uses the parallel session for connection pooling benefits.
+        """
+        response = self._parallel_session.get(url, headers=headers, stream=True, timeout=30, cookies=self.cookies)
+        response.raise_for_status()
+        self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
+        self.progress_event.set()
+
+        with open(self.dest, "wb") as f:
+            for chunk in response.iter_content(chunk_size=self.chunk_size):
+                if self.stop_request and self.stop_request.is_set():
+                    break
+                if chunk:
+                    self.downloaded_size += len(chunk)
+                    f.write(chunk)
+                self.progress_event.set()
+
+        self.on_download_completed()

--- a/tests/util/test_collection_progress.py
+++ b/tests/util/test_collection_progress.py
@@ -1,0 +1,718 @@
+"""Tests for DownloadCollectionProgressBox multi-file parallel downloads.
+
+These tests verify the prefetch-one concurrent download model, aggregate
+progress, per-file error handling, cancel-all, and edge cases — all
+without a running GTK display (GTK widgets are mocked).
+
+The module is loaded via importlib to avoid the normal lutris.gui package
+chain that requires a real GTK installation / display.
+"""
+
+import importlib
+import importlib.util
+import os
+import sys
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Load the target module in isolation ──────────────────────────────
+#
+# We can't ``import lutris.gui.widgets.download_collection_progress_box``
+# normally because the package __init__.py files pull in real GTK /
+# GObject, which requires a display.  Instead we:
+#
+#  1. Temporarily inject ``gi`` / ``gi.repository`` stubs into
+#     sys.modules (only if they are NOT already loaded — if real gi is
+#     present we leave it).
+#  2. Load the single .py file via importlib.util.spec_from_file_location
+#     under its fully qualified name so that ``patch()`` calls work.
+#  3. After loading, remove temporary stubs (but keep the target module
+#     and its own ``gi.repository`` references alive — they are already
+#     bound in the module's global namespace).
+
+_SRC_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
+_MOD_NAME = "lutris.gui.widgets.download_collection_progress_box"
+_MOD_PATH = os.path.join(_SRC_ROOT, "lutris", "gui", "widgets", "download_collection_progress_box.py")
+
+
+def _load_module():
+    """Load the target module, stubbing GTK if necessary."""
+    # If the module was already loaded (e.g. in a previous test-collection
+    # pass), just reuse it.
+    if _MOD_NAME in sys.modules:
+        return sys.modules[_MOD_NAME]
+
+    # Track what we add so we can clean up only our additions.
+    # We use setdefault so we NEVER overwrite a real module — this avoids
+    # poisoning sys.modules["gi"] when real GTK is installed.
+    added: list[str] = []
+
+    def _ensure(name, mod):
+        if name not in sys.modules:
+            sys.modules[name] = mod
+            added.append(name)
+
+    # gi / gi.repository stubs — only if not already present
+    _gi = types.ModuleType("gi")
+    _gi.require_version = lambda *a, **kw: None  # type: ignore[attr-defined]
+    _ensure("gi", _gi)
+
+    _mock_gtk = MagicMock()
+    _mock_gtk.Box = type("Box", (), {"__init__": lambda self, **kw: None})
+    _mock_gtk.Orientation.VERTICAL = 0
+
+    _mock_gobject = MagicMock()
+    _mock_gobject.SignalFlags.RUN_LAST = 1
+    _mock_gobject.TYPE_PYOBJECT = object
+
+    _gi_repo = types.ModuleType("gi.repository")
+    _gi_repo.Gtk = _mock_gtk  # type: ignore[attr-defined]
+    _gi_repo.GLib = MagicMock()  # type: ignore[attr-defined]
+    _gi_repo.GObject = _mock_gobject  # type: ignore[attr-defined]
+    _gi_repo.Pango = MagicMock()  # type: ignore[attr-defined]
+    _ensure("gi.repository", _gi_repo)
+
+    # Ensure parent package stubs so importlib can place our module
+    for pkg in ("lutris.gui", "lutris.gui.widgets", "lutris.gui.dialogs"):
+        stub = types.ModuleType(pkg)
+        stub.__path__ = []  # type: ignore[attr-defined]
+        _ensure(pkg, stub)
+
+    # The module imports display_error from lutris.gui.dialogs
+    sys.modules["lutris.gui.dialogs"].display_error = MagicMock()  # type: ignore[attr-defined]
+
+    # Load the module
+    spec = importlib.util.spec_from_file_location(_MOD_NAME, _MOD_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[_MOD_NAME] = mod
+    spec.loader.exec_module(mod)
+
+    # Clean up ALL stubs we added — the loaded module's globals already
+    # captured their references to Gtk, GObject, etc., so removing the
+    # sys.modules entries doesn't break the module.
+    for key in added:
+        sys.modules.pop(key, None)
+
+    return mod
+
+
+_mod = _load_module()
+
+MAX_CONCURRENT_FILES = _mod.MAX_CONCURRENT_FILES
+DownloadCollectionProgressBox = _mod.DownloadCollectionProgressBox
+_ActiveDownload = _mod._ActiveDownload
+
+
+# ── Helpers ──────────────────────────────────────────────────────────
+
+
+def _make_file(
+    filename="game.bin",
+    url="https://cdn.example.com/game.bin",
+    dest="/tmp/downloads/game.bin",
+    size=1000,
+    downloader_class=None,
+    referer=None,
+):
+    """Create a mock InstallerFile."""
+    f = MagicMock()
+    f.filename = filename
+    f.url = url
+    f.dest_file = dest
+    f.tmp_file = None
+    f.referer = referer
+    if downloader_class:
+        f.downloader_class = downloader_class
+    else:
+        # Simulate no downloader_class attribute: getattr returns None
+        del f.downloader_class
+    return f
+
+
+def _make_collection(files, human_url="Test Collection"):
+    """Create a mock InstallerFileCollection."""
+    coll = MagicMock()
+    coll.files_list = files
+    coll.human_url = human_url
+    coll.num_files = len(files)
+    coll.full_size = sum(getattr(f, "_size", 1000) for f in files)
+    return coll
+
+
+def _make_downloader(state="DOWNLOADING", downloaded_size=0):
+    """Create a mock Downloader with state constants."""
+    dl = MagicMock()
+    dl.DOWNLOADING = "DOWNLOADING"
+    dl.COMPLETED = "COMPLETED"
+    dl.CANCELLED = "CANCELLED"
+    dl.ERROR = "ERROR"
+    dl.state = state
+    dl.downloaded_size = downloaded_size
+    dl.error = None
+    dl.dest = "/tmp/test.tmp"
+    return dl
+
+
+# ── Fixture ──────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def two_files():
+    """Two files for typical multi-file test."""
+    return [
+        _make_file("part1.bin", dest="/tmp/dl/part1.bin"),
+        _make_file("part2.bin", dest="/tmp/dl/part2.bin"),
+    ]
+
+
+@pytest.fixture
+def three_files():
+    """Three files for prefetch boundary test."""
+    return [
+        _make_file("a.bin", dest="/tmp/dl/a.bin"),
+        _make_file("b.bin", dest="/tmp/dl/b.bin"),
+        _make_file("c.bin", dest="/tmp/dl/c.bin"),
+    ]
+
+
+# ── Tests: _ActiveDownload ───────────────────────────────────────────
+
+
+class TestActiveDownload:
+    def test_init_sets_fields(self):
+        f = _make_file()
+        dl = _make_downloader()
+        ad = _ActiveDownload(f, dl)
+        assert ad.file is f
+        assert ad.downloader is dl
+        assert ad.num_retries == 0
+
+    def test_retry_count_increments(self):
+        ad = _ActiveDownload(_make_file(), _make_downloader())
+        ad.num_retries += 1
+        assert ad.num_retries == 1
+
+
+# ── Tests: Initialisation ───────────────────────────────────────────
+
+
+class TestInit:
+    def test_active_downloads_initially_empty(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._active_downloads = []
+        assert box._active_downloads == []
+
+    def test_completed_sizes_initially_empty(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._completed_sizes = {}
+        assert box._completed_sizes == {}
+
+    def test_max_concurrent_files_is_two(self):
+        assert MAX_CONCURRENT_FILES == 2
+
+
+# ── Tests: _create_downloader ───────────────────────────────────────
+
+
+class TestCreateDownloader:
+    @patch("lutris.gui.widgets.download_collection_progress_box.create_cache_lock")
+    @patch("lutris.gui.widgets.download_collection_progress_box.Downloader")
+    @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=False)
+    def test_creates_downloader_with_correct_args(self, mock_exists, MockDL, mock_lock):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        f = _make_file(url="https://cdn.example.com/f.bin", dest="/tmp/dl/f.bin")
+
+        box._create_downloader(f)
+
+        MockDL.assert_called_once_with(
+            "https://cdn.example.com/f.bin",
+            "/tmp/dl/f.bin.tmp",
+            referer=None,
+            overwrite=True,
+        )
+        assert f.tmp_file == "/tmp/dl/f.bin.tmp"
+
+    @patch("lutris.gui.widgets.download_collection_progress_box.create_cache_lock")
+    @patch("lutris.gui.widgets.download_collection_progress_box.Downloader")
+    @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=True)
+    @patch("lutris.gui.widgets.download_collection_progress_box.os.remove")
+    def test_removes_existing_tmp_file(self, mock_remove, mock_exists, MockDL, mock_lock):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        f = _make_file(dest="/tmp/dl/f.bin")
+
+        box._create_downloader(f)
+        mock_remove.assert_called_once_with("/tmp/dl/f.bin.tmp")
+
+    @patch("lutris.gui.widgets.download_collection_progress_box.create_cache_lock")
+    @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=False)
+    def test_uses_custom_downloader_class(self, mock_exists, mock_lock):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        custom_dl_cls = MagicMock()
+        f = _make_file(dest="/tmp/dl/f.bin")
+        f.downloader_class = custom_dl_cls
+
+        box._create_downloader(f)
+        custom_dl_cls.assert_called_once()
+
+    @patch("lutris.gui.widgets.download_collection_progress_box.display_error")
+    @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=False)
+    def test_returns_none_on_runtime_error(self, mock_exists, mock_display):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box.get_toplevel = MagicMock(return_value=None)
+        f = _make_file(dest="/tmp/dl/f.bin")
+        # Simulate no downloader_class → use default Downloader which will fail
+        with patch(
+            "lutris.gui.widgets.download_collection_progress_box.Downloader",
+            side_effect=RuntimeError("oops"),
+        ):
+            result = box._create_downloader(f)
+        assert result is None
+        mock_display.assert_called_once()
+
+
+# ── Tests: _pop_next_downloadable_file ───────────────────────────────
+
+
+class TestPopNextDownloadableFile:
+    def test_returns_file_when_not_cached(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        f = _make_file(dest="/tmp/dl/notexist.bin")
+        box._file_queue = [f]
+        box.num_files_downloaded = 0
+        box._completed_sizes = {}
+
+        with patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=False):
+            result = box._pop_next_downloadable_file()
+        assert result is f
+
+    def test_skips_cached_file(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        cached = _make_file("cached.bin", dest="/tmp/dl/cached.bin")
+        fresh = _make_file("fresh.bin", dest="/tmp/dl/fresh.bin")
+        box._file_queue = [fresh, cached]  # pop() takes from end
+        box.num_files_downloaded = 0
+        box._completed_sizes = {}
+
+        def exists_side(path):
+            return path == "/tmp/dl/cached.bin"
+
+        with patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", side_effect=exists_side):
+            with patch("lutris.gui.widgets.download_collection_progress_box.os.path.getsize", return_value=500):
+                result = box._pop_next_downloadable_file()
+
+        assert result is fresh
+        assert box.num_files_downloaded == 1
+        assert box._completed_sizes["/tmp/dl/cached.bin"] == 500
+
+    def test_returns_none_when_empty(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._file_queue = []
+        box.num_files_downloaded = 0
+        box._completed_sizes = {}
+        assert box._pop_next_downloadable_file() is None
+
+
+# ── Tests: Aggregate progress ────────────────────────────────────────
+
+
+class TestAggregateDownloadedSize:
+    def test_sums_completed_and_active(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._completed_sizes = {"/a": 100, "/b": 200}
+
+        dl1 = _make_downloader(downloaded_size=50)
+        dl2 = _make_downloader(downloaded_size=75)
+        ad1 = _ActiveDownload(_make_file(), dl1)
+        ad2 = _ActiveDownload(_make_file(), dl2)
+        box._active_downloads = [ad1, ad2]
+
+        assert box._aggregate_downloaded_size() == 100 + 200 + 50 + 75
+
+    def test_empty_state(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._completed_sizes = {}
+        box._active_downloads = []
+        assert box._aggregate_downloaded_size() == 0
+
+
+# ── Tests: File labels ───────────────────────────────────────────────
+
+
+class TestUpdateActiveFileLabels:
+    def test_comma_separated_names(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box.file_name_label = MagicMock()
+
+        f1 = _make_file("part1.bin")
+        f2 = _make_file("part2.bin")
+        box._active_downloads = [
+            _ActiveDownload(f1, _make_downloader()),
+            _ActiveDownload(f2, _make_downloader()),
+        ]
+
+        box._update_active_file_labels()
+        box.file_name_label.set_text.assert_called_once_with("part1.bin, part2.bin")
+
+    def test_single_name(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box.file_name_label = MagicMock()
+
+        f = _make_file("only.bin")
+        box._active_downloads = [_ActiveDownload(f, _make_downloader())]
+
+        box._update_active_file_labels()
+        box.file_name_label.set_text.assert_called_once_with("only.bin")
+
+    def test_empty_when_no_active(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box.file_name_label = MagicMock()
+        box._active_downloads = []
+
+        box._update_active_file_labels()
+        box.file_name_label.set_text.assert_called_once_with("")
+
+
+# ── Tests: Start / prefetch ──────────────────────────────────────────
+
+
+class TestStartPrefetch:
+    def test_start_launches_two_downloads(self, three_files):
+        """start() should launch primary + prefetch = 2 concurrent downloads."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._file_queue = three_files.copy()
+        box.downloader = None
+        box.is_complete = False
+        box.num_files_downloaded = 0
+        box._active_downloads = []
+        box._completed_sizes = {}
+        box.cancel_button = MagicMock()
+        box.file_name_label = MagicMock()
+        box.emit = MagicMock()
+
+        mock_dl = _make_downloader()
+        with patch.object(box, "_create_downloader", return_value=mock_dl):
+            with patch("lutris.gui.widgets.download_collection_progress_box.schedule_repeating_at_idle"):
+                box.start()
+
+        assert len(box._active_downloads) == 2
+        # One file left in queue
+        assert len(box._file_queue) == 1
+
+    def test_start_emits_complete_when_no_files(self):
+        """start() with empty queue should emit complete."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._file_queue = []
+        box.downloader = None
+        box.is_complete = False
+        box._active_downloads = []
+        box._completed_sizes = {}
+        box.cancel_button = MagicMock()
+        box.emit = MagicMock()
+
+        with patch.object(box, "_pop_next_downloadable_file", return_value=None):
+            box.start()
+
+        box.emit.assert_called_once_with("complete", {})
+        assert box.is_complete is True
+
+    def test_prefetch_respects_max_concurrent(self):
+        """_start_prefetch() should not exceed MAX_CONCURRENT_FILES."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._file_queue = [_make_file(), _make_file()]
+        box._active_downloads = [
+            _ActiveDownload(_make_file(), _make_downloader()),
+            _ActiveDownload(_make_file(), _make_downloader()),
+        ]
+        box.file_name_label = MagicMock()
+
+        box._start_prefetch()
+        # Should NOT have added more
+        assert len(box._active_downloads) == 2
+
+    def test_prefetch_starts_when_room(self):
+        """_start_prefetch() launches download when under limit."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        f = _make_file(dest="/tmp/dl/next.bin")
+        box._file_queue = [f]
+        box._active_downloads = [_ActiveDownload(_make_file(), _make_downloader())]
+        box.file_name_label = MagicMock()
+        box.num_files_downloaded = 0
+        box._completed_sizes = {}
+
+        mock_dl = _make_downloader()
+        with patch.object(box, "_create_downloader", return_value=mock_dl):
+            with patch(
+                "lutris.gui.widgets.download_collection_progress_box.os.path.exists",
+                return_value=False,
+            ):
+                box._start_prefetch()
+
+        assert len(box._active_downloads) == 2
+
+
+# ── Tests: Progress callback ─────────────────────────────────────────
+
+
+class TestProgress:
+    def _setup_box(self):
+        """Create a box ready for _progress() calls."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._active_downloads = []
+        box._completed_sizes = {}
+        box._file_queue = []
+        box.full_size = 2000
+        box.num_files_downloaded = 0
+        box.is_complete = False
+        box.downloader = None
+        box.progressbar = MagicMock()
+        box.progress_label = MagicMock()
+        box.cancel_button = MagicMock()
+        box.file_name_label = MagicMock()
+        box.emit = MagicMock()
+        box.time_left = "00:00:00"
+        box.time_left_check_time = 0
+        box.last_size = 0
+        box.avg_speed = 0
+        box.speed_list = []
+        return box
+
+    def test_returns_false_when_no_active(self):
+        box = self._setup_box()
+        assert box._progress() is False
+
+    def test_returns_true_when_downloading(self):
+        box = self._setup_box()
+        dl = _make_downloader(state="DOWNLOADING", downloaded_size=500)
+        ad = _ActiveDownload(_make_file(), dl)
+        box._active_downloads = [ad]
+        box._file_queue = [_make_file()]  # still more to do
+
+        result = box._progress()
+        assert result is True
+
+    def test_completed_file_moves_to_completed_sizes(self):
+        box = self._setup_box()
+        dl = _make_downloader(state="COMPLETED", downloaded_size=1000)
+        f = _make_file(dest="/tmp/dl/done.bin")
+        f.tmp_file = "/tmp/dl/done.bin.tmp"
+        ad = _ActiveDownload(f, dl)
+        box._active_downloads = [ad]
+
+        with patch("lutris.gui.widgets.download_collection_progress_box.os.rename") as mock_rename:
+            with patch("lutris.gui.widgets.download_collection_progress_box.update_cache_lock"):
+                box._progress()
+
+        assert box._completed_sizes["/tmp/dl/done.bin"] == 1000
+        assert box.num_files_downloaded == 1
+        mock_rename.assert_called_once_with("/tmp/dl/done.bin.tmp", "/tmp/dl/done.bin")
+
+    def test_completion_triggers_prefetch(self):
+        box = self._setup_box()
+        dl = _make_downloader(state="COMPLETED", downloaded_size=500)
+        f = _make_file(dest="/tmp/dl/done.bin")
+        f.tmp_file = "/tmp/dl/done.bin.tmp"
+        ad = _ActiveDownload(f, dl)
+        box._active_downloads = [ad]
+        box._file_queue = [_make_file()]  # one more in queue
+
+        with patch("lutris.gui.widgets.download_collection_progress_box.os.rename"):
+            with patch("lutris.gui.widgets.download_collection_progress_box.update_cache_lock"):
+                with patch.object(box, "_start_prefetch") as mock_prefetch:
+                    box._progress()
+
+        mock_prefetch.assert_called_once()
+
+    def test_all_done_emits_complete(self):
+        box = self._setup_box()
+        dl = _make_downloader(state="COMPLETED", downloaded_size=1000)
+        f = _make_file(dest="/tmp/dl/last.bin")
+        f.tmp_file = "/tmp/dl/last.bin.tmp"
+        ad = _ActiveDownload(f, dl)
+        box._active_downloads = [ad]
+        box._file_queue = []  # nothing left
+
+        with patch("lutris.gui.widgets.download_collection_progress_box.os.rename"):
+            with patch("lutris.gui.widgets.download_collection_progress_box.update_cache_lock"):
+                result = box._progress()
+
+        assert result is False
+        box.emit.assert_called_with("complete", {})
+        assert box.is_complete is True
+
+    def test_cancelled_state_cancels_all(self):
+        box = self._setup_box()
+        dl1 = _make_downloader(state="CANCELLED")
+        dl2 = _make_downloader(state="DOWNLOADING")
+        box._active_downloads = [
+            _ActiveDownload(_make_file(), dl1),
+            _ActiveDownload(_make_file(), dl2),
+        ]
+
+        result = box._progress()
+        assert result is False
+        # Should cancel remaining downloads
+        dl2.cancel.assert_called()
+
+    def test_error_retries_independently(self):
+        box = self._setup_box()
+        dl = _make_downloader(state="ERROR")
+        dl.error = RuntimeError("network failure")
+        f = _make_file(dest="/tmp/dl/fail.bin")
+        ad = _ActiveDownload(f, dl)
+        ad.num_retries = 0
+        box._active_downloads = [ad]
+        box._file_queue = [_make_file()]  # keep loop going
+
+        new_dl = _make_downloader(state="DOWNLOADING")
+        with patch.object(box, "_create_downloader", return_value=new_dl):
+            box._progress()
+
+        assert ad.num_retries == 1
+        assert ad.downloader is new_dl
+        new_dl.start.assert_called_once()
+
+    def test_error_exhausts_retries_emits_error(self):
+        box = self._setup_box()
+        dl = _make_downloader(state="ERROR")
+        dl.error = RuntimeError("permanent failure")
+        f = _make_file(dest="/tmp/dl/fail.bin")
+        ad = _ActiveDownload(f, dl)
+        ad.num_retries = 3  # equals max_retries
+        box._active_downloads = [ad]
+
+        result = box._progress()
+        assert result is False
+        box.emit.assert_called_with("error", dl.error)
+
+
+# ── Tests: Cancel ────────────────────────────────────────────────────
+
+
+class TestCancel:
+    def test_cancel_stops_all_active(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        dl1 = _make_downloader()
+        dl2 = _make_downloader()
+        box._active_downloads = [
+            _ActiveDownload(_make_file(), dl1),
+            _ActiveDownload(_make_file(), dl2),
+        ]
+        box.downloader = MagicMock()
+        box.cancel_button = MagicMock()
+        box.emit = MagicMock()
+
+        box.on_cancel_clicked()
+
+        dl1.cancel.assert_called_once()
+        dl2.cancel.assert_called_once()
+        assert box._active_downloads == []
+        assert box.downloader is None
+        box.emit.assert_called_once_with("cancel")
+
+    def test_cancel_all_internal(self):
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        dl = _make_downloader()
+        box._active_downloads = [_ActiveDownload(_make_file(), dl)]
+        box.cancel_button = MagicMock()
+        box.downloader = MagicMock()
+
+        box._cancel_all()
+
+        dl.cancel.assert_called_once()
+        assert box._active_downloads == []
+        assert box.downloader is None
+
+
+# ── Tests: Edge cases ────────────────────────────────────────────────
+
+
+class TestEdgeCases:
+    def test_single_file_collection(self):
+        """A single-file collection should work normally without prefetch."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        f = _make_file(dest="/tmp/dl/only.bin")
+        box._file_queue = [f]
+        box.downloader = None
+        box.is_complete = False
+        box.num_files_downloaded = 0
+        box._active_downloads = []
+        box._completed_sizes = {}
+        box.cancel_button = MagicMock()
+        box.file_name_label = MagicMock()
+        box.emit = MagicMock()
+
+        mock_dl = _make_downloader()
+        with patch.object(box, "_create_downloader", return_value=mock_dl):
+            with patch(
+                "lutris.gui.widgets.download_collection_progress_box.os.path.exists",
+                return_value=False,
+            ):
+                with patch("lutris.gui.widgets.download_collection_progress_box.schedule_repeating_at_idle"):
+                    box.start()
+
+        # Only 1 active (no prefetch since queue is empty)
+        assert len(box._active_downloads) == 1
+
+    def test_all_cached_emits_complete(self):
+        """When all files exist in cache, should immediately complete."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box.downloader = None
+        box.is_complete = False
+        box.num_files_downloaded = 0
+        box._active_downloads = []
+        box._completed_sizes = {}
+        box.cancel_button = MagicMock()
+        box.file_name_label = MagicMock()
+        box.emit = MagicMock()
+
+        f1 = _make_file(dest="/tmp/dl/cached1.bin")
+        f2 = _make_file(dest="/tmp/dl/cached2.bin")
+        box._file_queue = [f1, f2]
+
+        with patch(
+            "lutris.gui.widgets.download_collection_progress_box.os.path.exists",
+            return_value=True,
+        ):
+            with patch(
+                "lutris.gui.widgets.download_collection_progress_box.os.path.getsize",
+                return_value=500,
+            ):
+                box.start()
+
+        box.emit.assert_called_with("complete", {})
+        assert box.is_complete is True
+        assert box.num_files_downloaded == 2
+
+    def test_retry_button_clears_active_downloads(self):
+        """on_retry_clicked should clear active downloads and restart."""
+        box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
+        box._active_downloads = [
+            _ActiveDownload(_make_file(), _make_downloader()),
+        ]
+        box.downloader = _make_downloader()
+        box.cancel_cb_id = 123
+        box.cancel_button = MagicMock()
+        box._file_queue = [_make_file()]
+        box.is_complete = False
+        box.num_files_downloaded = 0
+        box._completed_sizes = {}
+        box.file_name_label = MagicMock()
+        box.emit = MagicMock()
+
+        mock_dl = _make_downloader()
+        button = MagicMock()
+        button.connect = MagicMock(return_value=456)
+
+        with patch.object(box, "_create_downloader", return_value=mock_dl):
+            with patch(
+                "lutris.gui.widgets.download_collection_progress_box.os.path.exists",
+                return_value=False,
+            ):
+                with patch("lutris.gui.widgets.download_collection_progress_box.schedule_repeating_at_idle"):
+                    box.on_retry_clicked(button)
+
+        # Active downloads should have been cleared before restart
+        assert len(box._active_downloads) >= 1  # re-populated by start()

--- a/tests/util/test_download_cache.py
+++ b/tests/util/test_download_cache.py
@@ -1,0 +1,288 @@
+"""Tests for the download cache protection module."""
+
+import json
+import os
+import tempfile
+import time
+
+import pytest
+
+from lutris.util.download_cache import (
+    CacheState,
+    create_cache_lock,
+    get_cache_state,
+    is_safe_to_delete,
+    remove_cache_lock,
+    safe_delete_folder,
+    update_cache_lock,
+)
+
+
+@pytest.fixture
+def temp_dir():
+    """Create a temporary directory for test files."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        yield tmpdir
+
+
+@pytest.fixture
+def temp_file(temp_dir):
+    """Create a temporary file for testing."""
+    path = os.path.join(temp_dir, "test_game_installer.bin")
+    with open(path, "w") as f:
+        f.write("test data")
+    return path
+
+
+class TestCacheState:
+    """Test CacheState enum values."""
+
+    def test_state_values(self):
+        assert CacheState.DOWNLOADING.value == "downloading"
+        assert CacheState.DOWNLOADED.value == "downloaded"
+        assert CacheState.INSTALLING.value == "installing"
+        assert CacheState.INSTALLED.value == "installed"
+        assert CacheState.FAILED.value == "failed"
+
+    def test_state_from_string(self):
+        assert CacheState("downloading") == CacheState.DOWNLOADING
+        assert CacheState("installed") == CacheState.INSTALLED
+
+
+class TestCreateCacheLock:
+    """Test cache lock file creation."""
+
+    def test_creates_lock_file(self, temp_file):
+        create_cache_lock(temp_file)
+        lock_path = temp_file + ".cache_lock"
+        assert os.path.exists(lock_path)
+
+    def test_lock_contains_correct_state(self, temp_file):
+        create_cache_lock(temp_file, CacheState.DOWNLOADING)
+        lock_path = temp_file + ".cache_lock"
+        with open(lock_path) as f:
+            data = json.load(f)
+        assert data["state"] == "downloading"
+        assert data["file_path"] == temp_file
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    def test_lock_with_custom_state(self, temp_file):
+        create_cache_lock(temp_file, CacheState.DOWNLOADED)
+        assert get_cache_state(temp_file) == CacheState.DOWNLOADED
+
+    def test_creates_directory_if_needed(self, temp_dir):
+        nested_path = os.path.join(temp_dir, "subdir", "file.bin")
+        create_cache_lock(nested_path)
+        assert os.path.exists(nested_path + ".cache_lock")
+
+
+class TestUpdateCacheLock:
+    """Test cache lock state updates."""
+
+    def test_updates_state(self, temp_file):
+        create_cache_lock(temp_file, CacheState.DOWNLOADING)
+        update_cache_lock(temp_file, CacheState.DOWNLOADED)
+        assert get_cache_state(temp_file) == CacheState.DOWNLOADED
+
+    def test_updates_timestamp(self, temp_file):
+        create_cache_lock(temp_file, CacheState.DOWNLOADING)
+        lock_path = temp_file + ".cache_lock"
+        with open(lock_path) as f:
+            data1 = json.load(f)
+
+        time.sleep(0.1)
+        update_cache_lock(temp_file, CacheState.INSTALLED)
+        with open(lock_path) as f:
+            data2 = json.load(f)
+
+        assert data2["updated_at"] >= data1["updated_at"]
+
+    def test_update_nonexistent_lock(self, temp_file):
+        """Update should create the lock if it doesn't exist."""
+        update_cache_lock(temp_file, CacheState.INSTALLED)
+        assert get_cache_state(temp_file) == CacheState.INSTALLED
+
+    def test_full_lifecycle(self, temp_file):
+        """Test transition through all states."""
+        create_cache_lock(temp_file, CacheState.DOWNLOADING)
+        assert get_cache_state(temp_file) == CacheState.DOWNLOADING
+
+        update_cache_lock(temp_file, CacheState.DOWNLOADED)
+        assert get_cache_state(temp_file) == CacheState.DOWNLOADED
+
+        update_cache_lock(temp_file, CacheState.INSTALLING)
+        assert get_cache_state(temp_file) == CacheState.INSTALLING
+
+        update_cache_lock(temp_file, CacheState.INSTALLED)
+        assert get_cache_state(temp_file) == CacheState.INSTALLED
+
+
+class TestGetCacheState:
+    """Test reading cache state."""
+
+    def test_returns_none_for_no_lock(self, temp_file):
+        assert get_cache_state(temp_file) is None
+
+    def test_returns_correct_state(self, temp_file):
+        create_cache_lock(temp_file, CacheState.INSTALLING)
+        assert get_cache_state(temp_file) == CacheState.INSTALLING
+
+    def test_handles_corrupted_lock(self, temp_file):
+        lock_path = temp_file + ".cache_lock"
+        with open(lock_path, "w") as f:
+            f.write("not valid json{{{")
+        assert get_cache_state(temp_file) is None
+
+
+class TestRemoveCacheLock:
+    """Test cache lock removal."""
+
+    def test_removes_lock(self, temp_file):
+        create_cache_lock(temp_file)
+        remove_cache_lock(temp_file)
+        assert not os.path.exists(temp_file + ".cache_lock")
+
+    def test_no_error_for_nonexistent_lock(self, temp_file):
+        remove_cache_lock(temp_file)  # Should not raise
+
+
+class TestIsSafeToDelete:
+    """Test deletion safety checks."""
+
+    def test_no_lock_is_safe(self, temp_file):
+        """Legacy files without locks can be deleted."""
+        assert is_safe_to_delete(temp_file) is True
+
+    def test_installed_is_safe(self, temp_file):
+        create_cache_lock(temp_file, CacheState.INSTALLED)
+        assert is_safe_to_delete(temp_file) is True
+
+    def test_downloading_is_not_safe(self, temp_file):
+        create_cache_lock(temp_file, CacheState.DOWNLOADING)
+        assert is_safe_to_delete(temp_file) is False
+
+    def test_downloaded_is_not_safe(self, temp_file):
+        create_cache_lock(temp_file, CacheState.DOWNLOADED)
+        assert is_safe_to_delete(temp_file) is False
+
+    def test_installing_is_not_safe(self, temp_file):
+        create_cache_lock(temp_file, CacheState.INSTALLING)
+        assert is_safe_to_delete(temp_file) is False
+
+    def test_failed_recent_is_not_safe(self, temp_file):
+        """Failed installations less than 7 days old should be preserved."""
+        create_cache_lock(temp_file, CacheState.FAILED)
+        assert is_safe_to_delete(temp_file) is False
+
+    def test_failed_old_is_safe(self, temp_file):
+        """Failed installations older than 7 days can be cleaned."""
+        create_cache_lock(temp_file, CacheState.FAILED)
+        lock_path = temp_file + ".cache_lock"
+        with open(lock_path) as f:
+            data = json.load(f)
+        # Set updated_at to 8 days ago
+        data["updated_at"] = time.time() - (8 * 86400)
+        with open(lock_path, "w") as f:
+            json.dump(data, f)
+        assert is_safe_to_delete(temp_file) is True
+
+
+class TestSafeDeleteFolder:
+    """Test cache-aware folder deletion."""
+
+    def test_deletes_unlocked_files(self, temp_dir):
+        """Files without locks should be deleted."""
+        file1 = os.path.join(temp_dir, "file1.bin")
+        file2 = os.path.join(temp_dir, "file2.bin")
+        with open(file1, "w") as f:
+            f.write("data1")
+        with open(file2, "w") as f:
+            f.write("data2")
+
+        result = safe_delete_folder(temp_dir)
+        assert result is True
+        assert not os.path.exists(temp_dir)
+
+    def test_preserves_locked_files(self, temp_dir):
+        """Files with active cache locks should be preserved."""
+        safe_file = os.path.join(temp_dir, "safe.bin")
+        locked_file = os.path.join(temp_dir, "locked.bin")
+        with open(safe_file, "w") as f:
+            f.write("safe")
+        with open(locked_file, "w") as f:
+            f.write("locked")
+
+        create_cache_lock(locked_file, CacheState.DOWNLOADED)
+
+        result = safe_delete_folder(temp_dir)
+        assert result is False  # Not fully cleaned
+        assert not os.path.exists(safe_file)
+        assert os.path.exists(locked_file)
+
+    def test_deletes_installed_files(self, temp_dir):
+        """Files marked as installed can be deleted."""
+        file1 = os.path.join(temp_dir, "game.bin")
+        with open(file1, "w") as f:
+            f.write("data")
+
+        create_cache_lock(file1, CacheState.INSTALLED)
+
+        result = safe_delete_folder(temp_dir)
+        assert result is True
+
+    def test_nonexistent_folder(self, temp_dir):
+        """Non-existent folder should return True."""
+        result = safe_delete_folder(os.path.join(temp_dir, "nonexistent"))
+        assert result is True
+
+    def test_mixed_states(self, temp_dir):
+        """Mix of safe and unsafe files."""
+        installed = os.path.join(temp_dir, "installed.bin")
+        downloading = os.path.join(temp_dir, "downloading.bin")
+        no_lock = os.path.join(temp_dir, "no_lock.bin")
+
+        for f in [installed, downloading, no_lock]:
+            with open(f, "w") as fp:
+                fp.write("data")
+
+        create_cache_lock(installed, CacheState.INSTALLED)
+        create_cache_lock(downloading, CacheState.DOWNLOADING)
+
+        result = safe_delete_folder(temp_dir)
+        assert result is False
+        assert not os.path.exists(installed)
+        assert os.path.exists(downloading)
+        assert not os.path.exists(no_lock)
+
+
+class TestDownloaderChunkSize:
+    """Test that the Downloader uses the new chunk size."""
+
+    def test_default_chunk_size(self):
+        from lutris.util.downloader import DEFAULT_CHUNK_SIZE, Downloader
+
+        d = Downloader("http://example.com/test", "/tmp/test")
+        assert d.chunk_size == DEFAULT_CHUNK_SIZE
+        assert d.chunk_size == 524288  # 512KB
+
+    def test_custom_chunk_size(self):
+        from lutris.util.downloader import Downloader
+
+        d = Downloader("http://example.com/test", "/tmp/test", chunk_size=1024)
+        assert d.chunk_size == 1024
+
+    def test_session_parameter(self):
+        import requests
+
+        from lutris.util.downloader import Downloader
+
+        session = requests.Session()
+        d = Downloader("http://example.com/test", "/tmp/test", session=session)
+        assert d.session is session
+
+    def test_no_session_by_default(self):
+        from lutris.util.downloader import Downloader
+
+        d = Downloader("http://example.com/test", "/tmp/test")
+        assert d.session is None

--- a/tests/util/test_download_progress.py
+++ b/tests/util/test_download_progress.py
@@ -1,0 +1,318 @@
+"""Tests for persistent download progress tracking (download_progress.py)."""
+
+import json
+import os
+import threading
+
+import pytest
+
+from lutris.util.download_progress import DownloadProgress
+
+
+@pytest.fixture
+def tmp_dest(tmp_path):
+    """Return a temporary download destination path."""
+    return str(tmp_path / "installer.exe")
+
+
+@pytest.fixture
+def progress(tmp_dest):
+    """Return a fresh DownloadProgress instance."""
+    return DownloadProgress(tmp_dest)
+
+
+# ------------------------------------------------------------------
+# Initialisation
+# ------------------------------------------------------------------
+
+
+class TestInit:
+    def test_progress_path_derived_from_dest(self, tmp_dest):
+        dp = DownloadProgress(tmp_dest)
+        assert dp.progress_path == tmp_dest + ".progress"
+
+    def test_progress_path_for_static_helper(self, tmp_dest):
+        assert DownloadProgress.progress_path_for(tmp_dest) == tmp_dest + ".progress"
+
+    def test_initial_data_is_empty(self, progress):
+        assert progress.file_size == 0
+        assert progress.url == ""
+        assert progress.completed_ranges == []
+        assert progress.total_ranges == []
+
+
+# ------------------------------------------------------------------
+# Create
+# ------------------------------------------------------------------
+
+
+class TestCreate:
+    def test_create_writes_progress_file(self, progress, tmp_dest):
+        ranges = [(0, 99), (100, 199)]
+        progress.create("https://example.com/file", 200, ranges)
+        assert os.path.exists(tmp_dest + ".progress")
+
+    def test_create_stores_expected_fields(self, progress):
+        ranges = [(0, 49), (50, 99)]
+        progress.create("https://cdn.gog.com/game.bin", 100, ranges)
+
+        with open(progress.progress_path, "r") as f:
+            data = json.load(f)
+        assert data["url"] == "https://cdn.gog.com/game.bin"
+        assert data["file_size"] == 100
+        assert data["total_ranges"] == [[0, 49], [50, 99]]
+        assert data["completed_ranges"] == []
+        assert "created_at" in data
+        assert "updated_at" in data
+
+    def test_properties_after_create(self, progress):
+        ranges = [(0, 999), (1000, 1999)]
+        progress.create("https://example.com/f", 2000, ranges)
+        assert progress.url == "https://example.com/f"
+        assert progress.file_size == 2000
+        assert progress.total_ranges == [(0, 999), (1000, 1999)]
+        assert progress.completed_ranges == []
+
+
+# ------------------------------------------------------------------
+# Load
+# ------------------------------------------------------------------
+
+
+class TestLoad:
+    def test_load_returns_false_when_no_file(self, progress):
+        assert progress.load() is False
+
+    def test_load_returns_true_for_valid_progress(self, progress):
+        progress.create("https://example.com", 500, [(0, 499)])
+        fresh = DownloadProgress(progress.dest_path)
+        assert fresh.load() is True
+        assert fresh.file_size == 500
+
+    def test_load_returns_false_for_corrupt_json(self, progress, tmp_dest):
+        path = tmp_dest + ".progress"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write("{invalid json!!!")
+        assert progress.load() is False
+
+    def test_load_returns_false_for_missing_fields(self, progress, tmp_dest):
+        path = tmp_dest + ".progress"
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            json.dump({"url": "x"}, f)  # missing required fields
+        assert progress.load() is False
+
+    def test_load_restores_completed_ranges(self, progress):
+        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        progress.mark_range_complete(0, 99)
+        progress.mark_range_complete(200, 299)
+
+        fresh = DownloadProgress(progress.dest_path)
+        assert fresh.load() is True
+        assert (0, 99) in fresh.completed_ranges
+        assert (200, 299) in fresh.completed_ranges
+        assert (100, 199) not in fresh.completed_ranges
+
+
+# ------------------------------------------------------------------
+# mark_range_complete
+# ------------------------------------------------------------------
+
+
+class TestMarkRangeComplete:
+    def test_marks_single_range(self, progress):
+        progress.create("https://example.com", 200, [(0, 99), (100, 199)])
+        progress.mark_range_complete(0, 99)
+        assert progress.completed_ranges == [(0, 99)]
+
+    def test_marks_multiple_ranges(self, progress):
+        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        progress.mark_range_complete(100, 199)
+        progress.mark_range_complete(0, 99)
+        assert (0, 99) in progress.completed_ranges
+        assert (100, 199) in progress.completed_ranges
+
+    def test_duplicate_mark_is_idempotent(self, progress):
+        progress.create("https://example.com", 100, [(0, 99)])
+        progress.mark_range_complete(0, 99)
+        progress.mark_range_complete(0, 99)
+        assert progress.completed_ranges.count((0, 99)) == 1
+
+    def test_persists_to_disk_after_mark(self, progress):
+        progress.create("https://example.com", 100, [(0, 99)])
+        progress.mark_range_complete(0, 99)
+
+        fresh = DownloadProgress(progress.dest_path)
+        fresh.load()
+        assert (0, 99) in fresh.completed_ranges
+
+
+# ------------------------------------------------------------------
+# get_remaining_ranges
+# ------------------------------------------------------------------
+
+
+class TestGetRemainingRanges:
+    def test_all_remaining_when_none_completed(self, progress):
+        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        remaining = progress.get_remaining_ranges()
+        assert remaining == [(0, 99), (100, 199), (200, 299)]
+
+    def test_some_remaining(self, progress):
+        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        progress.mark_range_complete(0, 99)
+        progress.mark_range_complete(200, 299)
+        remaining = progress.get_remaining_ranges()
+        assert remaining == [(100, 199)]
+
+    def test_none_remaining_when_all_complete(self, progress):
+        progress.create("https://example.com", 200, [(0, 99), (100, 199)])
+        progress.mark_range_complete(0, 99)
+        progress.mark_range_complete(100, 199)
+        assert progress.get_remaining_ranges() == []
+
+
+# ------------------------------------------------------------------
+# get_completed_size
+# ------------------------------------------------------------------
+
+
+class TestGetCompletedSize:
+    def test_zero_when_none_completed(self, progress):
+        progress.create("https://example.com", 200, [(0, 99), (100, 199)])
+        assert progress.get_completed_size() == 0
+
+    def test_partial_completed_size(self, progress):
+        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        progress.mark_range_complete(0, 99)
+        # Range 0-99 is 100 bytes
+        assert progress.get_completed_size() == 100
+
+    def test_full_completed_size(self, progress):
+        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        progress.mark_range_complete(0, 99)
+        progress.mark_range_complete(100, 199)
+        progress.mark_range_complete(200, 299)
+        assert progress.get_completed_size() == 300
+
+
+# ------------------------------------------------------------------
+# is_compatible
+# ------------------------------------------------------------------
+
+
+class TestIsCompatible:
+    def test_compatible_when_sizes_match(self, progress):
+        progress.create("https://old-cdn.com/file", 5000, [(0, 4999)])
+        assert progress.is_compatible(5000) is True
+
+    def test_incompatible_when_sizes_differ(self, progress):
+        progress.create("https://example.com", 5000, [(0, 4999)])
+        assert progress.is_compatible(6000) is False
+
+    def test_incompatible_when_size_is_zero(self, progress):
+        progress.create("https://example.com", 0, [])
+        assert progress.is_compatible(0) is False
+
+    def test_compatible_ignores_url_differences(self, progress):
+        """CDN URLs rotate between sessions; only size matters."""
+        progress.create("https://old-cdn.com/tokenA/file", 10000, [(0, 9999)])
+        assert progress.is_compatible(10000) is True
+
+
+# ------------------------------------------------------------------
+# cleanup
+# ------------------------------------------------------------------
+
+
+class TestCleanup:
+    def test_cleanup_removes_progress_file(self, progress):
+        progress.create("https://example.com", 100, [(0, 99)])
+        assert os.path.exists(progress.progress_path)
+        progress.cleanup()
+        assert not os.path.exists(progress.progress_path)
+
+    def test_cleanup_resets_internal_data(self, progress):
+        progress.create("https://example.com", 100, [(0, 99)])
+        progress.cleanup()
+        assert progress.file_size == 0
+        assert progress.completed_ranges == []
+
+    def test_cleanup_is_safe_when_no_file(self, progress):
+        # Should not raise
+        progress.cleanup()
+
+
+# ------------------------------------------------------------------
+# Atomic writes
+# ------------------------------------------------------------------
+
+
+class TestAtomicWrites:
+    def test_progress_file_not_corrupted_by_concurrent_marks(self, progress):
+        """Simulate concurrent range completions from multiple threads."""
+        num_ranges = 20
+        ranges = [(i * 100, (i + 1) * 100 - 1) for i in range(num_ranges)]
+        progress.create("https://example.com", num_ranges * 100, ranges)
+
+        errors = []
+
+        def mark(start, end):
+            try:
+                progress.mark_range_complete(start, end)
+            except Exception as ex:
+                errors.append(ex)
+
+        threads = [threading.Thread(target=mark, args=(s, e)) for s, e in ranges]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert not errors
+        # All ranges should be marked — even if ordering varied
+        fresh = DownloadProgress(progress.dest_path)
+        fresh.load()
+        assert len(fresh.completed_ranges) == num_ranges
+
+    def test_save_creates_directories(self, tmp_path):
+        deep = str(tmp_path / "a" / "b" / "c" / "file.bin")
+        dp = DownloadProgress(deep)
+        dp.create("https://example.com", 100, [(0, 99)])
+        assert os.path.exists(deep + ".progress")
+
+
+# ------------------------------------------------------------------
+# Edge cases
+# ------------------------------------------------------------------
+
+
+class TestEdgeCases:
+    def test_single_range_covers_full_file(self, progress):
+        progress.create("https://example.com", 1000, [(0, 999)])
+        progress.mark_range_complete(0, 999)
+        assert progress.get_remaining_ranges() == []
+        assert progress.get_completed_size() == 1000
+
+    def test_many_small_ranges(self, progress):
+        ranges = [(i, i) for i in range(100)]  # 1 byte each
+        progress.create("https://example.com", 100, ranges)
+        for s, e in ranges[:50]:
+            progress.mark_range_complete(s, e)
+        assert len(progress.get_remaining_ranges()) == 50
+        assert progress.get_completed_size() == 50
+
+    def test_load_after_process_restart(self, tmp_dest):
+        """Simulate a process restart by creating a new instance."""
+        dp1 = DownloadProgress(tmp_dest)
+        dp1.create("https://example.com", 400, [(0, 99), (100, 199), (200, 299), (300, 399)])
+        dp1.mark_range_complete(0, 99)
+        dp1.mark_range_complete(100, 199)
+
+        # Simulate restart: new instance, same path
+        dp2 = DownloadProgress(tmp_dest)
+        assert dp2.load() is True
+        assert dp2.get_completed_size() == 200
+        remaining = dp2.get_remaining_ranges()
+        assert remaining == [(200, 299), (300, 399)]

--- a/tests/util/test_gog_downloader.py
+++ b/tests/util/test_gog_downloader.py
@@ -1,0 +1,1008 @@
+"""Tests for the GOG multi-connection parallel downloader."""
+
+import os
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lutris.util.download_progress import DownloadProgress
+from lutris.util.downloader import DEFAULT_CHUNK_SIZE, Downloader
+from lutris.util.gog_downloader import GOGDownloader
+
+
+class TestGOGDownloaderInit:
+    """Test GOGDownloader initialization."""
+
+    def test_inherits_from_downloader(self):
+        """GOGDownloader must be a Downloader subclass for API compat."""
+        assert issubclass(GOGDownloader, Downloader)
+
+    def test_default_workers(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert dl.num_workers == GOGDownloader.DEFAULT_WORKERS
+
+    def test_custom_workers(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=8)
+        assert dl.num_workers == 8
+
+    def test_min_workers_clamped(self):
+        """Workers should be at least 1."""
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=0)
+        assert dl.num_workers == 1
+
+    def test_negative_workers_clamped(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=-5)
+        assert dl.num_workers == 1
+
+    def test_has_parallel_session(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert dl._parallel_session is not None
+
+    def test_has_download_lock(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert isinstance(dl._download_lock, type(threading.Lock()))
+
+    def test_default_chunk_size(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert dl.chunk_size == DEFAULT_CHUNK_SIZE
+
+    def test_repr(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=4)
+        assert "GOG parallel downloader" in repr(dl)
+        assert "4 workers" in repr(dl)
+
+    def test_passes_params_to_parent(self):
+        dl = GOGDownloader(
+            "https://example.com/file.bin",
+            "/tmp/test.bin",
+            overwrite=True,
+            referer="https://gog.com",
+        )
+        assert dl.url == "https://example.com/file.bin"
+        assert dl.dest == "/tmp/test.bin"
+        assert dl.overwrite is True
+        assert dl.referer == "https://gog.com"
+
+
+class TestBuildRequestHeaders:
+    """Test HTTP header construction."""
+
+    def test_basic_headers(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        headers = dl._build_request_headers()
+        assert "User-Agent" in headers
+        assert "Lutris/" in headers["User-Agent"]
+
+    def test_referer_header(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", referer="https://gog.com")
+        headers = dl._build_request_headers()
+        assert headers["Referer"] == "https://gog.com"
+
+    def test_custom_headers(self):
+        dl = GOGDownloader(
+            "https://example.com/file.bin",
+            "/tmp/test.bin",
+            headers={"X-Custom": "value"},
+        )
+        headers = dl._build_request_headers()
+        assert headers["X-Custom"] == "value"
+
+
+class TestCalculateRanges:
+    """Test byte range calculation for parallel downloads."""
+
+    def test_even_split(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=4)
+        ranges = dl._calculate_ranges(1000)
+        assert len(ranges) == 4
+        assert ranges[0] == (0, 249)
+        assert ranges[1] == (250, 499)
+        assert ranges[2] == (500, 749)
+        assert ranges[3] == (750, 999)
+
+    def test_uneven_split(self):
+        """Last worker gets the remainder."""
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=3)
+        ranges = dl._calculate_ranges(100)
+        assert len(ranges) == 3
+        assert ranges[0] == (0, 32)
+        assert ranges[1] == (33, 65)
+        assert ranges[2] == (66, 99)  # Last worker gets remainder
+
+    def test_single_worker(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=1)
+        ranges = dl._calculate_ranges(1000)
+        assert len(ranges) == 1
+        assert ranges[0] == (0, 999)
+
+    def test_covers_entire_file(self):
+        """All byte ranges together should cover the entire file."""
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=7)
+        file_size = 10_000_000
+        ranges = dl._calculate_ranges(file_size)
+        total = sum(end - start + 1 for start, end in ranges)
+        assert total == file_size
+
+    def test_no_gaps_or_overlaps(self):
+        """Byte ranges must be contiguous with no gaps or overlaps."""
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin", num_workers=5)
+        ranges = dl._calculate_ranges(123456)
+        for i in range(len(ranges) - 1):
+            assert ranges[i][1] + 1 == ranges[i + 1][0], f"Gap between range {i} and {i + 1}"
+
+
+class TestProbeServer:
+    """Test server probing for capabilities."""
+
+    def test_probe_with_range_support(self):
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+
+        mock_resp = MagicMock()
+        mock_resp.url = "https://cdn.gog.com/resolved/file.bin"
+        mock_resp.headers = {"Content-Length": "104857600", "Accept-Ranges": "bytes"}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_resp):
+            url, size, supports = dl._probe_server({})
+
+        assert url == "https://cdn.gog.com/resolved/file.bin"
+        assert size == 104857600
+        assert supports is True
+
+    def test_probe_without_range_header_but_206_response(self):
+        """Test fallback Range probe when Accept-Ranges header is missing."""
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {"Content-Length": "50000000"}
+        mock_head_resp.raise_for_status = MagicMock()
+
+        mock_get_resp = MagicMock()
+        mock_get_resp.status_code = 206
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", return_value=mock_get_resp):
+                url, size, supports = dl._probe_server({})
+
+        assert supports is True
+
+    def test_probe_no_range_support(self):
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {"Content-Length": "50000000", "Accept-Ranges": "none"}
+        mock_head_resp.raise_for_status = MagicMock()
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            url, size, supports = dl._probe_server({})
+
+        assert supports is False
+
+    def test_probe_no_content_length(self):
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+
+        mock_resp = MagicMock()
+        mock_resp.url = "https://cdn.gog.com/file.bin"
+        mock_resp.headers = {}
+        mock_resp.raise_for_status = MagicMock()
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_resp):
+            url, size, supports = dl._probe_server({})
+
+        assert size == 0
+        assert supports is False
+
+
+class TestFallbackToSingleStream:
+    """Test cases where parallel download falls back to single-stream."""
+
+    def test_fallback_when_no_range_support(self, tmp_path):
+        dest = str(tmp_path / "file.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+
+        test_data = b"Hello, World!"
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {"Content-Length": str(len(test_data)), "Accept-Ranges": "none"}
+        mock_head_resp.raise_for_status = MagicMock()
+
+        mock_get_resp = MagicMock()
+        mock_get_resp.headers = {"Content-Length": str(len(test_data))}
+        mock_get_resp.raise_for_status = MagicMock()
+        mock_get_resp.iter_content = MagicMock(return_value=[test_data])
+
+        dl.stop_request = threading.Event()
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", return_value=mock_get_resp):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        assert os.path.isfile(dest)
+        with open(dest, "rb") as f:
+            assert f.read() == test_data
+
+    def test_fallback_when_file_too_small(self, tmp_path):
+        dest = str(tmp_path / "small.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+
+        # File smaller than MIN_CHUNK_SIZE * 2
+        small_size = GOGDownloader.MIN_CHUNK_SIZE - 1
+        test_data = b"x" * 100
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {
+            "Content-Length": str(small_size),
+            "Accept-Ranges": "bytes",
+        }
+        mock_head_resp.raise_for_status = MagicMock()
+
+        mock_get_resp = MagicMock()
+        mock_get_resp.headers = {"Content-Length": str(len(test_data))}
+        mock_get_resp.raise_for_status = MagicMock()
+        mock_get_resp.iter_content = MagicMock(return_value=[test_data])
+
+        dl.stop_request = threading.Event()
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", return_value=mock_get_resp):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+
+
+class TestParallelDownload:
+    """Test multi-connection parallel download."""
+
+    def test_parallel_download_writes_correct_data(self, tmp_path):
+        """Verify parallel download correctly assembles a file from ranges."""
+        dest = str(tmp_path / "parallel.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+
+        file_size = 2000  # 2000 bytes, split into 2x 1000-byte chunks
+        data = bytes(range(256)) * (file_size // 256 + 1)
+        data = data[:file_size]
+
+        # Probe returns Range support
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/resolved.bin"
+        mock_head_resp.headers = {
+            "Content-Length": str(file_size),
+            "Accept-Ranges": "bytes",
+        }
+        mock_head_resp.raise_for_status = MagicMock()
+
+        # Worker responses return the correct byte range
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            range_header = headers.get("Range", "")
+            if range_header:
+                parts = range_header.replace("bytes=", "").split("-")
+                start, end = int(parts[0]), int(parts[1])
+                chunk = data[start : end + 1]
+                resp.status_code = 206
+                resp.iter_content = MagicMock(return_value=[chunk])
+            else:
+                resp.status_code = 200
+                resp.iter_content = MagicMock(return_value=[data])
+            return resp
+
+        dl.stop_request = threading.Event()
+        dl.MIN_CHUNK_SIZE = 100  # Lower threshold for testing
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        with open(dest, "rb") as f:
+            result = f.read()
+        assert result == data
+        assert dl.downloaded_size == file_size
+
+    def test_parallel_download_with_four_workers(self, tmp_path):
+        """Test 4 workers downloading a file."""
+        dest = str(tmp_path / "four_workers.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=4)
+
+        file_size = 4000
+        data = b"A" * 1000 + b"B" * 1000 + b"C" * 1000 + b"D" * 1000
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {
+            "Content-Length": str(file_size),
+            "Accept-Ranges": "bytes",
+        }
+        mock_head_resp.raise_for_status = MagicMock()
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            range_header = headers.get("Range", "")
+            parts = range_header.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            chunk = data[start : end + 1]
+            resp.status_code = 206
+            resp.iter_content = MagicMock(return_value=[chunk])
+            return resp
+
+        dl.stop_request = threading.Event()
+        dl.MIN_CHUNK_SIZE = 100
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        with open(dest, "rb") as f:
+            result = f.read()
+        assert result == data
+
+
+class TestDownloadRange:
+    """Test individual range download worker."""
+
+    def test_download_range_writes_to_correct_offset(self, tmp_path):
+        dest = str(tmp_path / "range_test.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+
+        file_size = 1000
+        with open(dest, "wb") as f:
+            f.truncate(file_size)
+
+        chunk_data = b"X" * 500
+        mock_resp = MagicMock()
+        mock_resp.status_code = 206
+        mock_resp.iter_content = MagicMock(return_value=[chunk_data])
+
+        with patch.object(dl._parallel_session, "get", return_value=mock_resp):
+            dl._download_range("https://cdn.gog.com/file.bin", {}, 500, 999)
+
+        # Drain the write queue via writer loop (pipelining)
+        dl._write_queue.put(None)  # Sentinel to stop writer
+        dl._writer_loop()
+
+        with open(dest, "rb") as f:
+            f.seek(500)
+            assert f.read(500) == chunk_data
+
+        assert dl.downloaded_size == 500
+
+    def test_download_range_retries_on_failure(self, tmp_path):
+        dest = str(tmp_path / "retry_test.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.RETRY_DELAY = 0  # No delay in tests
+
+        file_size = 100
+        with open(dest, "wb") as f:
+            f.truncate(file_size)
+
+        chunk_data = b"Y" * 100
+        mock_resp_fail = MagicMock()
+        mock_resp_fail.status_code = 500
+        mock_resp_fail.iter_content = MagicMock()
+
+        mock_resp_ok = MagicMock()
+        mock_resp_ok.status_code = 206
+        mock_resp_ok.iter_content = MagicMock(return_value=[chunk_data])
+
+        # Fail twice, succeed on third attempt
+        with patch.object(dl._parallel_session, "get", side_effect=[mock_resp_fail, mock_resp_fail, mock_resp_ok]):
+            dl._download_range("https://cdn.gog.com/file.bin", {}, 0, 99)
+
+        # Drain the write queue via writer loop (pipelining)
+        dl._write_queue.put(None)  # Sentinel to stop writer
+        dl._writer_loop()
+
+        assert dl.downloaded_size == 100
+
+    def test_download_range_cancellation(self, tmp_path):
+        dest = str(tmp_path / "cancel_test.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.stop_request.set()  # Pre-cancelled
+
+        file_size = 100
+        with open(dest, "wb") as f:
+            f.truncate(file_size)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 206
+        mock_resp.iter_content = MagicMock(return_value=[b"Z" * 100])
+
+        with patch.object(dl._parallel_session, "get", return_value=mock_resp):
+            dl._download_range("https://cdn.gog.com/file.bin", {}, 0, 99)
+
+        # Should not have downloaded anything since cancelled
+        assert dl.downloaded_size == 0
+
+
+class TestCancelAndStates:
+    """Test cancel and state management."""
+
+    def test_cancel_sets_state(self, tmp_path):
+        dest = str(tmp_path / "cancel.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.cancel()
+        assert dl.state == dl.CANCELLED
+
+    def test_cancel_sets_stop_request(self, tmp_path):
+        dest = str(tmp_path / "cancel.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.cancel()
+        assert dl.stop_request.is_set()
+
+    def test_cancel_removes_file(self, tmp_path):
+        dest = str(tmp_path / "cancel.bin")
+        with open(dest, "w") as f:
+            f.write("test")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.cancel()
+        assert not os.path.isfile(dest)
+
+    def test_on_download_completed_sets_state(self):
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+        dl.downloaded_size = 1000
+        dl.full_size = 1000
+        dl.on_download_completed()
+        assert dl.state == dl.COMPLETED
+
+    def test_on_download_completed_ignores_cancelled(self):
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+        dl.state = dl.CANCELLED
+        dl.on_download_completed()
+        assert dl.state == dl.CANCELLED
+
+    def test_on_download_failed_sets_error(self):
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+        error = Exception("test error")
+        dl.on_download_failed(error)
+        assert dl.state == dl.ERROR
+        assert dl.error is error
+
+
+class TestInstallerFileIntegration:
+    """Test GOGDownloader integration with InstallerFile."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_gi(self):
+        """Ensure GTK version is required before importing InstallerFile."""
+        try:
+            import gi
+
+            gi.require_version("Gtk", "3.0")
+            gi.require_version("Gdk", "3.0")
+        except (ValueError, ImportError):
+            pytest.skip("GTK 3.0 not available")
+
+    def test_installer_file_downloader_class(self):
+        """InstallerFile should expose downloader_class from file_meta."""
+        from lutris.installer.installer_file import InstallerFile
+
+        file = InstallerFile(
+            "test-game",
+            "test-file",
+            {
+                "url": "https://cdn.gog.com/file.bin",
+                "filename": "file.bin",
+                "downloader_class": GOGDownloader,
+            },
+        )
+        assert file.downloader_class is GOGDownloader
+
+    def test_installer_file_no_downloader_class(self):
+        """InstallerFile without downloader_class should return None."""
+        from lutris.installer.installer_file import InstallerFile
+
+        file = InstallerFile(
+            "test-game",
+            "test-file",
+            {
+                "url": "https://example.com/file.bin",
+                "filename": "file.bin",
+            },
+        )
+        assert file.downloader_class is None
+
+    def test_installer_file_string_meta_no_class(self):
+        """InstallerFile with string meta should return None for downloader_class."""
+        from lutris.installer.installer_file import InstallerFile
+
+        file = InstallerFile(
+            "test-game",
+            "test-file",
+            "https://example.com/file.bin",
+        )
+        assert file.downloader_class is None
+
+
+class TestGOGServiceIntegration:
+    """Test that the GOG service injects GOGDownloader into InstallerFile."""
+
+    @pytest.fixture(autouse=True)
+    def _setup_gi(self):
+        """Ensure GTK version is required before importing GOG service."""
+        try:
+            import gi
+
+            gi.require_version("Gtk", "3.0")
+            gi.require_version("Gdk", "3.0")
+        except (ValueError, ImportError):
+            pytest.skip("GTK 3.0 not available")
+
+    def test_gog_format_links_includes_downloader_class(self):
+        """_format_links should inject GOGDownloader as downloader_class."""
+        from unittest.mock import MagicMock
+
+        from lutris.services.gog import GOGService
+
+        service = GOGService()
+        installer = MagicMock()
+        installer.game_slug = "test-game"
+
+        links = [
+            {
+                "filename": "setup_test_game.exe",
+                "url": "https://cdn.gog.com/setup_test_game.exe",
+                "alternate_filenames": [],
+                "total_size": 100000,
+                "id": "1",
+            },
+        ]
+
+        files = service._format_links(installer, "goginstaller", links)
+        assert len(files) == 1
+        assert files[0].downloader_class is GOGDownloader
+
+
+class TestProgressTracking:
+    """Test that progress tracking works with parallel downloads."""
+
+    def test_downloaded_size_thread_safe(self, tmp_path):
+        """Verify downloaded_size is correctly accumulated from multiple threads."""
+        dest = str(tmp_path / "progress.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=4)
+        dl.stop_request = threading.Event()
+        dl.progress_event = threading.Event()
+
+        # Simulate 4 workers each adding 250 bytes
+        def add_bytes(amount):
+            for _ in range(amount):
+                with dl._download_lock:
+                    dl.downloaded_size += 1
+
+        threads = [threading.Thread(target=add_bytes, args=(250,)) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert dl.downloaded_size == 1000
+
+    def test_check_progress_returns_fraction(self):
+        """check_progress should work normally with parallel downloader."""
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", "/tmp/test.bin")
+        dl.full_size = 1000
+        dl.downloaded_size = 500
+        dl.state = dl.DOWNLOADING
+        dl.last_check_time = time.monotonic() - 1
+
+        progress = dl.check_progress()
+        assert 0.4 <= progress <= 0.6  # Approximately 50%
+
+
+# ==================================================================
+# Phase 3: Download resume tests
+# ==================================================================
+
+
+class TestResumeProgressCreation:
+    """Test that parallel downloads create progress files."""
+
+    def test_fresh_download_creates_progress_file(self, tmp_path):
+        """A parallel download should create a .progress sidecar file."""
+        dest = str(tmp_path / "fresh.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+
+        file_size = 2000
+        data = b"X" * file_size
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {
+            "Content-Length": str(file_size),
+            "Accept-Ranges": "bytes",
+        }
+        mock_head_resp.raise_for_status = MagicMock()
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            rng = headers.get("Range", "")
+            parts = rng.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            resp.status_code = 206
+            resp.iter_content = MagicMock(return_value=[data[start : end + 1]])
+            return resp
+
+        dl.stop_request = threading.Event()
+        dl.MIN_CHUNK_SIZE = 100
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        # Progress file should be cleaned up on success
+        assert not os.path.exists(dest + ".progress")
+
+    def test_progress_file_records_completed_ranges(self, tmp_path):
+        """Ranges that finish should be persisted in the progress file."""
+        dest = str(tmp_path / "track.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+
+        file_size = 2000
+        data = b"A" * 1000 + b"B" * 1000
+
+        mock_head_resp = MagicMock()
+        mock_head_resp.url = "https://cdn.gog.com/file.bin"
+        mock_head_resp.headers = {
+            "Content-Length": str(file_size),
+            "Accept-Ranges": "bytes",
+        }
+        mock_head_resp.raise_for_status = MagicMock()
+
+        call_count = [0]
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            rng = headers.get("Range", "")
+            parts = rng.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            call_count[0] += 1
+            # First range succeeds, second fails
+            if start == 0:
+                resp.status_code = 206
+                resp.iter_content = MagicMock(return_value=[data[start : end + 1]])
+            else:
+                raise ConnectionError("Network down")
+            return resp
+
+        dl.stop_request = threading.Event()
+        dl.MIN_CHUNK_SIZE = 100
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head_resp):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.RETRY_ATTEMPTS = 1  # Don't retry in test
+                dl.async_download()
+
+        # Download should have failed
+        assert dl.state == dl.ERROR
+        # But progress file should exist with completed range
+        progress = DownloadProgress(dest)
+        assert progress.load() is True
+        # At least the first range should be recorded
+        assert len(progress.completed_ranges) >= 1
+
+
+class TestResumeFromProgress:
+    """Test resuming downloads from existing progress files."""
+
+    def _make_head_resp(self, url, file_size):
+        resp = MagicMock()
+        resp.url = url
+        resp.headers = {
+            "Content-Length": str(file_size),
+            "Accept-Ranges": "bytes",
+        }
+        resp.raise_for_status = MagicMock()
+        return resp
+
+    def test_resume_downloads_only_remaining_ranges(self, tmp_path):
+        """Resume should only download ranges not yet completed."""
+        dest = str(tmp_path / "resume.bin")
+        file_size = 4000
+        data = b"A" * 1000 + b"B" * 1000 + b"C" * 1000 + b"D" * 1000
+
+        # Pre-create destination file (simulating a previous partial download)
+        with open(dest, "wb") as f:
+            f.truncate(file_size)
+            # Write the first two ranges
+            f.seek(0)
+            f.write(data[0:1000])
+            f.seek(1000)
+            f.write(data[1000:2000])
+
+        # Pre-create progress file showing ranges 0-1 complete
+        progress = DownloadProgress(dest)
+        all_ranges = [(0, 999), (1000, 1999), (2000, 2999), (3000, 3999)]
+        progress.create("https://cdn.gog.com/file.bin", file_size, all_ranges)
+        progress.mark_range_complete(0, 999)
+        progress.mark_range_complete(1000, 1999)
+
+        # Now create a downloader that should resume
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=4)
+        dl.MIN_CHUNK_SIZE = 100
+        dl.stop_request = threading.Event()
+
+        downloaded_ranges = []
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            rng = headers.get("Range", "")
+            parts = rng.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            downloaded_ranges.append((start, end))
+            resp.status_code = 206
+            resp.iter_content = MagicMock(return_value=[data[start : end + 1]])
+            return resp
+
+        mock_head = self._make_head_resp("https://cdn.gog.com/file.bin", file_size)
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        # Only ranges 2 and 3 should have been downloaded
+        assert (0, 999) not in downloaded_ranges
+        assert (1000, 1999) not in downloaded_ranges
+        assert (2000, 2999) in downloaded_ranges
+        assert (3000, 3999) in downloaded_ranges
+
+        # File should be complete
+        with open(dest, "rb") as f:
+            result = f.read()
+        assert result == data
+
+        # Progress file should be cleaned up
+        assert not os.path.exists(dest + ".progress")
+
+    def test_resume_credits_already_downloaded_bytes(self, tmp_path):
+        """Resume should credit bytes from completed ranges to downloaded_size."""
+        dest = str(tmp_path / "credit.bin")
+        file_size = 2000
+
+        with open(dest, "wb") as f:
+            f.truncate(file_size)
+            f.write(b"X" * 1000)
+
+        progress = DownloadProgress(dest)
+        progress.create("https://cdn.gog.com/file.bin", file_size, [(0, 999), (1000, 1999)])
+        progress.mark_range_complete(0, 999)
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+        dl.MIN_CHUNK_SIZE = 100
+        dl.stop_request = threading.Event()
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            rng = headers.get("Range", "")
+            parts = rng.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            resp.status_code = 206
+            resp.iter_content = MagicMock(return_value=[b"Y" * (end - start + 1)])
+            return resp
+
+        mock_head = self._make_head_resp("https://cdn.gog.com/file.bin", file_size)
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        # Total downloaded = 1000 (already on disk) + 1000 (newly downloaded)
+        assert dl.downloaded_size == 2000
+
+    def test_resume_with_incompatible_file_size_starts_fresh(self, tmp_path):
+        """If file size changed, progress is discarded and we start fresh."""
+        dest = str(tmp_path / "incompat.bin")
+        old_size = 3000
+
+        with open(dest, "wb") as f:
+            f.truncate(old_size)
+
+        # Create progress with old file size
+        progress = DownloadProgress(dest)
+        progress.create("https://cdn.gog.com/file.bin", old_size, [(0, 2999)])
+        progress.mark_range_complete(0, 2999)
+
+        new_size = 4000  # File size changed on server
+        data = b"N" * new_size
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+        dl.MIN_CHUNK_SIZE = 100
+        dl.stop_request = threading.Event()
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            rng = headers.get("Range", "")
+            parts = rng.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            resp.status_code = 206
+            resp.iter_content = MagicMock(return_value=[data[start : end + 1]])
+            return resp
+
+        mock_head = self._make_head_resp("https://cdn.gog.com/file.bin", new_size)
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        assert dl.downloaded_size == new_size
+
+    def test_resume_with_missing_dest_starts_fresh(self, tmp_path):
+        """If dest file is gone but progress exists, start fresh."""
+        dest = str(tmp_path / "missing.bin")
+        file_size = 2000
+
+        # Create progress without the actual file
+        progress = DownloadProgress(dest)
+        progress.create("https://cdn.gog.com/file.bin", file_size, [(0, 999), (1000, 1999)])
+        progress.mark_range_complete(0, 999)
+
+        data = b"F" * file_size
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+        dl.MIN_CHUNK_SIZE = 100
+        dl.stop_request = threading.Event()
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            resp = MagicMock()
+            rng = headers.get("Range", "")
+            parts = rng.replace("bytes=", "").split("-")
+            start, end = int(parts[0]), int(parts[1])
+            resp.status_code = 206
+            resp.iter_content = MagicMock(return_value=[data[start : end + 1]])
+            return resp
+
+        mock_head = self._make_head_resp("https://cdn.gog.com/file.bin", file_size)
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head):
+            with patch.object(dl._parallel_session, "get", side_effect=mock_get):
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        # Fresh download, should have downloaded full size
+        assert dl.downloaded_size == file_size
+
+    def test_resume_skips_when_all_ranges_already_done(self, tmp_path):
+        """If all ranges complete and file exists, skip download entirely."""
+        dest = str(tmp_path / "skip.bin")
+        file_size = 2000
+        data = b"D" * file_size
+
+        with open(dest, "wb") as f:
+            f.write(data)
+
+        progress = DownloadProgress(dest)
+        progress.create("https://cdn.gog.com/file.bin", file_size, [(0, 999), (1000, 1999)])
+        progress.mark_range_complete(0, 999)
+        progress.mark_range_complete(1000, 1999)
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
+        dl.MIN_CHUNK_SIZE = 100
+        dl.stop_request = threading.Event()
+
+        mock_head = self._make_head_resp("https://cdn.gog.com/file.bin", file_size)
+
+        with patch.object(dl._parallel_session, "head", return_value=mock_head):
+            with patch.object(dl._parallel_session, "get") as get_mock:
+                dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        assert dl.downloaded_size == file_size
+        # GET should not have been called — all ranges already done
+        get_mock.assert_not_called()
+        # Progress file should be cleaned up
+        assert not os.path.exists(dest + ".progress")
+
+
+class TestResumeStartMethod:
+    """Test that start() preserves files when resume is possible."""
+
+    def test_start_preserves_file_when_progress_exists(self, tmp_path):
+        """start() should not delete dest if resumable progress is found."""
+        dest = str(tmp_path / "preserve.bin")
+        data = b"P" * 1000
+
+        with open(dest, "wb") as f:
+            f.write(data)
+
+        progress = DownloadProgress(dest)
+        progress.create("https://cdn.gog.com/file.bin", 2000, [(0, 999), (1000, 1999)])
+        progress.mark_range_complete(0, 999)
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, overwrite=True, num_workers=2)
+
+        # Patch AsyncCall so start() doesn't actually launch a thread
+        with patch("lutris.util.gog_downloader.jobs.AsyncCall") as mock_async:
+            mock_thread = MagicMock()
+            mock_thread.stop_request = threading.Event()
+            mock_async.return_value = mock_thread
+            dl.start()
+
+        # File should still exist
+        assert os.path.isfile(dest)
+        with open(dest, "rb") as f:
+            assert f.read() == data
+
+    def test_start_deletes_file_when_no_progress(self, tmp_path):
+        """start() should delete dest if no resumable progress exists."""
+        dest = str(tmp_path / "delete.bin")
+        with open(dest, "wb") as f:
+            f.write(b"old data")
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, overwrite=True, num_workers=2)
+
+        with patch("lutris.util.gog_downloader.jobs.AsyncCall") as mock_async:
+            mock_thread = MagicMock()
+            mock_thread.stop_request = threading.Event()
+            mock_async.return_value = mock_thread
+            dl.start()
+
+        assert not os.path.isfile(dest)
+
+
+class TestCancelCleansProgress:
+    """Test that cancel() removes progress files."""
+
+    def test_cancel_removes_progress_file(self, tmp_path):
+        dest = str(tmp_path / "cancel.bin")
+        with open(dest, "wb") as f:
+            f.write(b"data")
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+
+        # Simulate active progress
+        dl._progress = DownloadProgress(dest)
+        dl._progress.create("https://cdn.gog.com/file.bin", 1000, [(0, 999)])
+
+        dl.cancel()
+
+        assert not os.path.isfile(dest)
+        assert not os.path.exists(dest + ".progress")
+        assert dl._progress is None
+
+    def test_cancel_without_progress(self, tmp_path):
+        """Cancel should work even if no progress was created."""
+        dest = str(tmp_path / "nocancel.bin")
+        with open(dest, "wb") as f:
+            f.write(b"data")
+
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.cancel()
+
+        assert not os.path.isfile(dest)
+
+
+class TestCompletionCleansProgress:
+    """Test that on_download_completed() removes progress files."""
+
+    def test_completed_removes_progress(self, tmp_path):
+        dest = str(tmp_path / "done.bin")
+        dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
+        dl.downloaded_size = 1000
+        dl.full_size = 1000
+
+        dl._progress = DownloadProgress(dest)
+        dl._progress.create("https://cdn.gog.com/file.bin", 1000, [(0, 999)])
+        dl._progress.mark_range_complete(0, 999)
+
+        dl.on_download_completed()
+
+        assert dl.state == dl.COMPLETED
+        assert not os.path.exists(dest + ".progress")
+        assert dl._progress is None

--- a/tests/util/test_pipelining.py
+++ b/tests/util/test_pipelining.py
@@ -1,0 +1,286 @@
+"""Tests for download pipelining in GOGDownloader."""
+
+import os
+import queue
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lutris.util.download_progress import DownloadProgress
+from lutris.util.gog_downloader import GOGDownloader
+
+
+class TestWriteQueue:
+    """Test the pipelining write queue setup."""
+
+    def test_has_write_queue(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert isinstance(dl._write_queue, queue.Queue)
+
+    def test_write_queue_maxsize(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert dl._write_queue.maxsize == 64
+
+    def test_has_writer_error_event(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert isinstance(dl._writer_error_event, threading.Event)
+
+    def test_writer_error_initially_none(self):
+        dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
+        assert dl._writer_error is None
+
+
+class TestWriterLoop:
+    """Test the _writer_loop() writer thread."""
+
+    def test_writes_data_correctly(self, tmp_path):
+        """Writer thread should write data at the correct offset."""
+        dest = str(tmp_path / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+
+        # Pre-allocate file
+        with open(dest, "wb") as f:
+            f.truncate(100)
+
+        # Enqueue some data
+        dl._write_queue.put((0, b"AAAA", 0, None))
+        dl._write_queue.put((50, b"BBBB", 50, None))
+        dl._write_queue.put(None)  # Sentinel
+
+        dl._writer_loop()
+
+        with open(dest, "rb") as f:
+            content = f.read()
+        assert content[:4] == b"AAAA"
+        assert content[50:54] == b"BBBB"
+
+    def test_updates_downloaded_size(self, tmp_path):
+        """Writer should increment downloaded_size after writing."""
+        dest = str(tmp_path / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+
+        with open(dest, "wb") as f:
+            f.truncate(100)
+
+        dl._write_queue.put((0, b"X" * 50, 0, None))
+        dl._write_queue.put((50, b"Y" * 50, 50, None))
+        dl._write_queue.put(None)
+
+        dl._writer_loop()
+
+        assert dl.downloaded_size == 100
+
+    def test_marks_range_complete(self, tmp_path):
+        """Writer marks range complete when range_end is set."""
+        dest = str(tmp_path / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+
+        with open(dest, "wb") as f:
+            f.truncate(100)
+
+        dl._progress = DownloadProgress(dest)
+        dl._progress.create("https://example.com/file.bin", 100, [(0, 49), (50, 99)])
+
+        # Last chunk of first range
+        dl._write_queue.put((0, b"A" * 50, 0, 49))
+        # Last chunk of second range
+        dl._write_queue.put((50, b"B" * 50, 50, 99))
+        dl._write_queue.put(None)
+
+        dl._writer_loop()
+
+        remaining = dl._progress.get_remaining_ranges()
+        assert len(remaining) == 0
+
+    def test_handles_stop_request(self, tmp_path):
+        """Writer should exit when stop_request is set."""
+        dest = str(tmp_path / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        dl.stop_request.set()  # Pre-cancel
+
+        with open(dest, "wb") as f:
+            f.truncate(100)
+
+        # Even with data in queue, should exit due to stop_request
+        dl._write_queue.put((0, b"data", 0, None))
+        dl._write_queue.put(None)
+
+        dl._writer_loop()  # Should not hang
+
+    def test_sets_error_on_write_failure(self, tmp_path):
+        """Writer should set error event on disk failure."""
+        dest = str(tmp_path / "readonly_dir" / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+
+        # Don't create the file — writer will fail to open it
+        dl._write_queue.put((0, b"data", 0, None))
+        dl._write_queue.put(None)
+
+        dl._writer_loop()
+
+        assert dl._writer_error is not None
+        assert dl._writer_error_event.is_set()
+
+
+class TestPipelineBackpressure:
+    """Test that backpressure works correctly with bounded queue."""
+
+    def test_queue_blocks_when_full(self, tmp_path):
+        """Workers should block when queue is at maxsize."""
+        dest = str(tmp_path / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest)
+
+        # Fill the queue to capacity
+        for i in range(64):
+            dl._write_queue.put((i, b"x", 0, None))
+
+        assert dl._write_queue.full()
+
+        # Verify put would block (use put_nowait to test)
+        with pytest.raises(queue.Full):
+            dl._write_queue.put_nowait((99, b"overflow", 0, None))
+
+
+class TestGOGDownloaderStallDetection:
+    """Test stall detection in GOGDownloader._download_range()."""
+
+    def test_stall_triggers_retry(self, tmp_path):
+        """A stalled range should trigger retry via the existing retry mechanism."""
+        dest = str(tmp_path / "output.bin")
+        dl = GOGDownloader("https://example.com/file.bin", dest, num_workers=1)
+        dl.stop_request = threading.Event()
+        dl._writer_error_event = threading.Event()
+
+        # Pre-allocate file
+        with open(dest, "wb") as f:
+            f.truncate(1000)
+
+        # Create a mock response that simulates a stall then success
+        call_count = [0]
+
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            call_count[0] += 1
+            mock_response = MagicMock()
+            mock_response.status_code = 206
+
+            if call_count[0] == 1:
+                # First attempt: simulate stall by manipulating stall state
+                def slow_iter(chunk_size=None):
+                    dl._stall_start = time.monotonic() - 35  # 35 seconds ago
+                    dl._stall_bytes_at_start = 0
+                    yield b"x"  # Tiny chunk triggers stall check
+
+                mock_response.iter_content = slow_iter
+            else:
+                # Retry: succeed
+                def fast_iter(chunk_size=None):
+                    yield b"A" * 1000
+
+                mock_response.iter_content = fast_iter
+
+            return mock_response
+
+        dl._parallel_session.get = mock_get
+
+        headers = dl._build_request_headers()
+
+        with patch.object(dl._write_queue, "put"):
+            dl._download_range("https://example.com/file.bin", headers, 0, 999)
+
+        # Verify retry occurred
+        assert call_count[0] >= 2
+
+
+class TestPipelinedDownloadEndToEnd:
+    """Integration test: full pipelined download with mock HTTP."""
+
+    @patch.object(GOGDownloader, "_probe_server")
+    def test_pipelined_download_completes(self, mock_probe, tmp_path):
+        """Full download should complete with pipelining."""
+        dest = str(tmp_path / "game.bin")
+        file_size = 20 * 1024 * 1024  # 20 MB — above MIN_CHUNK_SIZE * 2
+
+        dl = GOGDownloader("https://cdn.gog.com/game.bin", dest, num_workers=2)
+        dl.stop_request = threading.Event()
+
+        mock_probe.return_value = ("https://cdn.gog.com/game.bin", file_size, True)
+
+        # Mock the parallel session for range requests
+        def mock_get(url, headers=None, stream=None, timeout=None, cookies=None):
+            response = MagicMock()
+            response.status_code = 206
+
+            # Parse the Range header to determine what data to return
+            range_header = headers.get("Range", "")
+            if range_header.startswith("bytes="):
+                parts = range_header[6:].split("-")
+                start, end = int(parts[0]), int(parts[1])
+                size = end - start + 1
+                # Generate deterministic data based on offset
+                data = bytes([start % 256]) * size
+
+                def iter_content(chunk_size=None):
+                    remaining = size
+                    while remaining > 0:
+                        cs = min(chunk_size or 512 * 1024, remaining)
+                        yield data[:cs]
+                        remaining -= cs
+
+                response.iter_content = iter_content
+            return response
+
+        dl._parallel_session = MagicMock()
+        dl._parallel_session.get = mock_get
+        dl._parallel_session.head.return_value = MagicMock(
+            url="https://cdn.gog.com/game.bin",
+            headers={"Content-Length": str(file_size), "Accept-Ranges": "bytes"},
+            status_code=200,
+        )
+
+        dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        assert dl.downloaded_size == file_size
+        assert os.path.isfile(dest)
+        assert os.path.getsize(dest) == file_size
+
+    @patch.object(GOGDownloader, "_probe_server")
+    def test_small_file_skips_pipelining(self, mock_probe, tmp_path):
+        """Files below MIN_CHUNK_SIZE * 2 should use single-stream."""
+        dest = str(tmp_path / "small.bin")
+        file_size = 1000  # Very small
+
+        dl = GOGDownloader("https://cdn.gog.com/small.bin", dest, num_workers=4)
+        dl.stop_request = threading.Event()
+
+        mock_probe.return_value = ("https://cdn.gog.com/small.bin", file_size, True)
+
+        # Mock single-stream response
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"Content-Length": str(file_size)}
+
+        def iter_content(chunk_size=None):
+            yield b"X" * file_size
+
+        response.iter_content = iter_content
+
+        dl._parallel_session = MagicMock()
+        dl._parallel_session.get.return_value = response
+        dl._parallel_session.head.return_value = MagicMock(
+            url="https://cdn.gog.com/small.bin",
+            headers={"Content-Length": str(file_size), "Accept-Ranges": "bytes"},
+            status_code=200,
+        )
+
+        dl.async_download()
+
+        assert dl.state == dl.COMPLETED
+        assert dl.downloaded_size == file_size

--- a/tests/util/test_stall_detection.py
+++ b/tests/util/test_stall_detection.py
@@ -1,0 +1,232 @@
+"""Tests for stall detection and retry logic in the download system."""
+
+import threading
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from lutris.util.downloader import Downloader, DownloadStallError, get_time
+
+
+class TestDownloadStallError:
+    """Test the DownloadStallError exception class."""
+
+    def test_carries_throughput(self):
+        err = DownloadStallError(throughput=150.5, duration=30.0)
+        assert err.throughput == 150.5
+
+    def test_carries_duration(self):
+        err = DownloadStallError(throughput=100.0, duration=35.2)
+        assert err.duration == 35.2
+
+    def test_message_contains_throughput(self):
+        err = DownloadStallError(throughput=42.3, duration=30.0)
+        assert "42.3" in str(err)
+
+    def test_message_contains_duration(self):
+        err = DownloadStallError(throughput=100.0, duration=31.5)
+        assert "31.5" in str(err)
+
+    def test_is_exception(self):
+        err = DownloadStallError(throughput=0.0, duration=30.0)
+        assert isinstance(err, Exception)
+
+
+class TestCheckStall:
+    """Test the _check_stall() method on Downloader."""
+
+    def _make_downloader(self):
+        dl = Downloader("https://example.com/file.bin", "/tmp/test.bin")
+        dl._reset_stall_state()
+        return dl
+
+    def test_first_call_initializes_window(self):
+        """First call should set the stall window start, not raise."""
+        dl = self._make_downloader()
+        # Should not raise
+        dl._check_stall(1000)
+        assert dl._stall_start is not None
+        assert dl._stall_bytes_at_start == 1000
+
+    def test_good_throughput_resets_window(self):
+        """When throughput is above threshold, the stall window resets."""
+        dl = self._make_downloader()
+        dl._stall_start = get_time() - 5.0  # 5 seconds ago
+        dl._stall_bytes_at_start = 0
+        # 10000 bytes in 5 seconds = 2000 B/s — well above 200 B/s
+        dl._check_stall(10000)
+        # Window should have been reset
+        assert dl._stall_bytes_at_start == 10000
+
+    def test_low_throughput_does_not_raise_immediately(self):
+        """Low throughput within the time window should not raise."""
+        dl = self._make_downloader()
+        dl._stall_start = get_time() - 10.0  # 10 seconds ago
+        dl._stall_bytes_at_start = 0
+        # 100 bytes in 10 seconds = 10 B/s — below threshold but only 10s elapsed
+        dl._check_stall(100)
+        # Should not raise because LOW_SPEED_TIME (30s) not exceeded
+
+    def test_stall_raises_after_timeout(self):
+        """Low throughput exceeding LOW_SPEED_TIME should raise."""
+        dl = self._make_downloader()
+        dl._stall_start = get_time() - 31.0  # 31 seconds ago
+        dl._stall_bytes_at_start = 0
+        # 100 bytes in 31 seconds = ~3.2 B/s — below 200 B/s for > 30s
+        with pytest.raises(DownloadStallError) as exc_info:
+            dl._check_stall(100)
+        assert exc_info.value.duration >= 30.0
+        assert exc_info.value.throughput < 200.0
+
+    def test_zero_bytes_triggers_stall(self):
+        """Zero bytes received should eventually trigger stall."""
+        dl = self._make_downloader()
+        dl._stall_start = get_time() - 35.0
+        dl._stall_bytes_at_start = 0
+        with pytest.raises(DownloadStallError):
+            dl._check_stall(0)
+
+    def test_recovery_resets_timer(self):
+        """If throughput recovers within the window, timer resets."""
+        dl = self._make_downloader()
+        dl._stall_start = get_time() - 20.0  # 20 seconds of slow speed
+        dl._stall_bytes_at_start = 100
+        # Now deliver a burst: enough bytes to push throughput above threshold
+        # Need > 200 B/s over 20 seconds = 4000 bytes
+        dl._check_stall(100 + 5000)
+        # Window should have reset (not raised)
+        assert dl._stall_bytes_at_start == 5100
+
+    def test_reset_stall_state(self):
+        dl = self._make_downloader()
+        dl._stall_start = 12345.0
+        dl._stall_bytes_at_start = 9999
+        dl._reset_stall_state()
+        assert dl._stall_start is None
+        assert dl._stall_bytes_at_start == 0
+
+
+class TestDownloaderRetry:
+    """Test retry logic in the base Downloader."""
+
+    def _make_downloader(self, tmp_path):
+        dest = str(tmp_path / "test.bin")
+        dl = Downloader("https://example.com/file.bin", dest)
+        dl.stop_request = threading.Event()
+        return dl
+
+    @patch.object(Downloader, "on_download_completed")
+    @patch.object(Downloader, "_do_download")
+    def test_success_on_first_try(self, mock_do, mock_complete, tmp_path):
+        """Successful download should not retry."""
+        dl = self._make_downloader(tmp_path)
+        mock_do.return_value = None  # Success
+
+        dl.async_download()
+
+        assert mock_do.call_count == 1
+        mock_complete.assert_called_once()
+
+    @patch.object(Downloader, "on_download_completed")
+    @patch.object(Downloader, "_do_download")
+    def test_retries_on_stall_error(self, mock_do, mock_complete, tmp_path):
+        """DownloadStallError should trigger retry."""
+        dl = self._make_downloader(tmp_path)
+        # Fail twice with stall, succeed on third
+        mock_do.side_effect = [
+            DownloadStallError(throughput=50.0, duration=31.0),
+            DownloadStallError(throughput=30.0, duration=32.0),
+            None,  # Success
+        ]
+
+        with patch.object(dl, "_prepare_retry"):
+            with patch("lutris.util.downloader.time") as mock_time:
+                mock_time.monotonic = time.monotonic
+                mock_time.sleep = MagicMock()
+                dl.async_download()
+
+        assert mock_do.call_count == 3
+        mock_complete.assert_called_once()
+
+    @patch.object(Downloader, "_do_download")
+    def test_fails_after_max_retries(self, mock_do, tmp_path):
+        """Should fail after RETRY_ATTEMPTS exhausted."""
+        dl = self._make_downloader(tmp_path)
+        stall_err = DownloadStallError(throughput=10.0, duration=30.0)
+        mock_do.side_effect = stall_err
+
+        with patch.object(dl, "_prepare_retry"):
+            with patch("lutris.util.downloader.time") as mock_time:
+                mock_time.monotonic = time.monotonic
+                mock_time.sleep = MagicMock()
+                dl.async_download()
+
+        assert mock_do.call_count == dl.RETRY_ATTEMPTS
+        assert dl.state == dl.ERROR
+        assert dl.error is stall_err
+
+    @patch.object(Downloader, "_do_download")
+    def test_no_retry_on_404(self, mock_do, tmp_path):
+        """HTTP 404 should not retry."""
+        dl = self._make_downloader(tmp_path)
+        response = MagicMock()
+        response.status_code = 404
+        http_err = requests.HTTPError(response=response)
+        mock_do.side_effect = http_err
+
+        dl.async_download()
+
+        assert mock_do.call_count == 1
+        assert dl.state == dl.ERROR
+
+    @patch.object(Downloader, "on_download_completed")
+    @patch.object(Downloader, "_do_download")
+    def test_retry_on_500(self, mock_do, mock_complete, tmp_path):
+        """HTTP 500 should trigger retry."""
+        dl = self._make_downloader(tmp_path)
+        response = MagicMock()
+        response.status_code = 500
+        http_err = requests.HTTPError(response=response)
+        mock_do.side_effect = [http_err, None]
+
+        with patch.object(dl, "_prepare_retry"):
+            with patch("lutris.util.downloader.time") as mock_time:
+                mock_time.monotonic = time.monotonic
+                mock_time.sleep = MagicMock()
+                dl.async_download()
+
+        assert mock_do.call_count == 2
+        mock_complete.assert_called_once()
+
+    @patch.object(Downloader, "on_download_completed")
+    @patch.object(Downloader, "_do_download")
+    def test_retry_on_429(self, mock_do, mock_complete, tmp_path):
+        """HTTP 429 (rate limit) should trigger retry."""
+        dl = self._make_downloader(tmp_path)
+        response = MagicMock()
+        response.status_code = 429
+        http_err = requests.HTTPError(response=response)
+        mock_do.side_effect = [http_err, None]
+
+        with patch.object(dl, "_prepare_retry"):
+            with patch("lutris.util.downloader.time") as mock_time:
+                mock_time.monotonic = time.monotonic
+                mock_time.sleep = MagicMock()
+                dl.async_download()
+
+        assert mock_do.call_count == 2
+        mock_complete.assert_called_once()
+
+    def test_is_retryable_http_error_no_response(self):
+        """HTTP error with no response should be retryable."""
+        err = requests.HTTPError(response=None)
+        assert Downloader._is_retryable_http_error(err) is True
+
+    def test_is_retryable_http_error_403(self):
+        """HTTP 403 should not be retryable."""
+        response = MagicMock()
+        response.status_code = 403
+        err = requests.HTTPError(response=response)
+        assert Downloader._is_retryable_http_error(err) is False


### PR DESCRIPTION
## Summary

This PR introduces three phases of download speed optimization for GOG game downloads, with improvements that also benefit all other services.

---

## Phase 1: Chunk size & cache protection (`feat: Optimize download speed with larger chunks and cache protection`)

- **64× larger download chunks**: Increased from 8 KB to 512 KB, matching heroic-gogdl's proven chunk size. Reduces syscall overhead significantly.
- **Connection pooling**: New optional `session` and `chunk_size` parameters on `Downloader` for per-download customization. Fully backward-compatible.
- **Download cache protection** (`lutris/util/download_cache.py`): Prevents deletion of in-progress or recently downloaded files before installation completes. Tracks lifecycle states: `DOWNLOADING → DOWNLOADED → INSTALLING → INSTALLED/FAILED`. Failed installations preserve files for 7 days for retry — critical for 40 GB+ GOG downloads.
- Cache protection is integrated into `interpreter.py` cleanup, download progress boxes, and install commands.

---

## Phase 2: Multi-connection parallel downloader (`feat: Add GOG multi-connection parallel downloader`)

- New `GOGDownloader` class (`lutris/util/gog_downloader.py`) uses multiple simultaneous HTTP Range requests (4 workers by default) to download large GOG installer files in parallel.
- HTTP Range support detection with automatic fallback to single-stream for small files or servers without Range support.
- Connection pooling via `requests.Session` with `HTTPAdapter`.
- Per-worker retry with exponential backoff (3 attempts).
- Thread-safe progress tracking for UI integration.
- `InstallerFile` gains a `downloader_class` property for service-specific downloader injection. `DownloadCollectionProgressBox` uses it automatically.

---

## Phase 3: Download resume with persistent byte-range tracking (`feat: Phase 3 - download resume with persistent byte range tracking`)

- New `lutris/util/download_progress.py`: Persistent progress tracker using atomic JSON sidecar files (`.progress`) alongside downloads.
- Interrupted GOG downloads (hibernate, crash, network error, Lutris restart) resume from where they left off instead of starting over.
- Atomic write (`os.replace`) for crash-safe progress file updates.
- On start: checks for `.progress` file; resumes remaining ranges only if `file_size` matches; starts fresh if mismatched or file missing; skips entirely if all ranges complete.

---

## Quality gates

- `ruff check`: all checks passed
- `ruff format`: all files formatted
- `mypy`: success, no issues
- `pytest`: 117 tests passed (33 + 53 + 31), 0 failures

## Test coverage

- 31 tests for cache lock lifecycle, safe deletion, and downloader parameters
- 41 tests for parallel download, range calculation, server probing, fallback, cancellation, retry, and progress tracking
- Additional tests for Phase 3 resume logic