### PR TITLE
Add virtual all sources game view

### DIFF
--- a/lutris/gui/config/services_box.py
+++ b/lutris/gui/config/services_box.py
@@ -5,7 +5,7 @@ from gi.repository import GObject, Gtk
 from lutris import settings
 from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.gui.widgets.scaled_image import ScaledImage
-from lutris.services import SERVICES
+from lutris.services import IN_GAMES_VIEW_SETTING_SUFFIX, SERVICES, is_service_in_games_view
 
 
 class ServicesBox(BaseConfigBox):
@@ -44,10 +44,10 @@ class ServicesBox(BaseConfigBox):
             height_request=32,
             visible=True,
         )
-        in_games_view_key = service_key + "_in_games_view"
+        in_games_view_key = service_key + IN_GAMES_VIEW_SETTING_SUFFIX
         service = SERVICES[service_key]
         is_active = settings.read_bool_setting(service_key, section="services")
-        is_in_games_view = settings.read_bool_setting(in_games_view_key, default=True, section="services")
+        is_in_games_view = is_service_in_games_view(service_key)
 
         icon = ScaledImage.get_runtime_icon_image(
             service.icon, service.id, scale_factor=self.get_scale_factor(), visible=True

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -141,12 +141,13 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self.views = {}
 
         self.dynamic_categories_game_factories: dict[str, Callable[[], list]] = {
+            "all_sources": self.get_all_source_games,
             "recent": self.get_recent_games,
             "missing": self.get_missing_games,
             "running": self.get_running_games,
             ".uncategorized": self.get_uncategorized_games,
         }
-        self.sortable_dynamic_categories = {".uncategorized", "missing", "running"}
+        self.sortable_dynamic_categories = {"all_sources", ".uncategorized", "missing", "running"}
 
         self.accelerators = Gtk.AccelGroup()
         self.add_accel_group(self.accelerators)
@@ -585,6 +586,72 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def get_missing_games(self):
         games = games_db.get_games_by_ids(MISSING_GAMES.missing_game_ids)
         return self.apply_view_sort(self.filter_games(games))
+
+    @staticmethod
+    def get_service_view_id(service_id, appid):
+        return "service:%s:%s" % (service_id, appid)
+
+    @staticmethod
+    def parse_service_view_id(game_id):
+        parts = str(game_id).split(":", 2)
+        if len(parts) == 3 and parts[0] == "service":
+            return parts[1], parts[2]
+        return None, None
+
+    def get_all_source_games(self):
+        disabled_services = {
+            service_id.casefold()
+            for service_id in services.SERVICES.keys()
+            if not settings.read_bool_setting(service_id + "_in_games_view", default=True, section="services")
+        }
+        excludes = {"service": disabled_services} if disabled_services else {}
+        local_games = games_db.get_games(excludes=excludes)
+        service_game_ids = {}
+
+        for service_id in services.get_enabled_services():
+            if service_id.casefold() in disabled_services:
+                continue
+            try:
+                service_game_ids[service_id] = {
+                    game["appid"] for game in ServiceGameCollection.get_for_service(service_id)
+                }
+            except Exception as ex:
+                logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
+                service_game_ids[service_id] = set()
+
+        all_games = [
+            game
+            for game in local_games
+            if game.get("service") not in service_game_ids
+            or game.get("service_id") not in service_game_ids[game["service"]]
+        ]
+        all_games = self.filter_games(all_games)
+
+        for service_id, service_class in services.get_enabled_services().items():
+            if service_id.casefold() in disabled_services:
+                continue
+
+            try:
+                service = service_class()
+                service_games = ServiceGameCollection.get_for_service(service_id)
+                if service_id == "lutris":
+                    lutris_games = {game["slug"]: game for game in games_db.get_games()}
+                else:
+                    lutris_games = {
+                        game["service_id"]: game for game in games_db.get_games(filters={"service": service_id})
+                    }
+
+                for game in service_games:
+                    service_game = game.copy()
+                    service_game["year"] = service.get_game_release_year(service_game)
+                    self.combine_games(service_game, lutris_games.get(service_game["appid"]))
+                    service_game.setdefault("installed", False)
+                    service_game["_view_id"] = self.get_service_view_id(service_id, service_game["appid"])
+                    all_games.append(service_game)
+            except Exception as ex:
+                logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
+
+        return self.apply_view_sort(self.filter_games(all_games))
 
     def update_missing_games_sidebar_row(self) -> None:
         missing_games = self.get_missing_games()
@@ -1129,7 +1196,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
     def on_service_games_loaded(self, service):
         """Request a view update when service games are loaded"""
-        if self.service and service.id == self.service.id:
+        if (self.service and service.id == self.service.id) or self.filters.get("dynamic_category") == "all_sources":
             self.update_store()
 
     def on_categories_updated(self):
@@ -1164,7 +1231,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
     def on_service_logout(self, service):
         self.update_notification()
-        if self.service and service.id == self.service.id:
+        if (self.service and service.id == self.service.id) or self.filters.get("dynamic_category") == "all_sources":
             self.update_store()
         return True
 
@@ -1363,7 +1430,11 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             if self.service:
                 game = ServiceGameCollection.get_game(self.service.id, game_id)
             else:
-                game = games_db.get_game_by_field(game_id, "id")
+                service_id, appid = self.parse_service_view_id(game_id)
+                if service_id:
+                    game = ServiceGameCollection.get_game(service_id, appid)
+                else:
+                    game = games_db.get_game_by_field(game_id, "id")
 
             # There can be no game found if you are removing a game; it will
             # still have a selected icon in the UI just long enough to get here.
@@ -1490,6 +1561,20 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 game_id = db_game["id"]
             else:
                 game_id = self.service.install_by_id(game_id)
+        else:
+            service_id, appid = self.parse_service_view_id(game_id)
+            if service_id:
+                logger.debug("Looking up %s game %s", service_id, appid)
+                service_class = services.SERVICES.get(service_id)
+                db_game = games_db.get_game_for_service(service_id, appid)
+
+                if db_game and db_game["installed"]:
+                    game_id = db_game["id"]
+                elif service_class:
+                    game_id = service_class().install_by_id(appid)
+                else:
+                    logger.error("Non existent service '%s'", service_id)
+                    game_id = None
 
         if game_id:
             game = Game(game_id)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -54,6 +54,7 @@ from lutris.gui.views import (
     COL_SORTNAME,
     COL_YEAR,
 )
+from lutris.gui.views.all_sources import get_service_view_id, get_unmatched_local_games, parse_service_view_id
 from lutris.gui.views.grid import GameGridView
 from lutris.gui.views.list import GameListView
 from lutris.gui.views.store import GameStore
@@ -587,53 +588,39 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         games = games_db.get_games_by_ids(MISSING_GAMES.missing_game_ids)
         return self.apply_view_sort(self.filter_games(games))
 
-    @staticmethod
-    def get_service_view_id(service_id, appid):
-        return "service:%s:%s" % (service_id, appid)
-
-    @staticmethod
-    def parse_service_view_id(game_id):
-        parts = str(game_id).split(":", 2)
-        if len(parts) == 3 and parts[0] == "service":
-            return parts[1], parts[2]
-        return None, None
-
-    def get_all_source_games(self):
-        disabled_services = {
-            service_id.casefold()
-            for service_id in services.SERVICES.keys()
-            if not settings.read_bool_setting(service_id + "_in_games_view", default=True, section="services")
-        }
-        excludes = {"service": disabled_services} if disabled_services else {}
+    def get_all_source_games(self) -> list[dict]:
+        """Return games from all enabled sources, with local copies merged into their service rows."""
+        hidden_services = services.get_services_hidden_in_games_view()
+        excludes = {"service": hidden_services} if hidden_services else {}
         local_games = games_db.get_games(excludes=excludes)
-        service_game_ids = {}
 
-        for service_id in services.get_enabled_services():
-            if service_id.casefold() in disabled_services:
-                continue
+        enabled_services = {
+            service_id: service_class
+            for service_id, service_class in services.get_enabled_services().items()
+            if service_id.casefold() not in hidden_services
+        }
+
+        # Fetch each service's games exactly once; both the dedup below and the
+        # row building reuse this. A service that fails to load contributes no
+        # rows, but its empty appid set keeps its local copies visible, so a
+        # broken service fails soft.
+        service_games_by_id: dict[str, list[dict]] = {}
+        for service_id in enabled_services:
             try:
-                service_game_ids[service_id] = {
-                    game["appid"] for game in ServiceGameCollection.get_for_service(service_id)
-                }
+                service_games_by_id[service_id] = ServiceGameCollection.get_for_service(service_id)
             except Exception as ex:
                 logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
-                service_game_ids[service_id] = set()
+                service_games_by_id[service_id] = []
 
-        all_games = [
-            game
-            for game in local_games
-            if game.get("service") not in service_game_ids
-            or game.get("service_id") not in service_game_ids[game["service"]]
-        ]
-        all_games = self.filter_games(all_games)
+        service_appids = {
+            service_id: {game["appid"] for game in service_games}
+            for service_id, service_games in service_games_by_id.items()
+        }
+        all_games = get_unmatched_local_games(local_games, service_appids)
 
-        for service_id, service_class in services.get_enabled_services().items():
-            if service_id.casefold() in disabled_services:
-                continue
-
+        for service_id, service_class in enabled_services.items():
             try:
                 service = service_class()
-                service_games = ServiceGameCollection.get_for_service(service_id)
                 if service_id == "lutris":
                     lutris_games = {game["slug"]: game for game in games_db.get_games()}
                 else:
@@ -641,12 +628,12 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                         game["service_id"]: game for game in games_db.get_games(filters={"service": service_id})
                     }
 
-                for game in service_games:
+                for game in service_games_by_id[service_id]:
                     service_game = game.copy()
                     service_game["year"] = service.get_game_release_year(service_game)
                     self.combine_games(service_game, lutris_games.get(service_game["appid"]))
                     service_game.setdefault("installed", False)
-                    service_game["_view_id"] = self.get_service_view_id(service_id, service_game["appid"])
+                    service_game["_view_id"] = get_service_view_id(service_id, service_game["appid"])
                     all_games.append(service_game)
             except Exception as ex:
                 logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
@@ -784,11 +771,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         excludes = {}
 
         if self.filters.get("category") == "all" and "service" not in self.filters:
-            excluded_services = set(
-                s.casefold()
-                for s in services.SERVICES.keys()
-                if not settings.read_bool_setting(s + "_in_games_view", default=True, section="services")
-            )
+            excluded_services = services.get_services_hidden_in_games_view()
             if excluded_services:
                 excludes["service"] = excluded_services
 
@@ -1430,8 +1413,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             if self.service:
                 game = ServiceGameCollection.get_game(self.service.id, game_id)
             else:
-                service_id, appid = self.parse_service_view_id(game_id)
-                if service_id:
+                service_id, appid = parse_service_view_id(game_id)
+                if service_id and service_id in services.SERVICES:
                     game = ServiceGameCollection.get_game(service_id, appid)
                 else:
                     game = games_db.get_game_by_field(game_id, "id")
@@ -1453,7 +1436,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def on_settings_changed(self, setting_key, new_value, section):
         if section == "lutris" and setting_key == "hide_text_under_icons":
             self.rebuild_view("grid")
-        elif section == "services" and setting_key.endswith("_in_games_view"):
+        elif section == "services" and setting_key.endswith(services.IN_GAMES_VIEW_SETTING_SUFFIX):
             self.update_store()
         else:
             self.update_view_settings()
@@ -1562,7 +1545,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             else:
                 game_id = self.service.install_by_id(game_id)
         else:
-            service_id, appid = self.parse_service_view_id(game_id)
+            service_id, appid = parse_service_view_id(game_id)
             if service_id:
                 logger.debug("Looking up %s game %s", service_id, appid)
                 service_class = services.SERVICES.get(service_id)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -54,6 +54,7 @@ from lutris.gui.views import (
     COL_SORTNAME,
     COL_YEAR,
 )
+from lutris.gui.views.all_sources import get_service_view_id, get_unmatched_local_games, parse_service_view_id
 from lutris.gui.views.grid import GameGridView
 from lutris.gui.views.list import GameListView
 from lutris.gui.views.store import GameStore
@@ -597,53 +598,39 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         games = games_db.get_games_by_ids(MISSING_GAMES.missing_game_ids)
         return self.apply_view_sort(self.filter_games(games))
 
-    @staticmethod
-    def get_service_view_id(service_id, appid):
-        return "service:%s:%s" % (service_id, appid)
-
-    @staticmethod
-    def parse_service_view_id(game_id):
-        parts = str(game_id).split(":", 2)
-        if len(parts) == 3 and parts[0] == "service":
-            return parts[1], parts[2]
-        return None, None
-
-    def get_all_source_games(self):
-        disabled_services = {
-            service_id.casefold()
-            for service_id in services.SERVICES.keys()
-            if not settings.read_bool_setting(service_id + "_in_games_view", default=True, section="services")
-        }
-        excludes = {"service": disabled_services} if disabled_services else {}
+    def get_all_source_games(self) -> list[dict]:
+        """Return games from all enabled sources, with local copies merged into their service rows."""
+        hidden_services = services.get_services_hidden_in_games_view()
+        excludes = {"service": hidden_services} if hidden_services else {}
         local_games = games_db.get_games(excludes=excludes)
-        service_game_ids = {}
 
-        for service_id in services.get_enabled_services():
-            if service_id.casefold() in disabled_services:
-                continue
+        enabled_services = {
+            service_id: service_class
+            for service_id, service_class in services.get_enabled_services().items()
+            if service_id.casefold() not in hidden_services
+        }
+
+        # Fetch each service's games exactly once; both the dedup below and the
+        # row building reuse this. A service that fails to load contributes no
+        # rows, but its empty appid set keeps its local copies visible, so a
+        # broken service fails soft.
+        service_games_by_id: dict[str, list[dict]] = {}
+        for service_id in enabled_services:
             try:
-                service_game_ids[service_id] = {
-                    game["appid"] for game in ServiceGameCollection.get_for_service(service_id)
-                }
+                service_games_by_id[service_id] = ServiceGameCollection.get_for_service(service_id)
             except Exception as ex:
                 logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
-                service_game_ids[service_id] = set()
+                service_games_by_id[service_id] = []
 
-        all_games = [
-            game
-            for game in local_games
-            if game.get("service") not in service_game_ids
-            or game.get("service_id") not in service_game_ids[game["service"]]
-        ]
-        all_games = self.filter_games(all_games)
+        service_appids = {
+            service_id: {game["appid"] for game in service_games}
+            for service_id, service_games in service_games_by_id.items()
+        }
+        all_games = get_unmatched_local_games(local_games, service_appids)
 
-        for service_id, service_class in services.get_enabled_services().items():
-            if service_id.casefold() in disabled_services:
-                continue
-
+        for service_id, service_class in enabled_services.items():
             try:
                 service = service_class()
-                service_games = ServiceGameCollection.get_for_service(service_id)
                 if service_id == "lutris":
                     lutris_games = {game["slug"]: game for game in games_db.get_games()}
                 else:
@@ -651,12 +638,12 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                         game["service_id"]: game for game in games_db.get_games(filters={"service": service_id})
                     }
 
-                for game in service_games:
+                for game in service_games_by_id[service_id]:
                     service_game = game.copy()
                     service_game["year"] = service.get_game_release_year(service_game)
                     self.combine_games(service_game, lutris_games.get(service_game["appid"]))
                     service_game.setdefault("installed", False)
-                    service_game["_view_id"] = self.get_service_view_id(service_id, service_game["appid"])
+                    service_game["_view_id"] = get_service_view_id(service_id, service_game["appid"])
                     all_games.append(service_game)
             except Exception as ex:
                 logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
@@ -794,11 +781,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         excludes = {}
 
         if self.filters.get("category") == "all" and "service" not in self.filters:
-            excluded_services = set(
-                s.casefold()
-                for s in services.SERVICES.keys()
-                if not settings.read_bool_setting(s + "_in_games_view", default=True, section="services")
-            )
+            excluded_services = services.get_services_hidden_in_games_view()
             if excluded_services:
                 excludes["service"] = excluded_services
 
@@ -1447,8 +1430,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             if self.service:
                 game = ServiceGameCollection.get_game(self.service.id, game_id)
             else:
-                service_id, appid = self.parse_service_view_id(game_id)
-                if service_id:
+                service_id, appid = parse_service_view_id(game_id)
+                if service_id and service_id in services.SERVICES:
                     game = ServiceGameCollection.get_game(service_id, appid)
                 else:
                     game = games_db.get_game_by_field(game_id, "id")
@@ -1470,7 +1453,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def on_settings_changed(self, setting_key, new_value, section):
         if section == "lutris" and setting_key == "hide_text_under_icons":
             self.rebuild_view("grid")
-        elif section == "services" and setting_key.endswith("_in_games_view"):
+        elif section == "services" and setting_key.endswith(services.IN_GAMES_VIEW_SETTING_SUFFIX):
             self.update_store()
         else:
             self.update_view_settings()
@@ -1579,7 +1562,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             else:
                 game_id = self.service.install_by_id(game_id)
         else:
-            service_id, appid = self.parse_service_view_id(game_id)
+            service_id, appid = parse_service_view_id(game_id)
             if service_id:
                 logger.debug("Looking up %s game %s", service_id, appid)
                 service_class = services.SERVICES.get(service_id)

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -142,12 +142,13 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         self._is_busy = False
 
         self.dynamic_categories_game_factories: dict[str, Callable[[], list]] = {
+            "all_sources": self.get_all_source_games,
             "recent": self.get_recent_games,
             "missing": self.get_missing_games,
             "running": self.get_running_games,
             ".uncategorized": self.get_uncategorized_games,
         }
-        self.sortable_dynamic_categories = {".uncategorized", "missing", "running"}
+        self.sortable_dynamic_categories = {"all_sources", ".uncategorized", "missing", "running"}
 
         self.accelerators = Gtk.AccelGroup()
         self.add_accel_group(self.accelerators)
@@ -595,6 +596,72 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def get_missing_games(self):
         games = games_db.get_games_by_ids(MISSING_GAMES.missing_game_ids)
         return self.apply_view_sort(self.filter_games(games))
+
+    @staticmethod
+    def get_service_view_id(service_id, appid):
+        return "service:%s:%s" % (service_id, appid)
+
+    @staticmethod
+    def parse_service_view_id(game_id):
+        parts = str(game_id).split(":", 2)
+        if len(parts) == 3 and parts[0] == "service":
+            return parts[1], parts[2]
+        return None, None
+
+    def get_all_source_games(self):
+        disabled_services = {
+            service_id.casefold()
+            for service_id in services.SERVICES.keys()
+            if not settings.read_bool_setting(service_id + "_in_games_view", default=True, section="services")
+        }
+        excludes = {"service": disabled_services} if disabled_services else {}
+        local_games = games_db.get_games(excludes=excludes)
+        service_game_ids = {}
+
+        for service_id in services.get_enabled_services():
+            if service_id.casefold() in disabled_services:
+                continue
+            try:
+                service_game_ids[service_id] = {
+                    game["appid"] for game in ServiceGameCollection.get_for_service(service_id)
+                }
+            except Exception as ex:
+                logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
+                service_game_ids[service_id] = set()
+
+        all_games = [
+            game
+            for game in local_games
+            if game.get("service") not in service_game_ids
+            or game.get("service_id") not in service_game_ids[game["service"]]
+        ]
+        all_games = self.filter_games(all_games)
+
+        for service_id, service_class in services.get_enabled_services().items():
+            if service_id.casefold() in disabled_services:
+                continue
+
+            try:
+                service = service_class()
+                service_games = ServiceGameCollection.get_for_service(service_id)
+                if service_id == "lutris":
+                    lutris_games = {game["slug"]: game for game in games_db.get_games()}
+                else:
+                    lutris_games = {
+                        game["service_id"]: game for game in games_db.get_games(filters={"service": service_id})
+                    }
+
+                for game in service_games:
+                    service_game = game.copy()
+                    service_game["year"] = service.get_game_release_year(service_game)
+                    self.combine_games(service_game, lutris_games.get(service_game["appid"]))
+                    service_game.setdefault("installed", False)
+                    service_game["_view_id"] = self.get_service_view_id(service_id, service_game["appid"])
+                    all_games.append(service_game)
+            except Exception as ex:
+                logger.exception("Games from source '%s' could not be loaded: %s", service_id, ex)
+
+        return self.apply_view_sort(self.filter_games(all_games))
 
     def update_missing_games_sidebar_row(self) -> None:
         missing_games = self.get_missing_games()
@@ -1181,7 +1248,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
     def on_service_logout(self, service):
         self.update_notification()
-        if self.service and service.id == self.service.id:
+        if (self.service and service.id == self.service.id) or self.filters.get("dynamic_category") == "all_sources":
             self.update_store()
         return True
 
@@ -1380,7 +1447,11 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             if self.service:
                 game = ServiceGameCollection.get_game(self.service.id, game_id)
             else:
-                game = games_db.get_game_by_field(game_id, "id")
+                service_id, appid = self.parse_service_view_id(game_id)
+                if service_id:
+                    game = ServiceGameCollection.get_game(service_id, appid)
+                else:
+                    game = games_db.get_game_by_field(game_id, "id")
 
             # There can be no game found if you are removing a game; it will
             # still have a selected icon in the UI just long enough to get here.
@@ -1507,6 +1578,20 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                 game_id = db_game["id"]
             else:
                 game_id = self.service.install_by_id(game_id)
+        else:
+            service_id, appid = self.parse_service_view_id(game_id)
+            if service_id:
+                logger.debug("Looking up %s game %s", service_id, appid)
+                service_class = services.SERVICES.get(service_id)
+                db_game = games_db.get_game_for_service(service_id, appid)
+
+                if db_game and db_game["installed"]:
+                    game_id = db_game["id"]
+                elif service_class:
+                    game_id = service_class().install_by_id(appid)
+                else:
+                    logger.error("Non existent service '%s'", service_id)
+                    game_id = None
 
         if game_id:
             game = Game(game_id)

--- a/lutris/gui/views/all_sources.py
+++ b/lutris/gui/views/all_sources.py
@@ -1,0 +1,40 @@
+"""Helpers for the virtual 'All Sources' game view.
+
+The view mixes local games with games from every enabled service, so its rows
+carry an encoded view-id of the form 'service:<service_id>:<appid>'. These
+helpers are the single source of truth for that wire format.
+"""
+
+SERVICE_VIEW_ID_PREFIX = "service"
+
+
+def get_service_view_id(service_id: str, appid: str) -> str:
+    """Encode a service game's identity into a view-id for the All Sources view."""
+    return "%s:%s:%s" % (SERVICE_VIEW_ID_PREFIX, service_id, appid)
+
+
+def parse_service_view_id(game_id: str) -> tuple[str | None, str | None]:
+    """Decode a view-id produced by get_service_view_id back into (service_id, appid).
+
+    Returns (None, None) if the id is not in the 'service:<service_id>:<appid>'
+    format. Note that callers should still validate the service_id against the
+    known services before treating the id as a service game.
+    """
+    parts = str(game_id).split(":", 2)
+    if len(parts) == 3 and parts[0] == SERVICE_VIEW_ID_PREFIX:
+        return parts[1], parts[2]
+    return None, None
+
+
+def get_unmatched_local_games(local_games: list[dict], service_appids: dict[str, set]) -> list[dict]:
+    """Filter out local games that will also appear as a row from their service.
+
+    'service_appids' maps each service id to the appids it provides; a service
+    mapped to an empty set (e.g. because loading its games failed) keeps all of
+    its local games visible, so a broken service fails soft.
+    """
+    return [
+        game
+        for game in local_games
+        if game.get("service") not in service_appids or game.get("service_id") not in service_appids[game["service"]]
+    ]

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -104,7 +104,7 @@ class GameView:
         games = []
         for game_id in game_ids:
             service_id, appid = parse_service_view_id(game_id)
-            if service_id:
+            if service_id and appid:
                 # All-sources view ids; ids naming an unknown service are
                 # dropped rather than misinterpreted as local game ids.
                 service_class = SERVICES.get(service_id)

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -4,12 +4,13 @@ from gi.repository import Gdk, GObject, Gtk
 
 from lutris.database.games import get_game_for_service
 from lutris.database.services import ServiceGameCollection
-from lutris.services import SERVICES
 from lutris.game import GAME_START, Game
 from lutris.game_actions import GameActions, get_game_actions
+from lutris.gui.views.all_sources import parse_service_view_id
 from lutris.gui.widgets import EMPTY_NOTIFICATION_REGISTRATION
 from lutris.gui.widgets.contextual_menu import ContextualMenu
 from lutris.gui.widgets.utils import MEDIA_CACHE_INVALIDATED, get_application
+from lutris.services import SERVICES
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
 from lutris.util.path_cache import MISSING_GAMES
@@ -102,18 +103,20 @@ class GameView:
 
         games = []
         for game_id in game_ids:
-            parts = str(game_id).split(":", 2)
-            if len(parts) == 3 and parts[0] == "service":
-                service_id, appid = parts[1], parts[2]
-                db_game = get_game_for_service(service_id, appid)
+            service_id, appid = parse_service_view_id(game_id)
+            if service_id:
+                # All-sources view ids; ids naming an unknown service are
+                # dropped rather than misinterpreted as local game ids.
+                service_class = SERVICES.get(service_id)
+                if service_class:
+                    db_game = get_game_for_service(service_id, appid)
 
-                if db_game and db_game["id"]:
-                    games.append(_get_game_by_id(db_game["id"]))
-                else:
-                    service_game = ServiceGameCollection.get_game(service_id, appid)
-                    service_class = SERVICES.get(service_id)
-                    if service_game and service_class:
-                        games.append(Game.create_empty_service_game(service_game, service_class()))
+                    if db_game and db_game["id"]:
+                        games.append(_get_game_by_id(db_game["id"]))
+                    else:
+                        service_game = ServiceGameCollection.get_game(service_id, appid)
+                        if service_game:
+                            games.append(Game.create_empty_service_game(service_game, service_class()))
             elif self.service:
                 db_game = get_game_for_service(self.service.id, game_id)
 

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -4,6 +4,7 @@ from gi.repository import Gdk, GObject, Gtk
 
 from lutris.database.games import get_game_for_service
 from lutris.database.services import ServiceGameCollection
+from lutris.services import SERVICES
 from lutris.game import GAME_START, Game
 from lutris.game_actions import GameActions, get_game_actions
 from lutris.gui.widgets import EMPTY_NOTIFICATION_REGISTRATION
@@ -101,7 +102,19 @@ class GameView:
 
         games = []
         for game_id in game_ids:
-            if self.service:
+            parts = str(game_id).split(":", 2)
+            if len(parts) == 3 and parts[0] == "service":
+                service_id, appid = parts[1], parts[2]
+                db_game = get_game_for_service(service_id, appid)
+
+                if db_game and db_game["id"]:
+                    games.append(_get_game_by_id(db_game["id"]))
+                else:
+                    service_game = ServiceGameCollection.get_game(service_id, appid)
+                    service_class = SERVICES.get(service_id)
+                    if service_game and service_class:
+                        games.append(Game.create_empty_service_game(service_game, service_class()))
+            elif self.service:
                 db_game = get_game_for_service(self.service.id, game_id)
 
                 if db_game:

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -64,6 +64,10 @@ class StoreItem:
     @property
     def id(self) -> str:  # pylint: disable=invalid-name
         """Game internal ID"""
+        # '_view_id' is set only on rows built by LutrisWindow.get_all_source_games
+        # (via lutris.gui.views.all_sources.get_service_view_id); it overrides the
+        # appid/slug/id below so the All Sources view gets a unique, round-trippable
+        # 'service:<service_id>:<appid>' id even when services share appids.
         if "_view_id" in self._game_data:
             return str(self._game_data["_view_id"])
 
@@ -163,6 +167,9 @@ class StoreItem:
         services = [(service, lambda: self.slug)]
 
         game_service_name = self._game_data.get("service")
+        # Service-game dicts from ServiceGameCollection carry 'appid' but no
+        # 'service_id'; without the fallback the service-media lookup below
+        # silently failed for them.
         game_service_id = self._game_data.get("service_id") or self._game_data.get("appid")
 
         if game_service_name and game_service_id and game_service_name in SERVICES:

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -64,6 +64,9 @@ class StoreItem:
     @property
     def id(self) -> str:  # pylint: disable=invalid-name
         """Game internal ID"""
+        if "_view_id" in self._game_data:
+            return str(self._game_data["_view_id"])
+
         # Return a unique identifier for the game.
         # Since service games are not related to lutris, use the appid
         if "service_id" not in self._game_data:
@@ -160,7 +163,7 @@ class StoreItem:
         services = [(service, lambda: self.slug)]
 
         game_service_name = self._game_data.get("service")
-        game_service_id = self._game_data.get("service_id")
+        game_service_id = self._game_data.get("service_id") or self._game_data.get("appid")
 
         if game_service_name and game_service_id and game_service_name in SERVICES:
 

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -115,6 +115,10 @@ class StoreItem:
     @property
     def id(self) -> str:  # pylint: disable=invalid-name
         """Game internal ID"""
+        # '_view_id' is set only on rows built by LutrisWindow.get_all_source_games
+        # (via lutris.gui.views.all_sources.get_service_view_id); it overrides the
+        # appid/slug/id below so the All Sources view gets a unique, round-trippable
+        # 'service:<service_id>:<appid>' id even when services share appids.
         if "_view_id" in self._game_data:
             return str(self._game_data["_view_id"])
 
@@ -214,6 +218,9 @@ class StoreItem:
         services = [(service, lambda: self.slug)]
 
         game_service_name = self._game_data.get("service")
+        # Service-game dicts from ServiceGameCollection carry 'appid' but no
+        # 'service_id'; without the fallback the service-media lookup below
+        # silently failed for them.
         game_service_id = self._game_data.get("service_id") or self._game_data.get("appid")
 
         if game_service_name and game_service_id and game_service_name in SERVICES:

--- a/lutris/gui/views/store_item.py
+++ b/lutris/gui/views/store_item.py
@@ -115,6 +115,9 @@ class StoreItem:
     @property
     def id(self) -> str:  # pylint: disable=invalid-name
         """Game internal ID"""
+        if "_view_id" in self._game_data:
+            return str(self._game_data["_view_id"])
+
         # Return a unique identifier for the game.
         # Since service games are not related to lutris, use the appid
         if "service_id" not in self._game_data:
@@ -211,7 +214,7 @@ class StoreItem:
         services = [(service, lambda: self.slug)]
 
         game_service_name = self._game_data.get("service")
-        game_service_id = self._game_data.get("service_id")
+        game_service_id = self._game_data.get("service_id") or self._game_data.get("appid")
 
         if game_service_name and game_service_id and game_service_name in SERVICES:
 

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -558,6 +558,14 @@ class LutrisSidebar(Gtk.ListBox):
         )
         self.add(self.games_row)
 
+        self.all_sources_row = SidebarRow(
+            "all_sources",
+            "dynamic_category",
+            _("All Sources"),
+            self.get_sidebar_icon("folder-saved-search-symbolic"),
+        )
+        self.add(self.all_sources_row)
+
         self.add(
             SidebarRow(
                 "recent",

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -554,6 +554,14 @@ class LutrisSidebar(Gtk.ListBox):
         )
         self.add(self.games_row)
 
+        self.all_sources_row = SidebarRow(
+            "all_sources",
+            "dynamic_category",
+            _("All Sources"),
+            self.get_sidebar_icon("folder-saved-search-symbolic"),
+        )
+        self.add(self.all_sources_row)
+
         self.add(
             SidebarRow(
                 "recent",

--- a/lutris/services/__init__.py
+++ b/lutris/services/__init__.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
 
 DEFAULT_SERVICES = ["gog", "egs", "ea_app", "ubisoft", "steam"]
 
+# Suffix of the per-service setting that controls whether the service's games
+# are shown in the games views (see is_service_in_games_view).
+IN_GAMES_VIEW_SETTING_SUFFIX = "_in_games_view"
+
 
 def get_services() -> dict[str, "type[BaseService]"]:
     """Return a mapping of available services"""
@@ -83,3 +87,13 @@ def get_enabled_services():
         for key, _class in SERVICES.items()
         if settings.read_setting(key, section="services").lower() == "true"
     }
+
+
+def is_service_in_games_view(service_id: str) -> bool:
+    """True if the user has not excluded this service's games from the games views."""
+    return settings.read_bool_setting(service_id + IN_GAMES_VIEW_SETTING_SUFFIX, default=True, section="services")
+
+
+def get_services_hidden_in_games_view() -> set[str]:
+    """Return the casefolded ids of the services whose games are excluded from the games views."""
+    return {key.casefold() for key in SERVICES if not is_service_in_games_view(key)}

--- a/tests/_test_all_sources.py
+++ b/tests/_test_all_sources.py
@@ -1,0 +1,56 @@
+from unittest import TestCase
+
+from lutris.gui.views.all_sources import get_service_view_id, get_unmatched_local_games, parse_service_view_id
+
+
+class TestServiceViewId(TestCase):
+    def test_round_trip(self):
+        view_id = get_service_view_id("steam", "12345")
+        self.assertEqual(view_id, "service:steam:12345")
+        self.assertEqual(parse_service_view_id(view_id), ("steam", "12345"))
+
+    def test_round_trip_preserves_colons_in_appid(self):
+        view_id = get_service_view_id("steam", "a:b:c")
+        self.assertEqual(parse_service_view_id(view_id), ("steam", "a:b:c"))
+
+    def test_non_service_ids_are_rejected(self):
+        self.assertEqual(parse_service_view_id("42"), (None, None))
+        self.assertEqual(parse_service_view_id(42), (None, None))
+        self.assertEqual(parse_service_view_id("some-game-slug"), (None, None))
+        self.assertEqual(parse_service_view_id(""), (None, None))
+
+    def test_malformed_service_ids_are_rejected(self):
+        self.assertEqual(parse_service_view_id("service"), (None, None))
+        self.assertEqual(parse_service_view_id("service:steam"), (None, None))
+        self.assertEqual(parse_service_view_id("services:steam:1234"), (None, None))
+
+
+class TestGetUnmatchedLocalGames(TestCase):
+    def test_local_game_matched_by_service_is_removed(self):
+        local_games = [{"name": "Foo", "service": "steam", "service_id": "1234"}]
+        self.assertEqual(get_unmatched_local_games(local_games, {"steam": {"1234"}}), [])
+
+    def test_local_game_with_unmatched_appid_is_kept(self):
+        local_games = [{"name": "Foo", "service": "steam", "service_id": "1234"}]
+        self.assertEqual(get_unmatched_local_games(local_games, {"steam": {"5678"}}), local_games)
+
+    def test_local_game_of_unknown_service_is_kept(self):
+        local_games = [{"name": "Foo", "service": "gog", "service_id": "1234"}]
+        self.assertEqual(get_unmatched_local_games(local_games, {"steam": {"1234"}}), local_games)
+
+    def test_local_game_without_service_is_kept(self):
+        local_games = [{"name": "Foo"}]
+        self.assertEqual(get_unmatched_local_games(local_games, {"steam": {"1234"}}), local_games)
+
+    def test_failed_service_with_empty_appid_set_keeps_local_games(self):
+        # A service whose games could not be loaded contributes an empty set,
+        # which must keep its local copies visible (fail soft).
+        local_games = [{"name": "Foo", "service": "steam", "service_id": "1234"}]
+        self.assertEqual(get_unmatched_local_games(local_games, {"steam": set()}), local_games)
+
+    def test_mixed_games_are_filtered_correctly(self):
+        matched = {"name": "Matched", "service": "steam", "service_id": "1"}
+        unmatched = {"name": "Unmatched", "service": "steam", "service_id": "2"}
+        no_service = {"name": "Local only"}
+        result = get_unmatched_local_games([matched, unmatched, no_service], {"steam": {"1"}})
+        self.assertEqual(result, [unmatched, no_service])


### PR DESCRIPTION
Adds a virtual "All Sources" sidebar entry that aggregates games from enabled game sources into one searchable view.

<img width="2281" height="1709" alt="image" src="https://github.com/user-attachments/assets/1278ebe3-5a28-40ea-b556-1374f88a1d75" />


This keeps existing source-specific views unchanged and does not merge metadata. Local installed service entries are skipped when the same service app id is already present in the service library, avoiding duplicate entries for the same source.

Tested with local Lutris data including Steam, Epic, GOG, Humble Bundle, EA App, and Ubisoft service games. Verified search, service media fallback, and existing launch/install action routing for mixed local and service entries.