### PR TITLE
fix: handle empty CPU list and missing platform downloads

### DIFF
--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -256,7 +256,10 @@ class HumbleBundleService(OnlineService):
 
     @staticmethod
     def get_filename_for_platform(downloads, platform):
-        download = [d for d in downloads if d["platform"] == platform][0]
+        download = [d for d in downloads if d["platform"] == platform]
+        if not download:
+            return
+        download = download[0]
         url = pick_download_url_from_download_info(download)
         if not url:
             return

--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -540,10 +540,16 @@ def gather_system_info_dict() -> dict[str, Any]:
     system_info_readable["System"] = system_dict
     # Add CPU information
     cpu_dict = {}
-    cpu_dict["Vendor"] = system_info["cpus"][0].get("vendor_id", "Vendor unavailable")
-    cpu_dict["Model"] = system_info["cpus"][0].get("model name", "Model unavailable")
-    cpu_dict["Physical cores"] = system_info["cpus"][0].get("cpu cores", "Physical cores unavailable")
-    cpu_dict["Logical cores"] = system_info["cpus"][0].get("siblings", "Logical cores unavailable")
+    if system_info["cpus"]:
+        cpu_dict["Vendor"] = system_info["cpus"][0].get("vendor_id", "Vendor unavailable")
+        cpu_dict["Model"] = system_info["cpus"][0].get("model name", "Model unavailable")
+        cpu_dict["Physical cores"] = system_info["cpus"][0].get("cpu cores", "Physical cores unavailable")
+        cpu_dict["Logical cores"] = system_info["cpus"][0].get("siblings", "Logical cores unavailable")
+    else:
+        cpu_dict["Vendor"] = "Unavailable"
+        cpu_dict["Model"] = "Unavailable"
+        cpu_dict["Physical cores"] = "Unavailable"
+        cpu_dict["Logical cores"] = "Unavailable"
     system_info_readable["CPU"] = cpu_dict
     # Add memory information
     ram_dict = {}


### PR DESCRIPTION
## Bug 1: IndexError when CPU list is empty (`util/linux.py`)

### Problem
`gather_system_info_dict()` accesses `system_info["cpus"][0]` without checking if the list is empty. The `get_cpus()` function returns `[cpu for cpu in cpus if cpu]`, which can be an empty list on systems where `/proc/cpuinfo` is empty or malformed.

### Root Cause
`lutris/util/linux.py` lines 543-546 directly access `system_info["cpus"][0]` with no guard:
```python
cpu_dict["Vendor"] = system_info["cpus"][0].get("vendor_id", ...)
```

### Fix
Add an `if system_info["cpus"]:` guard and provide "Unavailable" fallback values.

---

## Bug 2: IndexError when platform not found (`services/humblebundle.py`)

### Problem
`get_filename_for_platform()` uses a list comprehension followed by `[0]` access without checking if the list is empty. If no download matches the requested platform, this raises `IndexError`.

### Root Cause
`lutris/services/humblebundle.py` line 259:
```python
download = [d for d in downloads if d["platform"] == platform][0]
```

### Fix
Separate the filter and the access; return `None` early if no download matches the platform.

---

## Impact
- Bug 1: Crashes system info gathering on edge-case Linux environments
- Bug 2: Crashes Humble Bundle download filename resolution for unsupported platforms