### PR TITLE
Quality: Debug print statement in production code

### DIFF
--- a/lutris/util/mame/ini.py
+++ b/lutris/util/mame/ini.py
@@ -29,7 +29,6 @@ class MameIni:
         with open(self.ini_path, "r", encoding="utf-8") as ini_file:
             for line in ini_file.readlines():
                 self.lines.append(line)
-                print(line)
                 config_key, config_value = self.parse(line)
                 if config_key:
                     self.config[config_key] = config_value


### PR DESCRIPTION
## Problem

The `MameIni.read` method contains a `print(line)` statement which outputs every line of the MAME configuration to stdout. This can clutter logs and impact performance in production environments.

**Severity**: `low`
**File**: `lutris/util/mame/ini.py`

## Solution

Remove the `print(line)` statement or replace it with `logger.debug(line)`.

## Changes

- `lutris/util/mame/ini.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
