### PR TITLE
Adding support to forward arguments supplied via the Command Line to the game launch arguments

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -666,12 +666,24 @@ class Game:
             gameplay_info["working_dir"] = self.runner.working_dir
 
         config = launch_ui_delegate.select_game_launch_config(self)
+        if "prepend_args" not in gameplay_info:
+            gameplay_info["prepend_args"] = launch_ui_delegate.get_extra_game_launch_prepend_args()
+        if "append_args" not in gameplay_info:
+            gameplay_info["append_args"] = launch_ui_delegate.get_extra_game_launch_append_args()
 
         if config is None:
             return {}  # no error here- the user cancelled out
 
         if config:  # empty dict for primary configuration
             self.runner.apply_launch_config(gameplay_info, config)
+        elif command := gameplay_info.get("command", []):
+            # For primary configuration splice the prepend after argument 0
+            # The append_args are added to the end of the command
+            if command:
+                gameplay_info["command"] = command[:1]
+                gameplay_info["command"] += gameplay_info["prepend_args"]
+                gameplay_info["command"] += command[1:]
+                gameplay_info["command"] += gameplay_info["append_args"]
 
         return gameplay_info
 

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -328,6 +328,30 @@ class LutrisApplication(Gtk.Application):
         )
         self.add_main_option("submit-issue", 0, GLib.OptionFlags.NONE, GLib.OptionArg.NONE, _("Submit an issue"), None)
         self.add_main_option(
+            "launch-config-name",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING,
+            _("Specify launch config to use for lutris:rungame/game-identifier and lutris:rungameid/numerical-id."),
+            None,
+        )
+        self.add_main_option(
+            "launch-args-prepend",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING_ARRAY,
+            _("Launch Arguments to forward to game. Arguments are prepended before regular args"),
+            None,
+        )
+        self.add_main_option(
+            "launch-args-append",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING_ARRAY,
+            _("Launch Arguments to forward to game. Arguments are appended after regular args"),
+            None,
+        )
+        self.add_main_option(
             GLib.OPTION_REMAINING,
             0,
             GLib.OptionFlags.NONE,
@@ -659,7 +683,14 @@ class LutrisApplication(Gtk.Application):
         appid = installer_info["appid"]
         launch_config_name = installer_info["launch_config_name"]
 
-        self.launch_ui_delegate = CommandLineUIDelegate(launch_config_name)
+        if launch_config_var := options.lookup_value("launch-config-name"):
+            launch_config_name = launch_config_var.get_string()
+
+        prepend_args_var = options.lookup_value("launch-args-prepend")
+        launch_prepend_args = prepend_args_var.get_strv() if prepend_args_var else []
+        append_args_var = options.lookup_value("launch-args-append")
+        launch_append_args = append_args_var.get_strv() if append_args_var else []
+        self.launch_ui_delegate = CommandLineUIDelegate(launch_config_name, launch_prepend_args, launch_append_args)
 
         revision = installer_info["revision"]
 

--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -67,6 +67,16 @@ class LaunchUIDelegate(Delegate):
         """
         on_ready()
 
+    def get_extra_game_launch_prepend_args(self) -> list[str]:
+        """Specifies additional arguments to prepend to the argument list
+        for the game launch command"""
+        return []
+
+    def get_extra_game_launch_append_args(self) -> list[str]:
+        """Specifies additional arguments to append to the argument list
+        for the game launch command"""
+        return []
+
 
 class InstallUIDelegate(Delegate):
     """These objects provide UI for a runner as it is installing itself.
@@ -112,8 +122,15 @@ class InstallUIDelegate(Delegate):
 class CommandLineUIDelegate(LaunchUIDelegate):
     """This delegate can provide user selections that were provided on the command line."""
 
-    def __init__(self, launch_config_name: str | None):
+    def __init__(
+        self,
+        launch_config_name: str | None,
+        launch_args_prepend: list[str] | None = None,
+        launch_args_append: list[str] | None = None,
+    ) -> None:
         self.launch_config_name = launch_config_name
+        self.launch_args_extra_prepend = launch_args_prepend[:] if launch_args_prepend else []
+        self.launch_args_extra_append = launch_args_append[:] if launch_args_append else []
 
     def select_game_launch_config(self, game: Game) -> "LaunchConfigDict | None":
         if not self.launch_config_name:
@@ -127,6 +144,12 @@ class CommandLineUIDelegate(LaunchUIDelegate):
                 return config
 
         raise RuntimeError("The launch configuration '%s' could not be found." % self.launch_config_name)
+
+    def get_extra_game_launch_prepend_args(self) -> list[str]:
+        return self.launch_args_extra_prepend
+
+    def get_extra_game_launch_append_args(self) -> list[str]:
+        return self.launch_args_extra_append
 
 
 class DialogInstallUIDelegate(InstallUIDelegate):

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -137,12 +137,18 @@ class linux(Runner):
 
         if "exe" in launch_config:
             config_exe = os.path.expanduser(launch_config["exe"] or "")
-            command.append(self.get_relative_exe(config_exe, working_dir))
+
+            if exe := self.get_relative_exe(config_exe, working_dir):
+                command.append(exe)
         elif len(command) == 0:
             raise GameConfigError(_("The runner could not find a command or exe to use for this configuration."))
 
-        if launch_config.get("args"):
-            command += split_arguments(launch_config["args"])
+        if prepend_args := gameplay_info.get("prepend_args"):
+            command += prepend_args
+        if args := launch_config.get("args"):
+            command += split_arguments(args)
+        if append_args := gameplay_info.get("append_args"):
+            command += append_args
 
         return command
 

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -405,8 +405,12 @@ class Runner:  # pylint: disable=too-many-public-methods
         if exe:
             command.append(exe)
 
-        if launch_config.get("args"):
-            command += strings.split_arguments(launch_config["args"])
+        if prepend_args := gameplay_info.get("prepend_args"):
+            command += prepend_args
+        if args := launch_config.get("args"):
+            command += strings.split_arguments(args)
+        if append_args := gameplay_info.get("append_args"):
+            command += append_args
 
         return command
 


### PR DESCRIPTION
Support has been added for a `--launch-args-prepend` and `--launch-args-append` options which can forward arguments to the game launched via the lutris:rungame or lutris:rungameid protocols

Added a `--launch-config-name` argument which can specify a launch config to run when using the rungame / rungameid protocols

fixes #4602

Below is a link to two videos of how the feature works when using the primary config + using the launch config

### Ex. Forwarding arguments for the primary config

https://github.com/user-attachments/assets/504ab35d-2da5-4ff1-8fc8-6d85feba88a6

### Ex. Forwarding arguments for a launch config

https://github.com/user-attachments/assets/4097e8ae-2cfb-4a54-9055-faeb68e8435a


