### PR TITLE
fix(download_cache): correct CacheState typo in is_safe_to_delete

### DIFF
--- a/lutris/util/download_cache.py
+++ b/lutris/util/download_cache.py
@@ -145,7 +145,7 @@ def is_safe_to_delete(file_path: str) -> bool:
         return True
 
     # Active states - never delete
-    if state in (CacheState.DOWNLOADING, CacheState.DOWNLOADING, CacheState.INSTALLING):
+    if state in (CacheState.DOWNLOADING, CacheState.DOWNLOADED, CacheState.INSTALLING):
         logger.info(
             "Cache protection: preserving %s (state: %s)",
             os.path.basename(file_path),


### PR DESCRIPTION
## Summary

`is_safe_to_delete` in `lutris/util/download_cache.py` lists `CacheState.DOWNLOADING` twice in the protection tuple, omitting `CacheState.DOWNLOADED`:

```python
# Before (line 148)
if state in (CacheState.DOWNLOADING, CacheState.DOWNLOADING, CacheState.INSTALLING):
```

This means files in the `DOWNLOADED` state (download complete, awaiting installation) are not protected and can be deleted before installation finishes.

## Fix

Replace the duplicate `DOWNLOADING` with `DOWNLOADED`:

```python
if state in (CacheState.DOWNLOADING, CacheState.DOWNLOADED, CacheState.INSTALLING):
```

## Notes

- Regression introduced in #6525
- One-line change, no behaviour change for `DOWNLOADING` or `INSTALLING` states

## Test plan

- [x] Download a GOG game to completion, then cancel/interrupt before installation — confirm the downloaded file is preserved
- [x] Verify `make test` passes