### PR TITLE
Substitute variables in working_dir

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -164,7 +164,9 @@ class CommandsMixin:
         if terminal:
             terminal = linux.get_default_terminal()
         if working_dir and not os.path.isdir(working_dir):
-            logger.warning("Working directory %s doesn't exist or is not a directory, using target path instead", working_dir)
+            logger.warning(
+                "Working directory %s doesn't exist or is not a directory, using target path instead", working_dir
+            )
             working_dir = None
         if not working_dir:
             working_dir = self.target_path


### PR DESCRIPTION
Substitute variables in working_dir and log errors if it does not exist.
Also checks if woking_dir is an actual directory.

Related to #6577.