### PR TITLE
fix: refresh view after service sync regardless of active service

### DIFF
--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -1129,8 +1129,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
     def on_service_games_loaded(self, service):
         """Request a view update when service games are loaded"""
-        if self.service and service.id == self.service.id:
-            self.update_store()
+        self.update_store()
 
     def on_categories_updated(self):
         self.update_store()


### PR DESCRIPTION
Fixes #4553

When a service finishes syncing, `on_service_games_loaded` only called
`update_store()` if the user was already viewing that specific service's
sidebar row. On the global "Games" view (`self.service is None`) or any
other service's view, the signal was a no-op — newly synced games
wouldn't appear until the user manually switched views and back.

The fix removes the stale guard. `update_store()` is safe to call
unconditionally: it uses a generation counter to coalesce rapid
reloads and cancel stale callbacks. This matches the existing pattern
in `on_categories_updated` and `on_local_library_updated`, which have
never had this guard.