### PR TITLE
Security: Command injection risk from shell=True with formatted command strings

### DIFF
--- a/utils/issuelocker.py
+++ b/utils/issuelocker.py
@@ -8,14 +8,39 @@ OWNER = "lutris"
 REPO = "lutris"
 
 response = subprocess.check_output(
-    "gh issue list -L 200 --state closed --json number --search 'is:unlocked'",
-    shell=True,
+    [
+        "gh",
+        "issue",
+        "list",
+        "-L",
+        "200",
+        "--state",
+        "closed",
+        "--json",
+        "number",
+        "--search",
+        "is:unlocked",
+    ],
     cwd=PROJECT_ROOT,
 )
 issues = json.loads(response)
 for issue in issues:
-    print(f"Locking issue {issue['number']}")
+    issue_number = issue.get("number")
+    if isinstance(issue_number, int):
+        issue_number = str(issue_number)
+    elif isinstance(issue_number, str) and issue_number.isdigit():
+        pass
+    else:
+        continue
+    print(f"Locking issue {issue_number}")
     subprocess.check_output(
-        f"gh api --method PUT /repos/{OWNER}/{REPO}/issues/{issue['number']}/lock -f lock_reason='resolved'",
-        shell=True,
+        [
+            "gh",
+            "api",
+            "--method",
+            "PUT",
+            f"/repos/{OWNER}/{REPO}/issues/{issue_number}/lock",
+            "-f",
+            "lock_reason=resolved",
+        ]
     )


### PR DESCRIPTION
## Problem

The script executes shell commands using `subprocess.check_output(..., shell=True)` and interpolates issue numbers into command strings. If command output is tampered with or unexpected values flow into `issue['number']`, this can lead to shell injection.

**Severity**: `high`
**File**: `utils/issuelocker.py`

## Solution

Avoid `shell=True` and pass arguments as a list (e.g., `subprocess.check_output(["gh", "api", "--method", "PUT", ...])`). Validate that issue numbers are strictly numeric before use.

## Changes

- `utils/issuelocker.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
