### PR TITLE
Security: Path traversal via unsanitized slug in filesystem path helpers

### DIFF
--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -1,20 +1,41 @@
 """Utility module to handle media resources"""
 
 import os
+import re
 
 from lutris import settings
 
 
+_SLUG_RE = re.compile(r"^[a-z0-9-]+$")
+
+
+def _sanitize_game_slug(game_slug: str) -> str:
+    if not _SLUG_RE.fullmatch(game_slug):
+        raise ValueError("Invalid game slug")
+    return game_slug
+
+
+def _safe_join(base_path: str, filename: str) -> str:
+    base_real = os.path.realpath(base_path)
+    candidate_path = os.path.realpath(os.path.join(base_real, filename))
+    if os.path.commonpath([base_real, candidate_path]) != base_real:
+        raise ValueError("Invalid resource path")
+    return candidate_path
+
+
 def get_icon_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug icon"""
-    return os.path.join(settings.ICON_PATH, "lutris_%s.png" % game_slug)
+    slug = _sanitize_game_slug(game_slug)
+    return _safe_join(settings.ICON_PATH, "lutris_%s.png" % slug)
 
 
 def get_banner_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug banner"""
-    return os.path.join(settings.BANNER_PATH, "{}.jpg".format(game_slug))
+    slug = _sanitize_game_slug(game_slug)
+    return _safe_join(settings.BANNER_PATH, "{}.jpg".format(slug))
 
 
 def get_cover_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug coverart"""
-    return os.path.join(settings.COVERART_PATH, "{}.jpg".format(game_slug))
+    slug = _sanitize_game_slug(game_slug)
+    return _safe_join(settings.COVERART_PATH, "{}.jpg".format(slug))


### PR DESCRIPTION
## Problem

Path builders directly concatenate `game_slug` into filesystem paths. If `game_slug` can contain `../` or absolute path segments from untrusted metadata, callers may read/write outside intended media directories.

**Severity**: `medium`
**File**: `lutris/util/resources.py`

## Solution

Normalize and validate slugs before path construction (allowlist characters like `[a-z0-9-]`), and enforce that resolved paths stay under the intended base directory using `os.path.realpath` prefix checks.

## Changes

- `lutris/util/resources.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
