### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/lutris/migrations/migrate_ge_proton.py
+++ b/lutris/migrations/migrate_ge_proton.py
@@ -11,10 +11,19 @@ def migrate():
     """Run migration"""
     try:
         config_paths = [os.path.join(settings.CONFIG_DIR, "runners/wine.yml")]
+        games_dir = os.path.realpath(os.path.join(settings.CONFIG_DIR, "games"))
 
         for db_game in get_games_by_runner("wine"):
             config_filename = db_game.get("configpath")
-            config_paths.append(os.path.join(settings.CONFIG_DIR, "games/%s.yml" % config_filename))
+            if not config_filename:
+                continue
+            safe_filename = os.path.basename(config_filename)
+            if safe_filename != config_filename:
+                continue
+            config_path = os.path.realpath(os.path.join(games_dir, "%s.yml" % safe_filename))
+            if os.path.commonpath([games_dir, config_path]) != games_dir:
+                continue
+            config_paths.append(config_path)
 
         for config_path in config_paths:
             try:

--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -1,20 +1,40 @@
 """Utility module to handle media resources"""
 
 import os
+import re
 
 from lutris import settings
 
 
+
+def _normalize_game_slug(game_slug: str) -> str:
+    game_slug = re.sub(r"[^a-z0-9_-]", "", game_slug.lower())
+    if not game_slug:
+        raise ValueError("Invalid game slug")
+    return game_slug
+
+
+def _get_media_path(base_path: str, filename: str) -> str:
+    base_path = os.path.realpath(base_path)
+    media_path = os.path.realpath(os.path.join(base_path, filename))
+    if os.path.commonpath([base_path, media_path]) != base_path:
+        raise ValueError("Invalid media path")
+    return media_path
+
+
 def get_icon_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug icon"""
-    return os.path.join(settings.ICON_PATH, "lutris_%s.png" % game_slug)
+    game_slug = _normalize_game_slug(game_slug)
+    return _get_media_path(settings.ICON_PATH, "lutris_%s.png" % game_slug)
 
 
 def get_banner_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug banner"""
-    return os.path.join(settings.BANNER_PATH, "{}.jpg".format(game_slug))
+    game_slug = _normalize_game_slug(game_slug)
+    return _get_media_path(settings.BANNER_PATH, "{}.jpg".format(game_slug))
 
 
 def get_cover_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug coverart"""
-    return os.path.join(settings.COVERART_PATH, "{}.jpg".format(game_slug))
+    game_slug = _normalize_game_slug(game_slug)
+    return _get_media_path(settings.COVERART_PATH, "{}.jpg".format(game_slug))


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `lutris/util/resources.py:L8`

Media paths are constructed by directly concatenating `game_slug` into filesystem paths (e.g., `lutris_%s.png`, `{}.jpg`) without sanitization. If a slug contains path separators or traversal sequences like `../`, callers that later read/write these paths may access files outside the intended media directories.

## Solution

Validate and normalize `game_slug` before use (e.g., allow only `[a-z0-9-_]`), and enforce containment by resolving the final path and verifying it remains under the expected base directory.

## Changes

- `lutris/util/resources.py` (modified)
- `lutris/migrations/migrate_ge_proton.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
