### PR TITLE
Changed the Game "Move" Directory Picker into a Set Location Dialog

### DIFF
--- a/lutris/gui/config/game_common.py
+++ b/lutris/gui/config/game_common.py
@@ -9,14 +9,15 @@ from gi.repository import Gtk
 
 from lutris import settings
 from lutris.config import LutrisConfig, make_game_config_id, rename_config
-from lutris.game import Game
+from lutris.game import GAME_UPDATED, Game
 from lutris.gui.config import DIALOG_HEIGHT, DIALOG_WIDTH
 from lutris.gui.config.boxes import GameBox, RunnerBox, SystemConfigBox
 from lutris.gui.config.game_info_box import GameInfoBox
 from lutris.gui.config.widget_generator import WidgetWarningMessageBox
-from lutris.gui.dialogs import DirectoryDialog, ErrorDialog, QuestionDialog, SavableModelessDialog, display_error
+from lutris.gui.dialogs import ErrorDialog, QuestionDialog, SavableModelessDialog, display_error
 from lutris.gui.dialogs.delegates import DialogInstallUIDelegate
 from lutris.gui.dialogs.move_game import MoveDialog
+from lutris.gui.dialogs.set_game_location import KEEP_ACTION, MOVE_ACTION, SetLocationDialog
 from lutris.gui.widgets.notifications import send_notification
 from lutris.runners import import_runner
 from lutris.services.lutris import download_lutris_media
@@ -142,14 +143,27 @@ class GameDialogCommon(SavableModelessDialog, DialogInstallUIDelegate):
         page_index = self._add_notebook_tab(info_sw, _("Game info"))
         self.option_page_indices.add(page_index)
 
-    def on_move_clicked(self, _button: Gtk.Button) -> None:
-        game_directory = self.game.directory if self.game else ""
-        new_location = DirectoryDialog("Select new location for the game", default_path=game_directory, parent=self)
-        if not new_location.folder or new_location.folder == game_directory:
+    def on_set_location_clicked(self, _button: Gtk.Button):
+        game_directory = ""
+        if self.game:
+            game_directory = self.game.directory
+        if not game_directory and self.lutris_config:
+            game_directory = self.lutris_config.system_config.get("game_path")
+        set_location_dialog = SetLocationDialog(parent=self, default_path=game_directory)
+        new_location = set_location_dialog.new_location
+        if not new_location or new_location == game_directory:
             return
-        move_dialog = MoveDialog(self.game, new_location.folder, parent=self)
-        move_dialog.connect("game-moved", self.on_game_moved)
-        move_dialog.move()
+
+        if set_location_dialog.action == KEEP_ACTION:
+            if self.game:
+                self.game.set_location(new_location)
+                GAME_UPDATED.fire(self.game)
+                if self.info_box and self.info_box.directory_entry:
+                    self.info_box.directory_entry.set_text(new_location)
+        elif set_location_dialog.action == MOVE_ACTION:
+            move_dialog = MoveDialog(self.game, new_location, parent=self)
+            move_dialog.connect("game-moved", self.on_game_moved)
+            move_dialog.move()
 
     def on_game_moved(self, dialog: MoveDialog) -> None:
         """Show a notification when the game is moved"""

--- a/lutris/gui/config/game_info_box.py
+++ b/lutris/gui/config/game_info_box.py
@@ -188,9 +188,9 @@ class GameInfoBox(AdvancedSettingsBox):
             self.directory_entry.set_text(self.game.directory)
         self.directory_entry.set_sensitive(False)
         box.pack_start(self.directory_entry, True, True, 0)
-        move_button = Gtk.Button(_("Move"), visible=True)
-        move_button.connect("clicked", self.parent_widget.on_move_clicked)
-        box.pack_start(move_button, False, False, 0)
+        set_location_button = Gtk.Button(_("Set Location"), visible=True)
+        set_location_button.connect("clicked", self.parent_widget.on_set_location_clicked)
+        box.pack_start(set_location_button, False, False, 0)
         return box
 
     def _get_launch_config_box(self):

--- a/lutris/gui/dialogs/set_game_location.py
+++ b/lutris/gui/dialogs/set_game_location.py
@@ -1,0 +1,67 @@
+from gettext import gettext as _
+
+from gi.repository import Gtk
+
+from lutris.gui.dialogs import ModalDialog
+from lutris.gui.widgets.common import FileChooserEntry
+
+KEEP_ACTION = "keep"
+MOVE_ACTION = "move"
+
+
+class SetLocationDialog(ModalDialog):
+    def __init__(self, parent: Gtk.Window | None = None, default_path: str = "") -> None:
+        super().__init__(parent=parent, border_width=24)
+
+        self.set_title("Set Game Location")
+
+        self.action = KEEP_ACTION
+
+        frame = Gtk.Frame(label=_("Location"), visible=True, shadow_type=Gtk.ShadowType.ETCHED_OUT)
+        frame_vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, visible=True)
+        frame.add(frame_vbox)
+
+        game_location_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=6, margin_start=12, margin_end=12)
+        game_location_label = Gtk.Label(label=_("Game location:"))
+        self._game_location_chooser = FileChooserEntry(
+            title=_("Select folder"),
+            action=Gtk.FileChooserAction.SELECT_FOLDER,
+            text=default_path,
+            default_path=default_path,
+        )
+        self._game_location_chooser.set_valign(Gtk.Align.CENTER)
+        self._game_location_chooser.set_size_request(400, -1)
+        game_location_box.pack_start(game_location_label, False, False, 0)
+        game_location_box.pack_start(self._game_location_chooser, True, True, 0)
+
+        self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
+        self.add_default_button(Gtk.STOCK_OK, Gtk.ResponseType.OK)
+
+        vbox = Gtk.Box.new(Gtk.Orientation.VERTICAL, 6)
+        keep_button = Gtk.RadioButton.new_with_label_from_widget(None, _("Game is already at location"))
+        keep_button.connect("toggled", self.on_button_toggled, KEEP_ACTION)
+        vbox.pack_start(keep_button, False, False, 0)
+        move_button = Gtk.RadioButton.new_from_widget(keep_button)
+        move_button.set_label(_("Move game to location"))
+        move_button.connect("toggled", self.on_button_toggled, MOVE_ACTION)
+        vbox.pack_start(move_button, False, False, 0)
+
+        frame_vbox.pack_start(game_location_box, False, False, 0)
+        frame_vbox.pack_start(vbox, False, False, 0)
+
+        self.get_content_area().add(frame)
+
+        self.show_all()
+        self.run()
+
+    @property
+    def new_location(self) -> str:
+        return self._game_location_chooser.get_path()
+
+    def on_button_toggled(self, _button, action):
+        self.action = action
+
+    def on_response(self, _widget, response):
+        if response == Gtk.ResponseType.CANCEL:
+            self.action = None
+        super().on_response(_widget, response)


### PR DESCRIPTION
The "Set Location" buttons opens up a dialog that allows the user to choose whether they want to set the location of the game directory or move the game directory.

resolves #3914

<img width="1198" height="689" alt="image" src="https://github.com/user-attachments/assets/84deca41-72f7-47ca-ae23-140c2bd31cc2" />
