### PR TITLE
Complete feature work for the install runner via CLI feature.

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -48,7 +48,7 @@ from lutris.runners import InvalidRunnerError, RunnerInstallationError, get_runn
 from lutris.services import get_enabled_services
 from lutris.startup import init_lutris, run_all_checks
 from lutris.style_manager import StyleManager
-from lutris.util import datapath, log, resources, system
+from lutris.util import datapath, log, resources
 from lutris.util.http import HTTPError, Request
 from lutris.util.log import file_handler, logger
 from lutris.util.savesync import save_check, show_save_stats, upload_save
@@ -575,13 +575,17 @@ class LutrisApplication(Gtk.Application):
         # install Runner
         if option := options.lookup_value("install-runner"):
             runner = option.get_string()
-            self.install_runner(runner)
+            args_variant_array = options.lookup_value(GLib.OPTION_REMAINING, expected_type=GLib.VariantType("as"))
+            args: list[str] = args_variant_array.get_strv() if args_variant_array else []
+            self.install_runner(runner, version=args[0] if args else None)
             return 0
 
         # Uninstall Runner
         if option := options.lookup_value("uninstall-runner"):
             runner = option.get_string()
-            self.uninstall_runner(runner)
+            args_variant_array = options.lookup_value(GLib.OPTION_REMAINING, expected_type=GLib.VariantType("as"))
+            args = args_variant_array.get_strv() if args_variant_array else []
+            self.uninstall_runner(runner, version=args[0] if args else None)
             return 0
 
         if option := options.lookup_value("export"):
@@ -1020,74 +1024,47 @@ class LutrisApplication(Gtk.Application):
             if i["version"]:
                 print(i)
 
-    def install_runner(self, runner: str) -> None:
-        if runner.startswith("lutris"):
-            self.install_wine_cli(runner)
+    def install_runner(self, runner: str, version: str | None) -> None:
+        if runner == "wine":
+            self.install_wine_cli(version)
         else:
-            self.install_cli(runner)
+            self.install_cli(runner, version)
 
-    def uninstall_runner(self, runner: str) -> None:
-        if "wine" in runner:
-            print("Are sure you want to delete Wine and all of the installed runners?[Y/N]")
-            ans = input()
-            if ans.lower() in ("y", "yes"):
-                self.uninstall_runner_cli(runner)
-            else:
-                print("Not Removing Wine")
-        elif runner.startswith("lutris"):
-            self.wine_runner_uninstall(runner)
-        else:
-            self.uninstall_runner_cli(runner)
+    def uninstall_runner(self, runner: str, version: str | None = None) -> None:
+        self.uninstall_runner_cli(runner, version=version)
 
-    def install_wine_cli(self, version: str) -> None:
+    def install_wine_cli(self, version: str | None = None) -> None:
         """
         Downloads wine runner using lutris -r <runner>
         """
+        # Parse the latest version from the api if available
+        if version == "latest":
+            if wine_runners := get_runners("wine"):
+                wine_versions = wine_runners.get("versions", [])
+                if wine_versions:
+                    version = wine_versions[-1].get("version")
+        if version == "latest":
+            print(_("Unable to locate latest wine version, skipping installation."))
+            return
 
-        WINE_DIR = os.path.join(settings.RUNNER_DIR, "wine")
-        runner_path = os.path.join(WINE_DIR, f"{version}{'' if '-x86_64' in version else '-x86_64'}")
-        if os.path.isdir(runner_path):
-            print(f"Wine version '{version}' is already installed.")
-        else:
-            try:
-                runner = import_runner("wine")
-                runner().install(self.install_ui_delegate, version=version)
-                print(f"Wine version '{version}' has been installed.")
-            except (InvalidRunnerError, RunnerInstallationError) as ex:
-                print(ex.message)
+        self.install_cli("wine", version=version)
 
-    def wine_runner_uninstall(self, version: str) -> None:
-        version = f"{version}{'' if '-x86_64' in version else '-x86_64'}"
-        WINE_DIR = os.path.join(settings.RUNNER_DIR, "wine")
-        runner_path = os.path.join(WINE_DIR, version)
-        if os.path.isdir(runner_path):
-            system.remove_folder(runner_path)
-            print(f"Wine version '{version}' has been removed.")
-        else:
-            print(
-                f"""
-Specified version of Wine is not installed: {version}.
-Please check if the Wine Runner and specified version are installed (for that use --list-wine-versions).
-Also, check that the version specified is in the correct format.
-                """
-            )
-
-    def install_cli(self, runner_name: str) -> None:
+    def install_cli(self, runner_name: str, version: str | None = None) -> None:
         """
         install the runner provided in prepare_runner_cli()
         """
 
         try:
             runner = import_runner(runner_name)()
-            if runner.is_installed():
-                print(f"'{runner_name}' is already installed.")
+            if runner.is_installed(version=version, fallback=False):
+                print(_("'%s' is already installed.") % runner_name)
             else:
-                runner.install(self.install_ui_delegate, version=None, callback=None)
-                print(f"'{runner_name}' has been installed")
+                runner.install(self.install_ui_delegate, version=version, callback=None)
+                print(_("'%s' has been installed") % runner_name)
         except (InvalidRunnerError, RunnerInstallationError) as ex:
             print(ex.message)
 
-    def uninstall_runner_cli(self, runner_name: str) -> None:
+    def uninstall_runner_cli(self, runner_name: str, version: str | None = None) -> None:
         """
         uninstall the runner given in application file located in lutris/gui/application.py
         provided using lutris -u <runner>
@@ -1098,14 +1075,13 @@ Also, check that the version specified is in the correct format.
         except InvalidRunnerError:
             logger.error("Failed to import Runner: %s", runner_name)
             return
-        if not runner.is_installed():
-            print(f"Runner '{runner_name}' is not installed.")
+        if not runner.is_installed(version=version, fallback=False):
+            print(_("Runner '%s' is not installed.") % runner_name)
             return
         if runner.can_uninstall():
-            runner.uninstall()
-            print(f"'{runner_name}' has been uninstalled.")
+            runner.uninstall(lambda: print(_("'%s' has been uninstalled.") % runner_name), version=version)
         else:
-            print(f"Runner '{runner_name}' cannot be uninstalled.")
+            print(_("Runner '%s' cannot be uninstalled.") % runner_name)
 
     def do_shutdown(self) -> None:  # pylint: disable=arguments-differ
         logger.info("Shutting down Lutris")

--- a/lutris/runners/flatpak.py
+++ b/lutris/runners/flatpak.py
@@ -83,7 +83,7 @@ class flatpak(Runner):
         },
     ]
 
-    def is_installed(self, flatpak_allowed: bool = True) -> bool:
+    def is_installed(self, flatpak_allowed: bool = True, version: str | None = None, fallback: bool = True) -> bool:
         return _flatpak.is_installed()
 
     def get_executable(self) -> str:
@@ -103,7 +103,7 @@ class flatpak(Runner):
     def can_uninstall(self):
         return False
 
-    def uninstall(self, uninstall_callback: Callable[[], None] | None = None) -> None:
+    def uninstall(self, uninstall_callback: Callable[[], None] | None = None, version: str | None = None) -> None:
         raise RuntimeError("Flatpak can't be uninstalled from Lutris")
 
     @property

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -276,7 +276,9 @@ class libretro(Runner):
     def get_version(self, use_default=True):
         return self.game_config["core"]
 
-    def is_installed(self, flatpak_allowed: bool = True, core=None) -> bool:
+    def is_installed(
+        self, flatpak_allowed: bool = True, version: str | None = None, fallback: bool = True, core=None
+    ) -> bool:
         if not core and self.has_explicit_config and self.game_config.get("core"):
             core = self.game_config["core"]
         if not core or self.runner_config.get("runner_executable"):

--- a/lutris/runners/linux.py
+++ b/lutris/runners/linux.py
@@ -115,14 +115,14 @@ class linux(Runner):
         """Linux programs should get individual shader caches if possible."""
         return self.game_path or self.shader_cache_dir
 
-    def is_installed(self, flatpak_allowed: bool = True) -> bool:
+    def is_installed(self, flatpak_allowed: bool = True, version: str | None = None, fallback: bool = True) -> bool:
         """Well of course Linux is installed, you're using Linux right ?"""
         return True
 
     def can_uninstall(self):
         return False
 
-    def uninstall(self, uninstall_callback: Callable[[], None] | None = None) -> None:
+    def uninstall(self, uninstall_callback: Callable[[], None] | None = None, version: str | None = None) -> None:
         raise RuntimeError("Linux shouldn't be installed.")
 
     def get_launch_config_command(self, gameplay_info, launch_config):

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -131,7 +131,7 @@ class pico8(Runner):
     def get_run_data(self):
         return {"command": self.launch_args, "env": self.get_env(os_env=False)}
 
-    def is_installed(self, flatpak_allowed: bool = True) -> bool:
+    def is_installed(self, flatpak_allowed: bool = True, version: str | None = None, fallback: bool = True) -> bool:
         """Checks if pico8 runner is installed and if the pico8 executable available."""
         if self.is_native and system.path_exists(self.runner_config.get("runner_executable")):
             return True

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -568,7 +568,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             return self.is_installed()
         return False
 
-    def is_installed(self, flatpak_allowed: bool = True) -> bool:
+    def is_installed(self, flatpak_allowed: bool = True, version: str | None = None, fallback: bool = True) -> bool:
         """Return whether the runner is installed"""
         try:
             # Don't care where the exe is, only if we can find it.
@@ -691,7 +691,7 @@ class Runner:  # pylint: disable=too-many-public-methods
     def can_uninstall(self) -> bool:
         return os.path.isdir(self.directory)
 
-    def uninstall(self, uninstall_callback: Callable[[], None] | None = None) -> None:
+    def uninstall(self, uninstall_callback: Callable[[], None] | None = None, version: str | None = None) -> None:
         runner_path = self.directory
         if os.path.isdir(runner_path):
             system.remove_folder(runner_path, completion_function=uninstall_callback)

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -3,7 +3,7 @@
 # pylint: disable=too-many-lines
 import os
 import shlex
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
@@ -67,6 +67,7 @@ from lutris.util.wine.wine import (
     is_fsync_supported,
     is_gstreamer_build,
     is_winewayland_available,
+    list_lutris_wine_versions,
 )
 
 if TYPE_CHECKING:
@@ -879,6 +880,21 @@ class wine(Runner):
             return bool(get_installed_wine_versions())
         except MisconfigurationError:
             return False
+
+    def uninstall(self, uninstall_callback: Callable[[], None] | None = None, version: str | None = None) -> None:
+        def error_func(ex: Exception):
+            logger.error(_("Uninstall of wine has failed with error: %s") % str(ex))
+
+        if version:
+            lutris_wine_versions = list_lutris_wine_versions()
+            for lutris_wine_version in lutris_wine_versions:
+                if not lutris_wine_version.startswith(version):
+                    continue
+                runner_path = os.path.join(settings.WINE_DIR, lutris_wine_version)
+                if os.path.isdir(runner_path):
+                    system.remove_folder(runner_path, completion_function=uninstall_callback, error_function=error_func)
+            return
+        super().uninstall(uninstall_callback, version)
 
     def is_installed_for(self, interpreter):
         try:

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -204,6 +204,9 @@ def get_wine_path_for_version(version: str, config: dict | None = None) -> str:
         if not wine_path:
             raise RuntimeError("The 'custom' Wine version can be used only if the custom wine path is set.")
         return wine_path
+    for wine_version_path in os.listdir(WINE_DIR):
+        if wine_version_path.startswith(version):
+            return os.path.join(WINE_DIR, wine_version_path, "bin/wine")
     return os.path.join(WINE_DIR, version, "bin/wine")
 
 


### PR DESCRIPTION
The version of the runner to install can be specified after the name of the runner to install specific wine version. Passing the `latest` parameter after the "wine" argument for the `--install-runner` will install the latest version of wine.

Fix broken code around the installation of a specific wine version. The code was looking for a runner with the name of "lutris" which doesn't exist when installing/removing wine.

Added support to uninstall a specific wine version from the CLI

### Testing Done
Verified the following install runner commands

* `lutris --install-runner wine latest` - Installed the latest version of wine from Lutris API https://lutris.net/api/runners/wine
* `lutris --install-runner wine wine-ge-8-26` - Installed wine-ge-8-26
* `lutris --install-runner azahar`  -  Installed the azahar runner using the `download_url`

The following --uninstall-runner commands were verified
* `lutris --uninstall-runner wine wine-ge-8-26` - Uninstalled wine-ge-8-26
* `lutris --uninstall-runner azahar` - Uninstalled azahar

resolves #3669 