### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/lutris/runners/commands/dosbox.py
+++ b/lutris/runners/commands/dosbox.py
@@ -47,4 +47,5 @@ def makeconfig(path, drives, commands):
         for drive in drives:
             config_file.write('mount {} "{}"\n'.format(drive, drives[drive]))
         for command in commands:
-            config_file.write("{}\n".format(command))
+            sanitized = command.replace('\n', ' ')
+            config_file.write("{}\n".format(sanitized))

--- a/lutris/util/yaml.py
+++ b/lutris/util/yaml.py
@@ -1,6 +1,7 @@
 """Utility functions for YAML handling"""
 
 import os
+import tempfile
 from typing import Any
 
 import yaml
@@ -27,11 +28,11 @@ def read_yaml_from_file(filename: str) -> dict[str, Any]:
 def write_yaml_to_file(config: dict[str, Any], filepath: str) -> None:
     yaml_config = yaml.safe_dump(config, default_flow_style=False)
 
-    temp_path = filepath + ".tmp"
+    fd, temp_path = tempfile.mkstemp(dir=os.path.dirname(filepath), suffix=".tmp")
     try:
-        with open(temp_path, "w", encoding="utf-8") as filehandler:
-            filehandler.write(yaml_config)
-        os.rename(temp_path, filepath)
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            f.write(yaml_config)
+        os.replace(temp_path, filepath)
     finally:
         if os.path.isfile(temp_path):
             os.unlink(temp_path)


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `lutris/util/yaml.py:L30`

The function `write_yaml_to_file` creates a temporary file with a predictable name (original path + '.tmp') in the same directory, then renames it. This is vulnerable to symlink attacks: an attacker with write access to the directory could create a symlink to an arbitrary system file, causing the application to overwrite it when the rename occurs. No use of secure temporary file APIs (e.g., `tempfile.mkstemp`) is present.

## Solution

Replace the manual '.tmp' naming with `tempfile.mkstemp()` to create an unpredictable temporary file, then use `shutil.move()` or `os.replace()` for atomic replacement.

## Changes

- `lutris/util/yaml.py` (modified)
- `lutris/runners/commands/dosbox.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced"