### PR TITLE
fix: correct transactional behavior and resource leak in db_cursor

### DIFF
--- a/lutris/database/sql.py
+++ b/lutris/database/sql.py
@@ -25,9 +25,14 @@ class db_cursor(object):
         cursor = self.db_conn.cursor()
         return cursor
 
-    def __exit__(self, _type: type[BaseException], value: BaseException, traceback: TracebackType) -> None:
-        self.db_conn.commit()
-        self.db_conn.close()
+    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
+        try:
+            if exc_type is None:
+                self.db_conn.commit()
+            else:
+                self.db_conn.rollback()
+        finally:
+            self.db_conn.close()
 
 
 def cursor_execute(cursor: sqlite3.Cursor, query: str, params: DBParams | None = None) -> sqlite3.Cursor:

--- a/lutris/database/sql.py
+++ b/lutris/database/sql.py
@@ -25,7 +25,12 @@ class db_cursor(object):
         cursor = self.db_conn.cursor()
         return cursor
 
-    def __exit__(self, exc_type: type[BaseException] | None, exc_value: BaseException | None, traceback: TracebackType | None) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
         try:
             if exc_type is None:
                 self.db_conn.commit()


### PR DESCRIPTION
## Problem

`db_cursor.__exit__` had two issues:

1. `commit()` was called unconditionally — even when the with-block exited due to an exception. Partial operations were committed, breaking transactional semantics.

2. No `try/finally` — if `commit()` itself raised, `close()` was never called, leaking database connections.

## Fix

Only commit on normal exit (`exc_type is None`), rollback on exception, and always close in a `finally` block.