### PR TITLE
Added explicit require version calls for gobject packages

### DIFF
--- a/lutris/gui/__init__.py
+++ b/lutris/gui/__init__.py
@@ -1,1 +1,10 @@
 """Lutris GUI package"""
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")
+gi.require_version("GnomeDesktop", "3.0")
+gi.require_version("Pango", "1.0")
+gi.require_version("PangoCairo", "1.0")
+gi.require_version("WebKit2", "4.1")


### PR DESCRIPTION
This fixes issues when trying to import Gtk, Gdk, Pango, GnomeDesktop, PangoCairo and WebKit2 inside of unit test when on system with Gtk 4.0 installed.

fixes #6569