### PR TITLE
Add CLI option to print a game "GameConfig" to stdout.

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -28,6 +28,7 @@ from datetime import datetime, timedelta
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any, Type, TypeVar, cast
 
+import yaml
 from gi.repository import Gio, GLib, Gtk
 
 from lutris import settings
@@ -64,6 +65,7 @@ LUTRIS_EXPERIMENTAL_FEATURES_ENABLED = os.environ.get("LUTRIS_EXPERIMENTAL_FEATU
 
 if TYPE_CHECKING:
     from lutris.api import InstallerInfoDict
+    from lutris.config import GameConfigDict
     from lutris.database.games import DbGameDict
     from lutris.database.services import DBServiceGame
     from lutris.services.base import BaseService
@@ -259,6 +261,14 @@ class LutrisApplication(Gtk.Application):
             GLib.OptionArg.STRING,
             _("Uninstall a Runner"),
             None,
+        )
+        self.add_main_option(
+            "list-game-config",
+            0,
+            GLib.OptionFlags.NONE,
+            GLib.OptionArg.STRING,
+            _("Output a game config data as YAML. Use --json to output as JSON instead."),
+            "<game-id-or-slug>",
         )
         self.add_main_option(
             "export",
@@ -585,6 +595,23 @@ class LutrisApplication(Gtk.Application):
             self.uninstall_runner(runner)
             return 0
 
+        # List game config
+        if option := options.lookup_value("list-game-config"):
+            game_slug = option.get_string()
+            db_game = games_db.get_game_by_field(game_slug, "id") or games_db.get_game_by_field(game_slug, "slug")
+            if not db_game:
+                print(_('Game "%s" could not be found') % game_slug)
+                return 1
+
+            game = Game(str(db_game["id"]))
+            game_config = game.config.game_level.get("game", {}) if game.config else {}
+            if options.contains("json"):
+                self.print_game_config_json(command_line, game_config)
+            else:
+                self.print_game_config_yaml(command_line, game_config)
+            return 0
+
+        # Export game to script
         if option := options.lookup_value("export"):
             slug = option.get_string()
             if not dest_dir:
@@ -943,6 +970,12 @@ class LutrisApplication(Gtk.Application):
             games.append(game_obj)
 
         self._print(command_line, json.dumps(games, indent=2))
+
+    def print_game_config_yaml(self, command_line: Gio.ApplicationCommandLine, game_config: "GameConfigDict") -> None:
+        self._print(command_line, yaml.safe_dump(game_config, default_flow_style=False))
+
+    def print_game_config_json(self, command_line: Gio.ApplicationCommandLine, game_config: "GameConfigDict") -> None:
+        self._print(command_line, json.dumps(game_config, indent=2))
 
     def print_service_game_list(
         self, command_line: Gio.ApplicationCommandLine, game_list: list["DBServiceGame"]


### PR DESCRIPTION

The Game Config can be output in either YAML or JSON for futher processing
This is useful for scripting + troubleshooting purposes.
For scripting this can be used to determine the available launch configs for a game.
For troubleshooting this can be used to output the arguments used to launch the game which can be added to bug reports.

### Ex: Getting list of available launch configs
```bash
[user@host]$ bin/lutris --list-game-config=test-ares --json 2>/dev/null | jq '.launch_configs | map(.name)'
[
  "nemo",
  "gvim"
]

[user@host]$ bin/lutris lutris:rungame/test-ares --launch-config-name nemo
2026-04-21 14:34:15,074: Command 'vulkaninfo' not found on your system
2026-04-21 14:34:15,250: Starting Lutris 0.5.23
...
```

relates #6584

### Testing Done

Ran all 4 combinations of the --list-game-config game option:
* game_slug
 ```bash
[user@host]$ bin/lutris --list-game-config=test-ares 2>/dev/null
launch_configs:
- args: /mnt/DataDrive/workspace/lutris-test
  command: nemo
  name: nemo
- args: /mnt/DataDrive/workspace/lutris-test/version
  command: gvim
  name: gvim
main_file: /mnt/DataDrive/media/Games/SNES/ROM/super_sudoku_v1.1.sfc
platform: Super Famicom
```
* game_id
```bash
[user@host]$ bin/lutris --list-game-config=3 2>/dev/null
launch_configs:
- args: /mnt/DataDrive/workspace/lutris-test
  command: nemo
  name: nemo
- args: /mnt/DataDrive/workspace/lutris-test/version
  command: gvim
  name: gvim
main_file: /mnt/DataDrive/media/Games/SNES/ROM/super_sudoku_v1.1.sfc
platform: Super Famicom
```
* game_slug + `--json` option
```bash
[user@host]$ bin/lutris --list-game-config=test-ares --json 2>/dev/null
{
  "launch_configs": [
    {
      "args": "/mnt/DataDrive/workspace/lutris-test",
      "command": "nemo",
      "name": "nemo"
    },
    {
      "args": "/mnt/DataDrive/workspace/lutris-test/version",
      "command": "gvim",
      "name": "gvim"
    }
  ],
  "main_file": "/mnt/DataDrive/media/Games/SNES/ROM/super_sudoku_v1.1.sfc",
  "platform": "Super Famicom"
}
```
* game_id + `--json`
```bash
[user@host]$ bin/lutris --list-game-config=3 --json 2>/dev/null
{
  "launch_configs": [
    {
      "args": "/mnt/DataDrive/workspace/lutris-test",
      "command": "nemo",
      "name": "nemo"
    },
    {
      "args": "/mnt/DataDrive/workspace/lutris-test/version",
      "command": "gvim",
      "name": "gvim"
    }
  ],
  "main_file": "/mnt/DataDrive/media/Games/SNES/ROM/super_sudoku_v1.1.sfc",
  "platform": "Super Famicom"
}
```
Also tested the failure scenario of a game id or slug not existing.
```bash
[user@host]$ bin/lutris --list-game-config=does-not-exist 2>/dev/null
Game "does-not-exist" could not be found
```