### PR TITLE
wine: get fstype correctly

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -194,10 +194,10 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
     @staticmethod
     def get_drives() -> list[dict[str, Any]]:
         """Return a list of drives with their filesystems"""
-        lsblk_output = system.read_process_output(["lsblk", "-f", "--json"])
-        if not lsblk_output:
+        findmnt_output = system.read_process_output(["findmnt", "-J", "--list"])
+        if not findmnt_output:
             return []
-        return [drive for drive in json.loads(lsblk_output)["blockdevices"] if drive["fstype"] != "squashfs"]
+        return [drive for drive in json.loads(findmnt_output)["filesystems"] if drive["fstype"] != "squashfs"]
 
     @staticmethod
     def get_ram_info() -> dict[str, str]:
@@ -310,8 +310,12 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
         while devices:
             device = devices.pop()
             devices.extend(device.get("children", []))
-            if mount_point in device.get("mountpoints", []) or mount_point == device.get("mountpoint"):
-                return cast(str, device["fstype"])
+            if mount_point == device.get("target"):
+                fs_type = device["fstype"]
+                if fs_type == "fuseblk":
+                    out = system.read_process_output(["blkid", "-o", "value", "-s", "TYPE", device["source"]])
+                    fs_type = out.strip() if out else fs_type
+                return cast(str, fs_type)
         return None
 
     def get_glxinfo(self) -> GlxInfo | None:


### PR DESCRIPTION
fix 
```
Can't create the prefix on a file system that does not support Linux symbolic links.

Traceback (most recent call last):

  File "/app/lib/python3.13/site-packages/lutris/exception_backstops.py", line 35, in wrapper
    result = function(*args, **kwargs)

  File "/app/lib/python3.13/site-packages/lutris/game.py", line 822, in configure_game
    raise error

  File "/app/lib/python3.13/site-packages/lutris/util/jobs.py", line 62, in target
    result = self.function(*a, **kw)

  File "/app/lib/python3.13/site-packages/lutris/runners/wine.py", line 1128, in prelaunch
    create_prefix(prefix_path, wine_path=self.get_executable(), arch=self.wine_arch, runner=self)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

  File "/app/lib/python3.13/site-packages/lutris/runners/commands/wine.py", line 163, in create_prefix
    raise RuntimeError(_("Can't create the prefix on a file system that does not support Linux symbolic links."))

RuntimeError: Can't create the prefix on a file system that does not support Linux symbolic links.
```
I fixed my patch by not reusing reuse`linux.LinuxSystem().get_fs_type_for_path(prefix)` because it returns the wrong value