### PR TITLE
fix: give each GOG parallel download worker its own stall monitor

### DIFF
--- a/lutris/gui/dialogs/delegates.py
+++ b/lutris/gui/dialogs/delegates.py
@@ -9,7 +9,7 @@ from lutris.game import Game
 from lutris.gui import dialogs
 from lutris.gui.dialogs.download import DownloadDialog
 from lutris.services import SERVICES
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import BaseDownloader, SimpleDownloader
 
 if TYPE_CHECKING:
     from lutris.config import LaunchConfigDict
@@ -104,7 +104,7 @@ class InstallUIDelegate(Delegate):
 
         The default is to download with no UI, and no option to cancel.
         """
-        downloader = Downloader(url, destination, overwrite=True)
+        downloader = SimpleDownloader(url, destination, overwrite=True)
         downloader.start()
         return downloader.join()
 
@@ -158,7 +158,7 @@ class DialogInstallUIDelegate(InstallUIDelegate):
     def download_install_file(self, url: str, destination: str) -> bool:
         dialog = DownloadDialog(url, destination, parent=self)
         dialog.run()
-        return dialog.downloader.state == Downloader.COMPLETED
+        return dialog.downloader.state == BaseDownloader.COMPLETED
 
 
 class DialogLaunchUIDelegate(LaunchUIDelegate):

--- a/lutris/gui/dialogs/download.py
+++ b/lutris/gui/dialogs/download.py
@@ -4,7 +4,7 @@ from gi.repository import Gtk
 
 from lutris.gui.dialogs import ModalDialog
 from lutris.gui.widgets.download_progress_box import DownloadProgressBox
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import BaseDownloader
 
 
 class DownloadDialog(ModalDialog):
@@ -25,7 +25,7 @@ class DownloadDialog(ModalDialog):
         self.dialog_progress_box.start()
 
     @property
-    def downloader(self) -> Downloader:
+    def downloader(self) -> BaseDownloader:
         return self.dialog_progress_box.downloader
 
     def download_complete(self, _widget, _data):

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -16,7 +16,7 @@ from lutris.game import Game
 from lutris.gui.dialogs import ErrorDialog, ModelessDialog, display_error
 from lutris.gui.widgets.stock_icon_image import StockIconImage
 from lutris.util import jobs, system
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import SimpleDownloader
 from lutris.util.extract import extract_archive
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
@@ -369,7 +369,7 @@ class RunnerInstallDialog(ModelessDialog):
         if not url:
             ErrorDialog(_("Version %s is no longer available") % version, parent=self)
             return
-        downloader = Downloader(url, dest_path, overwrite=True)
+        downloader = SimpleDownloader(url, dest_path, overwrite=True)
         schedule_repeating_at_idle(self.get_progress, downloader, row, interval_seconds=0.1)
         self.installing[version] = downloader
         downloader.start()

--- a/lutris/gui/widgets/download_collection_progress_box.py
+++ b/lutris/gui/widgets/download_collection_progress_box.py
@@ -7,7 +7,7 @@ from gi.repository import GObject, Gtk, Pango
 
 from lutris.gui.dialogs import display_error
 from lutris.util.download_cache import CacheState, create_cache_lock, update_cache_lock
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import BaseDownloader, SimpleDownloader
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
 from lutris.util.strings import gtk_safe, human_size
@@ -51,7 +51,7 @@ class DownloadCollectionProgressBox(Gtk.Box):
         self,
         file_collection: "InstallerFileCollection",
         cancelable: bool = True,
-        downloader: Downloader | None = None,
+        downloader: BaseDownloader | None = None,
     ) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
@@ -135,7 +135,7 @@ class DownloadCollectionProgressBox(Gtk.Box):
             os.remove(tmp_path)
 
         try:
-            downloader_cls = getattr(file, "downloader_class", None) or Downloader
+            downloader_cls = getattr(file, "downloader_class", None) or SimpleDownloader
             dl = downloader_cls(file.url, file.tmp_file, referer=file.referer, overwrite=True)
         except RuntimeError as ex:
             display_error(ex, parent=self.get_toplevel())

--- a/lutris/gui/widgets/download_progress_box.py
+++ b/lutris/gui/widgets/download_progress_box.py
@@ -6,7 +6,7 @@ from gi.repository import GObject, Gtk, Pango
 
 from lutris.gui.dialogs import display_error
 from lutris.util.download_cache import CacheState, create_cache_lock, update_cache_lock
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import BaseDownloader, SimpleDownloader
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
 from lutris.util.strings import gtk_safe, human_size
@@ -29,7 +29,7 @@ class DownloadProgressBox(Gtk.Box):
         referer: str | None = None,
         title: str | None = None,
         cancelable: bool = True,
-        downloader: Downloader | None = None,
+        downloader: BaseDownloader | None = None,
     ) -> None:
         super().__init__(orientation=Gtk.Orientation.VERTICAL)
 
@@ -80,9 +80,9 @@ class DownloadProgressBox(Gtk.Box):
             os.remove(self.temp)
 
     @property
-    def downloader(self) -> Downloader:
+    def downloader(self) -> BaseDownloader:
         if not self._downloader:
-            self._downloader = Downloader(self.url, self.temp, referer=self.referer, overwrite=True)
+            self._downloader = SimpleDownloader(self.url, self.temp, referer=self.referer, overwrite=True)
         return self._downloader
 
     def cancel_download(self):

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -8,7 +8,7 @@ from lutris.cache import get_url_cache_path, has_valid_custom_cache_path, save_t
 from lutris.gui.widgets.download_progress_box import DownloadProgressBox
 from lutris.installer.errors import ScriptingError
 from lutris.util import system
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import BaseDownloader
 from lutris.util.log import logger
 from lutris.util.strings import gtk_safe_urls
 
@@ -86,7 +86,7 @@ class InstallerFile:
             return self._file_meta.get("referer")
 
     @property
-    def downloader(self) -> Downloader | None:
+    def downloader(self) -> BaseDownloader | None:
         """Return custom downloader instance, if one was provided."""
         if callable(self._downloader):
             self._downloader = self._downloader(self)
@@ -99,7 +99,7 @@ class InstallerFile:
 
         Services can specify a 'downloader_class' in _file_meta to use
         a specialized downloader (e.g., GOGDownloader for parallel downloads)
-        instead of the default Downloader.
+        instead of the default SimpleDownloader.
         """
         if isinstance(self._file_meta, dict):
             return self._file_meta.get("downloader_class")

--- a/lutris/runners/pico8.py
+++ b/lutris/runners/pico8.py
@@ -12,7 +12,7 @@ from lutris.database.games import get_game_by_field
 from lutris.exceptions import MissingGameExecutableError
 from lutris.runners.runner import Runner
 from lutris.util import system
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import BaseDownloader, SimpleDownloader
 from lutris.util.log import logger
 from lutris.util.strings import split_arguments
 
@@ -168,7 +168,7 @@ class pico8(Runner):
                         os.remove(cartPath + ".download")
                     downloadCompleted = True
 
-                dl = Downloader(
+                dl = SimpleDownloader(
                     downloadUrl,
                     cartPath + ".download",
                     True,
@@ -178,7 +178,7 @@ class pico8(Runner):
 
                 # Wait for download to complete or continue if it exists (to work in offline mode)
                 while not os.path.exists(cartPath):
-                    if downloadCompleted or dl.state == Downloader.ERROR:
+                    if downloadCompleted or dl.state == BaseDownloader.ERROR:
                         logger.error("Could not download cartridge from %s", downloadUrl)
                         return False
                     sleep(0.1)
@@ -193,7 +193,7 @@ class pico8(Runner):
             if not os.path.exists(enginePath):
                 downloadUrl = "https://www.lexaloffle.com/bbs/" + self.runner_config.get("engine") + ".js"
                 system.create_folder(os.path.dirname(enginePath))
-                dl = Downloader(downloadUrl, enginePath, True)
+                dl = SimpleDownloader(downloadUrl, enginePath, True)
                 dl.start()
                 dl.join()
 

--- a/lutris/runtime.py
+++ b/lutris/runtime.py
@@ -16,7 +16,7 @@ from lutris.api import (
 )
 from lutris.gui.widgets.progress_box import ProgressInfo
 from lutris.util import http, system
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import SimpleDownloader
 from lutris.util.extract import extract_archive
 from lutris.util.jobs import AsyncCall
 from lutris.util.linux import LINUX_SYSTEM
@@ -319,7 +319,7 @@ class RuntimeExtractedComponentUpdater(RuntimeComponentUpdater):
     def __init__(self, remote_runtime_info: dict[str, Any]) -> None:
         super().__init__(remote_runtime_info)
         self.url = remote_runtime_info["url"]
-        self.downloader: Downloader | None = None
+        self.downloader: SimpleDownloader | None = None
         self.complete_event = threading.Event()
 
     def get_progress(self) -> ProgressInfo:
@@ -340,7 +340,7 @@ class RuntimeExtractedComponentUpdater(RuntimeComponentUpdater):
         self.complete_event.clear()
 
         archive_path = self.archive_path
-        self.downloader = Downloader(self.url, archive_path, overwrite=True)
+        self.downloader = SimpleDownloader(self.url, archive_path, overwrite=True)
         self.downloader.start()
         self.downloader.join()
         self.downloader = None

--- a/lutris/services/gamejolt.py
+++ b/lutris/services/gamejolt.py
@@ -13,7 +13,7 @@ from lutris.runners import get_runner_human_name
 from lutris.services.base import SERVICE_LOGIN, OnlineService
 from lutris.services.service_game import ServiceGame
 from lutris.services.service_media import ServiceMedia
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import SimpleDownloader
 from lutris.util.http import HTTPError, Request
 from lutris.util.log import logger
 from lutris.util.strings import slugify
@@ -422,7 +422,7 @@ class GameJoltService(OnlineService):
                 {
                     "url": download_url,
                     "filename": filename,
-                    "downloader": lambda f, url=download_url, headers=cookie_headers: Downloader(
+                    "downloader": lambda f, url=download_url, headers=cookie_headers: SimpleDownloader(
                         url, f.download_file, overwrite=True, headers=headers
                     ),
                 },

--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -20,7 +20,7 @@ from lutris.services.base import SERVICE_LOGIN, OnlineService
 from lutris.services.service_game import ServiceGame
 from lutris.services.service_media import ServiceMedia
 from lutris.util import linux
-from lutris.util.downloader import Downloader
+from lutris.util.downloader import SimpleDownloader
 from lutris.util.http import HTTPError, Request, UnauthorizedAccessError
 from lutris.util.log import logger
 from lutris.util.strings import slugify
@@ -684,7 +684,7 @@ class ItchIoService(OnlineService):
                         "itchupload": {
                             "url": patch_url,
                             "filename": "update.zip",
-                            "downloader": lambda f, url=patch_url: Downloader(
+                            "downloader": lambda f, url=patch_url: SimpleDownloader(
                                 url, f.download_file, overwrite=True, headers=self.get_headers()
                             ),
                         }
@@ -783,7 +783,7 @@ class ItchIoService(OnlineService):
                     {
                         "url": link,
                         "filename": filename or file.filename or "setup.zip",
-                        "downloader": lambda f, url=link: Downloader(
+                        "downloader": lambda f, url=link: SimpleDownloader(
                             url, f.download_file, overwrite=True, headers=self.get_headers()
                         ),
                     },
@@ -816,7 +816,7 @@ class ItchIoService(OnlineService):
                     {
                         "url": link,
                         "filename": upload["filename"],
-                        "downloader": lambda f, url=link: Downloader(
+                        "downloader": lambda f, url=link: SimpleDownloader(
                             url, f.download_file, overwrite=True, headers=self.get_headers()
                         ),
                     },

--- a/lutris/util/downloader.py
+++ b/lutris/util/downloader.py
@@ -1,3 +1,4 @@
+import abc
 import bisect
 import os
 import threading
@@ -37,12 +38,73 @@ class DownloadStallError(Exception):
         super().__init__("Download stalled: %.1f B/s for %.1f seconds" % (throughput, duration))
 
 
-class Downloader:
-    """Non-blocking downloader.
+class StallMonitor:
+    """Tracks throughput for a single download stream and detects stalls.
+
+    A monitor holds a mutable throughput window (the time and byte count at
+    which the current window opened). This state is *not* safe to share
+    between threads: each stream — including each parallel worker in
+    GOGDownloader — must use its own StallMonitor, otherwise one stream's
+    byte counter pollutes another's window and produces nonsensical
+    (even negative) throughput readings.
+    """
+
+    def __init__(self, low_speed_limit: int, low_speed_time: int) -> None:
+        self.low_speed_limit = low_speed_limit  # bytes/second
+        self.low_speed_time = low_speed_time  # seconds below threshold before triggering
+        self.window_start: float | None = None  # monotonic time when speed first dropped
+        self.bytes_at_window_start: int = 0  # stream bytes when the window opened
+
+    def check(self, bytes_received_total: int) -> None:
+        """Check if the stream has stalled and raise DownloadStallError if so.
+
+        Tracks a rolling throughput window. When throughput drops below
+        ``low_speed_limit`` for longer than ``low_speed_time``, raises
+        DownloadStallError to trigger a retry.
+
+        Args:
+            bytes_received_total: Total bytes received so far on *this*
+                stream. Must come from a counter owned by the calling
+                stream, never a value shared across workers.
+        """
+        now = get_time()
+
+        if self.window_start is None:
+            # Not currently in a stall window — start one
+            self.window_start = now
+            self.bytes_at_window_start = bytes_received_total
+            return
+
+        elapsed = now - self.window_start
+        if elapsed <= 0:
+            return
+
+        bytes_in_window = bytes_received_total - self.bytes_at_window_start
+        throughput = bytes_in_window / elapsed
+
+        if throughput >= self.low_speed_limit:
+            # Speed is good — reset the window
+            self.window_start = now
+            self.bytes_at_window_start = bytes_received_total
+            return
+
+        # Speed is below threshold — check if we've exceeded the time limit
+        if elapsed >= self.low_speed_time:
+            raise DownloadStallError(throughput=throughput, duration=elapsed)
+
+
+class BaseDownloader(abc.ABC):
+    """Non-blocking downloader framework — the public interface.
 
     Do start() then check_progress() at regular intervals.
     Download is done when check_progress() returns 1.0.
     Stop with cancel().
+
+    This base owns everything that is independent of *how* the bytes are
+    fetched: the state machine, progress/speed statistics, the retry loop,
+    and stall-detection configuration. Concrete subclasses (SimpleDownloader,
+    GOGDownloader) implement the actual transfer in async_download() and
+    release any transfer-specific resources in _release_resources().
     """
 
     (INIT, DOWNLOADING, CANCELLED, ERROR, COMPLETED) = list(range(5))
@@ -89,66 +151,33 @@ class Downloader:
         self.last_speeds = []
         self.speed_check_time = 0
         self.time_left_check_time = 0
-        self.file_pointer = None
         self.progress_event = threading.Event()
-
-        # Stall detection state
-        self._stall_start: float | None = None  # monotonic time when speed first dropped
-        self._stall_bytes_at_start: int = 0  # downloaded_size when stall window started
-
-    def _reset_stall_state(self) -> None:
-        """Reset stall detection tracking (call at start of each download attempt)."""
-        self._stall_start = None
-        self._stall_bytes_at_start = 0
-
-    def _check_stall(self, bytes_received_total: int) -> None:
-        """Check if download has stalled and raise DownloadStallError if so.
-
-        Tracks a rolling throughput window. When throughput drops below
-        LOW_SPEED_LIMIT for longer than LOW_SPEED_TIME, raises
-        DownloadStallError to trigger a retry.
-
-        Args:
-            bytes_received_total: Total bytes received so far in this
-                download stream (not self.downloaded_size, which may be
-                shared across workers).
-        """
-        now = get_time()
-
-        if self._stall_start is None:
-            # Not currently in a stall window — start one
-            self._stall_start = now
-            self._stall_bytes_at_start = bytes_received_total
-            return
-
-        elapsed = now - self._stall_start
-        if elapsed <= 0:
-            return
-
-        bytes_in_window = bytes_received_total - self._stall_bytes_at_start
-        throughput = bytes_in_window / elapsed
-
-        if throughput >= self.LOW_SPEED_LIMIT:
-            # Speed is good — reset the window
-            self._stall_start = now
-            self._stall_bytes_at_start = bytes_received_total
-            return
-
-        # Speed is below threshold — check if we've exceeded the time limit
-        if elapsed >= self.LOW_SPEED_TIME:
-            raise DownloadStallError(throughput=throughput, duration=elapsed)
 
     def __repr__(self):
         return "downloader for %s" % self.url
 
+    @property
+    def _log_name(self) -> str:
+        """Identifier used in lifecycle log lines.
+
+        Subclasses can override to surface details (e.g. GOG's worker count)
+        so log-grepping for a given download mode keeps working."""
+        return self.url
+
+    def _new_stall_monitor(self) -> StallMonitor:
+        """Create a fresh stall monitor for a single download stream.
+
+        Each stream must own its monitor — see StallMonitor — so this is a
+        factory rather than shared state on the downloader.
+        """
+        return StallMonitor(self.LOW_SPEED_LIMIT, self.LOW_SPEED_TIME)
+
     def start(self):
-        """Start download job."""
-        logger.debug("⬇ %s", self.url)
+        """Start the download on a background thread."""
+        logger.debug("⬇ %s", self._log_name)
         self.state = self.DOWNLOADING
         self.last_check_time = get_time()
-        if self.overwrite and os.path.isfile(self.dest):
-            os.remove(self.dest)
-        self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
+        self._prepare_destination()
         self.thread = jobs.AsyncCall(self.async_download, None)
         self.stop_request = self.thread.stop_request
 
@@ -167,7 +196,6 @@ class Downloader:
         self.last_speeds = []
         self.speed_check_time = 0
         self.time_left_check_time = 0
-        self.file_pointer = None
 
     def check_progress(self, blocking=False):
         """Append last downloaded chunk to dest file and store stats.
@@ -182,7 +210,7 @@ class Downloader:
             self.get_stats()
         return self.progress_fraction
 
-    def join(self, progress_callback: Callable[["Downloader"], None] | None = None) -> bool:
+    def join(self, progress_callback: Callable[["BaseDownloader"], None] | None = None) -> bool:
         """Blocks waiting for the download to complete.
 
         'progress_callback' is invoked repeatedly as the download
@@ -200,18 +228,145 @@ class Downloader:
 
     def cancel(self):
         """Request download stop and remove destination file."""
-        logger.debug("❌ %s", self.url)
+        logger.debug("❌ %s", self._log_name)
         self.state = self.CANCELLED
         if self.stop_request:
             self.stop_request.set()
-        if self.file_pointer:
-            self.file_pointer.close()
-            self.file_pointer = None
+        self._release_resources()
+        # The user gave up on this download — drop any resumable state too.
+        self._discard_persistent_state()
         if os.path.isfile(self.dest):
             os.remove(self.dest)
 
-    def async_download(self):
-        """Execute download with stall detection and retry logic.
+    # ------------------------------------------------------------------
+    # Transfer hooks — implemented by concrete downloaders
+    # ------------------------------------------------------------------
+
+    @abc.abstractmethod
+    def _prepare_destination(self) -> None:
+        """Prepare the destination before the transfer thread starts.
+
+        Called on the calling thread from start(). Subclasses set up whatever
+        the transfer needs (e.g. opening the output file)."""
+
+    @abc.abstractmethod
+    def async_download(self) -> None:
+        """Run the transfer to completion on the background thread.
+
+        Implementations must drive the download, then call
+        on_download_completed() on success or on_download_failed() on error."""
+
+    def _release_resources(self) -> None:  # noqa: B027
+        """Release transient transfer resources (e.g. an open file handle).
+
+        Called on every terminal path — completion, failure, and cancel. The
+        default does nothing; subclasses override when they hold resources."""
+
+    def _discard_persistent_state(self) -> None:  # noqa: B027
+        """Drop on-disk state that would let the download resume later.
+
+        Called only on completion and cancel — NOT on failure, where the state
+        is deliberately kept so the next attempt can resume. The default does
+        nothing; subclasses with resumable progress override it."""
+
+    def on_download_failed(self, error: Exception):
+        # Cancelling closes the file, which can result in an
+        # error. If so, we just remain cancelled.
+        if self.state != self.CANCELLED:
+            self.state = self.ERROR
+            self.error = error
+        # Keep any resumable progress: the next attempt should resume, not
+        # restart. Only release the transient handles.
+        self._release_resources()
+
+    def on_download_completed(self):
+        if self.state == self.CANCELLED:
+            return
+
+        logger.debug("Finished downloading %s", self._log_name)
+        if not self.downloaded_size:
+            logger.warning("Downloaded file is empty")
+
+        if not self.full_size:
+            self.progress_fraction = 1.0
+            self.progress_percentage = 100
+        self.state = self.COMPLETED
+        self._release_resources()
+        # Download is complete — the resumable state is no longer needed.
+        self._discard_persistent_state()
+
+    def get_stats(self):
+        """Calculate and store download stats."""
+        self.average_speed = self.get_speed()
+        self.time_left = self.get_average_time_left()
+        self.last_check_time = get_time()
+        self.last_size = self.downloaded_size
+
+        if self.full_size:
+            self.progress_fraction = float(self.downloaded_size) / float(self.full_size)
+            self.progress_percentage = self.progress_fraction * 100
+
+    def get_speed(self):
+        """Return the average speed of the download so far."""
+        elapsed_time = get_time() - self.last_check_time
+        if elapsed_time > 0:
+            chunk_size = self.downloaded_size - self.last_size
+            speed = chunk_size / elapsed_time or 1
+            # insert in sorted order, so we can omit the least and
+            # greatest value later
+            bisect.insort(self.last_speeds, speed)
+
+        # Until we get the first sample, just return our default
+        if not self.last_speeds:
+            return self.average_speed
+
+        if get_time() - self.speed_check_time < 1:  # Minimum delay
+            return self.average_speed
+
+        while len(self.last_speeds) > 20:
+            self.last_speeds.pop(0)
+
+        if len(self.last_speeds) > 7:
+            # Skip extreme values
+            samples = self.last_speeds[1:-1]
+        else:
+            samples = self.last_speeds[:]
+
+        average_speed = sum(samples) / len(samples)
+
+        self.speed_check_time = get_time()
+        return average_speed
+
+    def get_average_time_left(self) -> str:
+        """Return average download time left as string."""
+        if not self.full_size:
+            return "???"
+
+        elapsed_time = get_time() - self.time_left_check_time
+        if elapsed_time < 1:  # Minimum delay
+            return self.time_left
+
+        average_time_left = (self.full_size - self.downloaded_size) / self.average_speed
+        minutes, seconds = divmod(average_time_left, 60)
+        hours, minutes = divmod(minutes, 60)
+        self.time_left_check_time = get_time()
+        return "%d:%02d:%02d" % (hours, minutes, seconds)
+
+
+class SimpleDownloader(BaseDownloader):
+    """Single-connection downloader: fetches the whole file in one stream."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+        self.file_pointer = None
+
+    def _prepare_destination(self) -> None:
+        if self.overwrite and os.path.isfile(self.dest):
+            os.remove(self.dest)
+        self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
+
+    def async_download(self) -> None:
+        """Run the single-stream transfer with stall detection and retries.
 
         Retries up to RETRY_ATTEMPTS times on stalls and transient errors.
         Non-retryable errors (HTTP 4xx except 408/429) fail immediately.
@@ -278,7 +433,19 @@ class Downloader:
             logger.error("Download failed after %d attempts: %s", self.RETRY_ATTEMPTS, last_error)
             self.on_download_failed(last_error)
 
-    def _do_download(self):
+    @staticmethod
+    def _is_retryable_http_error(error: requests.HTTPError) -> bool:
+        """Check if an HTTP error is transient and worth retrying.
+
+        Retries on server errors (5xx), timeouts (408), and rate limits (429).
+        Client errors like 404, 403 are not retried.
+        """
+        if error.response is None:
+            return True  # No response means connection-level failure
+        status = error.response.status_code
+        return status >= 500 or status in (408, 429)
+
+    def _do_download(self) -> None:
         """Perform a single download attempt with stall detection."""
         headers = requests.utils.default_headers()
         headers["User-Agent"] = "Lutris/%s" % __version__
@@ -297,7 +464,8 @@ class Downloader:
         self.full_size = int(response.headers.get("Content-Length", "").strip() or 0)
         self.progress_event.set()
 
-        self._reset_stall_state()
+        # A fresh stall monitor per attempt — see StallMonitor.
+        stall_monitor = self._new_stall_monitor()
         stream_bytes = 0
 
         for chunk in response.iter_content(chunk_size=self.chunk_size):
@@ -309,110 +477,17 @@ class Downloader:
                 stream_bytes += len(chunk)
                 self.downloaded_size += len(chunk)
                 self.file_pointer.write(chunk)
-                self._check_stall(stream_bytes)
+                stall_monitor.check(stream_bytes)
             self.progress_event.set()
 
-    def _prepare_retry(self):
-        """Prepare state for a retry attempt.
-
-        Resets stall tracking and restarts the file from the beginning.
-        """
-        self._reset_stall_state()
+    def _prepare_retry(self) -> None:
+        """Restart the file from the beginning for a retry attempt."""
         self.downloaded_size = 0
         if self.file_pointer:
             self.file_pointer.close()
         self.file_pointer = open(self.dest, "wb")  # pylint: disable=consider-using-with
 
-    @staticmethod
-    def _is_retryable_http_error(error: requests.HTTPError) -> bool:
-        """Check if an HTTP error is transient and worth retrying.
-
-        Retries on server errors (5xx), timeouts (408), and rate limits (429).
-        Client errors like 404, 403 are not retried.
-        """
-        if error.response is None:
-            return True  # No response means connection-level failure
-        status = error.response.status_code
-        return status >= 500 or status in (408, 429)
-
-    def on_download_failed(self, error: Exception):
-        # Cancelling closes the file, which can result in an
-        # error. If so, we just remain cancelled.
-        if self.state != self.CANCELLED:
-            self.state = self.ERROR
-            self.error = error
+    def _release_resources(self) -> None:
         if self.file_pointer:
             self.file_pointer.close()
             self.file_pointer = None
-
-    def on_download_completed(self):
-        if self.state == self.CANCELLED:
-            return
-
-        logger.debug("Finished downloading %s", self.url)
-        if not self.downloaded_size:
-            logger.warning("Downloaded file is empty")
-
-        if not self.full_size:
-            self.progress_fraction = 1.0
-            self.progress_percentage = 100
-        self.state = self.COMPLETED
-        self.file_pointer.close()
-        self.file_pointer = None
-
-    def get_stats(self):
-        """Calculate and store download stats."""
-        self.average_speed = self.get_speed()
-        self.time_left = self.get_average_time_left()
-        self.last_check_time = get_time()
-        self.last_size = self.downloaded_size
-
-        if self.full_size:
-            self.progress_fraction = float(self.downloaded_size) / float(self.full_size)
-            self.progress_percentage = self.progress_fraction * 100
-
-    def get_speed(self):
-        """Return the average speed of the download so far."""
-        elapsed_time = get_time() - self.last_check_time
-        if elapsed_time > 0:
-            chunk_size = self.downloaded_size - self.last_size
-            speed = chunk_size / elapsed_time or 1
-            # insert in sorted order, so we can omit the least and
-            # greatest value later
-            bisect.insort(self.last_speeds, speed)
-
-        # Until we get the first sample, just return our default
-        if not self.last_speeds:
-            return self.average_speed
-
-        if get_time() - self.speed_check_time < 1:  # Minimum delay
-            return self.average_speed
-
-        while len(self.last_speeds) > 20:
-            self.last_speeds.pop(0)
-
-        if len(self.last_speeds) > 7:
-            # Skip extreme values
-            samples = self.last_speeds[1:-1]
-        else:
-            samples = self.last_speeds[:]
-
-        average_speed = sum(samples) / len(samples)
-
-        self.speed_check_time = get_time()
-        return average_speed
-
-    def get_average_time_left(self) -> str:
-        """Return average download time left as string."""
-        if not self.full_size:
-            return "???"
-
-        elapsed_time = get_time() - self.time_left_check_time
-        if elapsed_time < 1:  # Minimum delay
-            return self.time_left
-
-        average_time_left = (self.full_size - self.downloaded_size) / self.average_speed
-        minutes, seconds = divmod(average_time_left, 60)
-        hours, minutes = divmod(minutes, 60)
-        self.time_left_check_time = get_time()
-        return "%d:%02d:%02d" % (hours, minutes, seconds)

--- a/lutris/util/gog_downloader.py
+++ b/lutris/util/gog_downloader.py
@@ -4,8 +4,8 @@ Uses HTTP Range requests to download different byte ranges of a file
 simultaneously across multiple threads, significantly improving download
 speeds for large GOG installer files.
 
-This downloader is a drop-in replacement for the standard Downloader class,
-maintaining API compatibility with DownloadProgressBox and
+This downloader shares the BaseDownloader public interface with
+SimpleDownloader, maintaining API compatibility with DownloadProgressBox and
 DownloadCollectionProgressBox.
 """
 
@@ -20,13 +20,12 @@ import requests
 from requests.adapters import HTTPAdapter
 
 from lutris import __version__
-from lutris.util import jobs
 from lutris.util.download_progress import DownloadProgress
-from lutris.util.downloader import DEFAULT_CHUNK_SIZE, Downloader, get_time
+from lutris.util.downloader import DEFAULT_CHUNK_SIZE, BaseDownloader
 from lutris.util.log import logger
 
 
-class GOGDownloader(Downloader):
+class GOGDownloader(BaseDownloader):
     """Multi-connection parallel downloader optimized for GOG CDN downloads.
 
     Downloads large files using multiple simultaneous HTTP Range requests,
@@ -34,8 +33,8 @@ class GOGDownloader(Downloader):
     single-stream download if the server doesn't support Range requests
     or the file is too small to benefit from parallelism.
 
-    Designed to be API-compatible with Downloader so it works seamlessly
-    with DownloadProgressBox and DownloadCollectionProgressBox.
+    Shares the BaseDownloader public interface with SimpleDownloader so it
+    works seamlessly with DownloadProgressBox and DownloadCollectionProgressBox.
     """
 
     DEFAULT_WORKERS = 4
@@ -82,18 +81,18 @@ class GOGDownloader(Downloader):
     def __repr__(self):
         return "GOG parallel downloader (%d workers) for %s" % (self.num_workers, self.url)
 
-    def start(self):
-        """Start parallel download job.
+    @property
+    def _log_name(self) -> str:
+        return "GOG parallel (%d workers): %s" % (self.num_workers, self.url)
+
+    def _prepare_destination(self) -> None:
+        """Detect resumable progress, or clear stale files for a fresh start.
 
         If a previous download was interrupted (hibernate, crash, network
-        error), the progress file and partial destination file are detected
-        and the download resumes from the last completed byte ranges
+        error), the progress file and partial destination file are detected so
+        async_download() can resume from the last completed byte ranges
         instead of starting over.
         """
-        logger.debug("⬇ GOG parallel (%d workers): %s", self.num_workers, self.url)
-        self.state = self.DOWNLOADING
-        self.last_check_time = get_time()
-
         # Check for resumable progress before deleting anything
         can_resume = False
         if os.path.isfile(self.dest):
@@ -116,42 +115,13 @@ class GOGDownloader(Downloader):
             if os.path.isfile(progress_path):
                 os.remove(progress_path)
 
-        # Workers manage their own file I/O - no shared file_pointer needed
-        self.file_pointer = None
-        self.thread = jobs.AsyncCall(self.async_download, None)
-        self.stop_request = self.thread.stop_request
+    def _discard_persistent_state(self) -> None:
+        """Remove the progress sidecar file.
 
-    def cancel(self):
-        """Request download stop and remove destination file.
-
-        Explicit user cancellation removes both the partial file and
-        the progress file so the next attempt starts fresh.
-        """
-        logger.debug("❌ GOG parallel: %s", self.url)
-        self.state = self.CANCELLED
-        if self.stop_request:
-            self.stop_request.set()
-        # No shared file_pointer to close - workers handle their own
-        if os.path.isfile(self.dest):
-            os.remove(self.dest)
-        # Clean up progress file on explicit cancel
-        if self._progress:
-            self._progress.cleanup()
-            self._progress = None
-
-    def on_download_completed(self):
-        """Mark download as complete and clean up progress file."""
-        if self.state == self.CANCELLED:
-            return
-        logger.debug("✅ GOG parallel download finished: %s", self.url)
-        if not self.downloaded_size:
-            logger.warning("Downloaded file is empty")
-        if not self.full_size:
-            self.progress_fraction = 1.0
-            self.progress_percentage = 100
-        self.state = self.COMPLETED
-        # No shared file_pointer to close
-        # Remove progress file — download is complete
+        Workers manage their own file I/O, so there is no shared file handle to
+        release. The progress file is resumable state, so the base only calls
+        this on completion and cancel — on failure it is kept for the next
+        attempt to resume from."""
         if self._progress:
             self._progress.cleanup()
             self._progress = None
@@ -437,8 +407,11 @@ class GOGDownloader(Downloader):
                     self._write_from_full_response(response, start, end)
                     return
 
-                # Normal 206 Partial Content response — enqueue for writer
-                self._reset_stall_state()
+                # Normal 206 Partial Content response — enqueue for writer.
+                # Each worker keeps its own stall monitor: the shared
+                # instance-level window would be clobbered by sibling
+                # workers feeding their own byte counters into it.
+                stall_monitor = self._new_stall_monitor()
                 stream_bytes = 0
                 current_offset = start
                 range_size = end - start + 1
@@ -456,7 +429,7 @@ class GOGDownloader(Downloader):
                         range_end_marker = end if is_last_chunk else None
                         self._write_queue.put((current_offset, chunk, start, range_end_marker))
                         current_offset += len(chunk)
-                        self._check_stall(stream_bytes)
+                        stall_monitor.check(stream_bytes)
 
                 return  # Success
 
@@ -488,6 +461,7 @@ class GOGDownloader(Downloader):
         current_offset = start
         range_size = end - start + 1
         enqueued_bytes = 0
+        stall_monitor = self._new_stall_monitor()
 
         for chunk in response.iter_content(chunk_size=self.chunk_size):
             if self.stop_request and self.stop_request.is_set():
@@ -517,6 +491,7 @@ class GOGDownloader(Downloader):
                 is_last = enqueued_bytes >= range_size
                 self._write_queue.put((current_offset, data, start, end if is_last else None))
                 current_offset += len(data)
+                stall_monitor.check(enqueued_bytes)
 
             bytes_read += len(chunk)
             if bytes_read >= end + 1:

--- a/tests/util/_test_collection_progress.py
+++ b/tests/util/_test_collection_progress.py
@@ -219,7 +219,7 @@ class TestInit:
 
 class TestCreateDownloader:
     @patch("lutris.gui.widgets.download_collection_progress_box.create_cache_lock")
-    @patch("lutris.gui.widgets.download_collection_progress_box.Downloader")
+    @patch("lutris.gui.widgets.download_collection_progress_box.SimpleDownloader")
     @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=False)
     def test_creates_downloader_with_correct_args(self, mock_exists, MockDL, mock_lock):
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
@@ -236,7 +236,7 @@ class TestCreateDownloader:
         assert f.tmp_file == "/tmp/dl/f.bin.tmp"
 
     @patch("lutris.gui.widgets.download_collection_progress_box.create_cache_lock")
-    @patch("lutris.gui.widgets.download_collection_progress_box.Downloader")
+    @patch("lutris.gui.widgets.download_collection_progress_box.SimpleDownloader")
     @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=True)
     @patch("lutris.gui.widgets.download_collection_progress_box.os.remove")
     def test_removes_existing_tmp_file(self, mock_remove, mock_exists, MockDL, mock_lock):
@@ -265,7 +265,7 @@ class TestCreateDownloader:
         f = _make_file(dest="/tmp/dl/f.bin")
         # Simulate no downloader_class → use default Downloader which will fail
         with patch(
-            "lutris.gui.widgets.download_collection_progress_box.Downloader",
+            "lutris.gui.widgets.download_collection_progress_box.SimpleDownloader",
             side_effect=RuntimeError("oops"),
         ):
             result = box._create_downloader(f)

--- a/tests/util/_test_download_cache.py
+++ b/tests/util/_test_download_cache.py
@@ -260,29 +260,29 @@ class TestDownloaderChunkSize:
     """Test that the Downloader uses the new chunk size."""
 
     def test_default_chunk_size(self):
-        from lutris.util.downloader import DEFAULT_CHUNK_SIZE, Downloader
+        from lutris.util.downloader import DEFAULT_CHUNK_SIZE, SimpleDownloader
 
-        d = Downloader("http://example.com/test", "/tmp/test")
+        d = SimpleDownloader("http://example.com/test", "/tmp/test")
         assert d.chunk_size == DEFAULT_CHUNK_SIZE
         assert d.chunk_size == 524288  # 512KB
 
     def test_custom_chunk_size(self):
-        from lutris.util.downloader import Downloader
+        from lutris.util.downloader import SimpleDownloader
 
-        d = Downloader("http://example.com/test", "/tmp/test", chunk_size=1024)
+        d = SimpleDownloader("http://example.com/test", "/tmp/test", chunk_size=1024)
         assert d.chunk_size == 1024
 
     def test_session_parameter(self):
         import requests
 
-        from lutris.util.downloader import Downloader
+        from lutris.util.downloader import SimpleDownloader
 
         session = requests.Session()
-        d = Downloader("http://example.com/test", "/tmp/test", session=session)
+        d = SimpleDownloader("http://example.com/test", "/tmp/test", session=session)
         assert d.session is session
 
     def test_no_session_by_default(self):
-        from lutris.util.downloader import Downloader
+        from lutris.util.downloader import SimpleDownloader
 
-        d = Downloader("http://example.com/test", "/tmp/test")
+        d = SimpleDownloader("http://example.com/test", "/tmp/test")
         assert d.session is None

--- a/tests/util/_test_gog_downloader.py
+++ b/tests/util/_test_gog_downloader.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from lutris.util.download_progress import DownloadProgress
-from lutris.util.downloader import DEFAULT_CHUNK_SIZE, Downloader
+from lutris.util.downloader import DEFAULT_CHUNK_SIZE, BaseDownloader
 from lutris.util.gog_downloader import GOGDownloader
 
 
@@ -16,8 +16,8 @@ class TestGOGDownloaderInit:
     """Test GOGDownloader initialization."""
 
     def test_inherits_from_downloader(self):
-        """GOGDownloader must be a Downloader subclass for API compat."""
-        assert issubclass(GOGDownloader, Downloader)
+        """GOGDownloader must share the BaseDownloader interface for API compat."""
+        assert issubclass(GOGDownloader, BaseDownloader)
 
     def test_default_workers(self):
         dl = GOGDownloader("https://example.com/file.bin", "/tmp/test.bin")
@@ -915,7 +915,7 @@ class TestResumeStartMethod:
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, overwrite=True, num_workers=2)
 
         # Patch AsyncCall so start() doesn't actually launch a thread
-        with patch("lutris.util.gog_downloader.jobs.AsyncCall") as mock_async:
+        with patch("lutris.util.downloader.jobs.AsyncCall") as mock_async:
             mock_thread = MagicMock()
             mock_thread.stop_request = threading.Event()
             mock_async.return_value = mock_thread
@@ -934,7 +934,7 @@ class TestResumeStartMethod:
 
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, overwrite=True, num_workers=2)
 
-        with patch("lutris.util.gog_downloader.jobs.AsyncCall") as mock_async:
+        with patch("lutris.util.downloader.jobs.AsyncCall") as mock_async:
             mock_thread = MagicMock()
             mock_thread.stop_request = threading.Event()
             mock_async.return_value = mock_thread

--- a/tests/util/_test_pipelining.py
+++ b/tests/util/_test_pipelining.py
@@ -3,7 +3,6 @@
 import os
 import queue
 import threading
-import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -162,6 +161,14 @@ class TestGOGDownloaderStallDetection:
         with open(dest, "wb") as f:
             f.truncate(1000)
 
+        # Controllable monotonic clock. The test advances it explicitly, so
+        # the result does not depend on how many times StallMonitor samples
+        # the clock per check.
+        now = [0.0]
+
+        def fake_time():
+            return now[0]
+
         # Create a mock response that simulates a stall then success
         call_count = [0]
 
@@ -171,11 +178,15 @@ class TestGOGDownloaderStallDetection:
             mock_response.status_code = 206
 
             if call_count[0] == 1:
-                # First attempt: simulate stall by manipulating stall state
+                # First attempt: the first chunk opens the worker's stall
+                # window at t=0; we then advance the clock well past
+                # LOW_SPEED_TIME before the second chunk, so its near-zero
+                # throughput registers as a stall.
                 def slow_iter(chunk_size=None):
-                    dl._stall_start = time.monotonic() - 35  # 35 seconds ago
-                    dl._stall_bytes_at_start = 0
-                    yield b"x"  # Tiny chunk triggers stall check
+                    now[0] = 0.0
+                    yield b"x"
+                    now[0] = dl.LOW_SPEED_TIME + 5.0
+                    yield b"x"
 
                 mock_response.iter_content = slow_iter
             else:
@@ -192,7 +203,9 @@ class TestGOGDownloaderStallDetection:
         headers = dl._build_request_headers()
 
         with patch.object(dl._write_queue, "put"):
-            dl._download_range("https://example.com/file.bin", headers, 0, 999)
+            with patch("lutris.util.downloader.get_time", fake_time):
+                with patch("lutris.util.gog_downloader.time.sleep", MagicMock()):
+                    dl._download_range("https://example.com/file.bin", headers, 0, 999)
 
         # Verify retry occurred
         assert call_count[0] >= 2

--- a/tests/util/_test_stall_detection.py
+++ b/tests/util/_test_stall_detection.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from lutris.util.downloader import Downloader, DownloadStallError, get_time
+from lutris.util.downloader import BaseDownloader, DownloadStallError, SimpleDownloader, StallMonitor, get_time
 
 
 class TestDownloadStallError:
@@ -35,90 +35,125 @@ class TestDownloadStallError:
 
 
 class TestCheckStall:
-    """Test the _check_stall() method on Downloader."""
+    """Test the throughput-window logic in StallMonitor."""
 
-    def _make_downloader(self):
-        dl = Downloader("https://example.com/file.bin", "/tmp/test.bin")
-        dl._reset_stall_state()
-        return dl
+    def _make_monitor(self):
+        return StallMonitor(BaseDownloader.LOW_SPEED_LIMIT, BaseDownloader.LOW_SPEED_TIME)
 
     def test_first_call_initializes_window(self):
         """First call should set the stall window start, not raise."""
-        dl = self._make_downloader()
+        monitor = self._make_monitor()
         # Should not raise
-        dl._check_stall(1000)
-        assert dl._stall_start is not None
-        assert dl._stall_bytes_at_start == 1000
+        monitor.check(1000)
+        assert monitor.window_start is not None
+        assert monitor.bytes_at_window_start == 1000
 
     def test_good_throughput_resets_window(self):
         """When throughput is above threshold, the stall window resets."""
-        dl = self._make_downloader()
-        dl._stall_start = get_time() - 5.0  # 5 seconds ago
-        dl._stall_bytes_at_start = 0
+        monitor = self._make_monitor()
+        monitor.window_start = get_time() - 5.0  # 5 seconds ago
+        monitor.bytes_at_window_start = 0
         # 10000 bytes in 5 seconds = 2000 B/s — well above 200 B/s
-        dl._check_stall(10000)
+        monitor.check(10000)
         # Window should have been reset
-        assert dl._stall_bytes_at_start == 10000
+        assert monitor.bytes_at_window_start == 10000
 
     def test_low_throughput_does_not_raise_immediately(self):
         """Low throughput within the time window should not raise."""
-        dl = self._make_downloader()
-        dl._stall_start = get_time() - 10.0  # 10 seconds ago
-        dl._stall_bytes_at_start = 0
+        monitor = self._make_monitor()
+        monitor.window_start = get_time() - 10.0  # 10 seconds ago
+        monitor.bytes_at_window_start = 0
         # 100 bytes in 10 seconds = 10 B/s — below threshold but only 10s elapsed
-        dl._check_stall(100)
+        monitor.check(100)
         # Should not raise because LOW_SPEED_TIME (30s) not exceeded
 
     def test_stall_raises_after_timeout(self):
         """Low throughput exceeding LOW_SPEED_TIME should raise."""
-        dl = self._make_downloader()
-        dl._stall_start = get_time() - 31.0  # 31 seconds ago
-        dl._stall_bytes_at_start = 0
+        monitor = self._make_monitor()
+        monitor.window_start = get_time() - 31.0  # 31 seconds ago
+        monitor.bytes_at_window_start = 0
         # 100 bytes in 31 seconds = ~3.2 B/s — below 200 B/s for > 30s
         with pytest.raises(DownloadStallError) as exc_info:
-            dl._check_stall(100)
+            monitor.check(100)
         assert exc_info.value.duration >= 30.0
         assert exc_info.value.throughput < 200.0
 
     def test_zero_bytes_triggers_stall(self):
         """Zero bytes received should eventually trigger stall."""
-        dl = self._make_downloader()
-        dl._stall_start = get_time() - 35.0
-        dl._stall_bytes_at_start = 0
+        monitor = self._make_monitor()
+        monitor.window_start = get_time() - 35.0
+        monitor.bytes_at_window_start = 0
         with pytest.raises(DownloadStallError):
-            dl._check_stall(0)
+            monitor.check(0)
 
     def test_recovery_resets_timer(self):
         """If throughput recovers within the window, timer resets."""
-        dl = self._make_downloader()
-        dl._stall_start = get_time() - 20.0  # 20 seconds of slow speed
-        dl._stall_bytes_at_start = 100
+        monitor = self._make_monitor()
+        monitor.window_start = get_time() - 20.0  # 20 seconds of slow speed
+        monitor.bytes_at_window_start = 100
         # Now deliver a burst: enough bytes to push throughput above threshold
         # Need > 200 B/s over 20 seconds = 4000 bytes
-        dl._check_stall(100 + 5000)
+        monitor.check(100 + 5000)
         # Window should have reset (not raised)
-        assert dl._stall_bytes_at_start == 5100
+        assert monitor.bytes_at_window_start == 5100
 
-    def test_reset_stall_state(self):
-        dl = self._make_downloader()
-        dl._stall_start = 12345.0
-        dl._stall_bytes_at_start = 9999
-        dl._reset_stall_state()
-        assert dl._stall_start is None
-        assert dl._stall_bytes_at_start == 0
+
+class TestStallMonitorIsolation:
+    """Each download stream must own its StallMonitor.
+
+    Regression tests for the parallel-download stall race: GOGDownloader runs
+    several workers concurrently, each with its own byte counter. When they
+    shared a single window, one worker's counter polluted another's, producing
+    nonsensical (negative) throughput and spurious stalls on healthy downloads.
+    """
+
+    def test_separate_monitors_do_not_interfere(self):
+        """Two interleaved streams with independent counters never stall."""
+        fast = StallMonitor(BaseDownloader.LOW_SPEED_LIMIT, BaseDownloader.LOW_SPEED_TIME)
+        slow = StallMonitor(BaseDownloader.LOW_SPEED_LIMIT, BaseDownloader.LOW_SPEED_TIME)
+        # 'fast' streams huge byte counts, 'slow' streams small ones. If they
+        # shared a window, slow.check() would read fast's large start value and
+        # compute a negative throughput. With separate monitors, both are healthy.
+        fast_bytes = 0
+        slow_bytes = 0
+        for _ in range(50):
+            fast_bytes += 10_000_000
+            slow_bytes += 1_000_000
+            fast.check(fast_bytes)  # ~10 MB between calls — healthy
+            slow.check(slow_bytes)  # ~1 MB between calls — healthy
+        # No DownloadStallError raised: both windows reset on good throughput.
+
+    def test_shared_window_would_go_negative(self):
+        """Document the bug: one shared window across mismatched counters
+        yields negative throughput. This is what separate monitors prevent."""
+        shared = StallMonitor(BaseDownloader.LOW_SPEED_LIMIT, BaseDownloader.LOW_SPEED_TIME)
+        # Worker A opens the window at a high byte count.
+        shared.check(8_000_000)
+        # Worker B then reports its own, smaller counter into the same window.
+        shared.window_start = get_time() - 1.0  # 1s elapsed
+        bytes_in_window = 2_000_000 - shared.bytes_at_window_start
+        assert bytes_in_window < 0  # negative => bogus "stall" on a healthy stream
+
+    def test_monitor_raises_on_genuine_stall(self):
+        """A single monitor still detects a real stall (feature preserved)."""
+        monitor = StallMonitor(BaseDownloader.LOW_SPEED_LIMIT, BaseDownloader.LOW_SPEED_TIME)
+        monitor.check(0)  # open window
+        monitor.window_start = get_time() - 31.0  # 31s elapsed, no progress
+        with pytest.raises(DownloadStallError):
+            monitor.check(100)  # ~3 B/s for >30s
 
 
 class TestDownloaderRetry:
-    """Test retry logic in the base Downloader."""
+    """Test retry logic in SimpleDownloader."""
 
     def _make_downloader(self, tmp_path):
         dest = str(tmp_path / "test.bin")
-        dl = Downloader("https://example.com/file.bin", dest)
+        dl = SimpleDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
         return dl
 
-    @patch.object(Downloader, "on_download_completed")
-    @patch.object(Downloader, "_do_download")
+    @patch.object(SimpleDownloader, "on_download_completed")
+    @patch.object(SimpleDownloader, "_do_download")
     def test_success_on_first_try(self, mock_do, mock_complete, tmp_path):
         """Successful download should not retry."""
         dl = self._make_downloader(tmp_path)
@@ -129,8 +164,8 @@ class TestDownloaderRetry:
         assert mock_do.call_count == 1
         mock_complete.assert_called_once()
 
-    @patch.object(Downloader, "on_download_completed")
-    @patch.object(Downloader, "_do_download")
+    @patch.object(SimpleDownloader, "on_download_completed")
+    @patch.object(SimpleDownloader, "_do_download")
     def test_retries_on_stall_error(self, mock_do, mock_complete, tmp_path):
         """DownloadStallError should trigger retry."""
         dl = self._make_downloader(tmp_path)
@@ -150,7 +185,7 @@ class TestDownloaderRetry:
         assert mock_do.call_count == 3
         mock_complete.assert_called_once()
 
-    @patch.object(Downloader, "_do_download")
+    @patch.object(SimpleDownloader, "_do_download")
     def test_fails_after_max_retries(self, mock_do, tmp_path):
         """Should fail after RETRY_ATTEMPTS exhausted."""
         dl = self._make_downloader(tmp_path)
@@ -167,7 +202,7 @@ class TestDownloaderRetry:
         assert dl.state == dl.ERROR
         assert dl.error is stall_err
 
-    @patch.object(Downloader, "_do_download")
+    @patch.object(SimpleDownloader, "_do_download")
     def test_no_retry_on_404(self, mock_do, tmp_path):
         """HTTP 404 should not retry."""
         dl = self._make_downloader(tmp_path)
@@ -181,8 +216,8 @@ class TestDownloaderRetry:
         assert mock_do.call_count == 1
         assert dl.state == dl.ERROR
 
-    @patch.object(Downloader, "on_download_completed")
-    @patch.object(Downloader, "_do_download")
+    @patch.object(SimpleDownloader, "on_download_completed")
+    @patch.object(SimpleDownloader, "_do_download")
     def test_retry_on_500(self, mock_do, mock_complete, tmp_path):
         """HTTP 500 should trigger retry."""
         dl = self._make_downloader(tmp_path)
@@ -200,8 +235,8 @@ class TestDownloaderRetry:
         assert mock_do.call_count == 2
         mock_complete.assert_called_once()
 
-    @patch.object(Downloader, "on_download_completed")
-    @patch.object(Downloader, "_do_download")
+    @patch.object(SimpleDownloader, "on_download_completed")
+    @patch.object(SimpleDownloader, "_do_download")
     def test_retry_on_429(self, mock_do, mock_complete, tmp_path):
         """HTTP 429 (rate limit) should trigger retry."""
         dl = self._make_downloader(tmp_path)
@@ -222,11 +257,11 @@ class TestDownloaderRetry:
     def test_is_retryable_http_error_no_response(self):
         """HTTP error with no response should be retryable."""
         err = requests.HTTPError(response=None)
-        assert Downloader._is_retryable_http_error(err) is True
+        assert SimpleDownloader._is_retryable_http_error(err) is True
 
     def test_is_retryable_http_error_403(self):
         """HTTP 403 should not be retryable."""
         response = MagicMock()
         response.status_code = 403
         err = requests.HTTPError(response=response)
-        assert Downloader._is_retryable_http_error(err) is False
+        assert SimpleDownloader._is_retryable_http_error(err) is False


### PR DESCRIPTION
## Summary

Fixes a thread-safety bug in the GOG parallel downloader that can abort healthy downloads with a spurious "stall" error and can also hide genuine stalls.

Stall detection tracks its throughput window in two instance fields on the base `Downloader` (`_stall_start`, `_stall_bytes_at_start`). That is fine for the single-stream path, but `GOGDownloader` runs several worker threads, and each worker calls `_check_stall(stream_bytes)` with its **own** per-worker byte counter while mutating that one shared window — with no lock.

### The bug

When a fast worker opens the window at a high byte count and a slower worker then checks in with its smaller counter:

```
bytes_in_window = slower_worker_bytes - fast_worker_start   # negative
throughput = bytes_in_window / elapsed                       # negative
```

A negative throughput is always below `LOW_SPEED_LIMIT`, so the window never resets. After `LOW_SPEED_TIME` (30s) a perfectly healthy download is aborted with `DownloadStallError`, retried 3×, then fails. The reverse also happens: a fast worker can reset a genuinely stalled worker's window, so real stalls go undetected.

This affects every GOG game download, since `GOGDownloader` is the default downloader for GOG installer files.

### The fix

Extract the (unchanged) algorithm into a small `StallMonitor` class so each stream owns its own window:

- The base `Downloader` keeps a single monitor — the single-threaded path is behaviourally identical.
- Each GOG worker creates a **local** `StallMonitor` in `_download_range`, so worker counters never collide.
- `_stall_start` / `_stall_bytes_at_start` remain as backwards-compatible proxy properties.

## Testing

- Added `TestStallMonitorIsolation` regression tests: interleaved fast/slow streams stay healthy, a genuine stall still raises, and `_reset_stall_state` installs a fresh window.
- Adapted the existing pipelining stall test to drive the new per-worker mechanism through a deterministic fake clock instead of poking removed internals.
- All download-related tests pass (`_test_stall_detection.py`, `_test_pipelining.py`, `_test_gog_downloader.py`, `_test_download_progress.py`, `_test_collection_progress.py`).
- Verified end-to-end with a real 4-worker threaded download against a local Range-capable HTTP server with one deliberately throttled worker: download completes without a spurious stall and the output file is byte-for-byte correct (MD5 verified).
