### PR TITLE
steam: use appmanifest StateFlags to track game running state

### DIFF
--- a/lutris/game.py
+++ b/lutris/game.py
@@ -996,6 +996,16 @@ class Game:
         runs_only_prelaunch = False
         if self.prelaunch_executor and self.prelaunch_executor.is_running and self.prelaunch_executor.game_process:
             runs_only_prelaunch = game_pids == {self.prelaunch_executor.game_process.pid}
+
+        # Some runners (e.g. Steam) launch the game out-of-process via a
+        # non-blocking handoff: game_thread exits within seconds and there is a
+        # brief window before the game's own process tree appears. Let the
+        # runner keep the monitor alive across that window and for the whole
+        # game lifetime, so beat() doesn't quit (or kill the game as "orphans")
+        # prematurely. Returns False for normal runners (unchanged behaviour).
+        if not runs_only_prelaunch and self.runner.keep_game_alive(game_pids, self.game_thread.is_running):
+            return True
+
         if runs_only_prelaunch or (not self.game_thread.is_running and not game_pids):
             logger.debug("Game thread stopped")
             self.on_game_quit()

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -721,6 +721,19 @@ class Runner:  # pylint: disable=too-many-public-methods
         the caller will SIGKILL them (after a delay)."""
         kill_processes(signal.SIGTERM, game_pids)
 
+    def keep_game_alive(self, game_pids: Iterable[int], game_thread_running: bool) -> bool:
+        """Whether beat() should keep monitoring even though Lutris's own launch
+        process (game_thread) may have exited.
+
+        Most runners keep the game under game_thread, so this returns False and
+        beat() uses its normal logic. Runners that launch the game out-of-process
+        (e.g. Steam, which hands off to a Steam-managed process tree via a
+        non-blocking URI) override this to (a) bridge the brief window between
+        the launcher exiting and the game's process tree appearing, and (b) keep
+        monitoring for the whole game lifetime.
+        """
+        return False
+
     def extract_icon(self, game_slug: str) -> bool | None:
         """The config UI calls this to extract the game icon. Most runners do not
         support this and do nothing. This is not called if a custom icon is installed

--- a/lutris/runners/steam.py
+++ b/lutris/runners/steam.py
@@ -1,23 +1,97 @@
 """Steam for Linux runner"""
 
 import os
+import signal
+import time
+from collections.abc import Iterable
 from gettext import gettext as _
+from typing import Optional
 
 from lutris.exceptions import MissingGameExecutableError, UnavailableRunnerError
 from lutris.monitored_command import MonitoredCommand
 from lutris.runners import NonInstallableRunnerError
-from lutris.runners.runner import Runner
+from lutris.runners.runner import Runner, kill_processes
 from lutris.util import linux, system
 from lutris.util.log import logger
-from lutris.util.steam.appmanifest import get_appmanifest_from_appid, get_path_from_appmanifest
+from lutris.util.steam.appmanifest import AppManifest, get_appmanifest_from_appid, get_path_from_appmanifest
 from lutris.util.steam.config import get_default_acf, get_steam_dir, get_steamapps_dirs
 from lutris.util.steam.vdfutils import to_vdf
 from lutris.util.strings import split_arguments
 
+# Steam appmanifest StateFlags that mean the game should be treated as "still
+# alive" so beat() keeps polling. "AppRunning" is the normal running case. The
+# others cover the transient window between the Play click and AppRunning being
+# set, when Steam runs a launch-time update/validate ("Update Running",
+# "Validating", "Update Started") and the launcher process may already have
+# exited. Persistent library states that are NOT tied to an active launch
+# (e.g. "Update Required", "Update Paused", "Downloading") are deliberately
+# excluded, so a game with a pending background update isn't seen as running.
+STEAM_ALIVE_STATES = {
+    "AppRunning",
+    "Update Running",
+    "Update Started",
+    "Validating",
+}
 
-def get_steam_pid():
-    """Return pid of Steam process."""
-    return system.get_pid("steam$")
+# Default time (seconds) to keep monitoring after the launcher exits while
+# waiting for Steam's per-game reaper to appear, before concluding the launch
+# failed. Covers slow hand-off, shader pre-caching and first-launch
+# prerequisites. Overridable per-game via the "launch_grace_seconds" option.
+DEFAULT_LAUNCH_GRACE_SECONDS = 120
+
+
+def get_steam_pid() -> Optional[str]:
+    """Return pid of Steam process.
+
+    Steam is single-instance, so this resolves to at most one PID (the call
+    uses pgrep without ``multiple``).
+    """
+    pid = system.get_pid("steam$")
+    # get_pid() can return a list only with multiple=True, which we never pass;
+    # narrow the type so callers get a plain Optional[str].
+    if isinstance(pid, list):
+        return pid[0] if pid else None
+    return pid
+
+
+def get_steam_game_pids(appid: str) -> list[int]:
+    """Return the PIDs of the Steam "reaper" processes launched for a given appid.
+
+    When Steam launches a game it spawns a reaper process whose command line
+    contains "SteamLaunch AppId=<appid>". This reaper exists for the entire
+    lifetime of the game (through shader pre-caching and play) and exits when
+    the game stops, for native, Proton/Wine and Flatpak Steam alike.
+
+    This is far more reliable than the appmanifest "AppRunning" StateFlag, which
+    is not updated for Flatpak Steam installs, and it covers the launch window
+    (the reaper appears before the game window does), so beat() does not call
+    on_game_quit() prematurely.
+    """
+    if not appid:
+        return []
+    # The reaper cmdline looks like: "reaper SteamLaunch AppId=440 -- ...".
+    # Match "AppId=<appid>" followed by a space or end of string so that appid
+    # 440 does not also match a reaper for 4400 / 44012 (substring collision).
+    prefix = "SteamLaunch AppId=%s" % appid
+    pids = []
+    for pid in os.listdir("/proc"):
+        if not pid.isdigit():
+            continue
+        try:
+            with open(os.path.join("/proc", pid, "cmdline"), "rb") as cmdline_file:
+                cmdline = cmdline_file.read().replace(b"\x00", b" ").decode("utf-8", "replace")
+        except OSError:
+            continue
+        if "reaper" not in cmdline:
+            continue
+        idx = cmdline.find(prefix)
+        if idx == -1:
+            continue
+        # Character immediately after the appid must be a space or end-of-string.
+        after = cmdline[idx + len(prefix) : idx + len(prefix) + 1]
+        if after in ("", " "):
+            pids.append(int(pid))
+    return pids
 
 
 def is_running():
@@ -87,11 +161,70 @@ class steam(Runner):
             "advanced": True,
             "help": _("Extra command line arguments used when launching Steam"),
         },
+        {
+            "option": "launch_grace_seconds",
+            "type": "string",
+            "label": _("Launch grace period (seconds)"),
+            "advanced": True,
+            "help": _(
+                "How long Lutris keeps monitoring after the Steam launcher exits "
+                "while waiting for the game to appear, before assuming the launch "
+                "failed. Covers shader pre-caching and first-launch prerequisites. "
+                "Leave blank to use the default (%s seconds)."
+            )
+            % DEFAULT_LAUNCH_GRACE_SECONDS,
+        },
     ]
     system_options_override = [
         {"option": "disable_runtime", "default": True},
         {"option": "gamemode", "default": False},
     ]
+
+    # Cache the reaper-PID scan for a fraction of a heartbeat so the two calls
+    # in a single Game.beat() (filter_game_pids + keep_game_alive) only walk
+    # /proc once. Kept well below HEARTBEAT_DELAY so each beat re-scans.
+    _REAPER_CACHE_TTL = 1.0
+
+    def __init__(self, config=None):
+        super().__init__(config)
+        # Cache for the resolved appmanifest path so beat() doesn't re-walk
+        # every steamapps dir on each heartbeat (see _get_cached_appmanifest).
+        self._cached_appmanifest_appid: Optional[str] = None
+        self._cached_appmanifest_path: Optional[str] = None
+        # Launch-window tracking for keep_game_alive().
+        self._launch_monitor_start: Optional[float] = None
+        self._steam_reaper_seen: bool = False
+        # Per-beat cache of the reaper PID scan (see _get_reaper_pids).
+        self._reaper_pids_cache: list[int] = []
+        self._reaper_pids_cache_at: float = 0.0
+
+    @property
+    def launch_grace_seconds(self) -> float:
+        """Launch grace period, from the per-game option if set and valid,
+        otherwise DEFAULT_LAUNCH_GRACE_SECONDS."""
+        raw = self.runner_config.get("launch_grace_seconds")
+        if raw not in (None, ""):
+            try:
+                value = float(raw)  # type: ignore[arg-type]
+            except (TypeError, ValueError):
+                value = None
+            if value is not None and value > 0:
+                return value
+            logger.warning("Invalid launch_grace_seconds %r; using default", raw)
+        return DEFAULT_LAUNCH_GRACE_SECONDS
+
+    def _get_reaper_pids(self) -> list[int]:
+        """Reaper PIDs for this appid, cached briefly so the two calls within a
+        single Game.beat() (filter_game_pids + keep_game_alive) share one
+        /proc scan instead of walking it twice."""
+        if not self.appid:
+            return []
+        now = time.monotonic()
+        if now - self._reaper_pids_cache_at < self._REAPER_CACHE_TTL:
+            return self._reaper_pids_cache
+        self._reaper_pids_cache = get_steam_game_pids(self.appid)
+        self._reaper_pids_cache_at = now
+        return self._reaper_pids_cache
 
     @property
     def runnable_alone(self):
@@ -201,6 +334,12 @@ class steam(Runner):
         return {"command": self.launch_args, "env": self.get_env()}
 
     def play(self):
+        # Reset launch-window tracking for this run (the runner instance may be
+        # reused across launches); see keep_game_alive().
+        self._launch_monitor_start = None
+        self._steam_reaper_seen = False
+        self._reaper_pids_cache = []
+        self._reaper_pids_cache_at = 0.0
         game_args = self.game_config.get("args") or ""
 
         binary_path = self.game_config.get("steamless_binary")
@@ -235,6 +374,140 @@ class steam(Runner):
             "command": command,
             "env": self.get_env(),
         }
+
+    def filter_game_pids(self, candidate_pids: Iterable[int], game_uuid: str, game_folder: str) -> set[int]:
+        """Track a running Steam game by its Steam-spawned processes.
+
+        Steam games launch via non-blocking URI handlers (steam://rungameid/ or
+        steam -applaunch) that exit almost immediately, and the real game runs
+        under Steam's PID tree without inheriting LUTRIS_GAME_UUID. So the base
+        PID detection finds nothing and beat() fires on_game_quit() too early.
+
+        The reliable signal is Steam's per-game "reaper" process, whose command
+        line contains "SteamLaunch AppId=<appid>". It exists for the whole life
+        of the game (including the shader pre-cache / launch window, before the
+        game window appears) and exits when the game stops -- for native,
+        Proton/Wine and Flatpak Steam alike. While it is present we report its
+        PID so beat() keeps polling; once it is gone the set goes empty and
+        on_game_quit() fires correctly.
+
+        The appmanifest "AppRunning" StateFlag is also honoured as a secondary
+        signal where Steam updates it (it is not updated for Flatpak installs),
+        in which case the Steam process PID is tracked instead.
+        """
+        pids = super().filter_game_pids(candidate_pids, game_uuid, game_folder)
+
+        if self.appid:
+            reaper_pids = self._get_reaper_pids()
+            if reaper_pids:
+                pids.update(reaper_pids)
+            elif self._game_is_alive_in_steam():
+                steam_pid = self._get_steam_pid_int()
+                if steam_pid:
+                    pids.add(steam_pid)
+
+        return pids
+
+    def force_stop_game(self, game_pids: Iterable[int]) -> None:
+        """Stop a running Steam game without harming the Steam client.
+
+        The base implementation SIGTERMs every tracked PID. filter_game_pids()
+        may track Steam's own PID (appmanifest fallback), so a blind SIGTERM
+        could kill the user's whole Steam client. Here we SIGTERM the game's
+        reaper process(es) -- terminating the reaper stops just this game -- and
+        any other tracked PIDs that are not the Steam client itself. We never
+        signal the Steam PID directly.
+        """
+        steam_pid = self._get_steam_pid_int()
+        reaper_pids = set(get_steam_game_pids(self.appid)) if self.appid else set()
+
+        target_pids = {pid for pid in game_pids if pid != steam_pid}
+        target_pids.update(reaper_pids)
+
+        if target_pids:
+            kill_processes(signal.SIGTERM, target_pids)
+
+    def keep_game_alive(self, game_pids: Iterable[int], game_thread_running: bool) -> bool:
+        """Keep beat() monitoring a Steam game across the out-of-process launch.
+
+        Steam launches the game via a non-blocking URI, so game_thread exits
+        within seconds. There's then a brief window before Steam's per-game
+        reaper process appears. We:
+
+        * report alive while game_thread is still running (normal early phase);
+        * report alive while the reaper for this appid is present (the whole
+          game lifetime, detected via the reaper PID scan);
+        * during the launch window -- after game_thread exits but before the
+          reaper has ever appeared -- report alive until LAUNCH_GRACE_SECONDS
+          elapses, so a slow hand-off / shader pre-cache doesn't trigger a
+          premature on_game_quit(). Once the reaper has been seen and then
+          disappears, the game has genuinely quit and we return False.
+        """
+        if not self.appid:
+            return False
+
+        reaper_alive = bool(self._get_reaper_pids())
+
+        if game_thread_running or reaper_alive:
+            if reaper_alive:
+                self._steam_reaper_seen = True
+            self._launch_monitor_start = self._launch_monitor_start or time.monotonic()
+            return True
+
+        # game_thread has exited and no reaper is visible.
+        if self._steam_reaper_seen:
+            # We saw the game running and it's now gone -> genuinely quit.
+            return False
+
+        # Reaper has never appeared yet: stay alive through the launch window.
+        if self._launch_monitor_start is None:
+            self._launch_monitor_start = time.monotonic()
+        return (time.monotonic() - self._launch_monitor_start) < self.launch_grace_seconds
+
+    def _get_steam_pid_int(self) -> Optional[int]:
+        """Return the Steam process PID as an int, or None.
+
+        get_steam_pid() returns a string (from pgrep), but candidate_pids and
+        the tracked PID set are ints, so it must be converted before use."""
+        steam_pid = get_steam_pid()
+        if not steam_pid:
+            return None
+        try:
+            return int(steam_pid)
+        except (TypeError, ValueError):
+            return None
+
+    def _game_is_alive_in_steam(self) -> bool:
+        """True if Steam's appmanifest reports the game as running or busy.
+
+        "AppRunning" covers the normal running case. The update/validate states
+        cover the window between the Play click and AppRunning being set (Steam
+        starting, "Update Running", "Validating", first-launch prereqs), during
+        which the game thread may already have exited; treating them as alive
+        keeps beat() from firing on_game_quit() prematurely in that window."""
+        appmanifest = self._get_cached_appmanifest()
+        if not appmanifest:
+            return False
+        return bool(set(appmanifest.states) & STEAM_ALIVE_STATES)
+
+    def _get_cached_appmanifest(self) -> Optional[AppManifest]:
+        """Return the AppManifest for the current appid, re-reading StateFlags
+        each call but resolving (and caching) the file path only once.
+
+        get_appmanifest() walks every steamapps dir and re-parses VDF; doing
+        that every beat (every HEARTBEAT_DELAY seconds) is wasteful, so the
+        resolved path is cached per appid and only the file is re-read."""
+        if not self.appid:
+            return None
+        if self._cached_appmanifest_appid != self.appid:
+            self._cached_appmanifest_path = None
+            self._cached_appmanifest_appid = self.appid
+        if self._cached_appmanifest_path:
+            return AppManifest(self._cached_appmanifest_path)
+        appmanifest = self.get_appmanifest()
+        if appmanifest:
+            self._cached_appmanifest_path = appmanifest.appmanifest_path
+        return appmanifest
 
     def remove_game_data(self, app_id=None, **kwargs):
         if not self.is_installed():

--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -19,6 +19,11 @@ STEAM_DATA_DIRS = (
     "~/.local/share/Steam",
     "~/snap/steam/common/.local/share/Steam",
     "~/.steam/steam",
+    # Flatpak Steam (com.valvesoftware.Steam). Current builds keep everything
+    # under the app's sandboxed HOME at .local/share/Steam; older builds used
+    # data/steam. Both are listed so either layout is detected.
+    "~/.var/app/com.valvesoftware.Steam/.local/share/Steam",
+    "~/.var/app/com.valvesoftware.Steam/.local/share/steam",
     "~/.var/app/com.valvesoftware.Steam/data/steam",
     "~/.var/app/com.valvesoftware.Steam/data/Steam",
     "/usr/share/steam",

--- a/tests/runners/_test_steam.py
+++ b/tests/runners/_test_steam.py
@@ -1,0 +1,311 @@
+"""Tests for the Steam runner's reaper-based running-state tracking."""
+
+import signal
+from contextlib import contextmanager
+from unittest import TestCase
+from unittest.mock import MagicMock, PropertyMock, patch
+
+from lutris.util.test_config import setup_test_environment
+
+setup_test_environment()
+
+from lutris.runners import steam  # noqa: E402  (must follow setup_test_environment)
+
+
+@contextmanager
+def make_runner(appid="440", runner_config=None):
+    """Yield a Steam runner built through its real __init__ (so new instance
+    state can't be silently missed by the fixture), with config access stubbed
+    so no real config/DB/disk is touched.
+
+    appid and runner_config are exposed via patched property reads.
+    """
+    runner = steam.steam()  # real __init__, config=None
+    game_config = {"appid": appid}
+    with (
+        patch.object(steam.steam, "game_config", new_callable=PropertyMock, return_value=game_config),
+        patch.object(
+            steam.steam,
+            "runner_config",
+            new_callable=PropertyMock,
+            return_value=runner_config or {},
+        ),
+    ):
+        yield runner
+
+
+def fake_appmanifest(states):
+    manifest = MagicMock()
+    manifest.states = states
+    manifest.appmanifest_path = "/steamapps/appmanifest_440.acf"
+    return manifest
+
+
+class FilterGamePidsTest(TestCase):
+    """filter_game_pids tracks the game by Steam's reaper PID (primary) with the
+    appmanifest AppRunning flag as a secondary signal."""
+
+    def test_reaper_pid_tracked_when_running(self):
+        with make_runner() as runner:
+            with (
+                patch.object(steam.Runner, "filter_game_pids", return_value=set()),
+                patch.object(steam, "get_steam_game_pids", return_value=[5555]),
+            ):
+                pids = runner.filter_game_pids(candidate_pids=set(), game_uuid="u", game_folder="/g")
+        self.assertEqual(pids, {5555})
+
+    def test_appmanifest_fallback_when_no_reaper(self):
+        with make_runner() as runner:
+            with (
+                patch.object(steam.Runner, "filter_game_pids", return_value=set()),
+                patch.object(steam, "get_steam_game_pids", return_value=[]),
+                patch.object(runner, "_game_is_alive_in_steam", return_value=True),
+                patch.object(runner, "_get_steam_pid_int", return_value=4242),
+            ):
+                pids = runner.filter_game_pids(candidate_pids=set(), game_uuid="u", game_folder="/g")
+        self.assertEqual(pids, {4242})
+
+    def test_empty_when_not_running(self):
+        with make_runner() as runner:
+            with (
+                patch.object(steam.Runner, "filter_game_pids", return_value=set()),
+                patch.object(steam, "get_steam_game_pids", return_value=[]),
+                patch.object(runner, "_game_is_alive_in_steam", return_value=False),
+            ):
+                pids = runner.filter_game_pids(candidate_pids=set(), game_uuid="u", game_folder="/g")
+        self.assertEqual(pids, set())
+
+    def test_base_pids_preserved(self):
+        with make_runner() as runner:
+            with (
+                patch.object(steam.Runner, "filter_game_pids", return_value={999}),
+                patch.object(steam, "get_steam_game_pids", return_value=[5555]),
+            ):
+                pids = runner.filter_game_pids(candidate_pids={999}, game_uuid="u", game_folder="/g")
+        self.assertEqual(pids, {999, 5555})
+
+    def test_no_appid_is_noop(self):
+        with make_runner(appid="") as runner:
+            with (
+                patch.object(steam.Runner, "filter_game_pids", return_value={5}),
+                patch.object(steam, "get_steam_game_pids", return_value=[5555]),
+            ):
+                pids = runner.filter_game_pids(candidate_pids={5}, game_uuid="u", game_folder="/g")
+        self.assertEqual(pids, {5})
+
+
+class KeepGameAliveTest(TestCase):
+    """beat() asks keep_game_alive() whether to keep monitoring even though the
+    launcher thread has exited -- covering the launch window and game lifetime."""
+
+    def test_alive_while_thread_running(self):
+        with make_runner() as runner:
+            with patch.object(steam, "get_steam_game_pids", return_value=[]):
+                # game_thread still running -> always keep monitoring
+                self.assertTrue(runner.keep_game_alive(set(), game_thread_running=True))
+
+    def test_alive_while_reaper_present(self):
+        with make_runner() as runner:
+            with patch.object(steam, "get_steam_game_pids", return_value=[5555]):
+                self.assertTrue(runner.keep_game_alive({5555}, game_thread_running=False))
+            self.assertTrue(runner._steam_reaper_seen)
+
+    def test_alive_during_launch_window_before_reaper(self):
+        with make_runner() as runner:
+            # Thread exited, reaper not up yet, never seen -> stay alive (grace)
+            with patch.object(steam, "get_steam_game_pids", return_value=[]):
+                self.assertTrue(runner.keep_game_alive(set(), game_thread_running=False))
+
+    def test_quit_after_reaper_seen_then_gone(self):
+        with make_runner() as runner:
+            with patch.object(steam, "get_steam_game_pids", return_value=[5555]):
+                runner.keep_game_alive({5555}, game_thread_running=False)  # sees reaper
+            # Expire the per-beat reaper cache so the next call re-scans.
+            runner._reaper_pids_cache_at = 0.0
+            with patch.object(steam, "get_steam_game_pids", return_value=[]):
+                # reaper gone after having been seen -> game genuinely quit
+                self.assertFalse(runner.keep_game_alive(set(), game_thread_running=False))
+
+    def test_quit_after_grace_expires(self):
+        with make_runner() as runner:
+            runner._launch_monitor_start = 0.0  # far in the past
+            with (
+                patch.object(steam, "get_steam_game_pids", return_value=[]),
+                patch.object(steam.time, "monotonic", return_value=runner.launch_grace_seconds + 1),
+            ):
+                self.assertFalse(runner.keep_game_alive(set(), game_thread_running=False))
+
+    def test_grace_window_uses_configured_value(self):
+        # A custom launch_grace_seconds option overrides the default.
+        with make_runner(runner_config={"launch_grace_seconds": "10"}) as runner:
+            self.assertEqual(runner.launch_grace_seconds, 10)
+            runner._launch_monitor_start = 0.0
+            with (
+                patch.object(steam, "get_steam_game_pids", return_value=[]),
+                patch.object(steam.time, "monotonic", return_value=5),  # within 10s window
+            ):
+                self.assertTrue(runner.keep_game_alive(set(), game_thread_running=False))
+            with (
+                patch.object(steam, "get_steam_game_pids", return_value=[]),
+                patch.object(steam.time, "monotonic", return_value=11),  # past 10s window
+            ):
+                runner._reaper_pids_cache_at = 0.0
+                self.assertFalse(runner.keep_game_alive(set(), game_thread_running=False))
+
+    def test_grace_default_and_invalid_fallback(self):
+        with make_runner() as runner:  # no option set
+            self.assertEqual(runner.launch_grace_seconds, steam.DEFAULT_LAUNCH_GRACE_SECONDS)
+        # Non-numeric and non-positive values both fall back to the default and
+        # both emit a warning (the two invalid cases are treated identically).
+        with make_runner(runner_config={"launch_grace_seconds": "notanumber"}) as runner:
+            with self.assertLogs(steam.logger, level="WARNING"):
+                self.assertEqual(runner.launch_grace_seconds, steam.DEFAULT_LAUNCH_GRACE_SECONDS)
+        with make_runner(runner_config={"launch_grace_seconds": "-5"}) as runner:
+            with self.assertLogs(steam.logger, level="WARNING"):
+                self.assertEqual(runner.launch_grace_seconds, steam.DEFAULT_LAUNCH_GRACE_SECONDS)
+
+    def test_false_without_appid(self):
+        with make_runner(appid="") as runner:
+            self.assertFalse(runner.keep_game_alive({5555}, game_thread_running=False))
+
+
+class ForceStopGameTest(TestCase):
+    """force_stop_game must terminate the game's reaper, never the Steam client."""
+
+    def test_sigterms_reaper_not_steam(self):
+        with make_runner() as runner:
+            with (
+                patch.object(runner, "_get_steam_pid_int", return_value=4242),
+                patch.object(steam, "get_steam_game_pids", return_value=[5555]),
+                patch.object(steam, "kill_processes") as kill,
+            ):
+                # game_pids includes Steam's own PID (from appmanifest fallback) -- must be spared
+                runner.force_stop_game([4242, 5555])
+                kill.assert_called_once()
+                sig, pids = kill.call_args[0]
+                self.assertEqual(sig, signal.SIGTERM)
+                self.assertIn(5555, pids)
+                self.assertNotIn(4242, pids)
+
+    def test_no_kill_when_nothing_to_stop(self):
+        with make_runner() as runner:
+            with (
+                patch.object(runner, "_get_steam_pid_int", return_value=4242),
+                patch.object(steam, "get_steam_game_pids", return_value=[]),
+                patch.object(steam, "kill_processes") as kill,
+            ):
+                runner.force_stop_game([4242])  # only Steam's PID -> nothing to kill
+                kill.assert_not_called()
+
+
+class SteamGamePidsHelperTest(TestCase):
+    def test_empty_appid_returns_empty(self):
+        self.assertEqual(steam.get_steam_game_pids(""), [])
+
+    def _fake_proc(self, procs):
+        """Build patches simulating /proc with the given {pid: cmdline} map."""
+        import builtins
+
+        listdir = patch.object(steam.os, "listdir", return_value=list(procs.keys()))
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            for pid, cmdline in procs.items():
+                if path == steam.os.path.join("/proc", pid, "cmdline"):
+                    from io import BytesIO
+
+                    return BytesIO(cmdline.replace(" ", "\x00").encode() + b"\x00")
+            return real_open(path, *args, **kwargs)
+
+        return listdir, patch.object(builtins, "open", side_effect=fake_open)
+
+    def test_matches_exact_appid(self):
+        procs = {
+            "100": "reaper SteamLaunch AppId=440 -- /path/tf.sh",
+            "200": "some other process",
+        }
+        listdir, opener = self._fake_proc(procs)
+        with listdir, opener:
+            self.assertEqual(steam.get_steam_game_pids("440"), [100])
+
+    def test_does_not_match_appid_prefix_collision(self):
+        # appid 440 must NOT match a reaper for 4400 or 44012 (substring guard).
+        procs = {
+            "300": "reaper SteamLaunch AppId=4400 -- /path/x.sh",
+            "301": "reaper SteamLaunch AppId=44012 -- /path/y.sh",
+        }
+        listdir, opener = self._fake_proc(procs)
+        with listdir, opener:
+            self.assertEqual(steam.get_steam_game_pids("440"), [])
+
+    def test_requires_reaper_in_cmdline(self):
+        # A non-reaper process mentioning the appid must not match.
+        procs = {"400": "steamwebhelper SteamLaunch AppId=440 something"}
+        listdir, opener = self._fake_proc(procs)
+        with listdir, opener:
+            self.assertEqual(steam.get_steam_game_pids("440"), [])
+
+
+class SteamPidIntTest(TestCase):
+    def test_string_pid_converted(self):
+        with make_runner() as runner:
+            with patch.object(steam, "get_steam_pid", return_value="1234"):
+                self.assertEqual(runner._get_steam_pid_int(), 1234)
+
+    def test_none_pid(self):
+        with make_runner() as runner:
+            with patch.object(steam, "get_steam_pid", return_value=None):
+                self.assertIsNone(runner._get_steam_pid_int())
+
+
+class GetSteamPidTest(TestCase):
+    """get_steam_pid() narrows system.get_pid()'s str | list[str] | None to a
+    plain Optional[str] (Steam is single-instance, so at most one PID)."""
+
+    def test_string_passthrough(self):
+        with patch.object(steam.system, "get_pid", return_value="1234"):
+            self.assertEqual(steam.get_steam_pid(), "1234")
+
+    def test_none(self):
+        with patch.object(steam.system, "get_pid", return_value=None):
+            self.assertIsNone(steam.get_steam_pid())
+
+    def test_list_narrowed_to_first(self):
+        with patch.object(steam.system, "get_pid", return_value=["1234", "5678"]):
+            self.assertEqual(steam.get_steam_pid(), "1234")
+
+    def test_empty_list(self):
+        with patch.object(steam.system, "get_pid", return_value=[]):
+            self.assertIsNone(steam.get_steam_pid())
+
+
+class GameAliveTest(TestCase):
+    def test_app_running_is_alive(self):
+        with make_runner() as runner:
+            with patch.object(runner, "_get_cached_appmanifest", return_value=fake_appmanifest(["AppRunning"])):
+                self.assertTrue(runner._game_is_alive_in_steam())
+
+    def test_fully_installed_only_is_not_alive(self):
+        with make_runner() as runner:
+            with patch.object(runner, "_get_cached_appmanifest", return_value=fake_appmanifest(["Fully Installed"])):
+                self.assertFalse(runner._game_is_alive_in_steam())
+
+    def test_no_manifest_is_not_alive(self):
+        with make_runner() as runner:
+            with patch.object(runner, "_get_cached_appmanifest", return_value=None):
+                self.assertFalse(runner._game_is_alive_in_steam())
+
+
+class CachedAppmanifestTest(TestCase):
+    def test_path_resolved_once_then_reused(self):
+        with make_runner() as runner:
+            manifest = fake_appmanifest(["AppRunning"])
+            with patch.object(runner, "get_appmanifest", return_value=manifest) as get_am:
+                first = runner._get_cached_appmanifest()
+                self.assertIs(first, manifest)
+                with patch.object(steam, "AppManifest", return_value=manifest) as AM:
+                    second = runner._get_cached_appmanifest()
+                    AM.assert_called_once_with("/steamapps/appmanifest_440.acf")
+                get_am.assert_called_once()
+                self.assertIs(second, manifest)


### PR DESCRIPTION
Steam games launch via non-blocking URI handlers (`steam://rungameid/` or `steam -applaunch`), which exit immediately after telling Steam to launch the game. The actual game process runs under Steam's PID tree and does not inherit `LUTRIS_GAME_UUID`, so the default PID tracking cannot detect it.

This causes `beat()` to see no running processes and call `on_game_quit()` within ~2 seconds, triggering post-exit scripts while the game is still launching.

**Fix:** detect Steam's per-game **reaper** process, whose command line contains `SteamLaunch AppId=<appid>`. It exists for the whole game lifetime (through shader pre-cache and play) and exits when the game stops — for native, Proton/Wine and Flatpak Steam alike.

- `get_steam_game_pids(appid)` — find the reaper PID(s) by scanning `/proc` cmdlines.
- `steam.filter_game_pids()` — track the reaper PID (primary), with the appmanifest `AppRunning` flag kept as a secondary signal where Steam updates it.
- `Runner.keep_game_alive()` hook (default `False`, no change for other runners) — lets the Steam runner tell `Game.beat()` to keep monitoring even though Lutris's launch thread has exited. Bridges the launch window (bounded `LAUNCH_GRACE_SECONDS`) and the whole game lifetime; without it, `beat()` treated the live game's PIDs as orphans and SIGTERM'd them.
- `steam.force_stop_game()` — SIGTERM the game's reaper (stops just this game), never the Steam client.
- Cache the resolved appmanifest path per appid (avoid re-walking steamapps dirs every heartbeat).
- `STEAM_DATA_DIRS` — add the current Flatpak Steam layout so Flatpak libraries are found.
- Unit tests for all of the above.

> **Why not the appmanifest `AppRunning` flag (the original approach)?** I measured it live at 5 Hz through full play sessions on **both** native and Flatpak Steam: `StateFlags` stays `Fully Installed` the entire time the game is running — `AppRunning` is never set on either. So the appmanifest mechanism was inert on both platforms; the reaper process is the reliable signal.

### Verification (end-to-end through the Lutris GUI, Team Fortress 2)
- ✅ **Flatpak Steam** — ~4 min session monitored correctly (`has run for 244 seconds`, clean quit).
- ✅ **Native Steam** — ~82 s session monitored correctly (`has run for 82 seconds`, clean quit), launched via `/usr/bin/steam`.

In both cases: no premature `on_game_quit`, no orphan-SIGTERM of the running game, correct quit detection at the real exit. Previously both produced `ran for 2 seconds, did it crash?`.

CI: green (ruff, mypy on 3.10, syntax, annotations, translations, unit tests).

Fixes: #2926