### PR TITLE
Refactored the JSON Runner to be built upon a ModelRunner base class 

### DIFF
--- a/lutris/runners/json.py
+++ b/lutris/runners/json.py
@@ -1,91 +1,58 @@
 """Base class and utilities for JSON based runners"""
 
 import json
-import os
-import shlex
+from pathlib import Path
+from typing import Any
 
 from lutris import settings
-from lutris.exceptions import MissingGameExecutableError
-from lutris.runners.runner import Runner
-from lutris.util import datapath, system
+from lutris.runners.model import ModelRunner
+from lutris.util import datapath
+
+SETTING_JSON_RUNNER_DIR = Path(settings.RUNNER_DIR) / "json"
 
 JSON_RUNNER_DIRS = [
-    os.path.join(datapath.get(), "json"),
-    os.path.join(settings.RUNNER_DIR, "json"),
+    Path(datapath.get()) / "json",
+    SETTING_JSON_RUNNER_DIR,
 ]
 
 
-class JsonRunner(Runner):
-    json_path = None
+class JsonRunner(ModelRunner):
+    json_path: Path | None = None
 
-    def __init__(self, config=None):
-        super().__init__(config)
-        if not self.json_path:
-            raise RuntimeError("Create subclasses of JsonRunner with the json_path attribute set")
-        with open(self.json_path, encoding="utf-8") as json_file:
-            self._json_data = json.load(json_file)
+    def __init__(
+        self,
+        config=None,
+        *,
+        dict_data: dict[str, Any] | None = None,
+    ):
+        if not self.json_path and not isinstance(dict_data, dict):
+            raise RuntimeError(
+                "Create subclasses of JsonRunner with the json_path attribute set,"
+                " or supply the `dict_data` argument with a dictionary"
+            )
 
-        self.game_options = self._json_data["game_options"]
-        self.runner_options = self._json_data.get("runner_options", [])
-        self.human_name = self._json_data["human_name"]
-        self.description = self._json_data["description"]
-        platforms = self._json_data.get("platforms", {})
-        self.platform_dict = (
-            self._json_data["platforms"]
-            if isinstance(platforms, dict)
-            else {platform: platform for platform in platforms}
-        )
-        self.runner_executable = self._json_data["runner_executable"]
-        self.system_options_override = self._json_data.get("system_options_override", [])
-        self.entry_point_option = self._json_data.get("entry_point_option", "main_file")
-        self.download_url = self._json_data.get("download_url")
-        self.runnable_alone = self._json_data.get("runnable_alone")
-        self.flatpak_id = self._json_data.get("flatpak_id")
+        json_data: dict[str, Any] = {}
+        if self.json_path:
+            with open(self.json_path, encoding="utf-8") as json_file:
+                json_data = json.load(json_file)
+        else:
+            json_data = dict_data if dict_data else {}
+        super().__init__(dict_data=json_data, config=config)
 
-    def play(self):
-        """Return a launchable command constructed from the options"""
-        arguments = self.get_command()
-        for option in self.runner_options:
-            if option["option"] not in self.runner_config:
-                continue
-            if option["type"] == "bool":
-                if self.runner_config.get(option["option"]):
-                    arguments.append(option["argument"])
-            elif option["type"] == "choice":
-                if self.runner_config.get(option["option"]) != "off":
-                    arguments.append(option["argument"])
-                    arguments.append(self.runner_config.get(option["option"]))
-            elif option["type"] == "string":
-                arguments.append(option["argument"])
-                arguments.append(self.runner_config.get(option["option"]))
-            elif option["type"] == "command_line":
-                arg = option.get("argument")
-                if arg:
-                    arguments.append(arg)
-                arguments += shlex.split(self.runner_config.get(option["option"]))
-            else:
-                raise RuntimeError("Unhandled type %s" % option["type"])
-        main_file = self.game_config.get(self.entry_point_option)
-        if not system.path_exists(main_file):
-            raise MissingGameExecutableError(filename=main_file)
-        arguments.append(main_file)
-        result = {"command": arguments}
-        if self._json_data.get("env"):
-            result["env"] = self._json_data["env"]
-        if self._json_data.get("working_dir") == "runner":
-            result["working_dir"] = os.path.dirname(os.path.join(settings.RUNNER_DIR, self.runner_executable))
-        return result
+    @property
+    def file_path(self):
+        return self.json_path
 
 
 def load_json_runners():
     json_runners = {}
     for json_dir in JSON_RUNNER_DIRS:
-        if not os.path.exists(json_dir):
+        if not json_dir.exists():
             continue
-        for json_path in os.listdir(json_dir):
-            if not json_path.endswith(".json"):
+        for json_path in json_dir.iterdir():
+            if json_path.suffix not in [".json"]:
                 continue
-            runner_name = json_path[:-5]
-            runner_class = type(runner_name, (JsonRunner,), {"json_path": os.path.join(json_dir, json_path)})
+            runner_name = json_path.stem
+            runner_class = type(runner_name, (JsonRunner,), {"json_path": json_dir / json_path})
             json_runners[runner_name] = runner_class
     return json_runners

--- a/lutris/runners/model.py
+++ b/lutris/runners/model.py
@@ -1,0 +1,175 @@
+"""Base class and utilities for JSON based runners"""
+
+import shlex
+from pathlib import Path
+from typing import Any, Callable
+
+from lutris.exceptions import MissingGameExecutableError
+from lutris.runners.runner import Runner
+from lutris.util import system
+
+FILE_BASED_ENTRY_POINTS = set(["exe", "main_file", "iso", "rom", "disk-a", "path", "files"])
+DEFAULT_ENTRY_POINT_OPTION = "main_file"
+
+AppendFunction = Callable[[list[str], Any, dict[str, Any]], None]
+
+
+def _append_args_string(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    if option_value := config.get(option_key):
+        option_arg = option_dict.get("argument")
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.append(option_value)
+
+
+def _append_args_bool(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    value = config.get(option_key)
+    option_arg = option_dict.get("argument")
+    if value and isinstance(option_arg, str) and len(option_arg) > 0:
+        arguments.append(option_arg)
+
+
+def _append_args_choice(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    value = config.get(option_key)
+    if isinstance(value, str) and value == "off":
+        return
+    if value is not None:
+        option_arg = option_dict.get("argument")
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.append(value)
+
+
+def _append_args_multi_string(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    if option_values := shlex.split(str(config.get(option_key))):
+        option_arg = option_dict.get("argument")
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.extend(option_values)
+
+
+def _append_args_mapping(arguments: list[str], option_dict: Any, config: dict[str, Any]):
+    option_key = option_dict.get("option")
+    option_arg = option_dict.get("argument")
+    option_value = config.get(option_key)
+    if not isinstance(option_value, dict):
+        return
+    for name, value in option_value.items():
+        if isinstance(option_arg, str) and len(option_arg) > 0:
+            arguments.append(option_arg)
+        arguments.append(f"{name}={value}")
+
+
+_argument_append_funcs: dict[str, AppendFunction] = {
+    # adds arguments from the supplied option dictionary to the arguments list
+    "label": lambda _1, _2, _3: None,
+    "string": _append_args_string,
+    "bool": _append_args_bool,
+    "range": _append_args_string,
+    "choice": _append_args_choice,
+    "choice_with_entry": _append_args_choice,
+    "choice_with_search": _append_args_choice,
+    "file": _append_args_string,
+    "multiple_file": _append_args_multi_string,
+    "directory": _append_args_string,
+    "mapping": _append_args_mapping,
+    "command_line": _append_args_multi_string,
+}
+
+
+def append_args(
+    arguments: list[str],
+    options_dict_list: list[dict[str, Any]],
+    config: dict[str, Any],
+):
+    for option_dict in options_dict_list:
+        option_key = option_dict.get("option")
+        if option_key not in config:
+            continue
+
+        option_type = option_dict.get("type")
+        if append_func := _argument_append_funcs.get(str(option_type)):
+            append_func(arguments, option_dict, config)
+        else:
+            raise RuntimeError(f"Unhandled option type {option_dict.get('type')}")
+
+
+class ModelRunner(Runner):
+    def __init__(self, dict_data: dict[str, Any] | None = None, config=None):
+        super().__init__(config)
+        if dict_data:
+            self.from_dict(dict_data)
+
+    def from_dict(self, dict_data: dict[str, Any]):
+        self.game_options = dict_data.get("game_options", [])
+        self.runner_options = dict_data.get("runner_options", [])
+        self.human_name = dict_data.get("human_name", "")
+        self.description = dict_data.get("description", "")
+        platform_dict = dict_data.get("platforms", [])
+        self.platform_dict = (
+            platform_dict if isinstance(platform_dict, dict) else {platform: platform for platform in platform_dict}
+        )
+        self.runner_executable = dict_data.get("runner_executable", "")
+        self.system_options_override = dict_data.get("system_options_override", [])
+        self.entry_point_option = dict_data.get("entry_point_option", DEFAULT_ENTRY_POINT_OPTION)
+        self.download_url = dict_data.get("download_url", "")
+        self.runnable_alone = dict_data.get("runnable_alone", True)
+        self.flatpak_id = dict_data.get("flatpak_id", "")
+        self.env = dict_data.get("env", {})
+        self.launch_working_dir = dict_data.get("working_dir", "")
+
+    def to_dict(self) -> dict[str, Any]:
+        output_dict_data: dict[str, Any] = {}
+        output_dict_data["human_name"] = self.human_name
+        output_dict_data["description"] = self.description
+        output_dict_data["platforms"] = self.platform_dict
+        output_dict_data["runner_executable"] = self.runner_executable
+        output_dict_data["runnable_alone"] = self.runnable_alone
+        output_dict_data["flatpak_id"] = self.flatpak_id
+        output_dict_data["download_url"] = self.download_url
+        output_dict_data["entry_point_option"] = self.entry_point_option
+        output_dict_data["game_options"] = self.game_options
+        output_dict_data["runner_options"] = self.runner_options
+        output_dict_data["system_options_override"] = self.system_options_override
+        output_dict_data["env"] = self.env
+        output_dict_data["working_dir"] = self.launch_working_dir
+
+        return output_dict_data
+
+    def get_platform(self):
+        """Queries the platform from either a list, dict"""
+        if not self.platform_dict:
+            return ""
+        selected_platform = self.game_config.get("platform")
+        for lutris_platform, runner_platform in self.platform_dict.items():
+            if selected_platform == runner_platform:
+                return lutris_platform
+        return next(iter(self.platform_dict.keys()))
+
+    def play(self) -> dict[str, Any]:
+        """Runs the game"""
+        entry_point_value = self.game_config.get(self.entry_point_option, "")
+        if self.entry_point_option in FILE_BASED_ENTRY_POINTS and not system.path_exists(entry_point_value):
+            raise MissingGameExecutableError(filename=entry_point_value)
+
+        arguments = self.get_command()
+
+        # Append the runner arguments first, and game arguments afterwards
+        append_args(arguments, self.runner_options, self.runner_config)
+        append_args(arguments, self.game_options, self.game_config)
+
+        result: dict[str, Any] = {"command": arguments}
+        if self.env:
+            result["env"] = self.env
+        if self.launch_working_dir == "runner":
+            result["working_dir"] = str(Path(self.get_executable()).parent)
+        return result
+
+    @property
+    def file_path(self) -> Path | None:
+        """Override to specify file path to the runner definition if applicable"""
+        return None

--- a/lutris/runners/model_validator.py
+++ b/lutris/runners/model_validator.py
@@ -1,0 +1,405 @@
+"""Base class and utilities for JSON based runners"""
+
+from enum import Enum
+from gettext import gettext as _
+from typing import Any
+
+from lutris.runners.model import DEFAULT_ENTRY_POINT_OPTION
+
+REQUIRED_OPTION_KEYS = {"option", "type", "label"}
+CHOICE_TYPES = {"choice", "choice_with_entry", "choice_with_search"}
+RANGE_TYPE_REQUIRED_KEYS = {"min", "max"}
+
+
+class RunnerDefinitionCategory(str, Enum):
+    WARNING = "warning"
+    ERROR = "error"
+
+
+class RunnerDefinitionMessage:
+    def __init__(self, key_path, message, category=RunnerDefinitionCategory.ERROR) -> None:
+        self.key_path: str = key_path
+        self.message: str = message
+        self.category = category
+
+
+class RunnerDefinitionMessages:
+    def __init__(
+        self,
+    ) -> None:
+        self.runner_messages: list[RunnerDefinitionMessage] = []
+
+    def get_all(self) -> list[RunnerDefinitionMessage]:
+        return self.runner_messages
+
+    def get_errors(self) -> list[RunnerDefinitionMessage]:
+        return list(filter(lambda msg: msg.category == RunnerDefinitionCategory.ERROR, self.runner_messages))
+
+    def get_warnings(self) -> list[RunnerDefinitionMessage]:
+        return list(filter(lambda msg: msg.category == RunnerDefinitionCategory.WARNING, self.runner_messages))
+
+    def has_errors(self) -> bool:
+        for runner_message in self.runner_messages:
+            if runner_message.category == RunnerDefinitionCategory.ERROR:
+                return True
+        return False
+
+
+def validate_runner_name(runner_name: str) -> RunnerDefinitionMessages:
+    """Validate the runner name only contains alphanumeric characters and underscore
+    [0-9A-Za-z\\-]
+    """
+    error_list = RunnerDefinitionMessages()
+    if runner_name == "":
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path="runner_name", message=_("Runner name cannot be empty"))
+        )
+    else:
+        for c in runner_name:
+            if not c.isalnum() and c != "-":
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path="runner_name",
+                        message=_("Runner name '%s' contains invalid character '%s'") % (runner_name, c),
+                    )
+                )
+                break
+    return error_list
+
+
+def validate(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the dictionary contains the required fields to use as a valid Runner"""
+
+    error_list = RunnerDefinitionMessages()
+
+    error_list.runner_messages.extend(validate_human_name(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_description(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_platforms(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_runner_executable(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_runnable_alone(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_flatpak_id(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_download_url(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_entry_point_option(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_game_options(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_runner_options(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_system_options_override(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_envs(data_dict).runner_messages)
+    error_list.runner_messages.extend(validate_working_dir(data_dict).runner_messages)
+
+    return error_list
+
+
+def _validate_string_non_empty(data_dict: dict[str, Any], key: str) -> RunnerDefinitionMessages:
+    """Verify key exist and is non empty.
+    i.e The key is required
+    """
+    error_list = RunnerDefinitionMessages()
+    if key not in data_dict:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must exist") % key)
+        )
+    else:
+        try:
+            str_value = str(data_dict[key])
+            if str_value == "":
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must be non-empty") % key)
+                )
+        except Exception as ex:
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=key, message=_("Error `%s` not convertible to string: %s") % (key, str(ex))
+                )
+            )
+
+    return error_list
+
+
+def _validate_string_non_empty_if_exist(data_dict: dict[str, Any], key: str) -> RunnerDefinitionMessages:
+    """Verify key is non empty if it exist.
+    i.e The key is optional
+    """
+    error_list = RunnerDefinitionMessages()
+    if key not in data_dict:
+        return error_list
+
+    try:
+        str_value = str(data_dict[key])
+        if str_value == "":
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=key,
+                    message=_("Field `%s` must be non-empty") % key,
+                    category=RunnerDefinitionCategory.WARNING,
+                )
+            )
+    except Exception as ex:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key,
+                message=_("Error `%s` not convertible to string: %s") % (key, str(ex)),
+                category=RunnerDefinitionCategory.WARNING,
+            )
+        )
+    return error_list
+
+
+def _validate_bool_if_exist(data_dict: dict[str, Any], key: str) -> RunnerDefinitionMessages:
+    """Verify key is convertible to boolean if it exist."""
+    error_list = RunnerDefinitionMessages()
+    if key not in data_dict:
+        return error_list
+    try:
+        bool(data_dict[key])
+    except Exception as ex:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key,
+                message=_("Error `%s` not convertible to bool: %s") % (str(key), str(ex)),
+                category=RunnerDefinitionCategory.WARNING,
+            )
+        )
+    return error_list
+
+
+def validate_human_name(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner human name is valid"""
+    return _validate_string_non_empty(data_dict, "human_name")
+
+
+def validate_description(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner description is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "description")
+
+
+def validate_platforms(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner platform list is valid"""
+    error_list = RunnerDefinitionMessages()
+
+    key = "platforms"
+    if key not in data_dict:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must exist") % key)
+        )
+    else:
+        platforms = data_dict[key]
+        if isinstance(platforms, dict):
+            if len(platforms) == 0:
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path=key, message=_("`%s` dict must contain at least one string element") % key
+                    )
+                )
+            else:
+                for index, platform_name in enumerate(platforms.values()):
+                    if platform_name == "":
+                        key_prefix = f"{key}.{index}"
+                        error_list.runner_messages.append(
+                            RunnerDefinitionMessage(
+                                key_path=key, message=_("`%s` dict string entry cannot be empty") % key_prefix
+                            )
+                        )
+        elif isinstance(platforms, list):
+            if len(platforms) == 0:
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path=key, message=_("`%s` list must contain at least one string element") % key
+                    )
+                )
+            else:
+                for index, platform_name in enumerate(platforms):
+                    if platform_name == "":
+                        key_prefix = f"{key}.{index}"
+                        error_list.runner_messages.append(
+                            RunnerDefinitionMessage(
+                                key_path=key, message=_("`%s` list string entry cannot be empty") % key_prefix
+                            )
+                        )
+        elif isinstance(platforms, str):
+            platform_name = platforms
+            if platform_name == "":
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(key_path=key, message=_("`%s` string field cannot be empty") % key)
+                )
+    return error_list
+
+
+def validate_runner_executable(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runner executable is valid"""
+    return _validate_string_non_empty(data_dict, "runner_executable")
+
+
+def validate_runnable_alone(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies runnable alone option is is valid"""
+    return _validate_bool_if_exist(data_dict, "runnable_alone")
+
+
+def validate_download_url(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the download url is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "download_url")
+
+
+def validate_flatpak_id(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the download url is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "flatpak_id")
+
+
+def validate_entry_point_option(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies the entry_point_option is valid"""
+    return _validate_string_non_empty_if_exist(data_dict, "entry_point_option")
+
+
+def _validate_option(option_dict: dict[str, Any], key_prefix="") -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+
+    error_list.runner_messages.extend(
+        [
+            RunnerDefinitionMessage(
+                key_path=f"{key_prefix}{'.' if key_prefix else ''}{key}",
+                message=_("Option is missing required key '%s'") % key,
+            )
+            for key in REQUIRED_OPTION_KEYS
+            if key not in option_dict
+        ]
+    )
+    widget_type = option_dict.get("type", "")
+    if widget_type in CHOICE_TYPES:
+        if not option_dict.get("choices", []):
+            key = "choices"
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=f"{key_prefix}{'.' if key_prefix else ''}{key}",
+                    message=_(
+                        "'choices' key is required for widget type %s with a least one element."
+                        ' Ex. `"choices": [ {"option1": "value1"}, {"option2": "value2"} ]`'
+                    )
+                    % widget_type,
+                )
+            )
+
+    if widget_type == "range":
+        error_list.runner_messages.extend(
+            [
+                RunnerDefinitionMessage(
+                    key_path=f"{key_prefix}{'.' if key_prefix else ''}{key}",
+                    message=_("'%s' key is required for widget type '%s'") % (key, widget_type),
+                )
+                for key in RANGE_TYPE_REQUIRED_KEYS
+                if key not in option_dict
+            ]
+        )
+
+    return error_list
+
+
+def _validate_options(option_list: list[dict[str, Any]], prefix="") -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+    for index, option in enumerate(option_list):
+        error_list.runner_messages.extend(
+            _validate_option(option, key_prefix=f"{prefix}{'.' if prefix else ''}{index}").runner_messages
+        )
+    return error_list
+
+
+def validate_game_options(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies game option field is list and contains at least one entry
+    The entry point option must exist as option in order to allow the user to specify the game
+    """
+    error_list = RunnerDefinitionMessages()
+
+    key = "game_options"
+    if key not in data_dict:
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(key_path=key, message=_("Field `%s` must exist") % key)
+        )
+    else:
+        game_options = data_dict[key]
+        # Need the entry point to verify the game_options field contains an option for it
+        entry_point_option = data_dict.get("entry_point_option", DEFAULT_ENTRY_POINT_OPTION)
+        if not isinstance(game_options, list):
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(key_path=key, message=_("`%s` must be a list") % key)
+            )
+        elif len(game_options) == 0:
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(key_path=key, message=_("`%s` list must contain at least one element") % key)
+            )
+        elif len([option for option in game_options if option.get("option", "") == entry_point_option]) != 1:
+            error_list.runner_messages.append(
+                RunnerDefinitionMessage(
+                    key_path=key,
+                    message=_("`%s` require exactly one 'option' for the entry point field: %s")
+                    % (key, entry_point_option),
+                )
+            )
+        else:
+            error_list.runner_messages.extend(_validate_options(game_options, prefix=key).runner_messages)
+
+    return error_list
+
+
+def validate_runner_options(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+
+    key = "runner_options"
+    if key not in data_dict:
+        return error_list
+
+    runner_options = data_dict[key]
+    if not isinstance(runner_options, list):
+        error_list.runner_messages.append(RunnerDefinitionMessage(key_path=key, message=_("`%s` must be a list") % key))
+    else:
+        error_list.runner_messages.extend(_validate_options(runner_options, prefix=key).runner_messages)
+
+    return error_list
+
+
+def validate_system_options_override(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    error_list = RunnerDefinitionMessages()
+
+    key = "system_options_override"
+    if key not in data_dict:
+        return error_list
+
+    system_options_override = data_dict[key]
+    if not isinstance(system_options_override, list):
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key, message=_("`%s` must be a list") % key, category=RunnerDefinitionCategory.WARNING
+            )
+        )
+    else:
+        for index, option_override in enumerate(system_options_override):
+            if "option" not in option_override:
+                error_list.runner_messages.append(
+                    RunnerDefinitionMessage(
+                        key_path=key,
+                        message=_("`%s` element:%d must contain an 'option' in order to override system option")
+                        % (key, index),
+                        category=RunnerDefinitionCategory.WARNING,
+                    )
+                )
+    return error_list
+
+
+def validate_envs(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies environment variable dict is valid if it exist"""
+    error_list = RunnerDefinitionMessages()
+
+    key = "env"
+    if key not in data_dict:
+        return error_list
+
+    env_dict = data_dict[key]
+    if not isinstance(env_dict, dict):
+        error_list.runner_messages.append(
+            RunnerDefinitionMessage(
+                key_path=key, message=_("`%s` must be a dictionary") % key, category=RunnerDefinitionCategory.WARNING
+            )
+        )
+    return error_list
+
+
+def validate_working_dir(data_dict: dict[str, Any]) -> RunnerDefinitionMessages:
+    """Verifies working directory is valid if it exist"""
+    return _validate_string_non_empty_if_exist(data_dict, "working_dir")

--- a/lutris/runners/yaml.py
+++ b/lutris/runners/yaml.py
@@ -1,0 +1,57 @@
+"""Base class and utilities for YAML based runners"""
+
+from pathlib import Path
+from typing import Any
+
+from lutris import settings
+from lutris.runners.model import ModelRunner
+from lutris.util import datapath
+from lutris.util.yaml import read_yaml_from_file
+
+SETTING_YAML_RUNNER_DIR = Path(settings.RUNNER_DIR) / "yaml"
+
+YAML_RUNNER_DIRS = [
+    Path(datapath.get()) / "yaml",
+    SETTING_YAML_RUNNER_DIR,
+]
+
+
+class YamlRunner(ModelRunner):
+    yaml_path: Path | None = None
+
+    def __init__(
+        self,
+        config=None,
+        *,
+        dict_data: dict[str, Any] | None = None,
+    ):
+        if not self.yaml_path and not isinstance(dict_data, dict):
+            raise RuntimeError(
+                f"Create subclasses of {self.__class__.__name__} with the yaml_path attribute set,"
+                " or supply the `dict_data` argument with a dictionary"
+            )
+
+        yaml_data: dict[str, Any] = {}
+        if self.yaml_path:
+            yaml_data = read_yaml_from_file(str(self.yaml_path))
+        else:
+            yaml_data = dict_data if dict_data else {}
+        super().__init__(dict_data=yaml_data, config=config)
+
+    @property
+    def file_path(self):
+        return self.yaml_path
+
+
+def load_yaml_runners():
+    yaml_runners = {}
+    for yaml_dir in YAML_RUNNER_DIRS:
+        if not yaml_dir.exists():
+            continue
+        for yaml_path in yaml_dir.iterdir():
+            if yaml_path.suffix not in [".yml", ".yaml"]:
+                continue
+            runner_name = yaml_path.stem
+            runner_class = type(runner_name, (YamlRunner,), {"yaml_path": yaml_dir / yaml_path})
+            yaml_runners[runner_name] = runner_class
+    return yaml_runners

--- a/lutris/startup.py
+++ b/lutris/startup.py
@@ -17,6 +17,7 @@ from lutris.database.games import get_games
 from lutris.database.schema import syncdb
 from lutris.game import Game
 from lutris.runners.json import load_json_runners
+from lutris.runners.yaml import load_yaml_runners
 from lutris.services import DEFAULT_SERVICES
 from lutris.util.graphics import vkquery
 from lutris.util.graphics.gpu import preload_gpus
@@ -157,6 +158,7 @@ def run_all_checks() -> None:
 def init_lutris():
     """Run full initialization of Lutris"""
     runners.inject_runners(load_json_runners())
+    runners.inject_runners(load_yaml_runners())
     init_dirs()
     try:
         syncdb()

--- a/tests/runners/_test_json.py
+++ b/tests/runners/_test_json.py
@@ -1,0 +1,28 @@
+import unittest
+
+from lutris.runners import json
+from lutris.runners.model_validator import validate
+
+
+class TestJsonRunner(unittest.TestCase):
+    def setUp(self):
+        self.runners = [runner_class() for runner_class in json.load_json_runners().values()]
+
+    def test_validate_installed_runners(self):
+        for runner in self.runners:
+            with self.subTest(runner.name):
+                runner_messages = validate(runner.to_dict())
+                error_messages = list(runner_messages.get_errors())
+                self.assertEqual(
+                    len(error_messages),
+                    0,
+                    f"Validation failed for runner at path '{runner.file_path}':\nErrors:\n"
+                    f"{
+                        '\n'.join(
+                            [
+                                f'{runner_message.key_path}: {runner_message.message}'
+                                for runner_message in error_messages
+                            ]
+                        )
+                    }",
+                )

--- a/tests/runners/_test_model.py
+++ b/tests/runners/_test_model.py
@@ -1,0 +1,593 @@
+import unittest
+from copy import deepcopy
+from typing import Any, NamedTuple
+from unittest.mock import MagicMock, patch
+
+from lutris.exceptions import MissingGameExecutableError
+from lutris.runners.model import (
+    DEFAULT_ENTRY_POINT_OPTION,
+    ModelRunner,
+)
+
+TEST_RUNNER_DICT = {
+    "human_name": "ModelRunner",
+    "description": "Model Description",
+    "platforms": ["Windows", "Linux"],
+    "download_url": "https://lutris.net",
+    "flatpak_id": "net.lutris.model.test",
+    "runnable_alone": False,
+    "entry_point_option": "rom",
+    "runner_executable": "model-runner",
+    "game_options": [{"option": "rom", "type": "file", "label": "Path to Game", "help": "help text"}],
+    "runner_options": [
+        {
+            "option": "fullscreen",
+            "type": "bool",
+            "label": "Fullscreen",
+            "default": True,
+            "argument": "--fullscreen",
+            "help": "Start Game in fullscreen mode.",
+        }
+    ],
+    "system_options_override": [{"option": "disable_runtime", "default": True}],
+    "env": {"SDL_VIDEODRIVER": "x11"},
+    "working_dir": "runner",
+}
+
+
+TEST_OPTION_TYPES_DICT_TEMPLATE = {
+    "human_name": "ModelRunner",
+    "description": "Model Description",
+    "platforms": ["Windows", "Linux"],
+    "download_url": "https://lutris.net",
+    "flatpak_id": "net.lutris.model.test",
+    "runnable_alone": False,
+    "entry_point_option": "rom",
+    "runner_executable": "model-runner",
+    "game_options": [{"option": "rom", "type": "file", "label": "Path to Game", "help": "help text"}],
+    "runner_options": [],
+    "system_options_override": [{"option": "disable_runtime", "default": True}],
+    "env": {"SDL_VIDEODRIVER": "x11"},
+    "working_dir": "runner",
+}
+
+
+TEST_REQUIRED_STRING_KEYS = {
+    "human_name",
+    "runner_executable",
+}
+
+
+class OptionConfigParams(NamedTuple):
+    runner_config: dict[str, Any]
+    expected_command_args: list[str | bool | int | float]
+    expected_result: bool
+
+
+class OptionTestParams(NamedTuple):
+    option_dict: dict[str, Any]
+    option_configs: list[OptionConfigParams]
+
+
+TEST_OPTIONAL_STRING_KEYS = {"description", "flatpak_id", "download_url", "entry_point_option"}
+
+
+TEST_OPTION_TYPES_PARAMS: list[OptionTestParams] = [
+    OptionTestParams(
+        {
+            "option": "bool_argument",
+            "type": "bool",
+            "label": "Bool",
+            "default": True,
+            "argument": "--bool",
+        },
+        [
+            OptionConfigParams({"bool_argument": True}, ["--bool"], True),
+            OptionConfigParams({"bool_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "bool_no_argument",
+            "type": "bool",
+            "label": "Bool",
+            "default": False,
+        },
+        [
+            OptionConfigParams({"bool_no_argument": True}, [], True),
+            OptionConfigParams({"bool_no_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "bool_empty_argument",
+            "type": "bool",
+            "label": "Bool",
+            "default": True,
+            "argument": "",
+        },
+        [
+            OptionConfigParams({"bool_empty_argument": True}, [], True),
+            OptionConfigParams({"bool_empty_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "label",
+            "type": "label",
+            "label": "This is a Note",
+        },
+        [
+            OptionConfigParams({"label": "Could be any type"}, [], True),
+            OptionConfigParams({"label": False}, [], True),
+            OptionConfigParams({"label": 42}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "string_argument", "type": "string", "argument": "--string"},
+        [
+            OptionConfigParams({"string_argument": "True"}, ["--string", "True"], True),
+            OptionConfigParams({"string_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "string_no_argument",
+            "type": "string",
+        },
+        [
+            OptionConfigParams({"string_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"string_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "string_with_empty_argument", "type": "string", "argument": ""},
+        [
+            OptionConfigParams({"string_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"string_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "range_argument", "type": "range", "argument": "--range"},
+        [
+            OptionConfigParams({"range_argument": "True"}, ["--range", "True"], True),
+            OptionConfigParams({"range_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "range_no_argument",
+            "type": "range",
+        },
+        [
+            OptionConfigParams({"range_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"range_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "range_with_empty_argument", "type": "range", "argument": ""},
+        [
+            OptionConfigParams({"range_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"range_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "file_argument", "type": "file", "argument": "--file"},
+        [
+            OptionConfigParams({"file_argument": "True"}, ["--file", "True"], True),
+            OptionConfigParams({"file_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "file_no_argument",
+            "type": "file",
+        },
+        [
+            OptionConfigParams({"file_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"file_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "file_with_empty_argument", "type": "file", "argument": ""},
+        [
+            OptionConfigParams({"file_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"file_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "directory_argument", "type": "directory", "argument": "--directory"},
+        [
+            OptionConfigParams({"directory_argument": "True"}, ["--directory", "True"], True),
+            OptionConfigParams({"directory_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "directory_no_argument",
+            "type": "directory",
+        },
+        [
+            OptionConfigParams({"directory_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"directory_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "directory_with_empty_argument", "type": "directory", "argument": ""},
+        [
+            OptionConfigParams({"directory_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"directory_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "multiple_file_argument", "type": "multiple_file", "argument": "--multiple-file"},
+        [
+            OptionConfigParams({"multiple_file_argument": "True"}, ["--multiple-file", "True"], True),
+            OptionConfigParams({"multiple_file_argument": "True False"}, ["--multiple-file", "True", "False"], True),
+            OptionConfigParams({"multiple_file_argument": '"True False"'}, ["--multiple-file", "True False"], True),
+            OptionConfigParams({"multiple_file_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "multiple_file_no_argument",
+            "type": "multiple_file",
+        },
+        [
+            OptionConfigParams({"multiple_file_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"multiple_file_no_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"multiple_file_no_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"multiple_file_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "multiple_file_with_empty_argument", "type": "multiple_file", "argument": ""},
+        [
+            OptionConfigParams({"multiple_file_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"multiple_file_with_empty_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"multiple_file_with_empty_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"multiple_file_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "command_line_argument", "type": "command_line", "argument": "--command-line"},
+        [
+            OptionConfigParams({"command_line_argument": "True"}, ["--command-line", "True"], True),
+            OptionConfigParams({"command_line_argument": "True False"}, ["--command-line", "True", "False"], True),
+            OptionConfigParams({"command_line_argument": '"True False"'}, ["--command-line", "True False"], True),
+            OptionConfigParams({"command_line_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "command_line_no_argument",
+            "type": "command_line",
+        },
+        [
+            OptionConfigParams({"command_line_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"command_line_no_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"command_line_no_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"command_line_no_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "command_line_with_empty_argument", "type": "command_line", "argument": ""},
+        [
+            OptionConfigParams({"command_line_with_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"command_line_with_empty_argument": "True False"}, ["True", "False"], True),
+            OptionConfigParams({"command_line_with_empty_argument": '"True False"'}, ["True False"], True),
+            OptionConfigParams({"command_line_with_empty_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "mapping_argument", "type": "mapping", "argument": "--mapping"},
+        [
+            OptionConfigParams(
+                {"mapping_argument": {"foo": "True", "bar": 1}}, ["--mapping", "foo=True", "--mapping", "bar=1"], True
+            ),
+            OptionConfigParams({"mapping_argument": "NotADictShouldNotAddArguments"}, [], True),
+            OptionConfigParams({"mapping_argument": ""}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {
+            "option": "mapping_no_argument",
+            "type": "mapping",
+        },
+        [
+            OptionConfigParams({"mapping_no_argument": {"foo": "True", "bar": 1}}, ["foo=True", "bar=1"], True),
+            OptionConfigParams({"mapping_no_argument": "NotADictShouldNotAddArguments"}, [], True),
+            OptionConfigParams({"mapping_no_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "mapping_empty_argument", "type": "mapping", "argument": ""},
+        [
+            OptionConfigParams({"mapping_empty_argument": {"foo": "True", "bar": 1}}, ["foo=True", "bar=1"], True),
+            OptionConfigParams({"mapping_empty_argument": "NotADictShouldNotAddArguments"}, [], True),
+            OptionConfigParams({"mapping_empty_argument": False}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_argument", "type": "choice", "argument": "--choice"},
+        [
+            OptionConfigParams({"choice_argument": "True"}, ["--choice", "True"], True),
+            OptionConfigParams({"choice_argument": 7}, ["--choice", 7], True),
+            OptionConfigParams({"choice_argument": False}, ["--choice", False], True),
+            OptionConfigParams({"choice_argument": 14.0}, ["--choice", 14.0], True),
+            # Having an empty string choice make sense for selecting from a drop-down
+            OptionConfigParams({"choice_argument": ""}, ["--choice", ""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_no_argument", "type": "choice"},
+        [
+            OptionConfigParams({"choice_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_no_argument": 7}, [7], True),
+            OptionConfigParams({"choice_no_argument": False}, [False], True),
+            OptionConfigParams({"choice_no_argument": 14.0}, [14.0], True),
+            # Having an empty string choice make sense for selecting from a drop-down
+            OptionConfigParams({"choice_no_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_no_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_empty_argument", "type": "choice", "argument": ""},
+        [
+            OptionConfigParams({"choice_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_empty_argument": 7}, [7], True),
+            OptionConfigParams({"choice_empty_argument": False}, [False], True),
+            OptionConfigParams({"choice_empty_argument": 14.0}, [14.0], True),
+            # Having an empty string choice make sense for selecting from a drop-down
+            OptionConfigParams({"choice_empty_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_empty_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_entry_argument", "type": "choice_with_entry", "argument": "choice-with-entry"},
+        [
+            OptionConfigParams({"choice_with_entry_argument": "True"}, ["choice-with-entry", "True"], True),
+            OptionConfigParams({"choice_with_entry_argument": 7}, ["choice-with-entry", 7], True),
+            OptionConfigParams({"choice_with_entry_argument": False}, ["choice-with-entry", False], True),
+            OptionConfigParams({"choice_with_entry_argument": 14.0}, ["choice-with-entry", 14.0], True),
+            # Having an empty string choice_with_entry make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_entry_argument": ""}, ["choice-with-entry", ""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_entry_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_entry_no_argument", "type": "choice_with_entry"},
+        [
+            OptionConfigParams({"choice_with_entry_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_entry_no_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_entry_no_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_entry_no_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_entry make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_entry_no_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_entry_no_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_entry_empty_argument", "type": "choice_with_entry", "argument": ""},
+        [
+            OptionConfigParams({"choice_with_entry_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_entry_empty_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_entry_empty_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_entry_empty_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_entry make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_entry_empty_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_entry_empty_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_search_argument", "type": "choice_with_search", "argument": "choice-with-search"},
+        [
+            OptionConfigParams({"choice_with_search_argument": "True"}, ["choice-with-search", "True"], True),
+            OptionConfigParams({"choice_with_search_argument": 7}, ["choice-with-search", 7], True),
+            OptionConfigParams({"choice_with_search_argument": False}, ["choice-with-search", False], True),
+            OptionConfigParams({"choice_with_search_argument": 14.0}, ["choice-with-search", 14.0], True),
+            # Having an empty string choice_with_search make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_search_argument": ""}, ["choice-with-search", ""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_search_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_search_no_argument", "type": "choice_with_search"},
+        [
+            OptionConfigParams({"choice_with_search_no_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_search_no_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_search_no_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_search_no_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_search make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_search_no_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_search_no_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+    OptionTestParams(
+        {"option": "choice_with_search_empty_argument", "type": "choice_with_search", "argument": ""},
+        [
+            OptionConfigParams({"choice_with_search_empty_argument": "True"}, ["True"], True),
+            OptionConfigParams({"choice_with_search_empty_argument": 7}, [7], True),
+            OptionConfigParams({"choice_with_search_empty_argument": False}, [False], True),
+            OptionConfigParams({"choice_with_search_empty_argument": 14.0}, [14.0], True),
+            # Having an empty string choice_with_search make sense for selecting from a drop-down
+            OptionConfigParams({"choice_with_search_empty_argument": ""}, [""], True),
+            # Check 'off' special case here
+            OptionConfigParams({"choice_with_search_empty_argument": "off"}, [], True),
+            OptionConfigParams({}, [], True),
+        ],
+    ),
+]
+
+
+def generate_runner_dict_for_option_test(test_param: OptionTestParams) -> dict[str, Any]:
+    test_dict = TEST_OPTION_TYPES_DICT_TEMPLATE.copy()
+    test_dict["runner_options"] = [test_param.option_dict]
+    return test_dict
+
+
+class TestModelRunner(unittest.TestCase):
+    def setUp(self):
+        self.runner = ModelRunner()
+
+    def test_create_model_runner(self):
+        self.assertEqual(self.runner.entry_point_option, DEFAULT_ENTRY_POINT_OPTION)
+
+    def test_init_from_dict(self):
+        test_dict_with_array_platforms = TEST_RUNNER_DICT
+        test_dict_with_dict_platforms = TEST_RUNNER_DICT.copy()
+        test_dict_with_dict_platforms["platforms"] = {
+            platform: platform for platform in TEST_RUNNER_DICT.get("platforms", [])
+        }
+        # The runner dict should be saved out with the "platforms" key pointing to a dict
+        expected_dict = test_dict_with_dict_platforms
+
+        # Test with the "platforms" key set to an array
+        self.runner.from_dict(test_dict_with_array_platforms)
+        output_dict = self.runner.to_dict()
+        self.assertDictEqual(output_dict, expected_dict)
+
+        # Test with the "platforms" key set to a dict
+        self.runner.from_dict(test_dict_with_dict_platforms)
+        output_dict = self.runner.to_dict()
+        self.assertDictEqual(output_dict, expected_dict)
+
+    # model.play test
+    @patch("lutris.runners.runner.Runner.get_executable")
+    @patch("os.path.isfile")
+    @patch("lutris.util.system.path_exists")
+    def test_play_valid_game_succeeds(self, mock_path_exists, mock_isfile, mock_get_executable):
+        rom_name = "good_game"
+        mock_path_exists.return_value = True
+        mock_isfile.return_value = True
+        mock_config = MagicMock()
+        mock_config.game_config = {"rom": rom_name}
+        mock_config.runner_config = {"fullscreen": True}
+
+        mock_get_executable.return_value = "/path/to/model-runner"
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        expected = {
+            "command": self.runner.get_command() + ["--fullscreen", rom_name],
+            "env": {"SDL_VIDEODRIVER": "x11"},
+            "working_dir": "/path/to",
+        }
+        self.assertDictEqual(self.runner.play(), expected)
+
+    @patch("os.path.isfile")
+    @patch("lutris.util.system.path_exists")
+    def test_play_missing_game_fails(self, mock_path_exists, mock_isfile):
+        rom_name = "good_game"
+        mock_path_exists.return_value = False
+        mock_isfile.return_value = True
+        mock_config = MagicMock()
+        mock_config.game_config = {"rom": rom_name}
+        mock_config.runner_config = {"fullscreen": True}
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        with self.assertRaises(MissingGameExecutableError):
+            self.runner.play()
+
+    @patch("lutris.runners.runner.Runner.get_executable")
+    @patch("os.path.isfile")
+    @patch("lutris.util.system.path_exists")
+    def test_play_for_all_option_types(self, mock_path_exists, mock_isfile, mock_get_executable):
+        for test_param in TEST_OPTION_TYPES_PARAMS:
+            test_dict = generate_runner_dict_for_option_test(test_param)
+            option_name = test_param.option_dict["option"]
+            for runner_config, expected_commang_args, _ in test_param.option_configs:
+                with self.subTest(
+                    f"Testing play for option {option_name}", option=option_name, runner_config=runner_config
+                ):
+                    rom_name = "good_game"
+                    mock_path_exists.return_value = True
+                    mock_isfile.return_value = True
+                    mock_config = MagicMock()
+                    mock_config.game_config = {"rom": rom_name}
+                    mock_config.runner_config = runner_config
+
+                    mock_get_executable.return_value = "/path/to/model-runner"
+
+                    self.runner.from_dict(test_dict)
+                    self.runner.config = mock_config
+                    expected = {
+                        "command": self.runner.get_command() + expected_commang_args + ["good_game"],
+                        "env": {"SDL_VIDEODRIVER": "x11"},
+                        "working_dir": "/path/to",
+                    }
+                    play_dict = self.runner.play()
+                    self.assertDictEqual(play_dict, expected)
+
+    ## get_platform tests
+    def test_get_platform_with_with_platform_key_succeeds(self):
+        mock_config = MagicMock()
+        mock_config.game_config = {"platform": "Linux"}
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        self.assertEqual(self.runner.get_platform(), "Linux")
+
+    def test_get_platform_with_without_platform_key_returns_first_key(self):
+        mock_config = MagicMock()
+        mock_config.game_config = {}
+
+        self.runner.from_dict(TEST_RUNNER_DICT)
+        self.runner.config = mock_config
+        self.assertEqual(self.runner.get_platform(), TEST_RUNNER_DICT["platforms"][0])
+
+    def test_get_platform_succeeds_if_platforms_key_is_dict(self):
+        mock_config = MagicMock()
+        mock_config.game_config = {"platform": "Pocket Challenge V2"}
+
+        valid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        valid_runner_dict["platforms"] = {
+            "Bandai WonderSwan Color": "WonderSwan Color",
+            "Benesse Pocket Challenge V2": "Pocket Challenge V2",
+        }
+        self.runner.from_dict(valid_runner_dict)
+        self.runner.config = mock_config
+        self.assertEqual(self.runner.get_platform(), "Benesse Pocket Challenge V2")

--- a/tests/runners/_test_model_validator.py
+++ b/tests/runners/_test_model_validator.py
@@ -1,0 +1,277 @@
+import unittest
+from copy import deepcopy
+from typing import Any
+
+from lutris.runners.model import (
+    ModelRunner,
+)
+from lutris.runners.model_validator import (
+    RANGE_TYPE_REQUIRED_KEYS,
+    REQUIRED_OPTION_KEYS,
+    RunnerDefinitionCategory,
+    validate,
+    validate_runner_name,
+)
+
+TEST_RUNNER_DICT = {
+    "human_name": "ModelRunner",
+    "description": "Model Description",
+    "platforms": ["Windows", "Linux"],
+    "download_url": "https://lutris.net",
+    "flatpak_id": "net.lutris.model.test",
+    "runnable_alone": False,
+    "entry_point_option": "rom",
+    "runner_executable": "model-runner",
+    "game_options": [{"option": "rom", "type": "file", "label": "Path to Game", "help": "help text"}],
+    "runner_options": [
+        {
+            "option": "fullscreen",
+            "type": "bool",
+            "label": "Fullscreen",
+            "default": True,
+            "argument": "--fullscreen",
+            "help": "Start Game in fullscreen mode.",
+        }
+    ],
+    "system_options_override": [{"option": "disable_runtime", "default": True}],
+    "env": {"SDL_VIDEODRIVER": "x11"},
+    "working_dir": "runner",
+}
+
+TEST_REQUIRED_STRING_KEYS = {
+    "human_name",
+    "runner_executable",
+}
+
+TEST_OPTIONAL_STRING_KEYS = {"description", "flatpak_id", "download_url", "entry_point_option", "working_dir"}
+
+
+class TestModelValidator(unittest.TestCase):
+    def setUp(self):
+        self.runner = ModelRunner()
+
+    def test_validate_runner_name_succeeds(self):
+        runner_messages = validate_runner_name("ThisIsAValidRunnerName")
+        self.assertEqual(len(runner_messages.get_all()), 0)
+        runner_messages = validate_runner_name("this-is-valid-as-well")
+        self.assertEqual(len(runner_messages.get_all()), 0)
+
+    def test_validate_runner_name_with_non_alphanumeric_fails(self):
+        runner_messages = validate_runner_name("inv@lid")
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        runner_messages = validate_runner_name("../../etc/cron.d/evil")
+        self.assertGreater(len(runner_messages.get_all()), 0)
+
+    ## Config option validation
+    def test_validate_good_config_succeeds(self):
+        valid_runner_dict = TEST_RUNNER_DICT
+        runner_messages = validate(valid_runner_dict)
+        self.assertEqual(len(runner_messages.get_all()), 0)
+
+    ### Game Options validation
+    def test_validate_bad_config_no_game_option_for_entry_point_fails(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["entry_point_option"] = "iso"
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("require exactly one 'option' for the entry point", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_game_options_missing(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        del invalid_runner_dict["game_options"]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("must exist", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_game_options_not_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["game_options"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("must be a list", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_game_options_empty_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["game_options"] = []
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "game_options")
+        self.assertIn("list must contain at least one element", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### Runner Options validation
+    def test_validate_bad_config_runner_options_not_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["runner_options"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "runner_options")
+        self.assertIn("must be a list", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### System Options Override validation
+    def test_validate_bad_config_system_options_override_not_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["system_options_override"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "system_options_override")
+        self.assertIn("must be a list", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)
+
+    def test_validate_bad_config_system_options_override_missing_option_field(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["system_options_override"] = [{"default": True}]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "system_options_override")
+        self.assertIn("must contain an 'option'", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)
+
+    ### Individual option validation
+    def test_validate_bad_config_option_required_keys_missing(self) -> None:
+        for required_key in REQUIRED_OPTION_KEYS:
+            with self.subTest(required_key):
+                invalid_runner_dict: dict[str, Any] = deepcopy(TEST_RUNNER_DICT)
+                del invalid_runner_dict["runner_options"][0][required_key]
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, f"runner_options.0.{required_key}")
+                self.assertIn("Option is missing required key", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_option_type_choice_missing_choices_field(self) -> None:
+        invalid_runner_dict: dict[str, Any] = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["runner_options"][0]["type"] = "choice"
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "runner_options.0.choices")
+        self.assertIn("'choices' key is required for widget type", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_option_type_range_missing_required_keys(self) -> None:
+        for range_req_key in RANGE_TYPE_REQUIRED_KEYS:
+            with self.subTest(range_req_key):
+                invalid_runner_dict: dict[str, Any] = deepcopy(TEST_RUNNER_DICT)
+                invalid_runner_dict["runner_options"][0]["type"] = "range"
+                # Add all the required range keys and then delete the key that is passed in to this method
+                for add_keys in RANGE_TYPE_REQUIRED_KEYS:
+                    invalid_runner_dict["runner_options"][0][add_keys] = 0
+                del invalid_runner_dict["runner_options"][0][range_req_key]
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, f"runner_options.0.{range_req_key}")
+                self.assertIn("key is required for widget type 'range'", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### Strings validation - human_name, description, runner_executable, flatpak_id, download_url, entry_point_option
+    def test_validate_bad_config_required_string_keys_missing(self):
+        for string_key in TEST_REQUIRED_STRING_KEYS:
+            with self.subTest(string_key):
+                invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+                del invalid_runner_dict[string_key]
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, string_key)
+                self.assertIn("must exist", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_required_string_keys_empty(self):
+        for string_key in TEST_REQUIRED_STRING_KEYS:
+            with self.subTest(string_key):
+                invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+                invalid_runner_dict[string_key] = ""
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, string_key)
+                self.assertIn("must be non-empty", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_optional_string_keys_empty(self):
+        for string_key in TEST_OPTIONAL_STRING_KEYS:
+            with self.subTest(string_key):
+                invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+                invalid_runner_dict[string_key] = ""
+                runner_messages = validate(invalid_runner_dict)
+                self.assertGreater(len(runner_messages.get_all()), 0)
+                self.assertEqual(runner_messages.get_all()[0].key_path, string_key)
+                self.assertIn("must be non-empty", runner_messages.get_all()[0].message)
+                self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)
+
+    ### Platforms validation
+    def test_validate_bad_config_platforms_key_is_missing(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        del invalid_runner_dict["platforms"]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("must exist", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_empty_list(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = []
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("list must contain at least one string element", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_empty_dict(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = {}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("dict must contain at least one string element", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_empty_string(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = ""
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("string field cannot be empty", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_list_contains_empty_string(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = [""]
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("list string entry cannot be empty", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    def test_validate_bad_config_platforms_key_is_dict_contains_empty_string(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["platforms"] = {"Windows": ""}
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "platforms")
+        self.assertIn("dict string entry cannot be empty", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.ERROR)
+
+    ### Runnable Alone Validation (i.e The runner can be invoked without a game argument)
+    def test_validate_good_config_runnable_alone_is_convertible_to_bool(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["runnable_alone"] = 1
+        runner_messages = validate(invalid_runner_dict)
+        self.assertEqual(len(runner_messages.get_all()), 0)
+
+    # env Grid validation
+    def test_validate_bad_config_env_key_is_dict_not_dict(self):
+        invalid_runner_dict = deepcopy(TEST_RUNNER_DICT)
+        invalid_runner_dict["env"] = []
+        runner_messages = validate(invalid_runner_dict)
+        self.assertGreater(len(runner_messages.get_all()), 0)
+        self.assertEqual(runner_messages.get_all()[0].key_path, "env")
+        self.assertIn("must be a dictionary", runner_messages.get_all()[0].message)
+        self.assertEqual(runner_messages.get_all()[0].category, RunnerDefinitionCategory.WARNING)

--- a/tests/runners/_test_yaml.py
+++ b/tests/runners/_test_yaml.py
@@ -1,0 +1,28 @@
+import unittest
+
+from lutris.runners import yaml
+from lutris.runners.model_validator import validate
+
+
+class TestYamlRunner(unittest.TestCase):
+    def setUp(self):
+        self.runners = [runner_class() for runner_class in yaml.load_yaml_runners().values()]
+
+    def test_validate_installed_runners(self):
+        for runner in self.runners:
+            with self.subTest(runner.name):
+                runner_messages = validate(runner.to_dict())
+                error_messages = list(runner_messages.get_errors())
+                self.assertEqual(
+                    len(error_messages),
+                    0,
+                    f"Validation failed for runner at path '{runner.file_path}':\nErrors:\n"
+                    f"{
+                        '\n'.join(
+                            [
+                                f'{runner_message.key_path}: {runner_message.message}'
+                                for runner_message in error_messages
+                            ]
+                        )
+                    }",
+                )


### PR DESCRIPTION

The ModelRunner abstracts the definition of a runner to a dictionary structure.

The JSON runner now just marshals to/from dictionary stored in the ModelRunner base class. Validation methods for the runner definition has been added to the ModelRunner which validates whether a supplied dict can be used for runner configuration.

Add support to Runners in YAML format

YAML runners are saved in a directory parallel to JSON runners. i.e "$XDG_CONFIG_HOME/lutris/runners/yaml" for user created runners Shared runners that come with lutris should be put in the source code directory of "share/lutris/yaml"

needed by #6439