### PR TITLE
Add new installer commands: input_text and input_dir

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -801,6 +801,54 @@ selected is French, the "$INPUT_LANG" alias would be available in
 following directives and would correspond to "fr". "$INPUT" would work as well,
 up until the next input directive.
 
+Displaying a directory picker
+-----------------------------
+
+The ``input_dir`` directive allows the user to select a path to a directory, it works
+similarly to ``insert_disc`` minus the autodetect disc option. Like in ``insert_disc``,
+the `requires` paremeter specifies a file or directory that must be present in the target
+directory, but here it's optional.
+
+You can set a custom message using the `message` parameter.
+
+The directory selected will be available with the ``$INPUT_DIR`` alias. If need be, you can
+add an ``id`` parameter to the directive which will make the selected value available with
+``$INPUT_<id>`` with "<id>" being the id you specified. The id must contain only
+numbers, letters and underscores.
+
+Example::
+
+    - input_dir:
+        id: modfolder
+        message: Select the path to the mod
+
+Displaying a text input field
+-----------------------------
+
+The ``input_text`` directive allows the user to write a line of text that can be later used
+by the install script. This can be used for asking for a CD-KEY when a game's installer is
+uncooperative or other information that can't be known ahead of time.
+
+You can set the label above the input field using the `message` parameter, and the placeholder
+text with the `placeholder` paramenter.
+
+The resulting text will be available with the ``$INPUT_TEXT`` alias. If need be, you can
+add an ``id`` parameter to the directive which will make the selected value available with
+``$INPUT_<id>`` with "<id>" being the id you specified. The id must contain only
+numbers, letters and underscores.
+
+``input_text`` does not offer any text validation, any validation must be done manually in a
+later ``execute`` directive.
+
+Example::
+
+    - input_text:
+        id: cdkey
+        message: Enter the CD-KEY in ALL CAPS with dashes (-)
+        placeholder: 0000-1111-2222-3333
+
+
+
 Example scripts
 ===============
 

--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -829,7 +829,7 @@ The ``input_text`` directive allows the user to write a line of text that can be
 by the install script. This can be used for asking for a CD-KEY when a game's installer is
 uncooperative or other information that can't be known ahead of time.
 
-You can set the label above the input field using the `message` parameter, and the placeholder
+You can set the label above the input field using the `label` parameter, and the placeholder
 text with the `placeholder` paramenter.
 
 The resulting text will be available with the ``$INPUT_TEXT`` alias. If need be, you can

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -997,7 +997,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             browse_button.set_halign(Gtk.Align.CENTER)
             browse_button.set_valign(Gtk.Align.START)
             callback_data = {"callback": wrapped_callback, "requires": requires, "alias": alias}
-            browse_button.connect("clicked", self.on_browse_clicked2, callback_data)
+            browse_button.connect("clicked", self.on_browse_dir_clicked, callback_data)
             vbox.pack_start(browse_button, False, False, 40)
 
             self.stack.present_replacement_page("ask_for_dir", vbox)
@@ -1008,7 +1008,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         previous_page = self.stack.save_current_page()
         self.stack.jump_to_page(present_ask_for_dir_page)
 
-    def on_browse_clicked2(self, btn, callback_data):
+    def on_browse_dir_clicked(self, btn, callback_data):
         dialog = DirectoryDialog(_("Select directory"), parent=self)
         folder = dialog.folder
         callback = callback_data["callback"]

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -976,7 +976,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
     # This page asks the user for a directory.
 
     def load_ask_for_dir_page(self, alias, message, requires, callback):
-        def present_ask_for_disc_page():
+        def present_ask_for_dir_page():
             """Ask the user to do insert a CD-ROM."""
 
             def wrapped_callback(*args, **kwargs):
@@ -993,7 +993,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             vbox.pack_start(label, False, False, 0)
 
             browse_button = Gtk.Button(label=_("Browse…"))
-            browse_button.set_size_request(200,35)
+            browse_button.set_size_request(200, 35)
             browse_button.set_halign(Gtk.Align.CENTER)
             browse_button.set_valign(Gtk.Align.START)
             callback_data = {"callback": wrapped_callback, "requires": requires, "alias": alias}
@@ -1006,7 +1006,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             self.display_cancel_button()
 
         previous_page = self.stack.save_current_page()
-        self.stack.jump_to_page(present_ask_for_disc_page)
+        self.stack.jump_to_page(present_ask_for_dir_page)
 
     def on_browse_clicked2(self, btn, callback_data):
         dialog = DirectoryDialog(_("Select directory"), parent=self)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -879,16 +879,21 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
                     # to run, so we'll go to error page.
                     self.load_error_page(err)
 
-            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            vbox.set_valign(Gtk.Align.START)
+            vbox.set_margin_top(20)
+            vbox.set_margin_left(20)
+            vbox.set_margin_right(20)
+
             label = Gtk.Label(wrap=True)
             label.set_text(message)
+            label.set_halign(Gtk.Align.START)
             vbox.pack_start(label, False, False, 0)
 
             entry = Gtk.Entry()
             entry.set_placeholder_text(placeholder)
             entry.set_max_length(0)
-            entry.set_margin_left(50)
-            entry.set_margin_right(50)
+            entry.connect("activate", wrapped_callback)
             vbox.pack_start(entry, False, False, 0)
 
             self.stack.present_replacement_page("ask_for_text", vbox)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -891,6 +891,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             entry.set_margin_right(50)
             vbox.pack_start(entry, False, False, 0)
             vbox.show_all()
+            entry.grab_focus()
             self.display_continue_button(wrapped_callback)
 
         previous_page = self.stack.save_current_page()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -378,8 +378,8 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             callback,
         )
 
-    def begin_text_prompt(self, alias, message, callback):
-        GLib.idle_add(self.load_ask_for_text_page, alias, message, callback)
+    def begin_text_prompt(self, alias, message, placeholder, callback):
+        GLib.idle_add(self.load_ask_for_text_page, alias, message, placeholder, callback)
 
     def begin_input_menu(self, alias, options, preselect, callback):
         GLib.idle_add(self.load_input_menu_page, alias, options, preselect, callback)
@@ -864,14 +864,13 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         """Enable continue button if a non-empty choice is selected"""
         self.continue_button.set_sensitive(bool(combobox.get_active_id()))
 
-
     # Ask for Text Page
     #
     # This page asks the user for a single line of text
 
     def load_ask_for_text_page(self, alias, message, placeholder, callback):
         def present_ask_for_text_page():
-            def wrapped_callback(*args):
+            def wrapped_callback(*args, **kwa):
                 try:
                     callback(entry, alias)
                     self.stack.restore_current_page(previous_page)
@@ -883,17 +882,16 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
             label = Gtk.Label(wrap=True)
             label.set_text(message)
-            vbox.pack_start(label)
+            vbox.pack_start(label, False, False, 0)
 
             entry = Gtk.Entry()
             entry.set_placeholder_text(placeholder)
             entry.set_max_length(0)
             entry.set_margin_left(50)
             entry.set_margin_right(50)
-            vbox.pack_start(entry)
+            vbox.pack_start(entry, False, False, 0)
             vbox.show_all()
             self.display_continue_button(wrapped_callback)
-
 
         previous_page = self.stack.save_current_page()
         self.stack.jump_to_page(present_ask_for_text_page)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -378,6 +378,9 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             callback,
         )
 
+    def begin_dir_prompt(self, alias, message, requires, callback):
+        GLib.idle_add(self.load_ask_for_dir_page, alias, message, requires, callback)
+
     def begin_text_prompt(self, alias, message, placeholder, callback):
         GLib.idle_add(self.load_ask_for_text_page, alias, message, placeholder, callback)
 
@@ -967,6 +970,50 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
 
     def on_eject_clicked(self, _widget, data=None):
         self.interpreter.eject_wine_disc()
+
+    # Ask for Dir Page
+    #
+    # This page asks the user for a directory.
+
+    def load_ask_for_dir_page(self, alias, message, requires, callback):
+        def present_ask_for_disc_page():
+            """Ask the user to do insert a CD-ROM."""
+
+            def wrapped_callback(*args, **kwargs):
+                try:
+                    callback(*args, **kwargs)
+                    self.stack.restore_current_page(previous_page)
+                except Exception as err:
+                    # If the callback fails, the installation does not continue
+                    # to run, so we'll go to error page.
+                    self.load_error_page(err)
+
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=6)
+            label = MarkupLabel(message)
+            vbox.pack_start(label, False, False, 0)
+
+            browse_button = Gtk.Button(label=_("Browse…"))
+            browse_button.set_margin_top(40)
+            browse_button.set_margin_bottom(40)
+            callback_data = {"callback": wrapped_callback, "requires": requires, "alias": alias}
+            browse_button.connect("clicked", self.on_browse_clicked2, callback_data)
+            vbox.pack_start(browse_button, True, True, 40)
+
+            self.stack.present_replacement_page("ask_for_dir", vbox)
+
+            vbox.show_all()
+            self.display_cancel_button()
+
+        previous_page = self.stack.save_current_page()
+        self.stack.jump_to_page(present_ask_for_disc_page)
+
+    def on_browse_clicked2(self, btn, callback_data):
+        dialog = DirectoryDialog(_("Select directory"), parent=self)
+        folder = dialog.folder
+        callback = callback_data["callback"]
+        requires = callback_data["requires"]
+        alias = callback_data["alias"]
+        callback(btn, requires, folder, alias)
 
     # Error Message Page
     #

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -993,11 +993,12 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             vbox.pack_start(label, False, False, 0)
 
             browse_button = Gtk.Button(label=_("Browse…"))
-            browse_button.set_margin_top(40)
-            browse_button.set_margin_bottom(40)
+            browse_button.set_size_request(200,35)
+            browse_button.set_halign(Gtk.Align.CENTER)
+            browse_button.set_valign(Gtk.Align.START)
             callback_data = {"callback": wrapped_callback, "requires": requires, "alias": alias}
             browse_button.connect("clicked", self.on_browse_clicked2, callback_data)
-            vbox.pack_start(browse_button, True, True, 40)
+            vbox.pack_start(browse_button, False, False, 40)
 
             self.stack.present_replacement_page("ask_for_dir", vbox)
 

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -378,6 +378,9 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             callback,
         )
 
+    def begin_text_prompt(self, alias, message, callback):
+        GLib.idle_add(self.load_ask_for_text_page, alias, message, callback)
+
     def begin_input_menu(self, alias, options, preselect, callback):
         GLib.idle_add(self.load_input_menu_page, alias, options, preselect, callback)
 
@@ -860,6 +863,40 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
     def on_input_menu_changed(self, combobox):
         """Enable continue button if a non-empty choice is selected"""
         self.continue_button.set_sensitive(bool(combobox.get_active_id()))
+
+
+    # Ask for Text Page
+    #
+    # This page asks the user for a single line of text
+
+    def load_ask_for_text_page(self, alias, message, placeholder, callback):
+        def present_ask_for_text_page():
+            def wrapped_callback(*args):
+                try:
+                    callback(entry, alias)
+                    self.stack.restore_current_page(previous_page)
+                except Exception as err:
+                    # If the callback fails, the installation does not continue
+                    # to run, so we'll go to error page.
+                    self.load_error_page(err)
+
+            vbox = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=3)
+            label = Gtk.Label(wrap=True)
+            label.set_text(message)
+            vbox.pack_start(label)
+
+            entry = Gtk.Entry()
+            entry.set_placeholder_text(placeholder)
+            entry.set_max_length(0)
+            entry.set_margin_left(50)
+            entry.set_margin_right(50)
+            vbox.pack_start(entry)
+            vbox.show_all()
+            self.display_continue_button(wrapped_callback)
+
+
+        previous_page = self.stack.save_current_page()
+        self.stack.jump_to_page(present_ask_for_text_page)
 
     # Ask for Disc Page
     #

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -870,7 +870,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
 
     def load_ask_for_text_page(self, alias, message, placeholder, callback):
         def present_ask_for_text_page():
-            def wrapped_callback(*args, **kwa):
+            def wrapped_callback(*a, **b):
                 try:
                     callback(entry, alias)
                     self.stack.restore_current_page(previous_page)
@@ -890,8 +890,10 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             entry.set_margin_left(50)
             entry.set_margin_right(50)
             vbox.pack_start(entry, False, False, 0)
+
+            self.stack.present_replacement_page("ask_for_text", vbox)
+
             vbox.show_all()
-            entry.grab_focus()
             self.display_continue_button(wrapped_callback)
 
         previous_page = self.stack.save_current_page()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -871,7 +871,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
     #
     # This page asks the user for a single line of text
 
-    def load_ask_for_text_page(self, alias, message, placeholder, callback):
+    def load_ask_for_text_page(self, alias, label_text, placeholder, callback):
         def present_ask_for_text_page():
             def wrapped_callback(*a, **b):
                 try:
@@ -889,7 +889,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             vbox.set_margin_right(20)
 
             label = Gtk.Label(wrap=True)
-            label.set_text(message)
+            label.set_text(label_text)
             label.set_halign(Gtk.Align.START)
             vbox.pack_start(label, False, False, 0)
 

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -256,7 +256,7 @@ class CommandsMixin:
 
     def _on_dir_selected(self, _btn, requires, dir, alias):
         if requires:
-            required_abspath = os.path.join(dir, requires)
+            required_abspath = self._check_requires(dir, requires)
             if system.path_exists(required_abspath):
                 logger.debug("Found required file %s on %s", requires, dir)
             else:
@@ -264,6 +264,18 @@ class CommandsMixin:
 
         self.user_inputs.append({"alias": alias, "value": dir})
         self._iter_commands()
+
+    @staticmethod
+    def _check_requires(dir, requires):
+        """Check requires clause so it doesn't reach outside the target directory w/ relative paths,
+        returns the validaded path"""
+        target = Path(dir)
+        assert target.is_dir(), "requires must be checked against a directory!"
+        requires = Path(requires)
+        abspath = str((target / requires).resolve())
+        if target.name not in abspath:
+            raise RuntimeError("Illegal 'requires' reaches outside the target directory", requires)
+        return abspath
 
     def insert_disc(self, data):
         """Request user to insert an optical disc"""

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -31,7 +31,7 @@ class CommandsMixin:
 
     # pylint: disable=no-member
     installer: LutrisInstaller = NotImplemented
-    user_inputs: list[dict]
+    user_inputs: list[dict[str, str]]
 
     def get_wine_path(self) -> str:
         """Return absolute path of wine version used during the installation, but
@@ -233,7 +233,7 @@ class CommandsMixin:
 
     def input_text(self, data):
         alias = f"INPUT_{data.get('id', 'TEXT')}"
-        message = data.get("message", _("Type bellow:"))
+        message = data.get("message", _("Type below:"))
         placeholder = data.get("placeholder", "...")
         self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text)
         return "STOP"

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -272,8 +272,8 @@ class CommandsMixin:
         target = Path(dir)
         assert target.is_dir(), "requires must be checked against a directory!"
         requires = Path(requires)
-        abspath = str((target / requires).resolve())
-        if target.name not in abspath:
+        abspath = (target / requires).resolve()
+        if not abspath.is_relative_to(target):
             raise RuntimeError("Illegal 'requires' reaches outside the target directory", requires)
         return abspath
 

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -230,7 +230,7 @@ class CommandsMixin:
         else:
             raise RuntimeError("A required input option was not selected, so the installation can't continue.")
 
-    def insert_text(self, data):
+    def input_text(self, data):
         alias = f"INPUT_{data.get('id', 'TEXT')}"
         message = data.get("message", _("Type bellow:"))
         placeholder = data.get("placeholder", "...")

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -31,6 +31,7 @@ class CommandsMixin:
 
     # pylint: disable=no-member
     installer: LutrisInstaller = NotImplemented
+    user_inputs: list[dict]
 
     def get_wine_path(self) -> str:
         """Return absolute path of wine version used during the installation, but
@@ -240,6 +241,28 @@ class CommandsMixin:
     def _on_text(self, entry, alias):
         text = entry.get_text()
         self.user_inputs.append({"alias": alias, "value": text.strip()})
+        self._iter_commands()
+
+    def input_dir(self, data):
+        """Request user to provide a path to a directory"""
+        requires = data.get("requires")
+        alias = f"INPUT_{data.get('id', 'DIR')}"
+        message = data.get("message", _("Click Browse to select a directory."))
+        if requires:
+            message += _("\nIt must contain\nthe following file or folder:\n<i>%s</i>") % requires
+
+        self.interpreter_ui_delegate.begin_dir_prompt(alias, message, requires, self._on_dir_selected)
+        return "STOP"
+
+    def _on_dir_selected(self, _btn, requires, dir, alias):
+        if requires:
+            required_abspath = os.path.join(dir, requires)
+            if system.path_exists(required_abspath):
+                logger.debug("Found required file %s on %s", requires, dir)
+            else:
+                raise RuntimeError(f"The required file '{requires}' could not be located.")
+
+        self.user_inputs.append({"alias": alias, "value": dir})
         self._iter_commands()
 
     def insert_disc(self, data):

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -230,6 +230,18 @@ class CommandsMixin:
         else:
             raise RuntimeError("A required input option was not selected, so the installation can't continue.")
 
+
+
+    def insert_text(self, data:dict):
+        alias = f"INPUT_{data.get("id", "TEXT")}"
+        message = data.get("message", _("Type bellow:"))
+        placeholder = data.get("placeholder", "...")
+        self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text_changed)
+
+    def _on_text_changed(self, entry, alias):
+        text = entry.get_text()
+        self.user_inputs.append({ "alias": alias, "value": text.strip() })
+
     def insert_disc(self, data):
         """Request user to insert an optical disc"""
         self._check_required_params("requires", data, "insert_disc")

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -234,10 +234,10 @@ class CommandsMixin:
         alias = f"INPUT_{data.get('id', 'TEXT')}"
         message = data.get("message", _("Type bellow:"))
         placeholder = data.get("placeholder", "...")
-        self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text_changed)
+        self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text)
         return "STOP"
 
-    def _on_text_changed(self, entry, alias):
+    def _on_text(self, entry, alias):
         text = entry.get_text()
         self.user_inputs.append({"alias": alias, "value": text.strip()})
         self._iter_commands()

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -235,10 +235,12 @@ class CommandsMixin:
         message = data.get("message", _("Type bellow:"))
         placeholder = data.get("placeholder", "...")
         self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text_changed)
+        return "STOP"
 
     def _on_text_changed(self, entry, alias):
         text = entry.get_text()
         self.user_inputs.append({"alias": alias, "value": text.strip()})
+        self._iter_commands()
 
     def insert_disc(self, data):
         """Request user to insert an optical disc"""

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -230,17 +230,15 @@ class CommandsMixin:
         else:
             raise RuntimeError("A required input option was not selected, so the installation can't continue.")
 
-
-
-    def insert_text(self, data:dict):
-        alias = f"INPUT_{data.get("id", "TEXT")}"
+    def insert_text(self, data):
+        alias = f"INPUT_{data.get('id', 'TEXT')}"
         message = data.get("message", _("Type bellow:"))
         placeholder = data.get("placeholder", "...")
         self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text_changed)
 
     def _on_text_changed(self, entry, alias):
         text = entry.get_text()
-        self.user_inputs.append({ "alias": alias, "value": text.strip() })
+        self.user_inputs.append({"alias": alias, "value": text.strip()})
 
     def insert_disc(self, data):
         """Request user to insert an optical disc"""

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -233,9 +233,9 @@ class CommandsMixin:
 
     def input_text(self, data):
         alias = f"INPUT_{data.get('id', 'TEXT')}"
-        message = data.get("message", _("Type below:"))
+        label = data.get("label", _("Type below:"))
         placeholder = data.get("placeholder", "...")
-        self.interpreter_ui_delegate.begin_text_prompt(alias, message, placeholder, self._on_text)
+        self.interpreter_ui_delegate.begin_text_prompt(alias, label, placeholder, self._on_text)
         return "STOP"
 
     def _on_text(self, entry, alias):
@@ -275,7 +275,7 @@ class CommandsMixin:
         abspath = (target / requires).resolve()
         if not abspath.is_relative_to(target):
             raise RuntimeError("Illegal 'requires' reaches outside the target directory", requires)
-        return abspath
+        return str(abspath)  # cause most path helpers assume str
 
     def insert_disc(self, data):
         """Request user to insert an optical disc"""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -58,6 +58,14 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             does so, the callback is invoked. The method returns immediately, however."""
             raise NotImplementedError()
 
+        def begin_dir_prompt(self, alias, message, requires, callback):
+            """Called to prompt for a directory"""
+            raise NotImplementedError()
+
+        def begin_text_prompt(self, alias, message, placeholder, callback):
+            """Called to prompt for a line of text, like a CD-KEY."""
+            raise NotImplementedError()
+
         def report_progress(self, fraction, text=""):
             """Called to report numeric progress (0.0 to 1.0) during installation.
             If fraction is None, hides the progress bar."""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -62,6 +62,10 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             """Called to prompt for a line of text, like a CD-KEY."""
             raise NotImplementedError()
 
+        def begin_dir_prompt(self, alias, message, requires, callback):
+            """Called to prompt for a directory."""
+            raise NotImplementedError()
+
         def report_progress(self, fraction, text=""):
             """Called to report numeric progress (0.0 to 1.0) during installation.
             If fraction is None, hides the progress bar."""

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -58,10 +58,6 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             does so, the callback is invoked. The method returns immediately, however."""
             raise NotImplementedError()
 
-        def begin_dir_prompt(self, alias, message, requires, callback):
-            """Called to prompt for a directory"""
-            raise NotImplementedError()
-
         def begin_text_prompt(self, alias, message, placeholder, callback):
             """Called to prompt for a line of text, like a CD-KEY."""
             raise NotImplementedError()

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -58,7 +58,7 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
             does so, the callback is invoked. The method returns immediately, however."""
             raise NotImplementedError()
 
-        def begin_text_prompt(self, alias, message, placeholder, callback):
+        def begin_text_prompt(self, alias, label, placeholder, callback):
             """Called to prompt for a line of text, like a CD-KEY."""
             raise NotImplementedError()
 


### PR DESCRIPTION
Greetings! This PR adds a couple of new installer commands: `input_text` and `input_dir`.

- `input_dir` is the same as `insert_disc` minus the disc detection stuff, it's less error prone then using the later and asking "pls don't use autodetect 🥺". It also has a `requires` arg, but it's optional.
- `input_text` asks the user for a line of text, will be useful for asking for CD-KEYs when bypassing installers or for questions that the script author can't know the answer ahead of time.
 
both are modeled after `input_menu`, they take an `id` argument and sets the result as `$INPUT_{id}`

any feedback is welcomed!

Fixes #6652 