### PR TITLE
Added download_url for TIC-80 emulator to fix install

### DIFF
--- a/share/lutris/json/tic80.json
+++ b/share/lutris/json/tic80.json
@@ -3,7 +3,8 @@
     "human_name": "TIC-80",
     "description": "TIC-80 tiny computer",
     "platforms": ["TIC-80"],
-    "runner_executable": "tic80",
+    "runner_executable": "bin/tic80",
+    "download_url": "https://github.com/nesbox/TIC-80/releases/download/v1.1.2837/tic80-v1.1-linux.deb",
     "flatpak_id": "com.tic80.TIC_80",
     "game_options": [
         {


### PR DESCRIPTION
The `download_url` points to the linux debian file from the github website

It turns out the download url was removed in commit https://github.com/lutris/lutris/commit/0429ebde2986d434407e04cd94501a562d659d3b

## Testing Done

Verified that the TIC-80 can be installed within Lutris and launch a game.

<img width="1024" height="623" alt="image" src="https://github.com/user-attachments/assets/72ae4fd1-4ec5-4d44-b1e3-ddafc60634f1" />


fixes #6618 