### PR TITLE
Pin the pygobject-stubs package to be at minimum 2.17.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ install-hooks:
 
 dev: install-hooks
 	pip3 install ruff==0.12.1 mypy==1.16.1 mypy-baseline nose2
-	pip3 install pygobject-stubs --no-cache-dir --config-settings=config=Gtk3,Gdk3,Soup2
+	pip3 install 'pygobject-stubs>=2.17.0' --no-cache-dir --config-settings=config=Gtk3,Gdk3,Soup2
 
 # ============
 # Style checks


### PR DESCRIPTION
Unpinned PyPi packages aren't upgraded by pip unless the `--upgrade` argument is supplied.