### PR TITLE
style: modernize string formatting and simplify returns (ruff autofix)

### DIFF
--- a/lutris/api.py
+++ b/lutris/api.py
@@ -93,7 +93,7 @@ def get_runtime_versions() -> RuntimeVersionsDict:
     if it is missing or stale."""
     if not system.path_exists(settings.RUNTIME_VERSIONS_PATH):
         return {}
-    with open(settings.RUNTIME_VERSIONS_PATH, mode="r", encoding="utf-8") as runtime_file:
+    with open(settings.RUNTIME_VERSIONS_PATH, encoding="utf-8") as runtime_file:
         return cast(RuntimeVersionsDict, json.load(runtime_file))
 
 
@@ -101,7 +101,7 @@ def read_api_key() -> dict[str, str] | None:
     """Read the API token from disk"""
     if not system.path_exists(API_KEY_FILE_PATH):
         return None
-    with open(API_KEY_FILE_PATH, "r", encoding="utf-8") as token_file:
+    with open(API_KEY_FILE_PATH, encoding="utf-8") as token_file:
         api_string = token_file.read()
     try:
         username, token = api_string.split(":")
@@ -192,7 +192,7 @@ def get_runners(runner_name: str) -> RunnerDict:
 
 def download_runner_versions(runner_name: str) -> list[RunnerVersionDict]:
     try:
-        request = Request("{}/api/runners/{}".format(settings.SITE_URL, runner_name))
+        request = Request(f"{settings.SITE_URL}/api/runners/{runner_name}")
         runner_info = request.get().json
         if not runner_info:
             logger.error("Failed to get runner information")
@@ -229,7 +229,7 @@ def format_version_architecture(base_version: str, arch: str | None = None) -> s
         return base_version
 
     if arch:
-        return "{}-{}".format(base_version, arch)
+        return f"{base_version}-{arch}"
 
     return base_version
 
@@ -344,7 +344,7 @@ def get_game_api_page(game_slugs: Collection[str] | None, page: int | str = 1) -
     """
     url = settings.SITE_URL + "/api/games"
     if int(page) > 1:
-        url += "?page={}".format(page)
+        url += f"?page={page}"
     if not game_slugs:
         return {}
     payload = json.dumps({"games": game_slugs, "page": page}).encode("utf-8")
@@ -355,7 +355,7 @@ def get_game_service_api_page(service: str, appids: Collection[str] | None, page
     """Get matching Lutris games from a list of appids from a given service"""
     url = settings.SITE_URL + "/api/games/service/%s" % service
     if int(page) > 1:
-        url += "?page={}".format(page)
+        url += f"?page={page}"
     if not appids:
         return {}
     payload = json.dumps({"appids": appids}).encode("utf-8")

--- a/lutris/cache.py
+++ b/lutris/cache.py
@@ -82,10 +82,7 @@ def validate_custom_cache_path(cache_path: str) -> tuple[bool, str | None]:
             return True, _(
                 "The cache path '%s' does not exist, but its parent does so it will be created when needed."
             ) % cache_path
-        else:
-            return False, _(
-                "The cache path %s does not exist, nor does its parent, so it won't be created."
-            ) % cache_path
+        return False, _("The cache path %s does not exist, nor does its parent, so it won't be created.") % cache_path
 
     return True, None
 

--- a/lutris/config.py
+++ b/lutris/config.py
@@ -19,7 +19,7 @@ SystemConfigDict: TypeAlias = dict[str, Any]
 
 def make_game_config_id(game_slug: str) -> str:
     """Return an unique config id to avoid clashes between multiple games"""
-    return "{}-{}".format(game_slug, int(time.time()))
+    return f"{game_slug}-{int(time.time())}"
 
 
 def write_game_config(game_slug: str, config: dict[str, Any]) -> str:

--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -69,12 +69,12 @@ def get_games_where(**conditions: Any) -> list[DbGameDict]:
         if extra_conditions:
             extra_condition = extra_conditions[0]
             if extra_condition == "lessthan":
-                condition_fields.append("{} < ?".format(field))
+                condition_fields.append(f"{field} < ?")
                 condition_values.append(value)
             if extra_condition == "isnull":
                 condition_fields.append("{} is {} null".format(field, "" if value else "not"))
             if extra_condition == "not":
-                condition_fields.append("{} != ?".format(field))
+                condition_fields.append(f"{field} != ?")
                 condition_values.append(value)
             if extra_condition == "in":
                 if not hasattr(value, "__iter__"):
@@ -85,7 +85,7 @@ def get_games_where(**conditions: Any) -> list[DbGameDict]:
                     condition_fields.append("{} in ({})".format(field, ", ".join("?" * len(value)) or ""))
                     condition_values = list(chain(condition_values, value))
         else:
-            condition_fields.append("{} = ?".format(field))
+            condition_fields.append(f"{field} = ?")
             condition_values.append(value)
     condition = " AND ".join(condition_fields)
     if condition:

--- a/lutris/database/sql.py
+++ b/lutris/database/sql.py
@@ -15,7 +15,7 @@ DBUpdateDict: TypeAlias = dict[str, Any]
 DBParams: TypeAlias = Sequence[Any]
 
 
-class db_cursor(object):
+class db_cursor:
     def __init__(self, db_path: str):
         self.db_path = db_path
         self.db_conn: sqlite3.Connection = None
@@ -60,7 +60,7 @@ def db_insert(db_path: str, table: str, fields: DBUpdateDict) -> int:
     with db_cursor(db_path) as cursor:
         cursor_execute(
             cursor,
-            "insert into {0}({1}) values ({2})".format(table, columns, placeholders),
+            f"insert into {table}({columns}) values ({placeholders})",
             field_values,
         )
         inserted_id = cursor.lastrowid
@@ -78,14 +78,14 @@ def db_update(db_path: str, table: str, updated_fields: DBUpdateDict, conditions
     condition_value = tuple(conditions.values())
 
     with db_cursor(db_path) as cursor:
-        query = "UPDATE {0} SET {1} WHERE {2}".format(table, columns, condition_field)
+        query = f"UPDATE {table} SET {columns} WHERE {condition_field}"
         result = cursor_execute(cursor, query, field_values + condition_value)
     return result
 
 
 def db_delete(db_path: str, table: str, field: str, value: Any) -> None:
     with db_cursor(db_path) as cursor:
-        cursor_execute(cursor, "delete from {0} where {1}=?".format(table, field), (value,))
+        cursor_execute(cursor, f"delete from {table} where {field}=?", (value,))
 
 
 def db_select(
@@ -168,13 +168,10 @@ def _create_filter(field: str, value: Any, params: list[Any], negate: bool = Fal
         if negate:
             if also_null:
                 return f"{field} IS NOT NULL"
-            else:
-                return "1 = 1"
-        else:
-            if also_null:
-                return f"{field} IS NULL"
-            else:
-                return "1 = 0"
+            return "1 = 1"
+        if also_null:
+            return f"{field} IS NULL"
+        return "1 = 0"
 
     if len(values) == 1:
         params.append(values[0])
@@ -191,12 +188,10 @@ def _create_filter(field: str, value: Any, params: list[Any], negate: bool = Fal
     if also_null:
         if negate:
             return f"({field} IS NOT NULL AND {sql})"
-        else:
-            return f"({field} IS NULL OR {sql})"
-    else:
-        if negate:
-            return f"({field} IS NULL OR {sql})"
-        return sql
+        return f"({field} IS NULL OR {sql})"
+    if negate:
+        return f"({field} IS NULL OR {sql})"
+    return sql
 
 
 def filtered_query(

--- a/lutris/game.py
+++ b/lutris/game.py
@@ -311,8 +311,7 @@ class Game:
         we'll use the game path as a fallback."""
         if self.has_runner and self.runner.has_working_dir:
             return self.runner.working_dir or self.resolve_game_path()
-        else:
-            return self.resolve_game_path()
+        return self.resolve_game_path()
 
     @property
     def game_config_id(self) -> str:
@@ -1261,7 +1260,7 @@ def import_game(file_path: str, dest_dir: str) -> None:
     with open(os.path.join(game_dir, game_config), encoding="utf-8") as config_file:
         lutris_config = json.load(config_file)
     old_dir = lutris_config["directory"]
-    with open(os.path.join(game_dir, game_config), "r", encoding="utf-8") as config_file:
+    with open(os.path.join(game_dir, game_config), encoding="utf-8") as config_file:
         config_data = config_file.read()
     config_data = config_data.replace(old_dir, game_dir)
     with open(os.path.join(game_dir, game_config), "w", encoding="utf-8") as config_file:

--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -398,9 +398,9 @@ class LutrisApplication(Gtk.Application):
             return window_inst
         if issubclass(window_class, Gtk.Dialog):
             if "parent" in kwargs or not self.window:
-                window_inst: "GtkWindowType" = window_class(**kwargs)
+                window_inst: GtkWindowType = window_class(**kwargs)
             else:
-                window_inst: "GtkWindowType" = window_class(parent=self.window, **kwargs)
+                window_inst: GtkWindowType = window_class(parent=self.window, **kwargs)
             window_inst.set_application(self)
         else:
             window_inst = window_class(application=self, **kwargs)

--- a/lutris/gui/config/boxes.py
+++ b/lutris/gui/config/boxes.py
@@ -274,8 +274,7 @@ class ConfigWidgetGenerator(WidgetGenerator):
     def get_setting(self, option_key: str, default: Any) -> Any:
         if option_key in self.config:
             return self.config.get(option_key)
-        else:
-            return default
+        return default
 
     def update_option_container(self, option, container: Gtk.Container, wrapper: Gtk.Container) -> None:
         super().update_option_container(option, container, wrapper)
@@ -348,7 +347,7 @@ class ConfigWidgetGenerator(WidgetGenerator):
 
                 if self.parent.filter:
                     return _("No options match '%s'") % self.parent.filter
-                elif any(c.lutris_advanced_hidden for c in self.option_containers.values()):  # type:ignore[attr-defined]
+                if any(c.lutris_advanced_hidden for c in self.option_containers.values()):  # type:ignore[attr-defined]
                     return _("Only advanced options available")
 
             return _("No options available")

--- a/lutris/gui/config/edit_category_games.py
+++ b/lutris/gui/config/edit_category_games.py
@@ -82,8 +82,7 @@ class EditCategoryGamesDialog(SavableModelessDialog):
     def _get_game(self, game_id: str) -> Game:
         if game_id in self.category_games:
             return self.category_games[game_id]
-        else:
-            return Game(game_id)
+        return Game(game_id)
 
     def on_save(self, _button: Gtk.Button) -> None:
         """Save game info and destroy widget."""

--- a/lutris/gui/config/updates_box.py
+++ b/lutris/gui/config/updates_box.py
@@ -84,7 +84,7 @@ class UpdatesBox(BaseConfigBox):
         application = Gio.Application.get_default()
         if not application or not application.window:
             logger.error("No application or window found, how does this happen?")
-            return
+            return None
         return application.window
 
     def on_runtime_update_clicked(self, _widget):

--- a/lutris/gui/config/widget_generator.py
+++ b/lutris/gui/config/widget_generator.py
@@ -146,8 +146,7 @@ class WidgetGenerator(ABC):
 
             self.option_container = option_container
             return option_container
-        else:
-            return None
+        return None
 
     def generate_widget(self, option: dict[str, Any], wrapper: Gtk.Box | None = None) -> Gtk.Widget | None:
         """This creates a wrapper box and a label and widget within it according to the options dict
@@ -249,8 +248,7 @@ class WidgetGenerator(ABC):
                 option_container.pack_start(widget, False, False, 0)
 
             return option_container
-        else:
-            return wrapper
+        return wrapper
 
     def build_option_widget(
         self, option: dict[str, Any], widget: Gtk.Widget | None, no_label: bool = False, expand: bool = True
@@ -355,16 +353,14 @@ class WidgetGenerator(ABC):
             the string 'False' is True!"""
             if to_convert is None:
                 return None
-            elif isinstance(to_convert, str):
+            if isinstance(to_convert, str):
                 text = to_convert.casefold().strip()
                 if text == "true":
                     return True
-                elif text == "false":
+                if text == "false":
                     return False
-                else:
-                    return None
-            else:
-                return bool(to_convert)
+                return None
+            return bool(to_convert)
 
         option_key = option["option"]
 
@@ -810,15 +806,15 @@ class WidgetGenerator(ABC):
 
             if argcount >= argsneeded:  # enough declared args?
                 return value(option_key, *self.callback_args, **self.callback_kwargs)
-            elif any(p.kind == Parameter.VAR_POSITIONAL for p in sig.parameters.values()):  # unlimited args via *args?
+            if any(p.kind == Parameter.VAR_POSITIONAL for p in sig.parameters.values()):  # unlimited args via *args?
                 return value(option_key, *self.callback_args, **self.callback_kwargs)
-            elif argcount == 0:  # no args?
+            if argcount == 0:  # no args?
                 return value(**self.callback_kwargs)
-            else:  # any other number of args
-                args = list(self.callback_args)
-                args.insert(0, option_key)
-                args = args[:argcount]
-                return value(*args, **self.callback_kwargs)
+            # any other number of args
+            args = list(self.callback_args)
+            args.insert(0, option_key)
+            args = args[:argcount]
+            return value(*args, **self.callback_kwargs)
 
         return value
 

--- a/lutris/gui/dialogs/__init__.py
+++ b/lutris/gui/dialogs/__init__.py
@@ -295,8 +295,7 @@ class ErrorDialog(Gtk.MessageDialog):
         def get_message_markup(err: BaseException | str) -> str:
             if isinstance(err, LutrisError):
                 return err.message_markup or gtk_safe(str(err))
-            else:
-                return gtk_safe(str(err))
+            return gtk_safe(str(err))
 
         if isinstance(error, builtins.BaseException):
             if secondary_markup:

--- a/lutris/gui/dialogs/log.py
+++ b/lutris/gui/dialogs/log.py
@@ -68,7 +68,7 @@ class LogWindow(GObject.Object):
         )
         log_path = file_dialog.filename
         if not log_path:
-            return None
+            return
 
         text = self.buffer.get_text(self.buffer.get_start_iter(), self.buffer.get_end_iter(), True)
         with open(log_path, "w", encoding="utf-8") as log_file:

--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -209,7 +209,7 @@ class InstallerFileBox(Gtk.VBox):
         if self.provider in ("pga", "user") and self.is_ready:
             self.emit("file-available")
             self.cache_file()
-            return
+            return None
         if self.start_func:
             return self.start_func()
 

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -459,13 +459,13 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
         if self.is_view_sort_sensitive:
             if self.view_sorting == "name":
                 return {COL_NAME, COL_SORTNAME}
-            elif self.view_sorting == "year":
+            if self.view_sorting == "year":
                 return {COL_YEAR}
-            elif self.view_sorting == "lastplayed":
+            if self.view_sorting == "lastplayed":
                 return {COL_LASTPLAYED, COL_LASTPLAYED_TEXT}
-            elif self.view_sorting == "installed_at":
+            if self.view_sorting == "installed_at":
                 return {COL_INSTALLED_AT, COL_INSTALLED_AT_TEXT}
-            elif self.view_sorting == "playtime":
+            if self.view_sorting == "playtime":
                 return {COL_PLAYTIME, COL_PLAYTIME_TEXT}
 
         return set()
@@ -519,12 +519,11 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
                     # Years can take many forms! We'll try to convert as best we can.
                     if isinstance(value, datetime):
                         return int(value.year)
-                    else:
-                        try:
-                            return int(value)
-                        except ValueError:
-                            as_date = datetime.strptime(str(value), "%Y-%m-%d")
-                            return int(as_date.year)
+                    try:
+                        return int(value)
+                    except ValueError:
+                        as_date = datetime.strptime(str(value), "%Y-%m-%d")
+                        return int(as_date.year)
                 else:
                     return float(value)
             except ValueError:
@@ -647,7 +646,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             return self.service
         if not service_name:
             self.service = None
-            return
+            return None
         try:
             self.service = services.SERVICES[service_name]()
         except KeyError:

--- a/lutris/gui/views/base.py
+++ b/lutris/gui/views/base.py
@@ -64,7 +64,7 @@ class GameView:
     def popup_contextual_menu(self, view, event):
         """Contextual menu."""
         if event.button != Gdk.BUTTON_SECONDARY:
-            return
+            return None
         current_path = self.get_path_at(event.x, event.y)
         if current_path:
             selection = self.get_selected()

--- a/lutris/gui/views/store.py
+++ b/lutris/gui/views/store.py
@@ -108,7 +108,7 @@ class GameStore(GObject.Object):
 
     def get_row_by_id(self, game_id):
         if not game_id:
-            return
+            return None
         path = self.get_path_by_id(game_id)
         if path is not None:
             return self.store[path]

--- a/lutris/gui/widgets/download_collection_progress_box.py
+++ b/lutris/gui/widgets/download_collection_progress_box.py
@@ -424,5 +424,5 @@ class DownloadCollectionProgressBox(Gtk.Box):
         self.cancel_button.set_sensitive(False)
 
     def _set_text(self, text):
-        markup = "<span size='10000'>{}</span>".format(gtk_safe(text))
+        markup = f"<span size='10000'>{gtk_safe(text)}</span>"
         self.progress_label.set_markup(markup)

--- a/lutris/gui/widgets/download_progress_box.py
+++ b/lutris/gui/widgets/download_progress_box.py
@@ -96,7 +96,7 @@ class DownloadProgressBox(Gtk.Box):
         except RuntimeError as ex:
             display_error(ex, parent=self.get_toplevel())
             self.emit("cancel")
-            return None
+            return
 
         create_cache_lock(self.dest, CacheState.DOWNLOADING)
         schedule_repeating_at_idle(self._progress, interval_seconds=0.5)
@@ -159,5 +159,5 @@ class DownloadProgressBox(Gtk.Box):
         return True
 
     def _set_text(self, text):
-        markup = "<span size='10000'>{}</span>".format(gtk_safe(text))
+        markup = f"<span size='10000'>{gtk_safe(text)}</span>"
         self.progress_label.set_markup(markup)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -364,7 +364,7 @@ class SidebarHeader(Gtk.ListBoxRow):
             halign=Gtk.Align.START,
             hexpand=True,
             use_markup=True,
-            label="<b>{}</b>".format(name),
+            label=f"<b>{name}</b>",
         )
 
         self.arrow = Gtk.Image.new_from_icon_name("pan-down-symbolic", Gtk.IconSize.MENU)

--- a/lutris/gui/widgets/utils.py
+++ b/lutris/gui/widgets/utils.py
@@ -61,8 +61,7 @@ def get_widget_window(widget: Gtk.Widget | None) -> Gtk.Window | None:
     like get_toplevel()."""
     if widget:
         return cast(Gtk.Window, widget.get_ancestor(Gtk.Window))
-    else:
-        return None
+    return None
 
 
 TChildWidget = TypeVar("TChildWidget", bound=Gtk.Widget)
@@ -75,10 +74,8 @@ def get_widget_children(widget: Gtk.Widget | None, child_type: type[TChildWidget
     if isinstance(widget, Gtk.Container):
         if child_type:
             return [w for w in widget.get_children() if isinstance(w, child_type)]
-        else:
-            return list(cast(Iterable[TChildWidget], widget.get_children()))
-    else:
-        return []
+        return list(cast(Iterable[TChildWidget], widget.get_children()))
+    return []
 
 
 def open_uri(uri: str) -> None:

--- a/lutris/installer/__init__.py
+++ b/lutris/installer/__init__.py
@@ -49,7 +49,7 @@ class InstallationKind(enum.Enum):
 def read_script(filename):
     """Return scripts from a local file"""
     logger.debug("Loading script(s) from %s", filename)
-    with open(filename, "r", encoding="utf-8") as local_file:
+    with open(filename, encoding="utf-8") as local_file:
         script = yaml.safe_load(local_file.read())
         if isinstance(script, list):
             return script

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -378,7 +378,7 @@ class CommandsMixin:
         filename = self._substitute(data["file"])
         logger.debug("Substituting variables for file %s", filename)
         tmp_filename = filename + ".tmp"
-        with open(filename, "r", encoding="utf-8") as source_file:
+        with open(filename, encoding="utf-8") as source_file:
             with open(tmp_filename, "w", encoding="utf-8") as dest_file:
                 line = "."
                 while line:

--- a/lutris/installer/errors.py
+++ b/lutris/installer/errors.py
@@ -22,8 +22,7 @@ class ScriptingError(LutrisError):
     def wrap(error: BaseException) -> "ScriptingError":
         if isinstance(error, LutrisError):
             return ScriptingError(error.message, message_markup=error.message_markup)
-        else:
-            return ScriptingError(str(error))
+        return ScriptingError(str(error))
 
     def __str__(self):
         if self.faulty_data is None:

--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -83,7 +83,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         if initial:
             return initial
         if not self.service:
-            return
+            return None
         service_id = None
         if self.service.id == "steam":
             service_id = installer.get("steamid") or installer.get("service_id")
@@ -96,7 +96,7 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
             service_id = game_config.get("itchid") or installer.get("itchid") or installer.get("service_id")
         if service_id:
             return service_id
-        return
+        return None
 
     def _get_discord_id_from_api(self):
         """Fetch the discord_id from the Lutris API if available."""

--- a/lutris/monitored_command.py
+++ b/lutris/monitored_command.py
@@ -126,7 +126,7 @@ class MonitoredCommand:
     def set_log_buffer(self, log_buffer: "Gtk.TextBuffer | None") -> None:
         """Attach a TextBuffer to this command enables the buffer handler"""
         if not log_buffer:
-            return None
+            return
         self.log_buffer = log_buffer
         if self.log_handler_buffer not in self.log_handlers:
             self.log_handlers.append(self.log_handler_buffer)
@@ -192,7 +192,7 @@ class MonitoredCommand:
 
         if not self.game_process:
             logger.error("No game process available")
-            return None
+            return
 
         GLib.child_watch_add(self.game_process.pid, self.on_stop)  # type: ignore
 
@@ -222,7 +222,7 @@ class MonitoredCommand:
     def log_handler_stdout(self, line: str) -> None:
         """Add the line to this command's stdout attribute"""
         if not self.log_filter(line):
-            return None
+            return
         self._stdout.write(line)
 
     def log_handler_buffer(self, line: str) -> None:
@@ -232,7 +232,7 @@ class MonitoredCommand:
     def log_handler_console_output(self, line: str) -> None:
         """Print the line to stdout"""
         if not self.log_filter(line):
-            return None
+            return
         with contextlib.suppress(BlockingIOError):
             sys.stdout.write(line)
             sys.stdout.flush()

--- a/lutris/runners/commands/dosbox.py
+++ b/lutris/runners/commands/dosbox.py
@@ -13,11 +13,11 @@ from lutris.util.log import logger
 def dosexec(config_file=None, executable=None, args=None, close_on_exit=True, working_dir=None):
     """Execute Dosbox with given config_file."""
     if config_file:
-        run_with = "config {}".format(config_file)
+        run_with = f"config {config_file}"
         if not working_dir:
             working_dir = os.path.dirname(config_file)
     elif executable:
-        run_with = "executable {}".format(executable)
+        run_with = f"executable {executable}"
         if not working_dir:
             working_dir = os.path.dirname(executable)
     else:
@@ -31,7 +31,7 @@ def dosexec(config_file=None, executable=None, args=None, close_on_exit=True, wo
         command += ["-conf", config_file]
     if executable:
         if not system.path_exists(executable):
-            raise OSError("Can't find file {}".format(executable))
+            raise OSError(f"Can't find file {executable}")
         command += [executable]
     if args:
         command += args.split()
@@ -45,6 +45,6 @@ def makeconfig(path, drives, commands):
     with open(path, "w", encoding="utf-8") as config_file:
         config_file.write("[autoexec]\n")
         for drive in drives:
-            config_file.write('mount {} "{}"\n'.format(drive, drives[drive]))
+            config_file.write(f'mount {drive} "{drives[drive]}"\n')
         for command in commands:
-            config_file.write("{}\n".format(command))
+            config_file.write(f"{command}\n")

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -363,7 +363,7 @@ def wineexec(
 
     executable, _args, working_dir = get_real_executable(executable, working_dir)
     if _args:
-        args = '{} "{}"'.format(_args[0], _args[1])
+        args = f'{_args[0]} "{_args[1]}"'
 
     wineenv = {"WINEARCH": arch}
     if winetricks_wine and winetricks_wine is not wine_path and not proton.is_proton_path(wine_path):

--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -259,7 +259,7 @@ class libretro(Runner):
         game_core = self.game_config.get("core")
         if not game_core:
             logger.warning("Game don't have a core set")
-            return
+            return None
         for core in get_libretro_cores():
             if core[1] == game_core and core[2] in self.platform_dict:
                 return self.platform_dict[core[2]]
@@ -269,7 +269,7 @@ class libretro(Runner):
     def get_core_path(self, core):
         """Return the path of a core from libretro's runner only"""
         lutris_cores_folder = get_default_config_path("cores")
-        core_filename = "{}_libretro.so".format(core)
+        core_filename = f"{core}_libretro.so"
         lutris_core = os.path.join(lutris_cores_folder, core_filename)
         return lutris_core
 
@@ -433,7 +433,7 @@ class libretro(Runner):
         if verbose:
             parameters.append("--verbose")
 
-        parameters.append("--config={}".format(self.get_config_file()))
+        parameters.append(f"--config={self.get_config_file()}")
         return parameters
 
     def play(self):
@@ -443,7 +443,7 @@ class libretro(Runner):
         core = self.game_config.get("core")
         if not core:
             raise GameConfigError(_("No core has been selected for this game"))
-        command.append("--libretro={}".format(self.get_core_path(core)))
+        command.append(f"--libretro={self.get_core_path(core)}")
 
         # Main file
         file = self.game_config.get("main_file")

--- a/lutris/runners/mednafen.py
+++ b/lutris/runners/mednafen.py
@@ -445,8 +445,8 @@ class mednafen(Runner):
 
         # Construct the controlls options
         for button in layout[machine]:
-            controls.append("-{}.input.{}.{}".format(machine, gamepad, button))
-            controls.append("joystick {} {}".format(joy_ids[0], map_code[button]))
+            controls.append(f"-{machine}.input.{gamepad}.{button}")
+            controls.append(f"joystick {joy_ids[0]} {map_code[button]}")
         return controls
 
     def play(self):

--- a/lutris/runners/reicast.py
+++ b/lutris/runners/reicast.py
@@ -118,7 +118,7 @@ class reicast(Runner):
 
         config_path = os.path.expanduser("~/.reicast/emu.cfg")
         if system.path_exists(config_path):
-            with open(config_path, "r", encoding="utf-8") as config_file:
+            with open(config_path, encoding="utf-8") as config_file:
                 parser.read_file(config_file)
 
         for section in config:
@@ -142,7 +142,7 @@ class reicast(Runner):
         for index in range(1, 5):
             config_string = "device_id_%d" % index
             joy_id = self.runner_config.get(config_string) or "-1"
-            reicast_config["input"]["evdev_{}".format(config_string)] = joy_id
+            reicast_config["input"][f"evdev_{config_string}"] = joy_id
             if index > 1 and joy_id != "-1":
                 players += 1
         reicast_config["players"]["nb"] = players

--- a/lutris/runners/runner.py
+++ b/lutris/runners/runner.py
@@ -79,7 +79,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             self._config = None
             self.game_data = {}
 
-    def __lt__(self, other: "Runner") -> bool:
+    def __lt__(self, other: Runner) -> bool:
         return bool(self.name < other.name)
 
     @property
@@ -249,7 +249,7 @@ class Runner:  # pylint: disable=too-many-public-methods
             if os.path.isfile(runner_executable):
                 return runner_executable
         if not self.runner_executable_path:
-            raise MisconfigurationError("runner_executable not set for {}".format(self.name))
+            raise MisconfigurationError(f"runner_executable not set for {self.name}")
 
         exe = os.path.join(settings.RUNNER_DIR, self.runner_executable_path)
         if not os.path.isfile(exe):
@@ -315,7 +315,7 @@ class Runner:  # pylint: disable=too-many-public-methods
         if sdl_gamecontrollerconfig:
             path = os.path.expanduser(sdl_gamecontrollerconfig)
             if system.path_exists(path):
-                with open(path, "r", encoding="utf-8") as controllerdb_file:
+                with open(path, encoding="utf-8") as controllerdb_file:
                     sdl_gamecontrollerconfig = controllerdb_file.read()
             env["SDL_GAMECONTROLLERCONFIG"] = sdl_gamecontrollerconfig
 
@@ -363,7 +363,7 @@ class Runner:  # pylint: disable=too-many-public-methods
     def finish_env(self, env: dict[str, str], game: Game) -> None:
         """This is called by the Game after setting up the environment to allow the runner
         to make final adjustments, which may be based on the environment so far."""
-        return None
+        return
 
     def get_runtime_env(self) -> dict[str, str]:
         """Return runtime environment variables.
@@ -465,7 +465,7 @@ class Runner:  # pylint: disable=too-many-public-methods
 
         return path
 
-    def attach_log_handlers(self, monitored_command: MonitoredCommand, game: "Game") -> None:
+    def attach_log_handlers(self, monitored_command: MonitoredCommand, game: Game) -> None:
         """Hook for runners to install extra log handlers on the game's
         MonitoredCommand just before it starts. The default implementation
         does nothing; subclasses may append callables to
@@ -598,7 +598,7 @@ class Runner:  # pylint: disable=too-many-public-methods
     def adjust_installer_runner_config(self, installer_runner_config: dict[str, Any]) -> None:
         """This is called during installation to let to run fix up in the runner's section of
         the confliguration before it is saved. This method should modify the dict given."""
-        return None
+        return
 
     def get_runner_version(self, version: str | None = None) -> RunnerVersionDict | None:
         """Get the appropriate version for a runner, as with get_default_runner_version(),
@@ -631,8 +631,7 @@ class Runner:  # pylint: disable=too-many-public-methods
                 raise RunnerInstallationError(
                     _("The '%s' version of the '%s' runner can't be downloaded." % (version, self.name))
                 )
-            else:
-                raise RunnerInstallationError(_("The the '%s' runner can't be downloaded." % self.name))
+            raise RunnerInstallationError(_("The the '%s' runner can't be downloaded." % self.name))
 
         if "wine" in self.name:
             opts["merge_single"] = True

--- a/lutris/runners/vice.py
+++ b/lutris/runners/vice.py
@@ -183,10 +183,10 @@ class vice(Runner):
         option_prefix = self.get_option_prefix(machine)
 
         if self.runner_config.get("fullscreen"):
-            params.append("-{}full".format(option_prefix))
+            params.append(f"-{option_prefix}full")
 
         if self.runner_config.get("double"):
-            params.append("-{}dsize".format(option_prefix))
+            params.append(f"-{option_prefix}dsize")
 
         if self.runner_config.get("renderer"):
             params.append("-sdl2renderer")
@@ -201,7 +201,7 @@ class vice(Runner):
 
         if self.runner_config.get("joy"):
             for dev in range(self.get_joydevs(machine)):
-                params += ["-joydev{}".format(dev + 1), "4"]
+                params += [f"-joydev{dev + 1}", "4"]
 
         params.extend(self.get_rom_args(machine, rom))
         return {"command": params}

--- a/lutris/runners/web.py
+++ b/lutris/runners/web.py
@@ -229,7 +229,7 @@ class web(Runner):
         ]:
             if self.runner_config.get(key):
                 converted_opt_name = key.replace("_", "-")
-                command.append("--{option}".format(option=converted_opt_name))
+                command.append(f"--{converted_opt_name}")
 
         if self.runner_config.get("window_size"):
             command.append("--window-size")

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -230,8 +230,7 @@ def _get_wine_wayland_warning(_option_key: str, config: LutrisConfig) -> str | N
         if not is_winewayland_available(runner_version):
             if _is_proton_config(config):
                 return _("Your Proton version does not support winewayland graphics driver")
-            else:
-                return _("Your Wine version does not support winewayland graphics driver")
+            return _("Your Wine version does not support winewayland graphics driver")
 
     return None
 
@@ -1441,8 +1440,7 @@ class wine(Runner):
             uuid_pids = set(pid for pid in candidate_pids if Process(pid).environ.get("LUTRIS_GAME_UUID") == game_uuid)
 
             return (folder_pids & uuid_pids) | gamescope_pids
-        else:
-            return super().filter_game_pids(candidate_pids, game_uuid, game_folder)
+        return super().filter_game_pids(candidate_pids, game_uuid, game_folder)
 
     def force_stop_game(self, game_pids: Iterable[int]) -> None:
         """Kill WINE with kindness, or at least with -k. This seems to leave a process

--- a/lutris/scanners/playtron.py
+++ b/lutris/scanners/playtron.py
@@ -79,7 +79,7 @@ def _get_mount_points() -> list[str]:
     mount_points = []
 
     try:
-        with open("/proc/mounts", "r", encoding="utf-8") as f:
+        with open("/proc/mounts", encoding="utf-8") as f:
             for line in f:
                 parts = line.split()
                 if len(parts) < 3:
@@ -337,7 +337,7 @@ def _get_gog_game_info(install_folder: str, provider_id: str) -> dict | None:
 def _load_gog_info_file(info_file: str) -> dict | None:
     """Load and parse a goggame-*.info JSON file"""
     try:
-        with open(info_file, "r", encoding="utf-8") as f:
+        with open(info_file, encoding="utf-8") as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError, FileNotFoundError):
         return None
@@ -369,7 +369,7 @@ def _extract_gog_primary_task(info: dict) -> dict | None:
 def _parse_playtron_info(filepath: str) -> dict | None:
     """Parse a playtron_info_v3.json file"""
     try:
-        with open(filepath, "r", encoding="utf-8") as f:
+        with open(filepath, encoding="utf-8") as f:
             return json.load(f)
     except (json.JSONDecodeError, OSError) as ex:
         logger.warning("Failed to parse %s: %s", filepath, ex)

--- a/lutris/services/amazon.py
+++ b/lutris/services/amazon.py
@@ -160,7 +160,7 @@ class AmazonService(OnlineService):
         """Load the user game library from the Amazon API"""
         if not self.is_connected():
             logger.error("User not connected to Amazon")
-            return
+            return None
         games = [AmazonGame.new_from_amazon_game(game) for game in self.get_library()]
         for game in games:
             game.save()
@@ -178,7 +178,7 @@ class AmazonService(OnlineService):
         if not os.path.exists(self.user_path):
             raise AuthenticationError(_("No Amazon user data available, please log in again"))
 
-        with open(self.user_path, "r", encoding="utf-8") as user_file:
+        with open(self.user_path, encoding="utf-8") as user_file:
             user_data = json.load(user_file)
 
         return user_data
@@ -341,7 +341,7 @@ class AmazonService(OnlineService):
         """Return the user's library of Amazon games"""
         if system.path_exists(self.cache_path):
             logger.debug("Returning cached Amazon library")
-            with open(self.cache_path, "r", encoding="utf-8") as amazon_cache:
+            with open(self.cache_path, encoding="utf-8") as amazon_cache:
                 return json.load(amazon_cache)
 
         access_token = self.get_access_token()

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -535,7 +535,7 @@ class OnlineService(BaseService):
         """Load cookies from disk"""
         if not system.path_exists(self.cookies_path):
             logger.warning("No cookies found in %s, please authenticate first", self.cookies_path)
-            return
+            return None
         cookiejar = WebkitCookieJar(self.cookies_path)
         cookiejar.load()
         return cookiejar

--- a/lutris/services/battlenet.py
+++ b/lutris/services/battlenet.py
@@ -156,11 +156,11 @@ class BattleNetService(BaseService):
         service_game = ServiceGameCollection.get_game("battlenet", app_id)
         if not service_game:
             logger.error("Aborting install, %s is not present in the game library.", app_id)
-            return
+            return None
         lutris_game_id = service_game["slug"] + "-" + self.id
         existing_game = get_game_by_field(lutris_game_id, "installer_slug")
         if existing_game:
-            return
+            return None
         game_config = LutrisConfig(game_config_id=bnet_game["configpath"]).game_level
         product_code = PRODUCT_CODES.get(game.ngdp, game.ngdp)
         game_config["game"]["args"] = '--exec="launch %s"' % product_code

--- a/lutris/services/dolphin.py
+++ b/lutris/services/dolphin.py
@@ -32,7 +32,7 @@ class DolphinService(BaseService):
 
     def load(self):
         if not system.path_exists(DOLPHIN_GAME_CACHE_FILE):
-            return
+            return None
         cache_reader = DolphinCacheReader()
         dolphin_games = [DolphinGame.new_from_cache(game) for game in cache_reader.get_games()]
         for game in dolphin_games:

--- a/lutris/services/ea_app.py
+++ b/lutris/services/ea_app.py
@@ -37,8 +37,7 @@ class EAAppGames:
     def iter_installed_games(self):
         if not os.path.exists(self.ea_games_path):
             return
-        for game_folder in os.listdir(self.ea_games_path):
-            yield game_folder
+        yield from os.listdir(self.ea_games_path)
 
     def get_installed_games_content_ids(self):
         installed_game_ids = []
@@ -506,11 +505,11 @@ class EAAppService(OnlineService):
         service_game = ServiceGameCollection.get_game("ea_app", offer_id)
         if not service_game:
             logger.error("Aborting install, %s is not present in the game library.", offer_id)
-            return
+            return None
         lutris_game_id = slugify(service_game["name"]) + "-" + self.id
         existing_game = get_game_by_field(lutris_game_id, "installer_slug")
         if existing_game:
-            return
+            return None
         game_config = LutrisConfig(game_config_id=ea_game["configpath"]).game_level
         game_config["game"]["args"] = get_launch_arguments(",".join(content_ids))
         configpath = write_game_config(lutris_game_id, game_config)

--- a/lutris/services/egs.py
+++ b/lutris/services/egs.py
@@ -350,11 +350,11 @@ class EpicGamesStoreService(OnlineService):
         service_game = ServiceGameCollection.get_game("egs", app_name)
         if not service_game:
             logger.error("Aborting install, %s is not present in the game library.", app_name)
-            return
+            return None
         lutris_game_id = slugify(service_game["name"]) + "-" + self.id
         existing_game = get_game_by_field(lutris_game_id, "installer_slug")
         if existing_game:
-            return
+            return None
         details = json.loads(service_game.get("details") or "{}")
         namespace = details.get("namespace")
         catalog_item_id = details.get("catalogItemId")

--- a/lutris/services/gamejolt.py
+++ b/lutris/services/gamejolt.py
@@ -137,7 +137,7 @@ class GameJoltService(OnlineService):
         """Load the user's GameJolt library"""
         if not self.is_connected():
             logger.error("User not connected to GameJolt")
-            return
+            return None
 
         games = self._get_library_games()
         result = []

--- a/lutris/services/gog.py
+++ b/lutris/services/gog.py
@@ -249,7 +249,7 @@ class GOGService(OnlineService):
         """Return the user's library of GOG games"""
         if system.path_exists(self.cache_path):
             logger.debug("Returning cached GOG library")
-            with open(self.cache_path, "r", encoding="utf-8") as gog_cache:
+            with open(self.cache_path, encoding="utf-8") as gog_cache:
                 return json.load(gog_cache)
 
         total_pages = 1
@@ -292,7 +292,7 @@ class GOGService(OnlineService):
         if not product_id:
             raise ValueError("Missing product ID")
         logger.info("Getting game details for %s", product_id)
-        url = "{}/products/{}?expand=downloads&locale={}".format(self.api_url, product_id, self.locale)
+        url = f"{self.api_url}/products/{product_id}?expand=downloads&locale={self.locale}"
         return self.make_api_request(url)
 
     def get_download_info(self, downlink: str) -> list[dict]:
@@ -584,8 +584,7 @@ class GOGService(OnlineService):
         platforms = [platform.casefold() for platform, is_supported in details["worksOn"].items() if is_supported]
         if "linux" in platforms:
             return self._generate_depot_installer(slug, "linux", db_game)
-        else:
-            return self._generate_depot_installer(slug, "wine", db_game)
+        return self._generate_depot_installer(slug, "wine", db_game)
 
     def generate_installers(self, db_game: dict[str, Any]) -> list[dict]:
         details = json.loads(db_game["details"])
@@ -684,7 +683,7 @@ class GOGService(OnlineService):
 
     def get_games_owned(self) -> dict:
         """Return IDs of games owned by user"""
-        url = "{}/user/data/games".format(self.embed_url)
+        url = f"{self.embed_url}/user/data/games"
         return self.make_api_request(url)
 
     def get_dlc_installers(self, db_game: dict) -> list[dict]:

--- a/lutris/services/humblebundle.py
+++ b/lutris/services/humblebundle.py
@@ -147,7 +147,7 @@ class HumbleBundleService(OnlineService):
             raise
         except HTTPError:
             logger.error("Failed to request %s", url)
-            return
+            return None
         return request.json
 
     def order_path(self, gamekey):
@@ -259,7 +259,7 @@ class HumbleBundleService(OnlineService):
         download = [d for d in downloads if d["platform"] == platform][0]
         url = pick_download_url_from_download_info(download)
         if not url:
-            return
+            return None
         return url.split("?")[0].split("/")[-1]
 
     @staticmethod
@@ -356,7 +356,7 @@ def pick_download_url_from_download_info(download_info):
     """
     if not download_info["download_struct"]:
         logger.warning("No downloads found")
-        return
+        return None
 
     def humble_sort(download):
         name = download["name"]
@@ -387,7 +387,7 @@ def get_humble_download_link(humbleid, runner):
     downloads = service.get_downloads(humbleid, platform)
     if not downloads:
         logger.error("Game %s for %s not found in the Humble Bundle library", humbleid, platform)
-        return
+        return None
     logger.info("Found %s download for %s", len(downloads), humbleid)
     download = downloads[0]
     logger.info("Reloading order %s", download["product"]["human_name"])

--- a/lutris/services/itchio.py
+++ b/lutris/services/itchio.py
@@ -164,15 +164,14 @@ class ItchIoService(OnlineService):
         if not os.path.exists(self.api_key_path):
             return None
 
-        with open(self.api_key_path, "r") as key_file:
+        with open(self.api_key_path) as key_file:
             return key_file.read()
 
     def get_headers(self):
         api_key = self.load_api_key()
         if api_key:
             return {"Authorization": f"Bearer {api_key}"}
-        else:
-            return {}
+        return {}
 
     def is_connected(self):
         """Check if service is connected and can call the API"""
@@ -189,7 +188,7 @@ class ItchIoService(OnlineService):
         """Load the user's itch.io library"""
         if not self.is_connected():
             logger.error("User not connected to itch.io")
-            return
+            return None
 
         library = self.get_games()
         games = []
@@ -205,9 +204,9 @@ class ItchIoService(OnlineService):
 
     def make_api_request(self, path, query=None):
         """Make API request"""
-        url = "{}/{}".format(self.api_url, path)
+        url = f"{self.api_url}/{path}"
         if query is not None and isinstance(query, dict):
-            url += "?{}".format(urlencode(query, quote_via=quote_plus))
+            url += f"?{urlencode(query, quote_via=quote_plus)}"
         try:
             request = Request(
                 url,
@@ -271,7 +270,7 @@ class ItchIoService(OnlineService):
         url = "{}/{}".format(self.api_url, f"uploads/{upload_id}/download")
         if dl_key is not None:
             query = {"download_key_id": dl_key}
-            url += "?{}".format(urlencode(query, quote_via=quote_plus))
+            url += f"?{urlencode(query, quote_via=quote_plus)}"
         return url
 
     def get_game_cache(self, appid):
@@ -293,7 +292,7 @@ class ItchIoService(OnlineService):
         fresh_data = True
 
         if (not force_load) and os.path.exists(self.key_cache_file):
-            with open(self.key_cache_file, "r", encoding="utf-8") as key_file:
+            with open(self.key_cache_file, encoding="utf-8") as key_file:
                 owned_keys = json.load(key_file)
             fresh_data = False
         else:
@@ -352,7 +351,7 @@ class ItchIoService(OnlineService):
             collection_cache_path = self.get_collection_cache(collection["id"])
 
             if (not force_load) and os.path.exists(collection_cache_path):
-                with open(collection_cache_path, "r", encoding="utf-8") as key_file:
+                with open(collection_cache_path, encoding="utf-8") as key_file:
                     collection = json.load(key_file)
                 fresh_data = False
             else:
@@ -387,7 +386,7 @@ class ItchIoService(OnlineService):
                         and game.get("min_price", 0) > 0
                         and os.path.exists(game_cache_path)
                     ):
-                        with open(game_cache_path, "r", encoding="utf-8") as key_file:
+                        with open(game_cache_path, encoding="utf-8") as key_file:
                             cached_game = json.load(key_file)
                             if "download_key_id" in cached_game:
                                 game["download_key_id"] = cached_game["download_key_id"]
@@ -408,7 +407,7 @@ class ItchIoService(OnlineService):
     def get_collection_list(self, force_load=False):
         collections = []
         if (not force_load) and os.path.exists(self.collection_list_cache_file):
-            with open(self.collection_list_cache_file, "r", encoding="utf-8") as key_file:
+            with open(self.collection_list_cache_file, encoding="utf-8") as key_file:
                 collections = json.load(key_file)
         else:
             collections = self.fetch_collections().get("collections", [])
@@ -449,25 +448,25 @@ class ItchIoService(OnlineService):
         game = {}
 
         if os.path.exists(game_filename):
-            with open(game_filename, "r", encoding="utf-8") as game_file:
+            with open(game_filename, encoding="utf-8") as game_file:
                 game = json.load(game_file)
         else:
             try:
                 game = self.fetch_game(appid).get("game", {})
                 self._cache_games([game])
             except HTTPError:
-                return
+                return None
 
         traits = game.get("traits", [])
         if "can_be_bought" not in traits:
             # If game can not be bought it can not have a key
-            return
+            return None
         if "download_key_id" in game:
             # Return cached key
             return game["download_key_id"]
         if not game.get("min_price", 0):
             # We have no key but the game can be played for free
-            return
+            return None
 
         # Reload whole key library to check if a key was added
         library = self.get_owned_games(True)
@@ -475,7 +474,7 @@ class ItchIoService(OnlineService):
 
         if "download_key_id" in game:
             return game["download_key_id"]
-        return
+        return None
 
     def get_extras(self, appid):
         """Return a list of bonus content for itch.io game."""
@@ -655,7 +654,7 @@ class ItchIoService(OnlineService):
                 if upload:
                     ts = self._rfc3999_to_timestamp(upload.get("updated_at", 0))
                     if int(info.get("date", 0)) >= ts:
-                        return
+                        return None
                     info["date"] = int(datetime.datetime.now().timestamp())
 
         # Skip time based checks if we already know it's outdated

--- a/lutris/services/service_media.py
+++ b/lutris/services/service_media.py
@@ -156,10 +156,10 @@ class ServiceMedia:
     def download(self, slug, url):
         """Downloads the banner if not present"""
         if not url:
-            return
+            return None
         cache_path = os.path.join(self.dest_path, self.get_filename(slug))
         if system.path_exists(cache_path, exclude_empty=True):
-            return
+            return None
         if system.path_exists(cache_path):
             cache_stats = os.stat(cache_path)
             # Empty files have a life time between 1 and 2 weeks, retry them after

--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -92,7 +92,7 @@ class SteamService(BaseService):
         steamid = get_active_steamid64()
         if not steamid:
             logger.error("Unable to find SteamID from Steam config")
-            return
+            return None
         steam_games = get_steam_library(steamid)
         if not steam_games:
             raise RuntimeError(_("Failed to load games. Check that your profile is set to public during the sync."))
@@ -123,18 +123,18 @@ class SteamService(BaseService):
     def install_from_steam(self, manifest):
         """Create a new Lutris game based on an existing Steam install"""
         if not manifest.is_installed():
-            return
+            return None
         appid = manifest.steamid
         if appid in self.excluded_appids:
-            return
+            return None
         try:
             service_game = ServiceGameCollection.get_game(self.id, appid)
             if not service_game:
-                return
+                return None
             lutris_game_id = "%s-%s" % (self.id, appid)
             existing_game = get_game_by_field(lutris_game_id, "installer_slug")
             if existing_game:
-                return
+                return None
             game_config = LutrisConfig().game_level
             game_config["game"]["appid"] = appid
             configpath = write_game_config(lutris_game_id, game_config)

--- a/lutris/services/ubisoft.py
+++ b/lutris/services/ubisoft.py
@@ -53,10 +53,10 @@ class UbisoftCover(ServiceMedia):
         if url.startswith("http"):
             return super().download(slug, url)
         if not url.endswith(".jpg"):
-            return
+            return None
         ubi_game = get_game_by_field("ubisoft-connect", "slug")
         if not ubi_game:
-            return
+            return None
         base_dir = ubi_game["directory"]
         asset_file = os.path.join(
             base_dir, "drive_c/Program Files (x86)/Ubisoft/Ubisoft Game Launcher/cache/assets", url
@@ -183,7 +183,7 @@ class UbisoftConnectService(OnlineService):
         except RuntimeError as ex:
             logger.error("Failed to authorize with API: %s. Re-login required." % ex)
             AsyncCall(self.logout, lambda _result, _error: self.login())
-            return
+            return None
         response = self.client.get_club_titles()
         games = response["data"]["viewer"]["ownedGames"].get("nodes", [])
         ubi_games = []
@@ -234,7 +234,7 @@ class UbisoftConnectService(OnlineService):
         existing_game = get_game_by_field(lutris_game_id, "installer_slug")
         if existing_game and existing_game["installed"] == 1:
             logger.debug("Ubisoft Connect game %s installed in Lutris", app_name)
-            return
+            return None
         logger.debug("Installing Ubisoft Connect game %s", app_name)
         game_config = LutrisConfig(game_config_id=ubisoft_connect["configpath"]).game_level
         details = json.loads(game["details"])

--- a/lutris/services/xdg.py
+++ b/lutris/services/xdg.py
@@ -62,8 +62,7 @@ class XDGService(BaseService):
     @property
     def lutris_games(self):
         """Iterates through Lutris games imported from XDG"""
-        for game in get_games_where(runner=XDGGame.runner, installer_slug=XDGGame.installer_slug, installed=1):
-            yield game
+        yield from get_games_where(runner=XDGGame.runner, installer_slug=XDGGame.installer_slug, installed=1)
 
     @classmethod
     def _is_importable(cls, app):

--- a/lutris/services/zoom.py
+++ b/lutris/services/zoom.py
@@ -153,7 +153,7 @@ class ZoomService(OnlineService):
         """Return the user's library of Zoom games"""
         if system.path_exists(self.cache_path):
             logger.debug("Returning cached Zoom library")
-            with open(self.cache_path, "r", encoding="utf-8") as zoom_cache:
+            with open(self.cache_path, encoding="utf-8") as zoom_cache:
                 return json.load(zoom_cache)
 
         url = f"{self.api_url}/li/games"
@@ -212,8 +212,7 @@ class ZoomService(OnlineService):
         platforms = details["operating_systems"]
         if "linux" in platforms:
             return self._generate_installer("linux", db_game)
-        else:
-            return self._generate_installer("wine", db_game)
+        return self._generate_installer("wine", db_game)
 
     def generate_installers(self, db_game: dict[str, Any]) -> list[dict]:
         details = json.loads(db_game["details"])

--- a/lutris/settings.py
+++ b/lutris/settings.py
@@ -86,7 +86,7 @@ def get_lutris_directory_settings(directory: str) -> dict[str, str]:
         path = os.path.join(directory, "lutris.json")
         try:
             if os.path.isfile(path):
-                with open(path, "r", encoding="utf-8") as f:
+                with open(path, encoding="utf-8") as f:
                     json_data = json.load(f)
                     if not isinstance(json_data, dict):
                         logger.error("'%s' does not contain a dict, and will be ignored.", path)

--- a/lutris/util/battlenet/definitions.py
+++ b/lutris/util/battlenet/definitions.py
@@ -12,7 +12,7 @@ class DataclassJSONEncoder(json.JSONEncoder):
 
 
 @dc.dataclass
-class WebsiteAuthData(object):
+class WebsiteAuthData:
     cookie_jar: requests.cookies.RequestsCookieJar
     access_token: str
     region: str
@@ -40,14 +40,14 @@ class RegionalGameInfo:
 
 
 @dc.dataclass
-class ConfigGameInfo(object):
+class ConfigGameInfo:
     uid: str
     uninstall_tag: str | None
     last_played: str | None
 
 
 @dc.dataclass
-class ProductDbInfo(object):
+class ProductDbInfo:
     uninstall_tag: str
     ngdp: str = ""
     install_path: str = ""
@@ -61,11 +61,11 @@ class Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
 
-class _Blizzard(object, metaclass=Singleton):
+class _Blizzard(metaclass=Singleton):
     TITLE_ID_MAP = {
         21297: RegionalGameInfo("s1", True),
         21298: RegionalGameInfo("s2", True),

--- a/lutris/util/datapath.py
+++ b/lutris/util/datapath.py
@@ -25,5 +25,5 @@ def get() -> str:
         lutris_module = lutris.__file__
         data_path = os.path.join(os.path.dirname(os.path.dirname(lutris_module)), "share/lutris")
     if not system.path_exists(data_path):
-        raise IOError("data_path can't be found at : %s" % data_path)
+        raise OSError("data_path can't be found at : %s" % data_path)
     return data_path

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -395,7 +395,7 @@ class DBusScreenSaverInhibitor:
                 logger.warning("Failed to inhibit screensaver via D-Bus, falling back to GTK: %s", ex)
 
         # GTK fallback
-        app: "LutrisApplication" = Gio.Application.get_default()
+        app: LutrisApplication = Gio.Application.get_default()
 
         window = app.window
         flags = Gtk.ApplicationInhibitFlags.SUSPEND | Gtk.ApplicationInhibitFlags.IDLE
@@ -422,7 +422,7 @@ class DBusScreenSaverInhibitor:
                 logger.warning("Failed to uninhibit screensaver via D-Bus: %s", ex)
 
         # GTK fallback
-        app: "LutrisApplication" = Gio.Application.get_default()
+        app: LutrisApplication = Gio.Application.get_default()
         app.uninhibit(cookie)
 
 

--- a/lutris/util/dolphin/cache_reader.py
+++ b/lutris/util/dolphin/cache_reader.py
@@ -10,12 +10,12 @@ SUPPORTED_CACHE_VERSION = 24
 
 def get_hex_string(string):
     """Return the hexadecimal representation of a string"""
-    return " ".join("{:02x}".format(c) for c in string)
+    return " ".join(f"{c:02x}" for c in string)
 
 
 def get_word_len(string):
     """Return the length of a string as specified in the Dolphin format"""
-    return int("0x" + "".join("{:02x}".format(c) for c in string[::-1]), 0)
+    return int("0x" + "".join(f"{c:02x}" for c in string[::-1]), 0)
 
 
 # https://github.com/dolphin-emu/dolphin/blob/90a994f93780ef8a7cccfc02e00576692e0f2839/Source/Core/UICommon/GameFile.h#L140

--- a/lutris/util/download_cache.py
+++ b/lutris/util/download_cache.py
@@ -69,7 +69,7 @@ def update_cache_lock(file_path: str, state: CacheState) -> None:
     try:
         lock_data = {}
         if os.path.exists(lock_file):
-            with open(lock_file, "r", encoding="utf-8") as f:
+            with open(lock_file, encoding="utf-8") as f:
                 lock_data = json.load(f)
         lock_data["state"] = state.value
         lock_data["updated_at"] = time.time()
@@ -92,7 +92,7 @@ def get_cache_state(file_path: str) -> CacheState | None:
     if not os.path.exists(lock_file):
         return None
     try:
-        with open(lock_file, "r", encoding="utf-8") as f:
+        with open(lock_file, encoding="utf-8") as f:
             lock_data = json.load(f)
         return CacheState(lock_data.get("state", "downloading"))
     except (OSError, json.JSONDecodeError, ValueError) as ex:
@@ -165,7 +165,7 @@ def is_safe_to_delete(file_path: str) -> bool:
     if state == CacheState.FAILED:
         lock_file = _lock_path(file_path)
         try:
-            with open(lock_file, "r", encoding="utf-8") as f:
+            with open(lock_file, encoding="utf-8") as f:
                 lock_data = json.load(f)
             updated_at = lock_data.get("updated_at", 0)
             days_old = (time.time() - updated_at) / 86400

--- a/lutris/util/download_progress.py
+++ b/lutris/util/download_progress.py
@@ -88,7 +88,7 @@ class DownloadProgress:
         if not os.path.exists(self.progress_path):
             return False
         try:
-            with open(self.progress_path, "r", encoding="utf-8") as f:
+            with open(self.progress_path, encoding="utf-8") as f:
                 self._data = json.load(f)
             required = ("url", "file_size", "total_ranges", "completed_ranges")
             if not all(k in self._data for k in required):

--- a/lutris/util/extract.py
+++ b/lutris/util/extract.py
@@ -204,9 +204,9 @@ def _decompress_gz(file_path: str, dest_path: str):
 
 def _extract_7zip(path: str, dest: str, archive_type: str | None = None) -> None:
     _7zip_path = _get_7zip_path()
-    command = [_7zip_path, "x", path, "-o{}".format(dest), "-aoa"]
+    command = [_7zip_path, "x", path, f"-o{dest}", "-aoa"]
     if archive_type and archive_type != "auto":
-        command.append("-t{}".format(archive_type))
+        command.append(f"-t{archive_type}")
     subprocess.call(command)
 
 
@@ -290,14 +290,14 @@ def _extract_deb(archive: str, dest: str) -> None:
 
     control_file_exts = [".gz", ".xz", ".zst", ""]
     for extension in control_file_exts:
-        control_tar_path = os.path.join(dest, "control.tar{}".format(extension))
+        control_tar_path = os.path.join(dest, f"control.tar{extension}")
         if os.path.exists(control_tar_path):
             shutil.move(control_tar_path, debian_folder)
             break
 
     data_file_exts = [".gz", ".xz", ".zst", ".bz2", ".lzma", ""]
     for extension in data_file_exts:
-        data_tar_path = os.path.join(dest, "data.tar{}".format(extension))
+        data_tar_path = os.path.join(dest, f"data.tar{extension}")
         if os.path.exists(data_tar_path):
             extract_archive(data_tar_path, dest)
             os.remove(data_tar_path)

--- a/lutris/util/fileio.py
+++ b/lutris/util/fileio.py
@@ -36,15 +36,15 @@ class EvilConfigParser(RawConfigParser):  # pylint: disable=too-many-ancestors
 
     def write(self, fp, space_around_delimiters=True):
         for section in self._sections:
-            fp.write("[{}]\n".format(section).encode("utf-8"))
+            fp.write(f"[{section}]\n".encode())
             for key, value in list(self._sections[section].items()):
                 if key == "__name__":
                     continue
                 if (value is not None) or (self._optcre == self.OPTCRE):
                     # Duplicated keys writing support inside
                     key = "=".join((key, str(value).replace("\n", "\n%s=" % key)))
-                fp.write("{}\n".format(key).encode("utf-8"))
-            fp.write("\n".encode("utf-8"))
+                fp.write(f"{key}\n".encode())
+            fp.write(b"\n")
 
 
 class MultiOrderedDict(OrderedDict):

--- a/lutris/util/gamecontrollerdb.py
+++ b/lutris/util/gamecontrollerdb.py
@@ -71,7 +71,7 @@ class GameControllerDB:
         return self.controllers[value]
 
     def parsedb(self):
-        with open(self.db_path, "r", encoding="utf-8") as db:
+        with open(self.db_path, encoding="utf-8") as db:
             for line in db.readlines():
                 line = line.strip()
                 if not line or line.startswith("#"):

--- a/lutris/util/gog.py
+++ b/lutris/util/gog.py
@@ -23,7 +23,7 @@ def get_gog_config(gog_game_path):
     config_files = glob.glob(os.path.join(gog_game_path, "goggame-*.info"))
     if not config_files:
         logger.error("No config file found in %s", gog_game_path)
-        return
+        return None
     gog_config_path = config_files[0]
     with open(gog_config_path, encoding="utf-8") as gog_config_file:
         gog_config = json.loads(gog_config_file.read())
@@ -51,7 +51,7 @@ def get_game_config(task, gog_game_path):
 
     config = {}
     if "path" not in task:
-        return
+        return None
 
     config["exe"] = resolve_path(task["path"])
     if task.get("workingDir"):

--- a/lutris/util/gog_downloader.py
+++ b/lutris/util/gog_downloader.py
@@ -479,19 +479,18 @@ class GOGDownloader(BaseDownloader):
                 # Before our range, skip
                 bytes_read += len(chunk)
                 continue
-            elif chunk_start >= end + 1:
+            if chunk_start >= end + 1:
                 # Past our range, done
                 break
-            else:
-                # Calculate the slice of this chunk we need
-                slice_start = max(0, start - chunk_start)
-                slice_end = min(len(chunk), end + 1 - chunk_start)
-                data = chunk[slice_start:slice_end]
-                enqueued_bytes += len(data)
-                is_last = enqueued_bytes >= range_size
-                self._write_queue.put((current_offset, data, start, end if is_last else None))
-                current_offset += len(data)
-                stall_monitor.check(enqueued_bytes)
+            # Calculate the slice of this chunk we need
+            slice_start = max(0, start - chunk_start)
+            slice_end = min(len(chunk), end + 1 - chunk_start)
+            data = chunk[slice_start:slice_end]
+            enqueued_bytes += len(data)
+            is_last = enqueued_bytes >= range_size
+            self._write_queue.put((current_offset, data, start, end if is_last else None))
+            current_offset += len(data)
+            stall_monitor.check(enqueued_bytes)
 
             bytes_read += len(chunk)
             if bytes_read >= end + 1:

--- a/lutris/util/graphics/xrandr.py
+++ b/lutris/util/graphics/xrandr.py
@@ -96,7 +96,7 @@ def get_outputs() -> list[Output]:
                 if rotate.startswith("("):  # Screen not rotated, no need to include
                     rotate = "normal"
                 _, x_pos, y_pos = geometry.split("+")
-                position = "{x_pos}x{y_pos}".format(x_pos=x_pos, y_pos=y_pos)
+                position = f"{x_pos}x{y_pos}"
                 name = candidate_name
             except ValueError as ex:
                 logger.error(

--- a/lutris/util/http.py
+++ b/lutris/util/http.py
@@ -69,7 +69,7 @@ class Request:
         if headers is None:
             headers = {}
         if not isinstance(headers, dict):
-            raise TypeError("HTTP headers needs to be a dict ({})".format(headers))
+            raise TypeError(f"HTTP headers needs to be a dict ({headers})")
         self.headers.update(headers)
         if cookies:
             cookie_processor = urllib.request.HTTPCookieProcessor(cookies)
@@ -96,7 +96,7 @@ class Request:
 
     @property
     def user_agent(self) -> str:
-        return "{} {}".format(PROJECT, VERSION)
+        return f"{PROJECT} {VERSION}"
 
     @property
     def redacted_url(self) -> str:

--- a/lutris/util/i18n.py
+++ b/lutris/util/i18n.py
@@ -19,7 +19,7 @@ def get_user_locale():
     user_locale, _user_encoding = locale.getlocale()
     if not user_locale:
         logger.error("Unable to get locale")
-        return
+        return None
     return user_locale
 
 

--- a/lutris/util/jobs.py
+++ b/lutris/util/jobs.py
@@ -66,8 +66,7 @@ class AsyncCall(threading.Thread):
 
             disconnecter = callback_target.call_when_destroyed(unhook)
             return fire
-        else:
-            return callback
+        return callback
 
     def target(self, *a: Any, **kw: Any) -> None:
         result = None

--- a/lutris/util/library_sync.py
+++ b/lutris/util/library_sync.py
@@ -47,7 +47,7 @@ class LibrarySyncer:
         """Return a request object and ensures authentication to the Lutris API"""
         credentials = read_api_key()
         if not credentials:
-            return
+            return None
         url = LIBRARY_URL
         if since:
             url += "?since=%s" % since
@@ -175,7 +175,7 @@ class LibrarySyncer:
                 request.post(data=json.dumps(local_library_updates).encode())
             except http.HTTPError as ex:
                 logger.error("Could not send local library to server: %s", ex)
-                return None
+                return
             library_keys = set()
             duplicate_keys = set()
             library_map = {}
@@ -226,7 +226,7 @@ class LibrarySyncer:
         """Task to delete a game entry from the remote library"""
         request = self._get_request()
         if not request:
-            return
+            return None
         try:
             request.delete(data=json.dumps(self._db_games_to_api(games)).encode())
         except http.HTTPError as ex:

--- a/lutris/util/libretro.py
+++ b/lutris/util/libretro.py
@@ -30,8 +30,8 @@ class RetroConfig:
         """Load the configuration from file"""
         self._config = []
         if not os.path.isfile(self.config_path):
-            raise OSError("Specified config file {} does not exist".format(self.config_path))
-        with open(self.config_path, "r", encoding="utf-8") as config_file:
+            raise OSError(f"Specified config file {self.config_path} does not exist")
+        with open(self.config_path, encoding="utf-8") as config_file:
             for line in config_file.readlines():
                 if not line:
                     continue
@@ -49,7 +49,7 @@ class RetroConfig:
     def save(self):
         with open(self.config_path, "w", encoding="utf-8") as config_file:
             for key, value in self.config:
-                config_file.write('{} = "{}"\n'.format(key, value))
+                config_file.write(f'{key} = "{value}"\n')
 
     def serialize_value(self, value):
         for k, v in self.value_map.items():

--- a/lutris/util/mame/database.py
+++ b/lutris/util/mame/database.py
@@ -100,7 +100,7 @@ def get_supported_systems(xml_path, force=False):
     """
     systems_cache_path = os.path.join(CACHE_DIR, "systems.json")
     if os.path.exists(systems_cache_path) and not force:
-        with open(systems_cache_path, "r", encoding="utf-8") as systems_cache_file:
+        with open(systems_cache_path, encoding="utf-8") as systems_cache_file:
             try:
                 systems = json.load(systems_cache_file)
             except json.JSONDecodeError:

--- a/lutris/util/mame/ini.py
+++ b/lutris/util/mame/ini.py
@@ -26,7 +26,7 @@ class MameIni:
 
     def read(self):
         """Reads the content of the ini file"""
-        with open(self.ini_path, "r", encoding="utf-8") as ini_file:
+        with open(self.ini_path, encoding="utf-8") as ini_file:
             for line in ini_file.readlines():
                 self.lines.append(line)
                 config_key, config_value = self.parse(line)

--- a/lutris/util/nvidia.py
+++ b/lutris/util/nvidia.py
@@ -83,7 +83,7 @@ def get_nvidia_dll_path():
     """
     libglx_path = get_nvidia_glx_path()
     if not libglx_path:
-        return
+        return None
     nvidia_wine_dir = os.path.join(os.path.dirname(libglx_path), "nvidia/wine")
     if os.path.exists(os.path.join(nvidia_wine_dir, "nvngx.dll")):
         return nvidia_wine_dir

--- a/lutris/util/process.py
+++ b/lutris/util/process.py
@@ -21,10 +21,10 @@ class Process:
             raise ValueError("'%s' is not a valid pid" % pid) from err
 
     def __repr__(self):
-        return "Process {}".format(self.pid)
+        return f"Process {self.pid}"
 
     def __str__(self):
-        return "{} ({}:{})".format(self.name, self.pid, self.state)
+        return f"{self.name} ({self.pid}:{self.state})"
 
     def _read_content(self, file_path):
         """Return the contents from a file in /proc"""
@@ -39,7 +39,7 @@ class Process:
         return content.strip("\x00")
 
     def get_stat(self, parsed=True):
-        stat_filename = "/proc/{}/stat".format(self.pid)
+        stat_filename = f"/proc/{self.pid}/stat"
         try:
             with open(stat_filename, encoding="utf-8", errors="replace") as stat_file:
                 _stat = stat_file.readline()
@@ -51,7 +51,7 @@ class Process:
 
     def get_thread_ids(self):
         """Return a list of thread ids opened by process."""
-        basedir = "/proc/{}/task/".format(self.pid)
+        basedir = f"/proc/{self.pid}/task/"
         if os.path.isdir(basedir):
             try:
                 return os.listdir(basedir)
@@ -62,7 +62,7 @@ class Process:
 
     def get_children_pids_of_thread(self, tid):
         """Return pids of child processes opened by thread `tid` of process."""
-        children_path = "/proc/{}/task/{}/children".format(self.pid, tid)
+        children_path = f"/proc/{self.pid}/task/{tid}/children"
         try:
             with open(children_path, encoding="utf-8", errors="replace") as children_file:
                 children_content = children_file.read()
@@ -93,7 +93,7 @@ class Process:
     @property
     def cmdline(self):
         """Return command line used to run the process `pid`."""
-        cmdline_path = "/proc/{}/cmdline".format(self.pid)
+        cmdline_path = f"/proc/{self.pid}/cmdline"
         _cmdline_content = self._read_content(cmdline_path)
         if _cmdline_content:
             return _cmdline_content.replace("\x00", " ").replace("\\", "/")
@@ -107,7 +107,7 @@ class Process:
     @property
     def environ(self):
         """Return the process' environment variables"""
-        environ_path = "/proc/{}/environ".format(self.pid)
+        environ_path = f"/proc/{self.pid}/environ"
         _environ_text = self._read_content(environ_path)
         if not _environ_text or "=" not in _environ_text:
             return {}

--- a/lutris/util/resources.py
+++ b/lutris/util/resources.py
@@ -12,9 +12,9 @@ def get_icon_path(game_slug: str) -> str:
 
 def get_banner_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug banner"""
-    return os.path.join(settings.BANNER_PATH, "{}.jpg".format(game_slug))
+    return os.path.join(settings.BANNER_PATH, f"{game_slug}.jpg")
 
 
 def get_cover_path(game_slug: str) -> str:
     """Return the absolute path for a game_slug coverart"""
-    return os.path.join(settings.COVERART_PATH, "{}.jpg".format(game_slug))
+    return os.path.join(settings.COVERART_PATH, f"{game_slug}.jpg")

--- a/lutris/util/savesync.py
+++ b/lutris/util/savesync.py
@@ -153,19 +153,19 @@ def create_dirs(client, path):
 def get_webdav_client():
     if not WEBDAV_AVAILABLE:
         logger.error("Python package 'webdav4' not installed.")
-        return
+        return None
     webdav_host = settings.read_setting("webdav_host")
     if not webdav_host:
         logger.error("No remote host set (webdav_host)")
-        return
+        return None
     webdav_user = settings.read_setting("webdav_user")
     if not webdav_user:
         logger.error("No remote username set (webdav_user)")
-        return
+        return None
     webdav_pass = settings.read_setting("webdav_pass")
     if not webdav_pass:
         logger.error("No remote password set (webdav_pass)")
-        return
+        return None
     return Client(webdav_host, auth=(webdav_user, webdav_pass), timeout=50)
 
 
@@ -235,7 +235,7 @@ def upload_save(game, sections=None):
 
 
 def load_save_info(save_info_path):
-    with open(save_info_path, "r", encoding="utf-8") as save_info_file:
+    with open(save_info_path, encoding="utf-8") as save_info_file:
         save_info = json.load(save_info_file)
     return save_info
 

--- a/lutris/util/steam/appmanifest.py
+++ b/lutris/util/steam/appmanifest.py
@@ -45,7 +45,7 @@ class AppManifest:
         self.appmanifest_data = {}
 
         if path_exists(appmanifest_path):
-            with open(appmanifest_path, "r", encoding="utf-8") as appmanifest_file:
+            with open(appmanifest_path, encoding="utf-8") as appmanifest_file:
                 self.appmanifest_data = vdf_parse(appmanifest_file, {})
         else:
             logger.error("Path to AppManifest file %s doesn't exist", appmanifest_path)
@@ -111,7 +111,7 @@ def get_appmanifest_from_appid(steamapps_path: str, appid: str) -> AppManifest |
     if not steamapps_path:
         raise ValueError("steamapps_path is mandatory")
     if not path_exists(steamapps_path):
-        raise IOError("steamapps_path must be a valid directory")
+        raise OSError("steamapps_path must be a valid directory")
     if not appid:
         raise ValueError("Missing mandatory appid")
     appmanifest_path = os.path.join(steamapps_path, "appmanifest_%s.acf" % appid)

--- a/lutris/util/steam/config.py
+++ b/lutris/util/steam/config.py
@@ -65,7 +65,7 @@ def read_user_config() -> dict[str, Any] | None:
     config_filename = search_in_steam_dirs("config/loginusers.vdf")
     if not config_filename or not system.path_exists(config_filename):
         return None
-    with open(config_filename, "r", encoding="utf-8") as steam_config_file:
+    with open(config_filename, encoding="utf-8") as steam_config_file:
         config: dict[str, Any] = vdf_parse(steam_config_file, {})
     return config
 
@@ -75,7 +75,7 @@ def get_config_value(config: dict[str, Any], key: str) -> Any:
     keymap = {k.lower(): k for k in config.keys()}
     if key not in keymap:
         logger.warning("Config key %s not found in %s", key, ", ".join(list(config.keys())))
-        return
+        return None
     return config[keymap[key.lower()]]
 
 
@@ -138,8 +138,8 @@ def get_steam_library(steamid: str) -> list[dict[str, Any]]:
     steam_games_url = (
         "https://api.steampowered.com/"
         "IPlayerService/GetOwnedGames/v0001/"
-        "?key={}&steamid={}&format=json&include_appinfo=1"
-        "&include_played_free_games=1".format(settings.STEAM_API_KEY, steamid)
+        f"?key={settings.STEAM_API_KEY}&steamid={steamid}&format=json&include_appinfo=1"
+        "&include_played_free_games=1"
     )
     response = requests.get(steam_games_url, timeout=30)
     if response.status_code > 400:
@@ -176,7 +176,7 @@ def read_config(steam_data_dir: str | None) -> dict[str, Any] | None:
     config_filename = os.path.join(steam_data_dir, "config/config.vdf")
     if not system.path_exists(config_filename):
         return None
-    with open(config_filename, "r", encoding="utf-8") as steam_config_file:
+    with open(config_filename, encoding="utf-8") as steam_config_file:
         config = vdf_parse(steam_config_file, {})
     try:
         return dict(get_entry_case_insensitive(config, ["InstallConfigStore", "Software", "Valve", "Steam"]))
@@ -201,7 +201,7 @@ def read_library_folders(steam_data_dir: str | None) -> dict[str, Any] | None:
     library_filename = os.path.join(steam_data_dir, "config/libraryfolders.vdf")
     if not system.path_exists(library_filename):
         return None
-    with open(library_filename, "r", encoding="utf-8") as steam_library_file:
+    with open(library_filename, encoding="utf-8") as steam_library_file:
         library = vdf_parse(steam_library_file, {})
         # The contentstatsid key is unused and causes problems when looking for library paths.
         library["libraryfolders"].pop("contentstatsid", None)

--- a/lutris/util/steam/log.py
+++ b/lutris/util/steam/log.py
@@ -12,7 +12,7 @@ def _get_last_content_log(steam_data_dir: str) -> list[str]:
     path = os.path.join(steam_data_dir, "logs/content_log.txt")
     log = []
     try:
-        with open(path, "r", encoding="utf-8") as logfile:
+        with open(path, encoding="utf-8") as logfile:
             line = logfile.readline()
             while line:
                 # Strip old logs
@@ -22,7 +22,7 @@ def _get_last_content_log(steam_data_dir: str) -> list[str]:
                 else:
                     log.append(line)
                     line = logfile.readline()
-    except IOError:
+    except OSError:
         return []
     return log
 

--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -87,7 +87,7 @@ def is_steam_game(game: "Game") -> bool:
 def create_shortcut(game: "Game", launch_config_name: str, standalone: bool = False) -> None:
     if is_steam_game(game):
         logger.warning("Not updating shortcut for Steam game")
-        return None
+        return
     logger.info("Creating Steam shortcut for %s", game)
     shortcut_path = get_shortcuts_vdf_path()
     if os.path.exists(shortcut_path):
@@ -111,13 +111,13 @@ def remove_shortcut(game: "Game") -> None:
     logger.info("Removing Steam shortcut for %s", game)
     shortcut_path = get_shortcuts_vdf_path()
     if not shortcut_path or not os.path.exists(shortcut_path):
-        return None
+        return
     with open(shortcut_path, "rb") as shortcut_file:
         shortcuts = vdf.binary_loads(shortcut_file.read())["shortcuts"].values()
     other_shortcuts = [s for s in shortcuts if not matches_id(s, game)]
     # Quit early if no shortcut is removed
     if len(shortcuts) == len(other_shortcuts):
-        return None
+        return
     updated_shortcuts = {"shortcuts": {str(index): elem for index, elem in enumerate(other_shortcuts)}}
     with open(shortcut_path, "wb") as shortcut_file:
         shortcut_file.write(vdf.binary_dumps(updated_shortcuts))
@@ -207,7 +207,7 @@ def is_flatpak_lutris() -> bool:
 def set_artwork(game: "Game") -> None:
     config_path = get_config_path()
     if not config_path:
-        return None
+        return
     artwork_path = os.path.join(config_path, "grid")
     if not os.path.exists(artwork_path):
         os.makedirs(artwork_path)
@@ -216,10 +216,10 @@ def set_artwork(game: "Game") -> None:
     source_banner = resources.get_banner_path(game.slug)
     source_icon = resources.get_icon_path(game.slug)
     assets = [
-        ("grid horizontal", source_banner, os.path.join(artwork_path, "{}.jpg".format(shortcut_id))),
-        ("grid vertical", source_cover, os.path.join(artwork_path, "{}p.jpg".format(shortcut_id))),
-        ("hero", source_banner, os.path.join(artwork_path, "{}_hero.jpg".format(shortcut_id))),
-        ("icon", source_icon, os.path.join(artwork_path, "{}_icon.jpg".format(shortcut_id))),
+        ("grid horizontal", source_banner, os.path.join(artwork_path, f"{shortcut_id}.jpg")),
+        ("grid vertical", source_cover, os.path.join(artwork_path, f"{shortcut_id}p.jpg")),
+        ("hero", source_banner, os.path.join(artwork_path, f"{shortcut_id}_hero.jpg")),
+        ("icon", source_icon, os.path.join(artwork_path, f"{shortcut_id}_icon.jpg")),
     ]
     for name, source, target in assets:
         if not system.path_exists(target, exclude_empty=True):

--- a/lutris/util/steam/steamid.py
+++ b/lutris/util/steam/steamid.py
@@ -162,7 +162,7 @@ class SteamID:
         if match:
             if match.group("path") not in TYPE_URL_PATH_MAP[LETTER_TYPE_MAP[match.group("type")]]:
                 warnings.warn(
-                    "Community URL ({}) path doesn't match type character".format(url.path),
+                    f"Community URL ({url.path}) path doesn't match type character",
                     stacklevel=2,
                 )
             steamid = int(match.group("steamid"))
@@ -180,7 +180,7 @@ class SteamID:
                 account_number = (steamid - instance - 0x0170000000000000) / 2
                 account_type = TYPE_CLAN
             return cls(account_number, instance, account_type, universe)
-        raise SteamIDError("Invalid Steam community URL ({})".format(url))
+        raise SteamIDError(f"Invalid Steam community URL ({url})")
 
     @classmethod
     def from_steamid64(
@@ -220,18 +220,18 @@ class SteamID:
             return cls(0, 0, TYPE_INVALID, 0)
         match = TEXTUAL_ID_REGEX.match(steam_id)
         if not match:
-            raise SteamIDError("ID '{}' doesn't match format {}".format(steam_id, TEXTUAL_ID_REGEX.pattern))
+            raise SteamIDError(f"ID '{steam_id}' doesn't match format {TEXTUAL_ID_REGEX.pattern}")
         return cls(int(match.group("Z")), int(match.group("Y")), account_type, int(match.group("X")))
 
     def __init__(self, account_number: int, instance: int, account_type: int, universe: int):
         if universe not in UNIVERSES:
-            raise SteamIDError("Invalid universe {}".format(universe))
+            raise SteamIDError(f"Invalid universe {universe}")
         if account_type not in ACCOUNT_TYPES:
-            raise SteamIDError("Invalid type {}".format(account_type))
+            raise SteamIDError(f"Invalid type {account_type}")
         if account_number < 0 or account_number > (2**32) - 1:
-            raise SteamIDError("Account number ({}) out of range".format(account_number))
+            raise SteamIDError(f"Account number ({account_number}) out of range")
         if instance not in [1, 0]:
-            raise SteamIDError("Expected instance to be 1 or 0, got {}".format(instance))
+            raise SteamIDError(f"Expected instance to be 1 or 0, got {instance}")
         self.account_number = int(account_number)  # Z
         self.instance = instance  # Y
         self.account_type = account_type
@@ -262,7 +262,7 @@ class SteamID:
             return "STEAM_ID_PENDING"
         if self.account_type == TYPE_INVALID:
             return "UNKNOWN"
-        return "STEAM_{}:{}:{}".format(self.universe, self.instance, self.account_number)
+        return f"STEAM_{self.universe}:{self.instance}:{self.account_number}"
 
     def __int__(self) -> int:
         """The 64 bit representation of the SteamID
@@ -283,7 +283,7 @@ class SteamID:
             return (self.account_number * 2) + 0x0110000100000000 + self.instance
         if self.account_type == TYPE_CLAN:
             return (self.account_number * 2) + 0x0170000000000000 + self.instance
-        raise SteamIDError("Cannot create 64-bit identifier for SteamID with type {}".format(self.type_name))
+        raise SteamIDError(f"Cannot create 64-bit identifier for SteamID with type {self.type_name}")
 
     def __eq__(self, other: object) -> bool | NotImplementedType:
         if not isinstance(other, SteamID):
@@ -313,11 +313,9 @@ class SteamID:
         """
 
         try:
-            return "[{}:1:{}]".format(TYPE_LETTER_MAP[self.account_type], self.get_32_bit_community_id())
+            return f"[{TYPE_LETTER_MAP[self.account_type]}:1:{self.get_32_bit_community_id()}]"
         except KeyError as ex:
-            raise SteamIDError(
-                "Cannot create 32-bit indentifier for SteamID with type {}".format(self.type_name)
-            ) from ex
+            raise SteamIDError(f"Cannot create 32-bit indentifier for SteamID with type {self.type_name}") from ex
 
     def get_32_bit_community_id(self) -> int:
         return (self.account_number * 2) + self.instance
@@ -347,4 +345,4 @@ class SteamID:
                 self.base_community_url, "/".join((TYPE_URL_PATH_MAP[self.account_type][0], path_func()))
             )
         except KeyError as ex:
-            raise SteamIDError("Cannot generate community URL for type {}".format(self.type_name)) from ex
+            raise SteamIDError(f"Cannot generate community URL for type {self.type_name}") from ex

--- a/lutris/util/steam/vdf/__init__.py
+++ b/lutris/util/steam/vdf/__init__.py
@@ -249,8 +249,7 @@ def _dump_gen(data: dict[str, Any], pretty: bool = False, escaped: bool = True, 
 
         if isinstance(value, dict):
             yield '%s"%s"\n%s{\n' % (line_indent, key, line_indent)
-            for chunk in _dump_gen(value, pretty, escaped, level + 1):
-                yield chunk
+            yield from _dump_gen(value, pretty, escaped, level + 1)
             yield "%s}\n" % line_indent
         else:
             if escaped and isinstance(value, string_type):
@@ -416,8 +415,7 @@ def _binary_dump_gen(obj: dict[str, Any], level: int = 0, alt_format: bool = Fal
 
         if isinstance(value, dict):
             yield BIN_NONE + key + BIN_NONE
-            for chunk in _binary_dump_gen(value, level + 1, alt_format=alt_format):
-                yield chunk
+            yield from _binary_dump_gen(value, level + 1, alt_format=alt_format)
         elif isinstance(value, UINT_64):
             yield BIN_UINT64 + key + BIN_NONE + uint64.pack(value)
         elif isinstance(value, INT_64):

--- a/lutris/util/steam/watcher.py
+++ b/lutris/util/steam/watcher.py
@@ -34,6 +34,6 @@ class SteamWatcher:
     ) -> None:
         path = _file.get_path()
         if path is None or not path.endswith(".acf"):
-            return None
+            return
         if self.callback:
             self.callback(event_type, path)

--- a/lutris/util/system.py
+++ b/lutris/util/system.py
@@ -111,7 +111,7 @@ def _execute(
     existing_env = get_environment()
     if env:
         if not quiet:
-            logger.debug(" ".join("{}={}".format(k, v) for k, v in env.items()))
+            logger.debug(" ".join(f"{k}={v}" for k, v in env.items()))
         env = {k: v for k, v in env.items() if v is not None}
         existing_env.update(env)
 
@@ -171,7 +171,7 @@ def spawn(
     existing_env = get_environment()
     if env:
         if not quiet:
-            logger.debug(" ".join("{}={}".format(k, v) for k, v in env.items()))
+            logger.debug(" ".join(f"{k}={v}" for k, v in env.items()))
         env = {k: v for k, v in env.items() if v is not None}
         existing_env.update(env)
 
@@ -215,7 +215,7 @@ def get_md5_hash(filename: str) -> bool | str:
     try:
         with open(filename, "rb") as _file:
             _hash = read_file_md5(_file)
-    except IOError:
+    except OSError:
         logger.warning("Error reading %s", filename)
         return False
     return _hash
@@ -346,7 +346,7 @@ def substitute(string_template: str, variables: dict[str, str]) -> str:
     # Replace the dashes with underscores in the mapping and template
     variables = dict((k.replace("-", "_"), v) for k, v in variables.items())
     for identifier in identifiers:
-        string_template = string_template.replace("${}".format(identifier), "${}".format(identifier.replace("-", "_")))
+        string_template = string_template.replace(f"${identifier}", "${}".format(identifier.replace("-", "_")))
 
     template = string.Template(string_template)
     if string_template in list(variables.keys()):

--- a/lutris/util/ubisoft/parser.py
+++ b/lutris/util/ubisoft/parser.py
@@ -6,7 +6,7 @@ import yaml
 from lutris.util.ubisoft.consts import UBISOFT_CONFIGURATIONS_BLACKLISTED_NAMES
 
 
-class UbisoftParser(object):
+class UbisoftParser:
     def __init__(self):
         self.configuration_raw = None
         self.ownership_raw = None
@@ -121,8 +121,7 @@ class UbisoftParser(object):
 
             launch_id_2 = self._convert_data(launch_id_2)
             return launch_id, launch_id_2, record_size + tmp_size + 1
-        else:
-            return None, None, None
+        return None, None, None
 
     def _parse_configuration(self):
         configuration_content = self.configuration_raw

--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -120,7 +120,7 @@ class DLLManager:
         if not system.path_exists(self.versions_path):
             return []
 
-        with open(self.versions_path, "r", encoding="utf-8") as dll_version_file:
+        with open(self.versions_path, encoding="utf-8") as dll_version_file:
             try:
                 dll_versions = [v["tag_name"] for v in json.load(dll_version_file)]
             except (KeyError, json.decoder.JSONDecodeError):
@@ -163,7 +163,7 @@ class DLLManager:
 
     def get_download_url(self):
         """Fetch the download URL from the JSON version file"""
-        with open(self.versions_path, "r", encoding="utf-8") as version_file:
+        with open(self.versions_path, encoding="utf-8") as version_file:
             releases = json.load(version_file)
         for release in releases:
             if release["tag_name"] != self.version:

--- a/lutris/util/wine/prefix.py
+++ b/lutris/util/wine/prefix.py
@@ -35,7 +35,7 @@ def find_prefix(path):
     dir_path = path
     if not dir_path:
         logger.info("No path given, unable to guess prefix location")
-        return
+        return None
     dir_path = os.path.expanduser(dir_path)
     while dir_path != "/" and dir_path:
         dir_path = os.path.dirname(dir_path)
@@ -109,13 +109,13 @@ class WinePrefixManager:
             return os.path.join(self.path, "user.reg")
         if key.startswith(self.hklm_prefix):
             return os.path.join(self.path, "system.reg")
-        raise ValueError("Unsupported key '{}'".format(key))
+        raise ValueError(f"Unsupported key '{key}'")
 
     def get_key_path(self, key):
         for prefix in (self.hkcu_prefix, self.hklm_prefix):
             if key.startswith(prefix):
                 return key[len(prefix) + 1 :]
-        raise ValueError("The key {} is currently not supported by WinePrefixManager".format(key))
+        raise ValueError(f"The key {key} is currently not supported by WinePrefixManager")
 
     def get_registry_key(self, key, subkey):
         registry = WineRegistry(self.get_registry_path(key))
@@ -229,7 +229,7 @@ class WinePrefixManager:
             # save the setting in the new form.
             obsolete_path = os.path.join(self.path, ".lutris_destkop_integration")
             if os.path.isfile(obsolete_path):
-                with open(obsolete_path, "r", encoding="utf-8") as f:
+                with open(obsolete_path, encoding="utf-8") as f:
                     desktop_dir = f.read()
                 self._set_desktop_integration_assignment(desktop_dir)
                 os.unlink(obsolete_path)
@@ -287,7 +287,7 @@ class WinePrefixManager:
         obsolete_path = os.path.join(self.path, ".lutris_dpi_assignment")
         try:
             if os.path.isfile(obsolete_path):
-                with open(obsolete_path, "r", encoding="utf-8") as f:
+                with open(obsolete_path, encoding="utf-8") as f:
                     dpi_assigned = int(f.read())
                 set_lutris_directory_settings(self.path, int(dpi_assigned))
                 os.unlink(obsolete_path)
@@ -371,8 +371,8 @@ class WinePrefixManager:
             # Although, those devices aren't returned by `get_joypads`
             # A better way would be to read /dev/input files directly.
             if "HARPOON RGB" in joypad_name:
-                self.set_registry_key(key, "{} (js)".format(joypad_name), "disabled")
-                self.set_registry_key(key, "{} (event)".format(joypad_name), "disabled")
+                self.set_registry_key(key, f"{joypad_name} (js)", "disabled")
+                self.set_registry_key(key, f"{joypad_name} (event)", "disabled")
 
         # This part of the code below avoids having 2 joystick interfaces
         # showing up simulatenously. It is not sure if it's still needed

--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -251,7 +251,7 @@ def get_game_id(game, env) -> str:
     if not os.path.exists(games_path):
         return DEFAULT_GAMEID
 
-    with open(games_path, "r", encoding="utf-8") as games_file:
+    with open(games_path, encoding="utf-8") as games_file:
         umu_games = json.load(games_file)
 
     for umu_game in umu_games:

--- a/lutris/util/wine/registry.py
+++ b/lutris/util/wine/registry.py
@@ -43,7 +43,7 @@ class WindowsFileTime:
         self.timestamp = timestamp
 
     def __repr__(self):
-        return "<{}>: {}".format(self.__class__.__name__, self.timestamp)
+        return f"<{self.__class__.__name__}>: {self.timestamp}"
 
     @classmethod
     def from_hex(cls, hexvalue):
@@ -51,7 +51,7 @@ class WindowsFileTime:
         return WindowsFileTime(timestamp)
 
     def to_hex(self):
-        return "{:x}".format(self.timestamp)
+        return f"{self.timestamp:x}"
 
     @classmethod
     def from_unix_timestamp(cls, timestamp):
@@ -100,7 +100,7 @@ class WineRegistry:
         """Return an array of the unprocessed contents of a registry file"""
         if not system.path_exists(reg_filename):
             return []
-        with open(reg_filename, "r", encoding="utf-8") as reg_file:
+        with open(reg_filename, encoding="utf-8") as reg_file:
             try:
                 registry_content = reg_file.readlines()
             except Exception:  # pylint: disable=broad-except
@@ -137,9 +137,9 @@ class WineRegistry:
                 self.arch = line.split("=")[1]
 
     def render(self):
-        content = "{}{}\n".format(self.version_header, self.version)
-        content += "{}{}\n\n".format(self.relative_to_header, self.relative_to)
-        content += "#arch={}\n".format(self.arch)
+        content = f"{self.version_header}{self.version}\n"
+        content += f"{self.relative_to_header}{self.relative_to}\n\n"
+        content += f"#arch={self.arch}\n"
         for key in self.keys:
             content += "\n"
             content += self.keys[key].render()
@@ -163,7 +163,7 @@ class WineRegistry:
         key = self.keys.get(path)
         if key:
             return key.get_subkey(subkey)
-        return
+        return None
 
     def set_value(self, path, subkey, value):
         key = self.keys.get(path)
@@ -192,10 +192,10 @@ class WineRegistry:
     def get_unix_path(self, windows_path):
         windows_path = windows_path.replace("\\", "/")
         if not self.prefix_path:
-            return
+            return None
         drives_path = os.path.join(self.prefix_path, "dosdevices")
         if not system.path_exists(drives_path):
-            return
+            return None
         letter, relpath = windows_path.split(":", 1)
         relpath = relpath.strip("/")
         drive_link = os.path.join(drives_path, letter.lower() + ":")
@@ -203,7 +203,7 @@ class WineRegistry:
             drive_path = os.readlink(drive_link)
         except FileNotFoundError:
             logger.error("Unable to read link for %s", drive_link)
-            return
+            return None
 
         if not os.path.isabs(drive_path):
             drive_path = os.path.join(drives_path, drive_path)
@@ -234,10 +234,10 @@ class WineRegistryKey:
         if len(ts_parts) == 1:
             self.timestamp = int(ts_parts[0])
         else:
-            self.timestamp = float("{}.{}".format(ts_parts[0], ts_parts[1]))
+            self.timestamp = float(f"{ts_parts[0]}.{ts_parts[1]}")
 
     def __str__(self):
-        return "{0} {1}".format(self.raw_name, self.raw_timestamp)
+        return f"{self.raw_name} {self.raw_timestamp}"
 
     def parse(self, line):
         """Parse a registry line, populating meta and subkeys"""
@@ -266,29 +266,29 @@ class WineRegistryKey:
         except StopIteration:
             logger.warning("Should this be happening?")
             return
-        self.subkeys[last_subkey] += "\n{}".format(line)
+        self.subkeys[last_subkey] += f"\n{line}"
 
     def render(self):
         """Return the content of the key in the wine .reg format"""
         content = self.raw_name + " " + self.raw_timestamp + "\n"
         for key, value in self.metas.items():
             if value is None:
-                content += "#{}\n".format(key)
+                content += f"#{key}\n"
             else:
-                content += "#{}={}\n".format(key, value)
+                content += f"#{key}={value}\n"
         for key, value in self.subkeys.items():
             if key == "default":
                 key = "@"
             else:
-                key = '"{}"'.format(key)
-            content += "{}={}\n".format(key, value)
+                key = f'"{key}"'
+            content += f"{key}={value}\n"
         return content
 
     def render_value(self, value):
         if isinstance(value, int):
-            return "dword:{:08x}".format(value)
+            return f"dword:{value:08x}"
         if isinstance(value, str):
-            return '"{}"'.format(value)
+            return f'"{value}"'
         raise NotImplementedError("TODO")
 
     @staticmethod
@@ -324,7 +324,7 @@ class WineRegistryKey:
             key = parts[0]
             value = None
         else:
-            raise ValueError("Invalid meta line '{}'".format(meta_line))
+            raise ValueError(f"Invalid meta line '{meta_line}'")
         self.metas[key] = value
 
     def get_meta(self, name):

--- a/lutris/util/wine/wine.py
+++ b/lutris/util/wine/wine.py
@@ -66,7 +66,7 @@ def detect_prefix_arch(prefix_path: str) -> str:
 
     prefix_path = os.path.expanduser(prefix_path)
     registry_path = os.path.join(prefix_path, "system.reg")
-    with open(registry_path, "r", encoding="utf-8") as registry:
+    with open(registry_path, encoding="utf-8") as registry:
         for _line_no in range(5):
             line = registry.readline()
             if "win64" in line:
@@ -179,10 +179,9 @@ def get_runner_files_dir_for_version(version: str) -> str | None:
         return None
     if version in WINE_PATHS:
         return None
-    elif proton.is_proton_version(version):
+    if proton.is_proton_version(version):
         return os.path.join(WINE_DIR, version, "files")
-    else:
-        return os.path.join(WINE_DIR, version)
+    return os.path.join(WINE_DIR, version)
 
 
 def get_wine_path_for_version(version: str, config: dict | None = None) -> str:

--- a/lutris/util/xdgshortcuts.py
+++ b/lutris/util/xdgshortcuts.py
@@ -46,14 +46,14 @@ def get_xdg_basename(game_slug: str, game_id: str, base_dir: str | None = None) 
         # When base dir is provided, lookup possible combinations
         # and return the first match
         for path in [
-            "net.lutris.{}-{}.desktop".format(game_slug, game_id),
-            "{}-{}.desktop".format(game_slug, game_id),
-            "{}.desktop".format(game_slug),
+            f"net.lutris.{game_slug}-{game_id}.desktop",
+            f"{game_slug}-{game_id}.desktop",
+            f"{game_slug}.desktop",
         ]:
             if system.path_exists(os.path.join(base_dir, path)):
                 return path
 
-    return "net.lutris.{}-{}.desktop".format(game_slug, game_id)
+    return f"net.lutris.{game_slug}-{game_id}.desktop"
 
 
 def create_launcher(

--- a/lutris/util/yaml.py
+++ b/lutris/util/yaml.py
@@ -15,7 +15,7 @@ def read_yaml_from_file(filename: str) -> dict[str, Any]:
     """Read filename and return parsed yaml"""
     if not path_exists(filename):
         return {}
-    with open(filename, "r", encoding="utf-8") as yaml_file:
+    with open(filename, encoding="utf-8") as yaml_file:
         try:
             yaml_content = yaml.safe_load(yaml_file) or {}
         except (ScannerError, ParserError):

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,7 +1,7 @@
 line-length = 120
 
 [lint]
-select = ["A", "ARG", "B", "E", "F", "I", "W", "PERF", "RUF"]
+select = ["A", "ARG", "B", "E", "F", "I", "W", "PERF", "RUF", "UP", "RET"]
 ignore = [
     # Ignores that is not worth/too hard to fix
     "RUF001", #  String contains ambiguous `！` (FULLWIDTH EXCLAMATION MARK). Did you mean `!` (EXCLAMATION MARK)? - used ,mostly on tests
@@ -28,6 +28,16 @@ ignore = [
     "ARG004", # Unused static method argument: `x`
     "B020", # Loop control variable `upstream_runners` overrides iterable it iterates
     "B018", # Found useless expression. Either assign it to a variable or remove it
+    # UP rules that require --unsafe-fixes or a newer Python target
+    "UP031", # Use format specifiers instead of percent format - gated behind --unsafe-fixes
+    "UP006", # Use `type` instead of `Type` for annotation - requires Python 3.9+
+    "UP007", # Use `X | Y` for union annotation - requires Python 3.10+
+    "UP035", # `typing` members deprecated - some still needed for Python 3.10 compat
+    # RET rules excluded as unsafe or too opinionated
+    "RET503", # Missing explicit `return` - can change behaviour
+    "RET504", # Unnecessary assignment before `return` - intermediate variable may be intentional
+    # UP037 — keep quoted annotations; some types are conditionally imported under TYPE_CHECKING
+    "UP037", # Remove quotes from type annotation - breaks forward references to conditional imports
 ]
 fixable = ["ALL"]
 unfixable = []

--- a/tests/_test_dialogs.py
+++ b/tests/_test_dialogs.py
@@ -45,14 +45,14 @@ class TestGameDialog(TestCase):
 
 
 class TestSort(TestCase):
-    class FakeModel(object):
+    class FakeModel:
         def __init__(self, rows):
             self.rows = rows
 
         def get_value(self, row_index, col_name):
             return self.rows[row_index].cols.get(col_name)
 
-    class FakeRow(object):
+    class FakeRow:
         def __init__(self, coldict):
             self.cols = coldict
 

--- a/tests/_test_registry.py
+++ b/tests/_test_registry.py
@@ -52,13 +52,13 @@ class TestWineRegistry(TestCase):
 
     def test_render_user_reg(self):
         content = self.registry.render()
-        with open(self.registry_path, "r") as registry_file:
+        with open(self.registry_path) as registry_file:
             original_content = registry_file.read()
         self.assertEqual(content, original_content)
 
     def test_can_render_system_reg(self):
         registry_path = os.path.join(FIXTURES_PATH, "system.reg")
-        with open(registry_path, "r") as registry_file:
+        with open(registry_path) as registry_file:
             original_content = registry_file.read()
         system_reg = WineRegistry(registry_path)
         content = system_reg.render()

--- a/tests/check_prefixes.py
+++ b/tests/check_prefixes.py
@@ -21,13 +21,13 @@ def get_registries():
 
 
 def check_registry(registry_path):
-    with open(registry_path, "r") as registry_file:
+    with open(registry_path) as registry_file:
         original_content = registry_file.read()
 
     try:
         wine_registry = WineRegistry(registry_path)
     except:
-        sys.stderr.write("Error parsing {}\n".format(registry_path))
+        sys.stderr.write(f"Error parsing {registry_path}\n")
         raise
     content = wine_registry.render()
     if content != original_content:
@@ -35,7 +35,7 @@ def check_registry(registry_path):
         with open(wrong_path, "w") as wrong_reg:
             wrong_reg.write(content)
 
-        print("Content of parsed registry doesn't match: {}".format(registry_path))
+        print(f"Content of parsed registry doesn't match: {registry_path}")
         subprocess.call(["meld", registry_path, wrong_path])
         sys.exit(2)
 
@@ -43,4 +43,4 @@ def check_registry(registry_path):
 registries = get_registries()
 for registry in registries:
     check_registry(registry)
-print("All {} registry files validated!".format(len(registries)))
+print(f"All {len(registries)} registry files validated!")

--- a/tests/util/_test_download_progress.py
+++ b/tests/util/_test_download_progress.py
@@ -56,7 +56,7 @@ class TestCreate:
         ranges = [(0, 49), (50, 99)]
         progress.create("https://cdn.gog.com/game.bin", 100, ranges)
 
-        with open(progress.progress_path, "r") as f:
+        with open(progress.progress_path) as f:
             data = json.load(f)
         assert data["url"] == "https://cdn.gog.com/game.bin"
         assert data["file_size"] == 100


### PR DESCRIPTION
## Summary

Mechanical-only modernization sweep applied with `ruff 0.12.1`, scoped strictly to **safe** autofixes. No behavioral change — pure style/readability cleanup.

Adds `UP` and `RET` to the `select` list in `ruff.toml` (with unsafe/opinionated sub-rules suppressed and commented) so the project enforces these rules going forward — addressing the feedback that rules shouldn't be applied without being enabled in config.

### Rules enabled in ruff.toml

- **UP032** — convert `str.format()` calls to f-strings (101 sites)
- **UP028** — replace `yield`-over-`for` loop with `yield from` (4 sites)
- **UP008** — use `super()` instead of `super(__class__, self)` (1 site)
- **RET501 / RET502** — drop redundant `return None` / implicit `None` returns
- **RET505 / RET506 / RET507** — remove `else`/`elif` after `return` / `raise` / `continue`

### Deliberately suppressed in ruff.toml (with inline comments)

- **UP031** — `%`-format → f-string: gated behind `--unsafe-fixes` in ruff
- **UP006 / UP007 / UP035** — typing annotation modernization: requires Python 3.9+/3.10+ or drops still-needed `typing` members
- **RET503** — missing explicit `return`: can change behaviour
- **RET504** — assign-before-return: opinionated; intermediate variable often intentional

98 files, +322 / −351 (net −29 lines).

## Verification

All run against the project's pinned tooling (`ruff 0.12.1`, `mypy 1.16.1`, `--python-version 3.10`):

- `ruff check` — clean
- `ruff format --check` — clean
- `mypy` — Success, no issues in 327 source files