### PR TITLE
Improve handling of malformed installer scripts

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -363,7 +363,7 @@ class LutrisApplication(Gtk.Application):
             return kwargs["runner"].name
         if kwargs.get("installers"):
             installer = kwargs["installers"][0]
-            return installer.get("slug") or installer.get("game_slug")
+            return installer.get("slug") or installer.get("game_slug") or "Malformed script"
         if kwargs.get("game"):
             return kwargs["game"].id
         return str(kwargs)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -444,7 +444,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         for script in installers:
             for item in ["description", "notes"]:
                 script[item] = script.get(item) or ""
-            for item in ["name", "runner", "version"]:
+            for item in ["name", "runner", "version", "script"]:
                 if item not in script:
                     raise ScriptingError(_('Missing field "%s" in install script') % item)
             for file_desc in script["script"].get("files", {}):


### PR DESCRIPTION
This fixes the installer crash before displaying meaningful error message if the script is malformed.