### PR TITLE
Additional GTK require_version fixes for UnitTest

### DIFF
--- a/lutris/__init__.py
+++ b/lutris/__init__.py
@@ -1,3 +1,8 @@
 """Main Lutris package"""
 
 __version__ = "0.5.23"
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+gi.require_version("Gdk", "3.0")

--- a/lutris/gui/__init__.py
+++ b/lutris/gui/__init__.py
@@ -2,6 +2,4 @@
 
 import gi
 
-gi.require_version("Gtk", "3.0")
-gi.require_version("Gdk", "3.0")
 gi.require_version("PangoCairo", "1.0")

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -25,11 +25,6 @@ import tempfile
 from datetime import datetime, timedelta
 from gettext import gettext as _
 
-import gi
-
-gi.require_version("Gdk", "3.0")
-gi.require_version("Gtk", "3.0")
-
 from gi.repository import Gio, GLib, Gtk
 
 from lutris import settings

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -8,16 +8,10 @@ from collections.abc import Callable
 from gettext import gettext as _
 from typing import Any, TypeVar, cast
 
-import gi
-
-from lutris.exceptions import LutrisError
-
-gi.require_version("Gdk", "3.0")
-gi.require_version("Gtk", "3.0")
-
 from gi.repository import Gdk, GObject, Gtk
 
 from lutris import api, settings
+from lutris.exceptions import LutrisError
 from lutris.gui.widgets.log_text_view import LogTextView
 from lutris.gui.widgets.utils import get_widget_children, get_widget_window
 from lutris.util import datapath

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -8,8 +8,6 @@ from gettext import gettext as _
 
 import gi
 
-gi.require_version("Gdk", "3.0")
-gi.require_version("Gtk", "3.0")
 gi.require_version("GdkPixbuf", "2.0")
 
 from gi.repository import GdkPixbuf


### PR DESCRIPTION
Moved the `gi.require_version` call to `lutris/__init__.py` for Gtk and Gdk.

This time the [lutris/util/log.py](https://github.com/lutris/lutris/blob/master/lutris/util/log.py#L8) script was loaded first with Gtk 4.0

To fix this issue permanently the Gtk and Gdk require_version calls have been moved to the top Lutris `__init__.py` to make sure that the 4.0 Gtk/Gdk cannot be implicitly imported.

Fixes the following issue with Unit Test discovery
```python
2026-03-29 02:52:56.188 [info] Started unittest discovery subprocess (execution factory) for workspace /mnt/DataDrive/workspace/lutris
2026-03-29 02:52:56.337 [error] /mnt/DataDrive/workspace/lutris/lutris/util/log.py:8: PyGIWarning: Gtk was imported without specifying a version first. Use gi.require_version('Gtk', '4.0') before import to ensure that the right version gets loaded.
  from gi.repository import GLib, Gtk

2026-03-29 02:52:56.426 [error] Unittest test discovery error for workspace:  /mnt/DataDrive/workspace/lutris 
 Failed to import test module: tests._test_api
Traceback (most recent call last):
  File "/usr/lib/python3.14/unittest/loader.py", line 426, in _find_test_path
    module = self._get_module_from_name(name)
  File "/usr/lib/python3.14/unittest/loader.py", line 367, in _get_module_from_name
    __import__(name)
    ~~~~~~~~~~^^^^^^
  File "/mnt/DataDrive/workspace/lutris/tests/_test_api.py", line 4, in <module>
    from lutris import api
  File "/mnt/DataDrive/workspace/lutris/lutris/api.py", line 19, in <module>
    from lutris import settings
  File "/mnt/DataDrive/workspace/lutris/lutris/settings.py", line 14, in <module>
    from lutris.util.settings import SettingsIO
  File "/mnt/DataDrive/workspace/lutris/lutris/util/settings.py", line 5, in <module>
    from lutris.gui.widgets import NotificationSource
  File "/mnt/DataDrive/workspace/lutris/lutris/gui/__init__.py", line 5, in <module>
    gi.require_version("Gtk", "3.0")
    ~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/mnt/DataDrive/workspace/lutris/.venv/lib/python3.14/site-packages/gi/__init__.py", line 139, in require_version
    raise ValueError(
        f"Namespace {namespace} is already loaded with version {loaded_version}"
    )
ValueError: Namespace Gtk is already loaded with version 4.0
```