### PR TITLE
Security: Potential path traversal via unsanitized game_slug in file paths

### DIFF
--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -7,14 +7,14 @@ from lutris import settings
 
 def get_icon_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug icon"""
-    return os.path.join(settings.ICON_PATH, "lutris_%s.png" % game_slug)
+    return os.path.join(settings.ICON_PATH, "lutris_%s.png" % os.path.basename(game_slug))
 
 
 def get_banner_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug banner"""
-    return os.path.join(settings.BANNER_PATH, "{}.jpg".format(game_slug))
+    return os.path.join(settings.BANNER_PATH, "{}.jpg".format(os.path.basename(game_slug)))
 
 
 def get_cover_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug coverart"""
-    return os.path.join(settings.COVERART_PATH, "{}.jpg".format(game_slug))
+    return os.path.join(settings.COVERART_PATH, "{}.jpg".format(os.path.basename(game_slug)))


### PR DESCRIPTION
## Problem

Functions `get_icon_path`, `get_banner_path`, and `get_cover_path` use `game_slug` directly in `os.path.join` without sanitizing for path traversal characters (e.g., `../`). If a malicious or corrupted game slug from a third-party service or installer script contains directory traversal sequences, files could be read from or written to unintended locations.

**Severity**: `low`
**File**: `lutris/util/resources.py`

## Solution

Validate that `game_slug` does not contain path separator characters (`/`, `\`, `..`) before constructing the path, or use `os.path.basename(game_slug)` to strip any directory components.

## Changes

- `lutris/util/resources.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
