### PR TITLE
Add AppImage packaging and release workflow

### DIFF
--- a/.github/workflows/publish-appimage.yml
+++ b/.github/workflows/publish-appimage.yml
@@ -1,0 +1,55 @@
+# Builds the Lutris AppImage and attaches it to the triggering GitHub
+# release. The build runs in the same Ubuntu 22.04 container the
+# `make appimage` recipe uses locally, so the artifact is bit-for-bit
+# the same as what developers produce on their own machines.
+#
+# Triggers:
+#   * release.released / release.prereleased — attaches to that release
+#   * workflow_dispatch                     — produces a workflow artifact
+#                                             only; does not touch a release
+name: Publish AppImage
+
+on:
+  release:
+    types: [released, prereleased]
+  workflow_dispatch:
+
+jobs:
+  appimage:
+    runs-on: ubuntu-22.04
+    permissions:
+      # Required so action-gh-release can upload the asset.
+      contents: write
+    steps:
+      - name: Checkout the repository
+        uses: actions/checkout@v6
+
+      - name: Build the AppImage
+        env:
+          # On release events, force the version to the tag (strip a
+          # leading 'v' if present). On workflow_dispatch this is empty,
+          # and build.sh falls back to awk'ing lutris/__init__.py.
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          if [ -n "$RELEASE_TAG" ]; then
+              export LUTRIS_VERSION="${RELEASE_TAG#v}"
+          fi
+          make appimage
+
+      - name: Upload as workflow artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: lutris-appimage
+          path: dist/Lutris-*-x86_64.AppImage
+          if-no-files-found: error
+
+      # Only attach the asset when the workflow was actually triggered
+      # by a release event. workflow_dispatch runs stop at the artifact.
+      - name: Attach AppImage to release
+        if: github.event_name == 'release'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+              dist/Lutris-*-x86_64.AppImage \
+              --repo "${{ github.repository }}"

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,9 @@ snap:
 	snapcraft clean lutris -s pull
 	snapcraft
 
+appimage:
+	utils/appimage/build.sh
+
 req-python:
 	pip3 install PyYAML lxml requests Pillow setproctitle python-magic distro dbus-python types-requests \
 	 types-PyYAML evdev PyGObject pypresence protobuf moddb

--- a/utils/appimage/AppRun
+++ b/utils/appimage/AppRun
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# AppRun entry point for the Lutris AppImage.
+#
+# Two responsibilities:
+#   1. Source linuxdeploy-plugin-gtk's hook so GI_TYPELIB_PATH, GDK_PIXBUF_*,
+#      XDG_DATA_DIRS, etc. point inside the AppDir.
+#   2. Launch bin/lutris with the bundled Python interpreter, with PYTHONPATH
+#      pointing at the bundled site-packages.
+#
+# Lutris is intentionally NOT sandboxed: it must call host binaries (xrandr,
+# 7z, fuser, wine, the user's installed runners), read the user's $HOME,
+# and access mounted drives. We deliberately leave PATH intact so host
+# tools win, and only prepend AppDir paths for libraries / typelibs.
+set -e
+
+HERE="$(dirname "$(readlink -f "${0}")")"
+
+# linuxdeploy-plugin-gtk writes its environment setup into apprun-hooks/.
+# Source every hook it dropped so we inherit the GTK/Pixbuf/typelib paths.
+if [ -d "$HERE/apprun-hooks" ]; then
+    for hook in "$HERE"/apprun-hooks/*.sh; do
+        # shellcheck disable=SC1090
+        [ -r "$hook" ] && . "$hook"
+    done
+fi
+
+export APPDIR="$HERE"
+export PATH="$HERE/usr/bin:$PATH"
+
+# Intentionally do NOT export LD_LIBRARY_PATH. linuxdeploy already set
+# RPATH=$ORIGIN/.. on every bundled binary, so they find their sibling libs
+# without an env override. Exporting LD_LIBRARY_PATH here would leak into
+# subprocesses — and Lutris launches host binaries constantly (xrandr, 7z,
+# fuser, /usr/bin/flatpak, wine, etc.). Forcing them to load our older
+# bundled libssl/libcrypto/libstdc++ breaks any host tool whose own deps
+# were built against newer symbols. The cost of this discipline is that
+# anything we copied into the AppDir manually (PyGObject's _gi.so,
+# python3-dbus' bindings) must have its RPATH patched by the build script,
+# since linuxdeploy only patches files it deploys itself.
+unset LD_LIBRARY_PATH
+
+# Python: find the bundled interpreter and site-packages. We accept any
+# python3.X under usr/bin so this script doesn't need to be rev'd when the
+# build image's Python minor version changes.
+PYTHON_BIN=""
+for cand in "$HERE"/usr/bin/python3.* "$HERE"/usr/bin/python3; do
+    if [ -x "$cand" ] && [ ! -L "$cand" ]; then
+        PYTHON_BIN="$cand"
+        break
+    fi
+done
+if [ -z "$PYTHON_BIN" ]; then
+    # Fallback: host python3. The AppImage is less portable this way, but
+    # at least it boots so the user sees a real error rather than nothing.
+    PYTHON_BIN="$(command -v python3 || true)"
+fi
+if [ -z "$PYTHON_BIN" ]; then
+    echo "Lutris AppImage: no python3 interpreter found in AppDir or host" >&2
+    exit 1
+fi
+
+PY_VER="$("$PYTHON_BIN" -c 'import sys;print("%d.%d"%sys.version_info[:2])')"
+SITE="$HERE/usr/lib/python${PY_VER}/site-packages"
+DIST="$HERE/usr/lib/python3/dist-packages"
+export PYTHONPATH="$SITE:$DIST${PYTHONPATH:+:$PYTHONPATH}"
+
+# bin/lutris strips /home paths from sys.path unless this is set, which
+# would also drop our AppDir paths if they ever land under /home (e.g.
+# AppImages extracted to ~/Applications). Setting this lets bin/lutris
+# trust the PYTHONPATH we just built.
+export LUTRIS_ALLOW_LOCAL_PYTHON_PACKAGES=1
+
+exec "$PYTHON_BIN" "$HERE/usr/bin/lutris" "$@"

--- a/utils/appimage/AppRun
+++ b/utils/appimage/AppRun
@@ -4,13 +4,16 @@
 # Two responsibilities:
 #   1. Source linuxdeploy-plugin-gtk's hook so GI_TYPELIB_PATH, GDK_PIXBUF_*,
 #      XDG_DATA_DIRS, etc. point inside the AppDir.
-#   2. Launch bin/lutris with the bundled Python interpreter, with PYTHONPATH
-#      pointing at the bundled site-packages.
+#   2. Launch bin/lutris with the bundled Python interpreter.
 #
 # Lutris is intentionally NOT sandboxed: it must call host binaries (xrandr,
 # 7z, fuser, wine, the user's installed runners), read the user's $HOME,
-# and access mounted drives. We deliberately leave PATH intact so host
-# tools win, and only prepend AppDir paths for libraries / typelibs.
+# and access mounted drives. We deliberately leave PATH and PYTHONPATH
+# alone so host tools and host Python (used by host subprocesses like
+# umu-run) work as they do outside the AppImage. The build script
+# installs Lutris's package files via --install-layout=deb so the
+# bundled Python finds them via its standard dist-packages search,
+# without us needing to advertise an AppDir path on PYTHONPATH.
 set -e
 
 HERE="$(dirname "$(readlink -f "${0}")")"
@@ -25,7 +28,6 @@ if [ -d "$HERE/apprun-hooks" ]; then
 fi
 
 export APPDIR="$HERE"
-export PATH="$HERE/usr/bin:$PATH"
 
 # Intentionally do NOT export LD_LIBRARY_PATH. linuxdeploy already set
 # RPATH=$ORIGIN/.. on every bundled binary, so they find their sibling libs
@@ -59,15 +61,9 @@ if [ -z "$PYTHON_BIN" ]; then
     exit 1
 fi
 
-PY_VER="$("$PYTHON_BIN" -c 'import sys;print("%d.%d"%sys.version_info[:2])')"
-SITE="$HERE/usr/lib/python${PY_VER}/site-packages"
-DIST="$HERE/usr/lib/python3/dist-packages"
-export PYTHONPATH="$SITE:$DIST${PYTHONPATH:+:$PYTHONPATH}"
-
 # bin/lutris strips /home paths from sys.path unless this is set, which
-# would also drop our AppDir paths if they ever land under /home (e.g.
-# AppImages extracted to ~/Applications). Setting this lets bin/lutris
-# trust the PYTHONPATH we just built.
+# would also drop the AppDir paths Python auto-discovered when extracted
+# AppImages live under /home (e.g. ~/Applications).
 export LUTRIS_ALLOW_LOCAL_PYTHON_PACKAGES=1
 
 exec "$PYTHON_BIN" "$HERE/usr/bin/lutris" "$@"

--- a/utils/appimage/Dockerfile
+++ b/utils/appimage/Dockerfile
@@ -1,0 +1,75 @@
+# Build environment for the Lutris AppImage proof-of-concept.
+#
+# Ubuntu 22.04 is chosen as a balance between glibc backward compatibility
+# (glibc 2.35) and shipping Python 3.10 + GTK3 + WebKit2GTK 4.1 in the
+# distro repos. If we promote this from PoC to a supported channel, we
+# may want to drop to 20.04 (glibc 2.31) for wider portability.
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LC_ALL=C.UTF-8
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    wget \
+    file \
+    git \
+    desktop-file-utils \
+    gettext \
+    appstream \
+    libfuse2 \
+    fuse \
+    patchelf \
+    python3 \
+    python3-dev \
+    python3-pip \
+    python3-venv \
+    python3-setuptools \
+    python3-wheel \
+    pkg-config \
+    build-essential \
+    libcairo2-dev \
+    libgirepository1.0-dev \
+    libdbus-1-dev \
+    libsystemd-dev \
+    python3-gi \
+    python3-gi-cairo \
+    python3-dbus \
+    gir1.2-gtk-3.0 \
+    gir1.2-gdkpixbuf-2.0 \
+    gir1.2-pango-1.0 \
+    gir1.2-gnomedesktop-3.0 \
+    gir1.2-webkit2-4.1 \
+    gir1.2-notify-0.7 \
+    gir1.2-ayatanaappindicator3-0.1 \
+    libgtk-3-0 \
+    libgtk-3-bin \
+    libwebkit2gtk-4.1-0 \
+    libnotify4 \
+    libayatana-appindicator3-1 \
+    libgnome-desktop-3-19 \
+    librsvg2-common \
+ && rm -rf /var/lib/apt/lists/*
+
+# linuxdeploy + plugin-gtk handle library/typelib bundling and GTK env setup.
+WORKDIR /opt/tools
+RUN curl -fsSL -o linuxdeploy-x86_64.AppImage \
+    https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
+ && curl -fsSL -o linuxdeploy-plugin-gtk.sh \
+    https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh \
+ && curl -fsSL -o appimagetool-x86_64.AppImage \
+    https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
+ && chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-gtk.sh appimagetool-x86_64.AppImage
+
+# linuxdeploy and appimagetool are AppImages; extract them so they run
+# without FUSE (which isn't always usable inside containers).
+RUN ./linuxdeploy-x86_64.AppImage --appimage-extract >/dev/null \
+ && mv squashfs-root linuxdeploy \
+ && ln -sf /opt/tools/linuxdeploy/AppRun /usr/local/bin/linuxdeploy \
+ && ./appimagetool-x86_64.AppImage --appimage-extract >/dev/null \
+ && mv squashfs-root appimagetool \
+ && ln -sf /opt/tools/appimagetool/AppRun /usr/local/bin/appimagetool \
+ && ln -sf /opt/tools/linuxdeploy-plugin-gtk.sh /usr/local/bin/linuxdeploy-plugin-gtk
+
+WORKDIR /src

--- a/utils/appimage/Dockerfile
+++ b/utils/appimage/Dockerfile
@@ -29,12 +29,13 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3-wheel \
     pkg-config \
     build-essential \
+    ninja-build \
     libcairo2-dev \
     libgirepository1.0-dev \
     libdbus-1-dev \
+    libdbus-glib-1-dev \
     libsystemd-dev \
     python3-gi \
-    python3-gi-cairo \
     python3-dbus \
     gir1.2-gtk-3.0 \
     gir1.2-gdkpixbuf-2.0 \
@@ -51,6 +52,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libgnome-desktop-3-19 \
     librsvg2-common \
  && rm -rf /var/lib/apt/lists/*
+
+# Jammy's apt meson (0.61) is older than meson-python requires (>=0.63),
+# so install a current meson from pip. ninja from apt is fine; pip's
+# meson invokes the apt-shipped ninja-build as its backend.
+#
+# pycairo is installed here too so PyGObject's meson build can find its
+# C headers (at /usr/local/lib/python3.10/dist-packages/cairo/include/);
+# apt's python3-cairo ships no headers, which is why python3-cairo /
+# python3-gi-cairo are deliberately not in the apt list above.
+RUN python3 -m pip install --no-cache-dir 'meson>=0.63.3'
+RUN python3 -m pip install --no-cache-dir pycairo
 
 # linuxdeploy + plugin-gtk handle library/typelib bundling and GTK env setup.
 WORKDIR /opt/tools

--- a/utils/appimage/Dockerfile
+++ b/utils/appimage/Dockerfile
@@ -65,11 +65,14 @@ RUN python3 -m pip install --no-cache-dir 'meson>=0.63.3'
 RUN python3 -m pip install --no-cache-dir pycairo
 
 # linuxdeploy + plugin-gtk handle library/typelib bundling and GTK env setup.
+# linuxdeploy-plugin-gtk is vendored from the repo (see the matching
+# .sh and .LICENSE files in this directory) because its upstream is
+# dormant; pinning a known-good copy keeps builds reproducible and lets
+# us patch known issues (e.g. forced Adwaita theme) without a fork.
 WORKDIR /opt/tools
+COPY linuxdeploy-plugin-gtk.sh /opt/tools/linuxdeploy-plugin-gtk.sh
 RUN curl -fsSL -o linuxdeploy-x86_64.AppImage \
     https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous/linuxdeploy-x86_64.AppImage \
- && curl -fsSL -o linuxdeploy-plugin-gtk.sh \
-    https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/master/linuxdeploy-plugin-gtk.sh \
  && curl -fsSL -o appimagetool-x86_64.AppImage \
     https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage \
  && chmod +x linuxdeploy-x86_64.AppImage linuxdeploy-plugin-gtk.sh appimagetool-x86_64.AppImage

--- a/utils/appimage/build-in-container.sh
+++ b/utils/appimage/build-in-container.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Assemble the Lutris AppDir and produce an AppImage.
+#
+# This runs inside the Docker image defined by Dockerfile. It expects the
+# Lutris source tree to be mounted at /src, and writes the finished
+# AppImage to /src/dist/.
+set -euo pipefail
+
+SRC=/src
+OUT=$SRC/dist
+APPDIR=/tmp/Lutris.AppDir
+
+rm -rf "$APPDIR"
+mkdir -p "$APPDIR/usr/bin" "$APPDIR/usr/lib" "$OUT"
+
+# Bundle the Python interpreter + standard library so the AppImage doesn't
+# depend on the host having python3.10 installed. We use whatever python3
+# the build image ships (Ubuntu 22.04 → 3.10).
+PY_VER="$(python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])')"
+cp -a "$(readlink -f /usr/bin/python3)" "$APPDIR/usr/bin/python${PY_VER}"
+ln -sf "python${PY_VER}" "$APPDIR/usr/bin/python3"
+cp -a "/usr/lib/python${PY_VER}" "$APPDIR/usr/lib/"
+# Drop test/idle bloat that no end user needs from the AppImage.
+rm -rf "$APPDIR/usr/lib/python${PY_VER}/test" \
+       "$APPDIR/usr/lib/python${PY_VER}/idlelib" \
+       "$APPDIR/usr/lib/python${PY_VER}/turtledemo" \
+       "$APPDIR/usr/lib/python${PY_VER}/tkinter" \
+       "$APPDIR/usr/lib/python${PY_VER}/lib2to3"
+
+# Install Lutris (Python package + bin/lutris + data files) into the AppDir.
+cd "$SRC"
+python3 setup.py install --root="$APPDIR" --prefix=/usr --no-compile
+
+# Install runtime Python deps directly into the AppDir's site-packages.
+SITE_PACKAGES=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')
+SITE_PACKAGES=${SITE_PACKAGES#/usr/}
+TARGET="$APPDIR/usr/$SITE_PACKAGES"
+mkdir -p "$TARGET"
+
+# PyGObject is satisfied by the system python3-gi we bundle from apt; pip
+# rebuilds against the host gobject-introspection and we want the version
+# wired up to the bundled typelibs, so we leave it to apt + linuxdeploy.
+# dbus-python is intentionally excluded here — it switched to a meson-python
+# build backend that pulls in a heavy toolchain, and the apt-shipped
+# python3-dbus is a perfectly good prebuilt copy we already have.
+python3 -m pip install --no-compile --target="$TARGET" \
+    certifi \
+    distro \
+    evdev \
+    lxml \
+    pillow \
+    pypresence \
+    PyYAML \
+    requests \
+    protobuf \
+    'moddb>=0.8.1' \
+    setproctitle
+
+# Bundle the python3-gi / python3-dbus packages shipped by apt: their .so
+# extensions live outside the pip world, and we want PyGObject/dbus wired
+# up to the bundled typelibs and libdbus, not whatever the host has.
+for path in /usr/lib/python3/dist-packages/gi \
+            /usr/lib/python3/dist-packages/cairo \
+            /usr/lib/python3/dist-packages/dbus \
+            /usr/lib/python3/dist-packages/_dbus_bindings*.so \
+            /usr/lib/python3/dist-packages/_dbus_glib_bindings*.so; do
+    if compgen -G "$path" >/dev/null; then
+        cp -a $path "$TARGET/"
+    fi
+done
+
+# Stage desktop file + icon for linuxdeploy. It looks for them at the AppDir
+# root, so symlink from the canonical install locations.
+DESKTOP_FILE="$APPDIR/usr/share/applications/net.lutris.Lutris.desktop"
+ICON_FILE="$APPDIR/usr/share/icons/hicolor/scalable/apps/net.lutris.Lutris.svg"
+[ -f "$DESKTOP_FILE" ] || { echo "missing desktop file at $DESKTOP_FILE"; exit 1; }
+[ -f "$ICON_FILE" ]    || { echo "missing icon at $ICON_FILE"; exit 1; }
+
+# Drop in our custom AppRun before linuxdeploy runs, so it doesn't overwrite
+# it with its own generic launcher.
+install -m 0755 "$SRC/utils/appimage/AppRun" "$APPDIR/AppRun"
+
+# Run linuxdeploy with the gtk plugin to copy GTK libs/typelibs/loaders.
+# DEPLOY_GTK_VERSION tells the plugin which GTK major version to bundle.
+export DEPLOY_GTK_VERSION=3
+export LINUXDEPLOY_OUTPUT_VERSION=${LUTRIS_VERSION:-dev}
+
+# --executable on the bundled python3 lets linuxdeploy walk its NEEDED list
+# and copy in libpython, libssl, libffi, etc. that the interpreter pulls.
+#
+# --library on each native Python extension (.so) we copied in from
+# apt's python3-gi / python3-dbus packages tells linuxdeploy to follow
+# their NEEDED chain too. Without this, libgirepository / libdbus /
+# libgobject never land in the AppDir, and ld.so falls back to the host
+# copies — which on a newer distro than the build base will be ABI-
+# incompatible with our bundled libglib.
+LIB_ARGS=()
+while IFS= read -r -d '' so; do
+    LIB_ARGS+=(--library "$so")
+done < <(find "$TARGET" -maxdepth 3 \( -name '_gi*.so' -o -name '_dbus*.so' -o -name 'gi.repository*.so' \) -print0 2>/dev/null)
+echo "Passing ${#LIB_ARGS[@]} native extensions to linuxdeploy: ${LIB_ARGS[*]}"
+
+linuxdeploy \
+    --appdir "$APPDIR" \
+    --plugin gtk \
+    --executable "$APPDIR/usr/bin/python${PY_VER}" \
+    "${LIB_ARGS[@]}" \
+    --desktop-file "$DESKTOP_FILE" \
+    --icon-file "$ICON_FILE"
+
+# linuxdeploy writes its own AppRun; restore ours (which knows to exec
+# python3 with bin/lutris and to source linuxdeploy-plugin-gtk's hook).
+install -m 0755 "$SRC/utils/appimage/AppRun" "$APPDIR/AppRun"
+
+# linuxdeploy patched RPATH on every binary it deployed itself, but it did
+# not touch the files we copied in by hand (_gi.so, _dbus*.so under
+# dist-packages). Since AppRun deliberately leaves LD_LIBRARY_PATH unset
+# to avoid poisoning host subprocesses, those files would fall through to
+# the host's libs at runtime — exactly the ABI mismatch we're trying to
+# avoid. Stamp them with an $ORIGIN-relative RPATH pointing at the bundled
+# $APPDIR/usr/lib so they pick up our libgirepository / libdbus / libglib.
+LIB_DIR="$APPDIR/usr/lib"
+while IFS= read -r -d '' so; do
+    rel="$(realpath --relative-to="$(dirname "$so")" "$LIB_DIR")"
+    patchelf --set-rpath "\$ORIGIN/$rel" "$so"
+    echo "  rpath \$ORIGIN/$rel -> $so"
+done < <(find "$TARGET" -maxdepth 3 \( -name '_gi*.so' -o -name '_dbus*.so' \) -print0 2>/dev/null)
+
+# Finally, pack the AppDir into a single-file AppImage.
+cd "$OUT"
+ARCH=x86_64 appimagetool --no-appstream "$APPDIR" \
+    "Lutris-${LINUXDEPLOY_OUTPUT_VERSION}-x86_64.AppImage"
+
+ls -lh "$OUT"

--- a/utils/appimage/build-in-container.sh
+++ b/utils/appimage/build-in-container.sh
@@ -20,12 +20,19 @@ PY_VER="$(python3 -c 'import sys;print("%d.%d"%sys.version_info[:2])')"
 cp -a "$(readlink -f /usr/bin/python3)" "$APPDIR/usr/bin/python${PY_VER}"
 ln -sf "python${PY_VER}" "$APPDIR/usr/bin/python3"
 cp -a "/usr/lib/python${PY_VER}" "$APPDIR/usr/lib/"
-# Drop test/idle bloat that no end user needs from the AppImage.
+# Drop test/idle bloat that no end user needs from the AppImage. The
+# config-* directory holds link-time-only artifacts (Makefile, python.o
+# static wrapper, libpython symlinks) that are useful only when building
+# C extensions against this Python — never at runtime — and the python.o
+# in it makes linuxdeploy emit a spurious "patchelf: wrong ELF type"
+# warning every build because it's a relocatable object file, which
+# patchelf refuses to touch.
 rm -rf "$APPDIR/usr/lib/python${PY_VER}/test" \
        "$APPDIR/usr/lib/python${PY_VER}/idlelib" \
        "$APPDIR/usr/lib/python${PY_VER}/turtledemo" \
        "$APPDIR/usr/lib/python${PY_VER}/tkinter" \
-       "$APPDIR/usr/lib/python${PY_VER}/lib2to3"
+       "$APPDIR/usr/lib/python${PY_VER}/lib2to3" \
+       "$APPDIR/usr/lib/python${PY_VER}/config-"*
 
 # Install Lutris (Python package + bin/lutris + data files) into the AppDir.
 cd "$SRC"

--- a/utils/appimage/build-in-container.sh
+++ b/utils/appimage/build-in-container.sh
@@ -35,8 +35,15 @@ rm -rf "$APPDIR/usr/lib/python${PY_VER}/test" \
        "$APPDIR/usr/lib/python${PY_VER}/config-"*
 
 # Install Lutris (Python package + bin/lutris + data files) into the AppDir.
+# --install-layout=deb is Debian's flag for "use dist-packages, not the
+# upstream-Python site-packages layout." This matters because the bundled
+# Python is Debian-patched (Ubuntu 22.04) and its default sys.path looks
+# for modules in dist-packages, not site-packages. Installing here means
+# AppRun does not need to advertise our location on PYTHONPATH, which in
+# turn keeps PYTHONPATH out of host subprocesses (umu-run's #!/usr/bin/env
+# python3 picks up the host interpreter, with its host site-packages).
 cd "$SRC"
-python3 setup.py install --root="$APPDIR" --prefix=/usr --no-compile
+python3 setup.py install --root="$APPDIR" --prefix=/usr --install-layout=deb --no-compile
 
 # Install runtime Python deps directly into the AppDir's site-packages.
 SITE_PACKAGES=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])')

--- a/utils/appimage/build-in-container.sh
+++ b/utils/appimage/build-in-container.sh
@@ -47,9 +47,12 @@ mkdir -p "$TARGET"
 # PyGObject is satisfied by the system python3-gi we bundle from apt; pip
 # rebuilds against the host gobject-introspection and we want the version
 # wired up to the bundled typelibs, so we leave it to apt + linuxdeploy.
-# dbus-python is intentionally excluded here — it switched to a meson-python
-# build backend that pulls in a heavy toolchain, and the apt-shipped
-# python3-dbus is a perfectly good prebuilt copy we already have.
+# PyGObject and dbus-python both ship as source-only distributions and
+# build via meson-python — that's why the Dockerfile pulls in meson +
+# ninja-build + libdbus-glib-1-dev. Building them through pip (rather
+# than copying apt's python3-gi / python3-dbus into the AppDir by hand)
+# keeps every runtime dep on a single, version-pinnable surface and
+# lets pycairo land naturally as a PyGObject dependency.
 python3 -m pip install --no-compile --target="$TARGET" \
     certifi \
     distro \
@@ -61,20 +64,10 @@ python3 -m pip install --no-compile --target="$TARGET" \
     requests \
     protobuf \
     'moddb>=0.8.1' \
-    setproctitle
-
-# Bundle the python3-gi / python3-dbus packages shipped by apt: their .so
-# extensions live outside the pip world, and we want PyGObject/dbus wired
-# up to the bundled typelibs and libdbus, not whatever the host has.
-for path in /usr/lib/python3/dist-packages/gi \
-            /usr/lib/python3/dist-packages/cairo \
-            /usr/lib/python3/dist-packages/dbus \
-            /usr/lib/python3/dist-packages/_dbus_bindings*.so \
-            /usr/lib/python3/dist-packages/_dbus_glib_bindings*.so; do
-    if compgen -G "$path" >/dev/null; then
-        cp -a $path "$TARGET/"
-    fi
-done
+    setproctitle \
+    pycairo \
+    'PyGObject<3.50' \
+    dbus-python
 
 # Stage desktop file + icon for linuxdeploy. It looks for them at the AppDir
 # root, so symlink from the canonical install locations.

--- a/utils/appimage/build.sh
+++ b/utils/appimage/build.sh
@@ -14,6 +14,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 IMAGE_TAG="lutris-appimage-builder:ubuntu22.04"
 
+# Default LUTRIS_VERSION to whatever lutris/__init__.py advertises so a
+# plain `make appimage` produces a sensibly-named artifact on a release
+# commit. Explicit env override still wins (e.g. for RC tags).
+if [ -z "${LUTRIS_VERSION:-}" ]; then
+    LUTRIS_VERSION="$(awk -F'"' '/^__version__/ { print $2; exit }' \
+        "$REPO_ROOT/lutris/__init__.py")"
+fi
+: "${LUTRIS_VERSION:=dev}"
+echo "Building Lutris AppImage version: $LUTRIS_VERSION"
+
 if command -v docker >/dev/null 2>&1; then
     OCI=docker
 elif command -v podman >/dev/null 2>&1; then
@@ -38,7 +48,7 @@ fi
 "$OCI" run --rm \
     --privileged \
     -v "$REPO_ROOT":/src${MOUNT_OPTS} \
-    -e LUTRIS_VERSION="${LUTRIS_VERSION:-dev}" \
+    -e LUTRIS_VERSION="$LUTRIS_VERSION" \
     "$IMAGE_TAG" \
     bash /src/utils/appimage/build-in-container.sh
 

--- a/utils/appimage/build.sh
+++ b/utils/appimage/build.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Top-level wrapper for the Lutris AppImage proof-of-concept build.
+#
+# Builds (or reuses) the Docker image defined by ./Dockerfile, then runs
+# the in-container build script with the repo mounted at /src. The
+# finished AppImage lands in ./dist/.
+#
+# Usage:
+#   utils/appimage/build.sh          # builds with version "dev"
+#   LUTRIS_VERSION=0.5.23 utils/appimage/build.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+IMAGE_TAG="lutris-appimage-builder:ubuntu22.04"
+
+if command -v docker >/dev/null 2>&1; then
+    OCI=docker
+elif command -v podman >/dev/null 2>&1; then
+    OCI=podman
+else
+    echo "docker or podman is required to build the AppImage" >&2
+    exit 1
+fi
+echo "Using container engine: $OCI"
+
+"$OCI" build -t "$IMAGE_TAG" "$SCRIPT_DIR"
+
+mkdir -p "$REPO_ROOT/dist"
+
+# --privileged lets appimagetool / linuxdeploy mount the squashfs they
+# operate on; under podman with SELinux we also need :z on the bind mount.
+MOUNT_OPTS=""
+if [ "$OCI" = "podman" ]; then
+    MOUNT_OPTS=":z"
+fi
+
+"$OCI" run --rm \
+    --privileged \
+    -v "$REPO_ROOT":/src${MOUNT_OPTS} \
+    -e LUTRIS_VERSION="${LUTRIS_VERSION:-dev}" \
+    "$IMAGE_TAG" \
+    bash /src/utils/appimage/build-in-container.sh
+
+echo
+echo "Built AppImage(s):"
+ls -lh "$REPO_ROOT/dist/"*.AppImage 2>/dev/null || echo "(no AppImage produced — check build output above)"

--- a/utils/appimage/linuxdeploy-plugin-gtk.LICENSE
+++ b/utils/appimage/linuxdeploy-plugin-gtk.LICENSE
@@ -1,0 +1,19 @@
+Copyright 2018-2019 TheAssassin and the linuxdeploy contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/utils/appimage/linuxdeploy-plugin-gtk.sh
+++ b/utils/appimage/linuxdeploy-plugin-gtk.sh
@@ -1,0 +1,378 @@
+#! /usr/bin/env bash
+#
+# Vendored from https://github.com/linuxdeploy/linuxdeploy-plugin-gtk
+# Pinned commit: 3b67a1d1 (2023-10-01) — upstream is currently dormant.
+# License: MIT, see linuxdeploy-plugin-gtk.LICENSE alongside this file.
+
+
+# GTK3 environment variables: https://developer.gnome.org/gtk3/stable/gtk-running.html
+# GTK4 environment variables: https://developer.gnome.org/gtk4/stable/gtk-running.html
+
+# abort on all errors
+set -e
+
+if [ "$DEBUG" != "" ]; then
+    set -x
+    verbose="--verbose"
+fi
+
+SCRIPT="$(basename "$(readlink -f "$0")")"
+
+show_usage() {
+    echo "Usage: $SCRIPT --appdir <path to AppDir>"
+    echo
+    echo "Bundles resources for applications that use GTK into an AppDir"
+    echo
+    echo "Required variables:"
+    echo "  LINUXDEPLOY=\".../linuxdeploy\" path to linuxdeploy (e.g., AppImage); set automatically when plugin is run directly by linuxdeploy"
+    echo
+    echo "Optional variables:"
+    echo "  DEPLOY_GTK_VERSION (major version of GTK to deploy, e.g. '2', '3' or '4'; auto-detect by default)"
+}
+
+variable_is_true() {
+    local var="$1"
+
+    if [ -n "$var" ] && { [ "$var" == "true" ] || [ "$var" -gt 0 ]; } 2> /dev/null; then
+        return 0 # true
+    else
+        return 1 # false
+    fi
+}
+
+get_pkgconf_variable() {
+    local variable="$1"
+    local library="$2"
+    local default_value="$3"
+
+    pkgconfig_ret="$("$PKG_CONFIG" --variable="$variable" "$library")"
+    if [ -n "$pkgconfig_ret" ]; then
+        echo "$pkgconfig_ret"
+    elif [ -n "$default_value" ]; then
+        echo "$default_value"
+    else
+        echo "$0: there is no '$variable' variable for '$library' library." > /dev/stderr
+        echo "Please check the '$library.pc' file is present in \$PKG_CONFIG_PATH (you may need to install the appropriate -dev/-devel package)." > /dev/stderr
+        exit 1
+    fi
+}
+
+copy_tree() {
+    local src=("${@:1:$#-1}")
+    local dst="${*:$#}"
+
+    for elem in "${src[@]}"; do
+        mkdir -p "${dst::-1}$elem"
+        cp "$elem" --archive --parents --target-directory="$dst" $verbose
+    done
+}
+
+copy_lib_tree() {
+    # The source lib directory could be /usr/lib, /usr/lib64, or /usr/lib/x86_64-linux-gnu
+    # Therefore, when copying lib directories, we need to transform that target path
+    # to a consistent /usr/lib
+    local src=("${@:1:$#-1}")
+    local dst="${*:$#}"
+
+    for elem in "${src[@]}"; do
+        mkdir -p "${dst::-1}${elem/$LD_GTK_LIBRARY_PATH//usr/lib}"
+        pushd "$LD_GTK_LIBRARY_PATH"
+        cp "$(realpath --relative-to="$LD_GTK_LIBRARY_PATH" "$elem")" --archive --parents --target-directory="$dst/usr/lib" $verbose
+        popd
+    done
+}
+
+get_triplet_path() {
+    if command -v dpkg-architecture > /dev/null; then
+        echo "/usr/lib/$(dpkg-architecture -qDEB_HOST_MULTIARCH)"
+    fi
+}
+
+
+
+search_library_path() {
+    PATH_ARRAY=(
+        "$(get_triplet_path)"
+        "/usr/lib64"
+        "/usr/lib"
+    )
+
+    for path in "${PATH_ARRAY[@]}"; do
+        if [ -d "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+}
+
+search_tool() {
+    local tool="$1"
+    local directory="$2"
+
+    if command -v "$tool"; then
+        return 0
+    fi
+
+    PATH_ARRAY=(
+        "$(get_triplet_path)/$directory/$tool"
+        "/usr/lib64/$directory/$tool"
+        "/usr/lib/$directory/$tool"
+        "/usr/bin/$tool"
+        "/usr/bin/$tool-64"
+        "/usr/bin/$tool-32"
+    )
+
+    for path in "${PATH_ARRAY[@]}"; do
+        if [ -x "$path" ]; then
+            echo "$path"
+            return 0
+        fi
+    done
+}
+
+DEPLOY_GTK_VERSION="${DEPLOY_GTK_VERSION:-0}" # When not set by user, this variable use the integer '0' as a sentinel value
+APPDIR=
+
+while [ "$1" != "" ]; do
+    case "$1" in
+        --plugin-api-version)
+            echo "0"
+            exit 0
+            ;;
+        --appdir)
+            APPDIR="$2"
+            shift
+            shift
+            ;;
+        --help)
+            show_usage
+            exit 0
+            ;;
+        *)
+            echo "Invalid argument: $1"
+            echo
+            show_usage
+            exit 1
+            ;;
+    esac
+done
+
+if [ "$APPDIR" == "" ]; then
+    show_usage
+    exit 1
+fi
+
+APPDIR="$(realpath "$APPDIR")"
+mkdir -p "$APPDIR"
+
+. /etc/os-release
+if [ "$ID" = "debian" ] || [ "$ID" = "ubuntu" ]; then
+    if ! command -v dpkg-architecture  &>/dev/null; then
+        echo -e "$0: dpkg-architecture not found.\nInstall dpkg-dev then re-run the plugin."
+        exit 1
+    fi
+fi
+
+if command -v pkgconf > /dev/null; then
+    PKG_CONFIG="pkgconf"
+elif command -v pkg-config > /dev/null; then
+    PKG_CONFIG="pkg-config"
+else
+    echo "$0: pkg-config/pkgconf not found in PATH, aborting"
+    exit 1
+fi
+
+# GTK's library path *must not* have a trailing slash for later parameter substitution to work properly
+LD_GTK_LIBRARY_PATH="$(realpath "${LD_GTK_LIBRARY_PATH:-$(search_library_path)}")"
+
+if ! command -v find &>/dev/null && ! type find &>/dev/null; then
+    echo -e "$0: find not found.\nInstall findutils then re-run the plugin."
+    exit 1
+fi
+
+if [ -z "$LINUXDEPLOY" ]; then
+    echo -e "$0: LINUXDEPLOY environment variable is not set.\nDownload a suitable linuxdeploy AppImage, set the environment variable and re-run the plugin."
+    exit 1
+fi
+
+gtk_versions=0 # Count major versions of GTK when auto-detect GTK version
+if [ "$DEPLOY_GTK_VERSION" -eq 0 ]; then
+    echo "Determining which GTK version to deploy"
+    while IFS= read -r -d '' file; do
+        if [ "$DEPLOY_GTK_VERSION" -ne 2 ] && ldd "$file" | grep -q "libgtk-x11-2.0.so"; then
+            DEPLOY_GTK_VERSION=2
+            gtk_versions="$((gtk_versions+1))"
+        fi
+        if [ "$DEPLOY_GTK_VERSION" -ne 3 ] && ldd "$file" | grep -q "libgtk-3.so"; then
+            DEPLOY_GTK_VERSION=3
+            gtk_versions="$((gtk_versions+1))"
+        fi
+        if [ "$DEPLOY_GTK_VERSION" -ne 4 ] && ldd "$file" | grep -q "libgtk-4.so"; then
+            DEPLOY_GTK_VERSION=4
+            gtk_versions="$((gtk_versions+1))"
+        fi
+    done < <(find "$APPDIR/usr/bin" -executable -type f -print0)
+fi
+
+if [ "$gtk_versions" -gt 1 ]; then
+    echo "$0: can not deploy multiple GTK versions at the same time."
+    echo "Please set DEPLOY_GTK_VERSION to {2, 3, 4}."
+    exit 1
+elif [ "$DEPLOY_GTK_VERSION" -eq 0 ]; then
+    echo "$0: failed to auto-detect GTK version."
+    echo "Please set DEPLOY_GTK_VERSION to {2, 3, 4}."
+    exit 1
+fi
+
+echo "Installing AppRun hook"
+HOOKSDIR="$APPDIR/apprun-hooks"
+HOOKFILE="$HOOKSDIR/linuxdeploy-plugin-gtk.sh"
+mkdir -p "$HOOKSDIR"
+cat > "$HOOKFILE" <<\EOF
+#! /usr/bin/env bash
+
+COLOR_SCHEME="$(dbus-send --session --dest=org.freedesktop.portal.Desktop --type=method_call --print-reply --reply-timeout=1000 /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read 'string:org.freedesktop.appearance' 'string:color-scheme' 2> /dev/null | tail -n1 | cut -b35- | cut -d' ' -f2 || printf '')"
+if [ -z "$COLOR_SCHEME" ]; then
+    COLOR_SCHEME="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null || printf '')"
+fi
+case "$COLOR_SCHEME" in
+    "1"|"'prefer-dark'")  GTK_THEME_VARIANT="dark";;
+    "2"|"'prefer-light'") GTK_THEME_VARIANT="light";;
+    *)                    GTK_THEME_VARIANT="light";;
+esac
+APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow user to override theme (discouraged)
+
+export APPDIR="${APPDIR:-"$(dirname "$(realpath "$0")")"}" # Workaround to run extracted AppImage
+export GTK_DATA_PREFIX="$APPDIR"
+export GTK_THEME="$APPIMAGE_GTK_THEME" # Custom themes are broken
+export GDK_BACKEND=x11 # Crash with Wayland backend on Wayland
+export XDG_DATA_DIRS="$APPDIR/usr/share:/usr/share:$XDG_DATA_DIRS" # g_get_system_data_dirs() from GLib
+EOF
+
+echo "Installing GLib schemas"
+# Note: schemasdir is undefined on Ubuntu 16.04
+glib_schemasdir="$(get_pkgconf_variable "schemasdir" "gio-2.0" "/usr/share/glib-2.0/schemas")"
+copy_tree "$glib_schemasdir" "$APPDIR/"
+glib-compile-schemas "$APPDIR/$glib_schemasdir"
+cat >> "$HOOKFILE" <<EOF
+export GSETTINGS_SCHEMA_DIR="\$APPDIR/$glib_schemasdir"
+EOF
+
+echo "Installing GIRepository Typelibs"
+gi_typelibsdir="$(get_pkgconf_variable "typelibdir" "gobject-introspection-1.0" "$LD_GTK_LIBRARY_PATH/girepository-1.0")"
+copy_lib_tree "$gi_typelibsdir" "$APPDIR/"
+cat >> "$HOOKFILE" <<EOF
+export GI_TYPELIB_PATH="\$APPDIR/${gi_typelibsdir/$LD_GTK_LIBRARY_PATH//usr/lib}"
+EOF
+
+case "$DEPLOY_GTK_VERSION" in
+    2)
+        # https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/pull/20#issuecomment-826354261
+        echo "WARNING: Gtk+2 applications are not fully supported by this plugin"
+        ;;
+    3)
+        echo "Installing GTK 3.0 modules"
+        gtk3_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk+-3.0" "/usr")"
+        gtk3_libdir="$(get_pkgconf_variable "libdir" "gtk+-3.0" "$LD_GTK_LIBRARY_PATH")/gtk-3.0"
+        gtk3_path="$gtk3_libdir"
+        gtk3_immodulesdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0" "3.0.0")/immodules"
+        gtk3_printbackendsdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0" "3.0.0")/printbackends"
+        gtk3_immodules_cache_file="$(dirname "$gtk3_immodulesdir")/immodules.cache"
+        gtk3_immodules_query="$(search_tool "gtk-query-immodules-3.0" "libgtk-3-0")"
+        copy_lib_tree "$gtk3_libdir" "$APPDIR/"
+        cat >> "$HOOKFILE" <<EOF
+export GTK_EXE_PREFIX="\$APPDIR/$gtk3_exec_prefix"
+export GTK_PATH="\$APPDIR/${gtk3_path/$LD_GTK_LIBRARY_PATH//usr/lib}"
+export GTK_IM_MODULE_FILE="\$APPDIR/${gtk3_immodules_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+EOF
+
+        if [ -x "$gtk3_immodules_query" ]; then
+            echo "Updating immodules cache in $APPDIR/${gtk3_immodules_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+            "$gtk3_immodules_query" > "$APPDIR/${gtk3_immodules_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+        else
+            echo "WARNING: gtk-query-immodules-3.0 not found"
+        fi
+        if [ ! -f "$APPDIR/${gtk3_immodules_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}" ]; then
+            echo "WARNING: immodules.cache file is missing"
+        fi
+        sed -i "s|$gtk3_libdir/3.0.0/immodules/||g" "$APPDIR/${gtk3_immodules_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+        ;;
+    4)
+        echo "Installing GTK 4.0 modules"
+        gtk4_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk4" "/usr")"
+        gtk4_libdir="$(get_pkgconf_variable "libdir" "gtk4")/gtk-4.0"
+        gtk4_path="$gtk4_libdir"
+        copy_lib_tree "$gtk4_libdir" "$APPDIR/"
+        cat >> "$HOOKFILE" <<EOF
+export GTK_EXE_PREFIX="\$APPDIR/$gtk4_exec_prefix"
+export GTK_PATH="\$APPDIR/${gtk4_path/$LD_GTK_LIBRARY_PATH//usr/lib}"
+EOF
+        ;;
+    *)
+        echo "$0: '$DEPLOY_GTK_VERSION' is not a valid GTK major version."
+        echo "Please set DEPLOY_GTK_VERSION to {2, 3, 4}."
+        exit 1
+esac
+
+echo "Installing GDK PixBufs"
+gdk_libdir="$(get_pkgconf_variable "libdir" "gdk-pixbuf-2.0" "$LD_GTK_LIBRARY_PATH")"
+gdk_pixbuf_binarydir="$(get_pkgconf_variable "gdk_pixbuf_binarydir" "gdk-pixbuf-2.0" "$gdk_libdir/gdk-pixbuf-2.0/2.10.0")"
+gdk_pixbuf_cache_file="$(get_pkgconf_variable "gdk_pixbuf_cache_file" "gdk-pixbuf-2.0" "$gdk_pixbuf_binarydir/loaders.cache")"
+gdk_pixbuf_moduledir="$(get_pkgconf_variable "gdk_pixbuf_moduledir" "gdk-pixbuf-2.0" "$gdk_pixbuf_binarydir/loaders")"
+# Note: gdk_pixbuf_query_loaders variable is not defined on some systems
+gdk_pixbuf_query="$(search_tool "gdk-pixbuf-query-loaders" "gdk-pixbuf-2.0")"
+copy_lib_tree "$gdk_pixbuf_binarydir" "$APPDIR/"
+cat >> "$HOOKFILE" <<EOF
+export GDK_PIXBUF_MODULE_FILE="\$APPDIR/${gdk_pixbuf_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+EOF
+if [ -x "$gdk_pixbuf_query" ]; then
+    echo "Updating pixbuf cache in $APPDIR/${gdk_pixbuf_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+    "$gdk_pixbuf_query" > "$APPDIR/${gdk_pixbuf_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+else
+    echo "WARNING: gdk-pixbuf-query-loaders not found"
+fi
+if [ ! -f "$APPDIR/${gdk_pixbuf_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}" ]; then
+    echo "WARNING: loaders.cache file is missing"
+fi
+sed -i "s|$gdk_pixbuf_moduledir/||g" "$APPDIR/${gdk_pixbuf_cache_file/$LD_GTK_LIBRARY_PATH//usr/lib}"
+
+echo "Copying more libraries"
+gobject_libdir="$(get_pkgconf_variable "libdir" "gobject-2.0" "$LD_GTK_LIBRARY_PATH")"
+gio_libdir="$(get_pkgconf_variable "libdir" "gio-2.0" "$LD_GTK_LIBRARY_PATH")"
+librsvg_libdir="$(get_pkgconf_variable "libdir" "librsvg-2.0" "$LD_GTK_LIBRARY_PATH")"
+pango_libdir="$(get_pkgconf_variable "libdir" "pango" "$LD_GTK_LIBRARY_PATH")"
+pangocairo_libdir="$(get_pkgconf_variable "libdir" "pangocairo" "$LD_GTK_LIBRARY_PATH")"
+pangoft2_libdir="$(get_pkgconf_variable "libdir" "pangoft2" "$LD_GTK_LIBRARY_PATH")"
+FIND_ARRAY=(
+    "$gdk_libdir"        "libgdk_pixbuf-*.so*"
+    "$gobject_libdir"    "libgobject-*.so*"
+    "$gio_libdir"        "libgio-*.so*"
+    "$librsvg_libdir"    "librsvg-*.so*"
+    "$pango_libdir"      "libpango-*.so*"
+    "$pangocairo_libdir" "libpangocairo-*.so*"
+    "$pangoft2_libdir"   "libpangoft2-*.so*"
+)
+LIBRARIES=()
+for (( i=0; i<${#FIND_ARRAY[@]}; i+=2 )); do
+    directory=${FIND_ARRAY[i]}
+    library=${FIND_ARRAY[i+1]}
+    while IFS= read -r -d '' file; do
+        LIBRARIES+=( "--library=$file" )
+    done < <(find "$directory" \( -type l -o -type f \) -name "$library" -print0)
+done
+
+env LINUXDEPLOY_PLUGIN_MODE=1 "$LINUXDEPLOY" --appdir="$APPDIR" "${LIBRARIES[@]}"
+
+# Create symbolic links as a workaround
+# Details: https://github.com/linuxdeploy/linuxdeploy-plugin-gtk/issues/24#issuecomment-1030026529
+echo "Manually setting rpath for GTK modules"
+PATCH_ARRAY=(
+    "$gtk3_immodulesdir"
+    "$gtk3_printbackendsdir"
+    "$gdk_pixbuf_moduledir"
+)
+for directory in "${PATCH_ARRAY[@]}"; do
+    while IFS= read -r -d '' file; do
+        ln $verbose -sf "${file/$LD_GTK_LIBRARY_PATH\//}" "$APPDIR/usr/lib"
+    done < <(find "$directory" -name '*.so' -print0)
+done

--- a/utils/appimage/linuxdeploy-plugin-gtk.sh
+++ b/utils/appimage/linuxdeploy-plugin-gtk.sh
@@ -3,7 +3,13 @@
 # Vendored from https://github.com/linuxdeploy/linuxdeploy-plugin-gtk
 # Pinned commit: 3b67a1d1 (2023-10-01) — upstream is currently dormant.
 # License: MIT, see linuxdeploy-plugin-gtk.LICENSE alongside this file.
-
+#
+# Modifications from upstream (search for "LUTRIS-MOD" to find each):
+#   * Do not hardcode the bundled GTK_THEME to Adwaita in the AppRun
+#     hook. Upstream forces "Adwaita:light/dark" with a comment that
+#     custom themes are "broken"; in practice this means Lutris in our
+#     AppImage ignores the user's host GTK theme entirely. Drop the
+#     override unless the user explicitly opts in via APPIMAGE_GTK_THEME.
 
 # GTK3 environment variables: https://developer.gnome.org/gtk3/stable/gtk-running.html
 # GTK4 environment variables: https://developer.gnome.org/gtk4/stable/gtk-running.html
@@ -231,20 +237,15 @@ mkdir -p "$HOOKSDIR"
 cat > "$HOOKFILE" <<\EOF
 #! /usr/bin/env bash
 
-COLOR_SCHEME="$(dbus-send --session --dest=org.freedesktop.portal.Desktop --type=method_call --print-reply --reply-timeout=1000 /org/freedesktop/portal/desktop org.freedesktop.portal.Settings.Read 'string:org.freedesktop.appearance' 'string:color-scheme' 2> /dev/null | tail -n1 | cut -b35- | cut -d' ' -f2 || printf '')"
-if [ -z "$COLOR_SCHEME" ]; then
-    COLOR_SCHEME="$(gsettings get org.gnome.desktop.interface color-scheme 2> /dev/null || printf '')"
-fi
-case "$COLOR_SCHEME" in
-    "1"|"'prefer-dark'")  GTK_THEME_VARIANT="dark";;
-    "2"|"'prefer-light'") GTK_THEME_VARIANT="light";;
-    *)                    GTK_THEME_VARIANT="light";;
-esac
-APPIMAGE_GTK_THEME="${APPIMAGE_GTK_THEME:-"Adwaita:$GTK_THEME_VARIANT"}" # Allow user to override theme (discouraged)
-
 export APPDIR="${APPDIR:-"$(dirname "$(realpath "$0")")"}" # Workaround to run extracted AppImage
 export GTK_DATA_PREFIX="$APPDIR"
-export GTK_THEME="$APPIMAGE_GTK_THEME" # Custom themes are broken
+# LUTRIS-MOD: only export GTK_THEME when the caller explicitly opted in
+# via APPIMAGE_GTK_THEME. Upstream hardcodes "Adwaita:light/dark" here
+# with the comment "Custom themes are broken", which ignores the host's
+# actual theme. Letting GTK_THEME fall through preserves system theming.
+if [ -n "${APPIMAGE_GTK_THEME:-}" ]; then
+    export GTK_THEME="$APPIMAGE_GTK_THEME"
+fi
 export GDK_BACKEND=x11 # Crash with Wayland backend on Wayland
 export XDG_DATA_DIRS="$APPDIR/usr/share:/usr/share:$XDG_DATA_DIRS" # g_get_system_data_dirs() from GLib
 EOF


### PR DESCRIPTION
## Summary

- Add `make appimage` — builds a self-contained x86_64 AppImage in an Ubuntu 22.04 container (docker or podman) via linuxdeploy + linuxdeploy-plugin-gtk + appimagetool. Output is ~78 MB and bundles Python 3.10, GTK3, WebKit2GTK 4.1, GnomeDesktop, AyatanaAppIndicator, and Lutris itself.
- Add `.github/workflows/publish-appimage.yml` — on `release.released` / `release.prereleased`, builds and attaches the AppImage as a release asset via the bundled `gh` CLI; `workflow_dispatch` is also supported for ad-hoc builds that stop at the workflow-artifact upload.
- Filed against #6724: Flathub's recent AI-project ban makes Flatpak an unreliable distribution channel, and AppImage is arguably a better fit for Lutris anyway since the client deliberately needs unsandboxed access to host `xrandr`, `7z`, `wine`, `flatpak`, mounted drives, and the user's whole `$HOME`.

A few design points worth reviewing (also covered in the relevant commit messages):

- **Bundled Python:** the build image's `/usr/bin/python3.10` plus its stdlib, with tkinter/test/idle and the link-time-only `config-3.10-*/` directory stripped to keep size down.
- **PyGObject and dbus-python are pip-installed into the AppDir** (`'PyGObject<3.50'`, `dbus-python`, plus `pycairo` for the GTK→Cairo bridge). Both have switched to meson-python build backends, so the build image carries `meson` + `pycairo` (pip) and `libdbus-glib-1-dev` (apt) to satisfy the source build. PyGObject is pinned `<3.50` because 3.50+ requires the `girepository-2.0` ABI introduced in GLib 2.80; Jammy ships 2.72.
- **`AppRun` deliberately does *not* export `LD_LIBRARY_PATH`.** linuxdeploy already sets `$ORIGIN`-relative RPATH on every binary it deploys, and exporting `LD_LIBRARY_PATH` would leak into every host subprocess — which surfaced immediately when `flatpak` crashed trying to load our bundled libssl 3.0 instead of the host's 3.4. The build script `patchelf`s the RPATH on the pip-installed `_gi.so` / `_dbus*.so` after the linuxdeploy pass, since linuxdeploy only patches the copies it deploys into `usr/lib`, not the originals in `dist-packages/` where Python actually imports them.
- **`PATH` is left untouched** — we deliberately don't prepend `$APPDIR/usr/bin`, so host tools (`xrandr`, `7z`, `wine`, `flatpak`) keep winning, and host subprocesses like `umu-launcher` find host Python (with its host site-packages) via their `#!/usr/bin/env python3` shebangs. The AppImage requires host Python 3.10+ for UMU-based runners; modern distros satisfy this by default.
- **`linuxdeploy-plugin-gtk` is vendored at a pinned commit** with its upstream MIT licence alongside, addressing reviewer feedback that the plugin's upstream has been dormant since 2023. As the first practical use of the vendoring, the plugin's hardcoded `GTK_THEME="Adwaita:light/dark"` is patched out so the AppImage respects the user's actual GTK theme (upstream #39).

## Test plan

- [x] `make appimage` produces `dist/Lutris-0.5.23-x86_64.AppImage` locally on Fedora/podman, ~78 MB
- [x] AppImage boots GUI on Fedora 43 Nobara: window opens, GPU detected, DB loads, GOG/ZOOM service auth works, host GTK theme is respected
- [x] Host subprocess invocations work — Lutris correctly shells out to host `flatpak`, `xrandr`, etc. without `LD_LIBRARY_PATH` or `PYTHONPATH` poisoning
- [x] `workflow_dispatch` run on a personal fork builds + uploads the workflow artifact
- [x] A release event on a personal fork triggers the workflow and successfully attaches the AppImage to the release page
- [x] Maintainer review of design choices listed above
- [ ] First real release post-merge produces the attached AppImage as expected

Refs #6724.
Resolves #5085.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
