### PR TITLE
Fixed Lutris UnitTest when run on github

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -107,7 +107,11 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
+          python -m venv .venv
+          . .venv/bin/activate
           make req-python
           make dev
       - name: Run Unit Test
-        run: nose2 --exclude-ci
+        run: |
+          . .venv/bin/activate
+          nose2 --exclude-ci

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -5,7 +5,8 @@ import time
 from lutris.database import games
 from lutris.database.services import ServiceGameCollection
 from lutris.runners import get_runner_human_name
-from lutris.services import SERVICES, LutrisService
+from lutris.services import SERVICES
+from lutris.services.lutris import LutrisService
 from lutris.services.service_media import MediaPath
 from lutris.util.log import logger
 from lutris.util.strings import get_formatted_playtime, gtk_safe

--- a/lutris/services/__init__.py
+++ b/lutris/services/__init__.py
@@ -67,9 +67,11 @@ SERVICES = get_services()
 
 
 # Those services are not yet ready to be used
-WIP_SERVICES = {
-    "mame": MAMEService,
-}
+def get_wip_services() -> dict[str, "type[BaseService]"]:
+    return {"mame": MAMEService}
+
+
+WIP_SERVICES = get_wip_services()
 
 if os.environ.get("LUTRIS_ENABLE_ALL_SERVICES"):
     SERVICES.update(WIP_SERVICES)

--- a/lutris/util/test_config.py
+++ b/lutris/util/test_config.py
@@ -5,12 +5,12 @@ import gi
 gi.require_version("Gdk", "3.0")
 gi.require_version("Gtk", "3.0")
 
-from lutris import startup
 from lutris.database import schema
+from lutris.startup import init_lutris
 
 
 def setup_test_environment():
     """Sets up a system to be able to run tests"""
     os.environ["LUTRIS_SKIP_INIT"] = "1"
     schema.syncdb()
-    startup.init_lutris()
+    init_lutris()

--- a/tests/_test_gog_cloud.py
+++ b/tests/_test_gog_cloud.py
@@ -14,42 +14,32 @@ Tests the GOG cloud save synchronization implementation including:
 
 import gzip
 import hashlib
-import importlib.util
 import json
 import os
-import sys
 import tempfile
 import unittest
+import urllib
 import zlib
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-# Load gog_cloud directly from file to avoid lutris.services.__init__
-# which triggers GTK imports that conflict in test environments.
-_spec = importlib.util.spec_from_file_location(
-    "lutris.services.gog_cloud",
-    os.path.join(os.path.dirname(__file__), "..", "lutris", "services", "gog_cloud.py"),
+import lutris.services.gog_cloud as _mod
+from lutris.services.gog_cloud import (
+    EMPTY_GZIP_MD5,
+    CloudSaveLocation,
+    GOGCloudStorageClient,
+    GOGCloudSync,
+    SyncAction,
+    SyncClassifier,
+    SyncFile,
+    SyncResult,
+    create_directory_map,
+    get_cloud_save_locations,
+    get_game_client_credentials,
+    get_game_scoped_token,
+    get_relative_path,
+    resolve_save_path,
 )
-assert _spec is not None and _spec.loader is not None
-_mod = importlib.util.module_from_spec(_spec)
-sys.modules["lutris.services.gog_cloud"] = _mod
-_spec.loader.exec_module(_mod)
-
-EMPTY_GZIP_MD5 = _mod.EMPTY_GZIP_MD5
-CloudSaveLocation = _mod.CloudSaveLocation
-GOGCloudStorageClient = _mod.GOGCloudStorageClient
-GOGCloudSync = _mod.GOGCloudSync
-SyncAction = _mod.SyncAction
-SyncClassifier = _mod.SyncClassifier
-SyncFile = _mod.SyncFile
-SyncResult = _mod.SyncResult
-create_directory_map = _mod.create_directory_map
-get_cloud_save_locations = _mod.get_cloud_save_locations
-get_game_client_credentials = _mod.get_game_client_credentials
-get_game_scoped_token = _mod.get_game_scoped_token
-get_relative_path = _mod.get_relative_path
-resolve_save_path = _mod.resolve_save_path
-
 from lutris.util.http import HTTPError
 
 
@@ -155,7 +145,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         mock_response.read.return_value = b'{"test": "data"}'
         mock_response.getheaders.return_value = [("Content-Type", "application/json")]
 
-        with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response) as mock_urlopen:
+        with patch.object(urllib.request, "urlopen", return_value=mock_response) as mock_urlopen:
             body, headers = self.client._make_request("GET", "/v1/test")
 
         self.assertEqual(body, b'{"test": "data"}')
@@ -167,7 +157,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
 
         error = urllib.error.HTTPError(url="http://test", code=404, msg="Not Found", hdrs={}, fp=None)
 
-        with patch.object(_mod.urllib.request, "urlopen", side_effect=error):
+        with patch.object(urllib.request, "urlopen", side_effect=error):
             body, headers = self.client._make_request("GET", "/v1/missing")
         self.assertEqual(body, b"")
         self.assertEqual(headers, {})
@@ -177,7 +167,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
 
         error = urllib.error.HTTPError(url="http://test", code=500, msg="Server Error", hdrs={}, fp=None)
 
-        with patch.object(_mod.urllib.request, "urlopen", side_effect=error):
+        with patch.object(urllib.request, "urlopen", side_effect=error):
             with self.assertRaises(HTTPError):
                 self.client._make_request("GET", "/v1/test")
 
@@ -185,7 +175,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         import urllib.error
 
         with patch.object(
-            _mod.urllib.request,
+            urllib.request,
             "urlopen",
             side_effect=urllib.error.URLError("Connection refused"),
         ):
@@ -214,7 +204,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         mock_response.read.return_value = json.dumps(cloud_data).encode()
         mock_response.getheaders.return_value = []
 
-        with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+        with patch.object(urllib.request, "urlopen", return_value=mock_response):
             files = self.client.list_files("saves")
 
         self.assertEqual(len(files), 2)
@@ -227,7 +217,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         mock_response.read.return_value = b""
         mock_response.getheaders.return_value = []
 
-        with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+        with patch.object(urllib.request, "urlopen", return_value=mock_response):
             files = self.client.list_files("saves")
         self.assertEqual(files, [])
 
@@ -236,7 +226,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         mock_response.read.return_value = b"not json"
         mock_response.getheaders.return_value = []
 
-        with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+        with patch.object(urllib.request, "urlopen", return_value=mock_response):
             files = self.client.list_files("saves")
         self.assertEqual(files, [])
 
@@ -255,7 +245,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
                 absolute_path=tmp_path,
                 update_time="2024-01-15T10:00:00+00:00",
             )
-            with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response) as mock_urlopen:
+            with patch.object(urllib.request, "urlopen", return_value=mock_response) as mock_urlopen:
                 result = self.client.upload_file(f, "saves")
             self.assertTrue(result)
 
@@ -290,7 +280,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
                 update_time="2024-01-15T10:00:00+00:00",
             )
             with patch.object(
-                _mod.urllib.request,
+                urllib.request,
                 "urlopen",
                 side_effect=urllib.error.HTTPError(url="http://test", code=500, msg="Error", hdrs={}, fp=None),
             ):
@@ -308,7 +298,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
             dest_path = os.path.join(tmpdir, "saves", "game.sav")
             f = SyncFile(relative_path="game.sav", absolute_path=dest_path)
 
-            with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+            with patch.object(urllib.request, "urlopen", return_value=mock_response):
                 result = self.client.download_file(f, "saves")
             self.assertTrue(result)
             self.assertTrue(os.path.exists(dest_path))
@@ -321,7 +311,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         mock_response.getheaders.return_value = []
 
         f = SyncFile(relative_path="game.sav", absolute_path="/tmp/test.sav")
-        with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+        with patch.object(urllib.request, "urlopen", return_value=mock_response):
             result = self.client.download_file(f, "saves")
         self.assertFalse(result)
 
@@ -330,7 +320,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
 
         f = SyncFile(relative_path="game.sav", absolute_path="/tmp/test.sav")
         with patch.object(
-            _mod.urllib.request,
+            urllib.request,
             "urlopen",
             side_effect=urllib.error.HTTPError(url="http://test", code=403, msg="Forbidden", hdrs={}, fp=None),
         ):
@@ -346,7 +336,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
             dest_path = os.path.join(tmpdir, "game.sav")
             f = SyncFile(relative_path="game.sav", absolute_path=dest_path)
 
-            with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+            with patch.object(urllib.request, "urlopen", return_value=mock_response):
                 result = self.client.download_file(f, "saves")
             self.assertTrue(result)
 
@@ -356,7 +346,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
         mock_response.getheaders.return_value = []
 
         f = SyncFile(relative_path="old.sav", absolute_path="/tmp/old.sav")
-        with patch.object(_mod.urllib.request, "urlopen", return_value=mock_response):
+        with patch.object(urllib.request, "urlopen", return_value=mock_response):
             result = self.client.delete_file(f, "saves")
         self.assertTrue(result)
 
@@ -365,7 +355,7 @@ class TestGOGCloudStorageClient(unittest.TestCase):
 
         f = SyncFile(relative_path="old.sav", absolute_path="/tmp/old.sav")
         with patch.object(
-            _mod.urllib.request,
+            urllib.request,
             "urlopen",
             side_effect=urllib.error.HTTPError(url="http://test", code=500, msg="Error", hdrs={}, fp=None),
         ):

--- a/tests/_test_gog_cloud_hooks.py
+++ b/tests/_test_gog_cloud_hooks.py
@@ -3,49 +3,24 @@
 Tests the game lifecycle integration hooks for GOG cloud sync.
 """
 
-import importlib.util
 import os
 import sys
-import types
 import unittest
 from unittest.mock import MagicMock, patch
 
-# ── Load gog_cloud first (no GTK dependency) ────────────────────────
-_cloud_spec = importlib.util.spec_from_file_location(
-    "lutris.services.gog_cloud",
-    os.path.join(os.path.dirname(__file__), "..", "lutris", "services", "gog_cloud.py"),
+import lutris.services.gog_cloud_hooks as _mod
+from lutris.services.gog_cloud import (
+    CloudSaveLocation,
+    SyncAction,
+    SyncResult,
 )
-assert _cloud_spec is not None and _cloud_spec.loader is not None
-_cloud_mod = importlib.util.module_from_spec(_cloud_spec)
-sys.modules["lutris.services.gog_cloud"] = _cloud_mod
-_cloud_spec.loader.exec_module(_cloud_mod)
-
-SyncAction = _cloud_mod.SyncAction
-SyncResult = _cloud_mod.SyncResult
-CloudSaveLocation = _cloud_mod.CloudSaveLocation
-
-# ── Stub lutris.services package to prevent __init__.py / GTK chain ─
-if "lutris.services" not in sys.modules:
-    _services_stub = types.ModuleType("lutris.services")
-    sys.modules["lutris.services"] = _services_stub
-sys.modules["lutris.services"].gog_cloud = _cloud_mod  # type: ignore[attr-defined]
-
-# ── Now load gog_cloud_hooks (its "from lutris.services.gog_cloud"
-#    will find the module we already placed in sys.modules) ──────────
-_spec = importlib.util.spec_from_file_location(
-    "lutris.services.gog_cloud_hooks",
-    os.path.join(os.path.dirname(__file__), "..", "lutris", "services", "gog_cloud_hooks.py"),
+from lutris.services.gog_cloud_hooks import (
+    _get_game_runner_info,
+    _get_gog_service,
+    _resolve_save_locations,
+    sync_after_quit,
+    sync_before_launch,
 )
-assert _spec is not None and _spec.loader is not None
-_mod = importlib.util.module_from_spec(_spec)
-sys.modules["lutris.services.gog_cloud_hooks"] = _mod
-_spec.loader.exec_module(_mod)
-
-sync_before_launch = _mod.sync_before_launch
-sync_after_quit = _mod.sync_after_quit
-_get_gog_service = _mod._get_gog_service
-_get_game_runner_info = _mod._get_game_runner_info
-_resolve_save_locations = _mod._resolve_save_locations
 
 
 class TestGetGogService(unittest.TestCase):

--- a/tests/util/_test_gog_downloader.py
+++ b/tests/util/_test_gog_downloader.py
@@ -530,17 +530,6 @@ class TestInstallerFileIntegration:
 class TestGOGServiceIntegration:
     """Test that the GOG service injects GOGDownloader into InstallerFile."""
 
-    @pytest.fixture(autouse=True)
-    def _setup_gi(self):
-        """Ensure GTK version is required before importing GOG service."""
-        try:
-            import gi
-
-            gi.require_version("Gtk", "3.0")
-            gi.require_version("Gdk", "3.0")
-        except (ValueError, ImportError):
-            pytest.skip("GTK 3.0 not available")
-
     def test_gog_format_links_includes_downloader_class(self):
         """_format_links should inject GOGDownloader as downloader_class."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
The primary causes of the issue is the manipulation of how the gog_cloud.py and gog_cloud_hooks.py was getting imported in UnitTest via the importlib mechanism. That seemed to have broken the resolution of paths to `lutris.services.*`. As the GTK issues that it was trying to side step has been fixed at the `tests` root level, the workaround is no longer needed.

Additional changes have been added to help harden any potentially UnitTest environment and  circular import issues.
* Updated the github unit test run to use a virtual env to install the package dependencies and run the test