### PR TITLE
move 'Kill all wine processes' option to wine submenu

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -293,7 +293,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             "open-forums": Action(lambda *x: open_uri("https://forums.lutris.net/")),
             "open-discord": Action(lambda *x: open_uri("https://discord.gg/Pnt5CuY")),
             "donate": Action(lambda *x: open_uri("https://lutris.net/donate")),
-            "kill-wine": Action(self.on_kill_wine),
         }
 
         self.actions = {}
@@ -1256,24 +1255,6 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                     self.game_bar.destroy()  # for gridview only
             self.current_view.set_cursor(Gtk.TreePath("0"), None, False)  # needed for both view types
             self.current_view.grab_focus()
-
-    def on_kill_wine(self, *_args):
-        """Callback to kill all Wine processes after confirmation."""
-        dlg = dialogs.QuestionDialog(
-            {
-                "title": _("Kill all Wine processes"),
-                "question": _(
-                    "This will kill <b>all</b> Wine processes on the system, "
-                    "including any not launched by Lutris.\n\n"
-                    "Are you sure you want to continue?"
-                ),
-                "parent": self,
-            }
-        )
-        if dlg.result == dlg.YES:
-            from lutris.util.wine.wine import kill_all_wine_processes  # noqa: PLC0415
-
-            kill_all_wine_processes()
 
     @GtkTemplate.Callback
     def on_about_clicked(self, *_args):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -21,7 +21,7 @@ from lutris.exceptions import (
     UnspecifiedVersionError,
 )
 from lutris.game import Game
-from lutris.gui.dialogs import FileDialog
+from lutris.gui.dialogs import FileDialog, QuestionDialog
 from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-import
     create_prefix,
     delete_registry_key,
@@ -144,6 +144,23 @@ def _get_dxvk_warning() -> str | None:
         ) % (driver_info["version"],)
 
     return None
+
+
+def _kill_wine(*_args):
+    dlg = QuestionDialog(
+        {
+            "title": _("Kill all Wine processes"),
+            "question": _(
+                "This will kill <b>all</b> Wine processes on the system, "
+                "including any not launched by Lutris.\n\n"
+                "Are you sure you want to continue?"
+            ),
+        }
+    )
+    if dlg.result == dlg.YES:
+        from lutris.util.wine.wine import kill_all_wine_processes  # noqa: PLC0415
+
+        kill_all_wine_processes()
 
 
 def _get_simple_vulkan_support_error(option_key: str, config: LutrisConfig, feature: str) -> str | None:
@@ -682,6 +699,7 @@ class wine(Runner):
     def context_menu_entries(self):
         """Return the contexual menu entries for wine"""
         return [
+            ("kill-wine", _("Kill all Wine processes"), _kill_wine),
             ("wineexec", _("Run EXE inside Wine prefix"), self.run_wineexec),
             ("wineshell", _("Open Bash terminal"), self.run_wine_terminal),
             ("wineconsole", _("Open Wine console"), self.run_wineconsole),


### PR DESCRIPTION
Moves 'Kill all wine processes' option from global context menu to wine runner sub menu 

## Why?

This wine related option being in the top right main context menu (three dots) is very confusing. Such wine related option fits it's personal context menu perfectly