### PR TITLE
Add git hooks to verify static anaylsis checks are run

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,71 @@
+#!/bin/env python
+"""
+An hook script to verify what is about to be committed.
+Called by "git commit" with no arguments.  The hook should
+exit with non-zero status after issuing an appropriate message if
+it wants to stop the commit.
+
+This validates that the Lutris static analysis checks from .github/workflows/static.yml
+"""
+
+import shutil
+import subprocess
+from os.path import devnull
+import sys
+from pathlib import Path
+
+
+def main():
+    error_list: list[str] = []
+
+    comp_process = subprocess.run(
+        ["git", "config", "--type=bool", "hooks.skip-static-analysis-checks"], capture_output=True
+    )
+    skip_static_analysis_checks: bool = bool(comp_process.stdout.decode("utf-8"))
+
+    if not skip_static_analysis_checks:
+        diff_against_rev: str = "HEAD"
+        comp_process = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], stdout=subprocess.DEVNULL)
+        if comp_process.returncode != 0:
+            # This would be the initial commit, so diff against an empty tree object
+            comp_process = subprocess.run(["git", "hash-object", "-t", "tree", devnull], capture_output=True)
+            diff_against_rev = comp_process.stdout.decode("utf-8")
+
+        comp_process = subprocess.run(
+            ["git", "diff-index", "--cached", "--name-only", "--diff-filter=ACMR", "-z", diff_against_rev],
+            capture_output=True,
+        )
+        modified_files: list[Path] = [Path(f.decode("utf-8")) for f in comp_process.stdout.split(b"\0") if f]
+        modified_python_files: list[Path] = [f for f in modified_files if f.suffix == '.py']
+
+        if modified_python_files:
+            # Run command existence checks
+            for command in ["mypy", "ruff"]:
+                command_path = shutil.which(command)
+                if not command_path:
+                    error_list.append(
+                        f"{command_path} command is missing: Have you run `make dev` to install it or sourced your virtual env?"
+                    )
+
+            checks_to_run: list[list[str]] = [
+                ["mypy", "--python-version=3.10"] + [str(f) for f in modified_python_files],
+                [sys.executable, "utils/check_annotations.py"],
+                ["ruff", "check"] + [str(f) for f in modified_python_files],
+                ["ruff", "format", "--check"] + [str(f) for f in modified_python_files],
+            ]
+            for check in checks_to_run:
+                comp_process = subprocess.run(check, capture_output=True)
+                if comp_process.returncode != 0:
+                    # Store both the stdout and stderr of the failed check in the error list
+                    error_list.append(f"{comp_process.stdout.decode('utf-8')}{comp_process.stderr.decode('utf-8')}")
+
+    # If any of the return codes are non-zero then return a non-zero rc
+    if error_list:
+        print("".join(error_list))
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,10 @@ req-python:
 	pip3 install PyYAML lxml requests Pillow setproctitle python-magic distro dbus-python types-requests \
 	 types-PyYAML evdev PyGObject pypresence protobuf moddb
 
-dev:
+install-hooks:
+	ln -sf -t .git/hooks/ ../../.hooks/pre-commit
+
+dev: install-hooks
 	pip3 install ruff==0.12.1 mypy==1.16.1 mypy-baseline nose2
 	pip3 install pygobject-stubs --no-cache-dir --config-settings=config=Gtk3,Gdk3,Soup2
 


### PR DESCRIPTION
The hooks run the `mypy`, `ruff` and the check_annotation.py script to verify that python files are in a valid state.

## Caveat
In order to have the hooks run on the client, the contributor must run `make dev` or `make install-hooks` in their environment at least once to symlink the hooks. The hooks are initially in the `.hooks/` directory, but need to be in `.git/hooks` to run.
However due to the `.git` directory not being part of the git repo, the `.git/hooks` directory can't be under source control. See [Customizing Git - Git Hooks](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks) page about Client-Side Hooks.

### Additional Notes

Originally I tried to use a shell script for this script, however it was quite hard to make a portable shell script that worked uniformly across  `dash`, `bash`, `ksh`, `zsh` and `fish`. 
So `python` was chosen instead since it works consistently across distros.

### Sample Output

```bash
(.venv) [user@host /mnt/DataDrive/workspace/lutris]$ git commit
lutris/gui/config/widget_generator.py:125: error: "int" has no attribute "pack_start"  [attr-defined]
lutris/gui/config/widget_generator.py:129: error: Item "None" of "Box | None" has no attribute "pack_start"  [union-attr]
Found 2 errors in 1 file (checked 2 source files)
lutris/gui/config/widget_generator.py:48: unquoted annotation 'ConfigBox' references a TYPE_CHECKING-only import
lutris/gui/config/widget_generator.py:3:1: I001 [*] Import block is un-sorted or un-formatted
   |
 1 |   """Widget generators and their signal handlers"""
 2 |
 3 | / from lutris.gui.config.boxes import ConfigBox
 4 | |
 5 | |
 6 | | import os
 7 | | from abc import ABC, abstractmethod
 8 | | from gettext import gettext as _
 9 | | from inspect import Parameter, signature
10 | | from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
11 | |
12 | | from gi.repository import Gdk, Gtk  # type: ignore
13 | |
14 | | from lutris.config import LutrisConfig
15 | | from lutris.gui.widgets import NotificationSource
16 | | from lutris.gui.widgets.common import EditableGrid, FileChooserEntry, Label
17 | | from lutris.gui.widgets.searchable_entrybox import SearchableEntrybox
18 | | from lutris.util.log import logger
19 | | from lutris.util.strings import gtk_safe
   | |________________________________________^ I001
20 |
21 |   if TYPE_CHECKING:
   |
   = help: Organize imports

Found 1 error.
[*] 1 fixable with the `--fix` option.
Would reformat: lutris/gui/config/runner_config_boxes.py
Would reformat: lutris/gui/config/widget_generator.py
2 files would be reformatted
```

fixes #6539