### PR TITLE
Updated references to `~/.local/share`, `~/.cache,` `~/.config` to use the XDG spec

### DIFF
--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -4,11 +4,11 @@
 # pylint: disable=too-many-public-methods
 import os
 from gettext import gettext as _
-from pathlib import Path
 from typing import List
 
 from gi.repository import Gio, Gtk
 
+from lutris import settings
 from lutris.config import duplicate_game_config
 from lutris.database import games
 from lutris.database.games import add_game, get_game_by_field
@@ -402,7 +402,7 @@ class SingleGameActions(GameActions):
             steam_shortcut.create_shortcut(game, launch_config_name, True)
             db_game = games.get_game_by_field(game.id, "id")
             if db_game:
-                gamepath = f"{Path.home()!s}/.local/share/applications/lutris-{game.slug}.sh"
+                gamepath = f"{settings.XDG_DATA_DIR}/applications/lutris-{game.slug}.sh"
                 generate_script(logger, LaunchUIDelegate(), db_game, gamepath)
 
     def on_create_desktop_shortcut(self, *_args):

--- a/lutris/runners/ryujinx.py
+++ b/lutris/runners/ryujinx.py
@@ -3,6 +3,7 @@ import os
 from gettext import gettext as _
 from shutil import copyfile
 
+from lutris import settings
 from lutris.exceptions import MissingGameExecutableError
 from lutris.runners.runner import Runner
 from lutris.util import system
@@ -50,7 +51,7 @@ class ryujinx(Runner):
     @property
     def ryujinx_data_dir(self):
         """Return dir where Ryujinx files lie."""
-        candidates = ("~/.local/share/ryujinx",)
+        candidates = (os.path.join(settings.XDG_DATA_DIR, "ryujinx"),)
         for candidate in candidates:
             path = system.fix_path_case(os.path.join(os.path.expanduser(candidate), "nand"))
             if system.path_exists(path):

--- a/lutris/runners/yuzu.py
+++ b/lutris/runners/yuzu.py
@@ -3,6 +3,7 @@ import os
 from gettext import gettext as _
 from shutil import copyfile
 
+from lutris import settings
 from lutris.exceptions import MissingGameExecutableError
 from lutris.runners.runner import Runner
 from lutris.util import system
@@ -51,7 +52,7 @@ class yuzu(Runner):
     @property
     def yuzu_data_dir(self):
         """Return dir where Yuzu files lie."""
-        candidates = ("~/.local/share/yuzu",)
+        candidates = (os.path.join(settings.XDG_DATA_DIR, "yuzu"),)
         for candidate in candidates:
             path = system.fix_path_case(os.path.join(os.path.expanduser(candidate), "nand"))
             if system.path_exists(path):

--- a/lutris/scanners/playtron.py
+++ b/lutris/scanners/playtron.py
@@ -4,6 +4,7 @@ import json
 import os
 from typing import Dict, List, Optional, Tuple
 
+from lutris import settings
 from lutris.api import get_api_games
 from lutris.config import write_game_config
 from lutris.database import sql
@@ -63,8 +64,8 @@ def _get_library_paths() -> List[str]:
     """Return all potential Playtron library paths (home + mounted drives)"""
     paths = []
 
-    # Home directory
-    home_data = os.path.expanduser("~/.local/share")
+    # $XDG_DATA_HOME directory
+    home_data = settings.XDG_DATA_DIR
     if os.path.isdir(os.path.join(home_data, DEFAULT_APPS_DIR)):
         paths.append(home_data)
 

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -23,11 +23,11 @@ from lutris.util.egs.egs_launcher import EGSLauncher
 from lutris.util.log import logger
 from lutris.util.strings import slugify
 
-EGS_GAME_ART_PATH = os.path.expanduser("~/.cache/lutris/egs/game_box")
-EGS_GAME_BOX_PATH = os.path.expanduser("~/.cache/lutris/egs/game_box_tall")
-EGS_LOGO_PATH = os.path.expanduser("~/.cache/lutris/egs/game_logo")
-EGS_BANNERS_PATH = os.path.expanduser("~/.cache/lutris/egs/banners")
-EGS_BOX_ART_PATH = os.path.expanduser("~/.cache/lutris/egs/boxart")
+EGS_GAME_ART_PATH = os.path.join(settings.XDG_CACHE_DIR, "/lutris/egs/game_box")
+EGS_GAME_BOX_PATH = os.path.join(settings.XDG_CACHE_DIR, "/lutris/egs/game_box_tall")
+EGS_LOGO_PATH = os.path.join(settings.XDG_CACHE_DIR, "/lutris/egs/game_logo")
+EGS_BANNERS_PATH = os.path.join(settings.XDG_CACHE_DIR, "/lutris/egs/banners")
+EGS_BOX_ART_PATH = os.path.join(settings.XDG_CACHE_DIR, "/lutris/egs/boxart")
 BANNER_SIZE = (316, 178)
 BOX_ART_SIZE = (200, 267)
 

--- a/lutris/services/gog_cloud.py
+++ b/lutris/services/gog_cloud.py
@@ -26,6 +26,7 @@ from gettext import gettext as _
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from lutris import settings
 from lutris.util.http import HTTPError, Request
 from lutris.util.log import logger
 
@@ -596,10 +597,10 @@ def get_cloud_save_locations(access_token: str, client_id: str, platform: str = 
 GOG_VARIABLE_MAP_LINUX_NATIVE = {
     "INSTALL": "",  # Will be set per-game
     "DOCUMENTS": str(Path.home() / "Documents"),
-    "APPLICATION_DATA_LOCAL": str(Path.home() / ".local" / "share"),
-    "APPLICATION_DATA_LOCAL_LOW": str(Path.home() / ".local" / "share"),
-    "APPLICATION_DATA_ROAMING": str(Path.home() / ".config"),
-    "SAVED_GAMES": str(Path.home() / ".local" / "share"),
+    "APPLICATION_DATA_LOCAL": str(settings.XDG_DATA_DIR),
+    "APPLICATION_DATA_LOCAL_LOW": str(settings.XDG_DATA_DIR),
+    "APPLICATION_DATA_ROAMING": str(settings.XDG_CONFIG_DIR),
+    "SAVED_GAMES": str(settings.XDG_DATA_DIR),
     "APPLICATION_SUPPORT": "",  # Not applicable on Linux
 }
 

--- a/lutris/services/scummvm.py
+++ b/lutris/services/scummvm.py
@@ -11,7 +11,7 @@ from lutris.services.service_media import ServiceMedia
 from lutris.util import system
 from lutris.util.strings import slugify
 
-SCUMMVM_CONFIG_FILE = os.path.join(os.path.expanduser("~/.config/scummvm"), "scummvm.ini")
+SCUMMVM_CONFIG_FILE = os.path.join(settings.XDG_CONFIG_DIR, "scummvm", "scummvm.ini")
 
 
 # Dummy banner. Maybe the download from lutris should be implemented at this place

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -19,17 +19,20 @@ COPYRIGHT = _("(c) 2009 Lutris Team")
 AUTHORS = [_("The Lutris team")]
 
 # Paths
-CONFIG_DIR = os.path.join(GLib.get_user_config_dir(), "lutris")
-DATA_DIR = os.path.join(GLib.get_user_data_dir(), "lutris")
+XDG_CONFIG_DIR = GLib.get_user_config_dir()
+CONFIG_DIR = os.path.join(XDG_CONFIG_DIR, "lutris")
+XDG_DATA_DIR = GLib.get_user_data_dir()
+DATA_DIR = os.path.join(XDG_DATA_DIR, "lutris")
 if not os.path.exists(CONFIG_DIR):
-    # Set the config dir to ~/.local/share/lutris as we're deprecating ~/.config/lutris
+    # Set the config dir to $XDG_DATA_HOME/lutris as we're deprecating $XDG_CONFIG_HOME/lutris
     CONFIG_DIR = DATA_DIR
 CONFIG_FILE = os.path.join(CONFIG_DIR, "lutris.conf")
 sio = SettingsIO(CONFIG_FILE)
 
 RUNNER_DIR = sio.read_setting("runner_dir") or os.path.join(DATA_DIR, "runners")
 RUNTIME_DIR = sio.read_setting("runtime_dir") or os.path.join(DATA_DIR, "runtime")
-CACHE_DIR = sio.read_setting("cache_dir") or os.path.join(GLib.get_user_cache_dir(), "lutris")
+XDG_CACHE_DIR = GLib.get_user_cache_dir()
+CACHE_DIR = sio.read_setting("cache_dir") or os.path.join(XDG_CACHE_DIR, "lutris")
 TMP_DIR = os.path.join(CACHE_DIR, "tmp")
 GAME_CONFIG_DIR = os.path.join(CONFIG_DIR, "games")
 RUNNERS_CONFIG_DIR = os.path.join(CONFIG_DIR, "runners")

--- a/lutris/util/dolphin/cache_reader.py
+++ b/lutris/util/dolphin/cache_reader.py
@@ -2,9 +2,10 @@
 
 import os
 
+from lutris import settings
 from lutris.util.log import logger
 
-DOLPHIN_GAME_CACHE_FILE = os.path.expanduser("~/.cache/dolphin-emu/gamelist.cache")
+DOLPHIN_GAME_CACHE_FILE = os.path.join(settings.XDG_CACHE_DIR, "dolphin-emu/gamelist.cache")
 SUPPORTED_CACHE_VERSION = 24
 
 

--- a/lutris/util/sniper.py
+++ b/lutris/util/sniper.py
@@ -4,11 +4,12 @@ import os
 from functools import lru_cache
 from typing import List, Optional
 
+from lutris import settings
 from lutris.util.log import logger
 
 _SNIPER_SEARCH_PATHS = [
-    os.path.expanduser("~/.local/share/umu/run-in-sniper"),
-    os.path.expanduser("~/.local/share/Steam/steamapps/common/SteamLinuxRuntime_sniper/run-in-sniper"),
+    os.path.join(settings.XDG_DATA_DIR, "umu/run-in-sniper"),
+    os.path.join(settings.XDG_DATA_DIR, "Steam/steamapps/common/SteamLinuxRuntime_sniper/run-in-sniper"),
 ]
 
 # Host library base directories. Inside the Sniper container, the host
@@ -31,8 +32,8 @@ def get_sniper_run_command() -> Optional[str]:
     """Return the path to the run-in-sniper script, or None if not found.
 
     Searches in order:
-      1. umu-launcher installation (~/.local/share/umu/)
-      2. Steam installation (~/.local/share/Steam/)
+      1. umu-launcher installation ($XDG_DATA_HOME/umu/)
+      2. Steam installation ($XDG_DATA_HOME/Steam/)
     """
     for path in _SNIPER_SEARCH_PATHS:
         if os.path.isfile(path) and os.access(path, os.X_OK):

--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -14,8 +14,8 @@ from lutris.util.steam.vdfutils import vdf_parse
 STEAM_DATA_DIRS = (
     "~/.steam/debian-installation",
     "~/.steam",
-    "~/.local/share/steam",
-    "~/.local/share/Steam",
+    f"{settings.XDG_DATA_DIR}/steam",
+    f"{settings.XDG_DATA_DIR}/Steam",
     "~/snap/steam/common/.local/share/Steam",
     "~/.steam/steam",
     "~/.var/app/com.valvesoftware.Steam/data/steam",

--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -7,6 +7,7 @@ import shlex
 import shutil
 from pathlib import Path
 
+from lutris import settings
 from lutris.api import format_installer_url
 from lutris.util import resources, system
 from lutris.util.log import logger
@@ -180,8 +181,8 @@ def generate_standalone_shortcut(game, launch_config_name):
     return {
         "appid": generate_shortcut_id(game),
         "AppName": game.name,
-        "Exe": f'"{Path.home()!s}/.local/share/applications/lutris-{game.slug}.sh"',
-        "StartDir": f'"{Path.home()!s}/.local/share/applications/"',
+        "Exe": f'"{settings.DATA_DIR}/applications/lutris-{game.slug}.sh"',
+        "StartDir": f'"{settings.DATA_DIR}/applications/"',
         "icon": resources.get_icon_path(game.slug),
         "LaunchOptions": launch_options,
         "IsHidden": 0,

--- a/tests/test_gog_cloud.py
+++ b/tests/test_gog_cloud.py
@@ -50,6 +50,7 @@ get_game_scoped_token = _mod.get_game_scoped_token
 get_relative_path = _mod.get_relative_path
 resolve_save_path = _mod.resolve_save_path
 
+from lutris import settings
 from lutris.util.http import HTTPError
 
 
@@ -629,7 +630,7 @@ class TestResolveSavePath(unittest.TestCase):
     def test_native_linux_appdata_local(self):
         loc = CloudSaveLocation(name="saves", location="<?APPLICATION_DATA_LOCAL?>/TestGame")
         result = resolve_save_path(loc, "/opt/games/mygame", is_native=True)
-        expected = os.path.normpath(str(Path.home() / ".local" / "share" / "TestGame"))
+        expected = os.path.normpath(str(Path(settings.XDG_DATA_DIR) / "TestGame"))
         self.assertEqual(result, expected)
 
     def test_wine_userprofile_documents(self):


### PR DESCRIPTION

References to those directories have been updated to use settings.DATA_DIR, settings.CACHE_DIR and settings.CONFIG_DIR respectively. Those refer to $XDG_DATA_HOME, $XDG_CACHE_HOME and $XDG_CONFIG_HOME values otherwise they fallback to the `$HOME/.local/share`, `$HOME/.cache` and `$HOME/.config`

References within to $HOME directories within any Flakpak related code has been unchanged and still references to `~` or `Path.home()` home values.