### PR TITLE
Add GOG installer download-only cache flow

### DIFF
--- a/lutris/cache.py
+++ b/lutris/cache.py
@@ -25,13 +25,13 @@ def get_cache_path(create: bool = False) -> str:
     return settings.INSTALLER_CACHE_DIR
 
 
-def get_installer_cache_entries() -> list[dict]:
+def get_installer_cache_entries() -> list[dict[str, object]]:
     """Return cached installer folders with their size and file count."""
     cache_path = get_cache_path()
     if not os.path.isdir(cache_path):
         return []
 
-    entries = []
+    entries: list[dict[str, object]] = []
     for name in sorted(os.listdir(cache_path)):
         path = os.path.join(cache_path, name)
         if not os.path.isdir(path):
@@ -68,13 +68,13 @@ def delete_installer_cache_entry(path: str) -> None:
         shutil.rmtree(path)
 
 
-def get_incomplete_installer_cache_entries() -> list[dict]:
+def get_incomplete_installer_cache_entries() -> list[dict[str, object]]:
     """Return incomplete installer download artifacts in the installer cache."""
     cache_path = get_cache_path()
     if not os.path.isdir(cache_path):
         return []
 
-    entries = []
+    entries: list[dict[str, object]] = []
     seen_paths = set()
     for root, _dirs, files in os.walk(cache_path):
         for filename in sorted(files):

--- a/lutris/cache.py
+++ b/lutris/cache.py
@@ -2,12 +2,15 @@
 
 import os
 import shutil
+import time
 from gettext import gettext as _
 from urllib.parse import urlparse
 
 from lutris import settings
 from lutris.util.log import logger
 from lutris.util.system import merge_folders, path_contains
+
+INCOMPLETE_CACHE_SUFFIXES = (".tmp", ".progress")
 
 
 def get_cache_path(create: bool = False) -> str:
@@ -20,6 +23,111 @@ def get_cache_path(create: bool = False) -> str:
             return cache_path
 
     return settings.INSTALLER_CACHE_DIR
+
+
+def get_installer_cache_entries() -> list[dict]:
+    """Return cached installer folders with their size and file count."""
+    cache_path = get_cache_path()
+    if not os.path.isdir(cache_path):
+        return []
+
+    entries = []
+    for name in sorted(os.listdir(cache_path)):
+        path = os.path.join(cache_path, name)
+        if not os.path.isdir(path):
+            continue
+
+        size = 0
+        file_count = 0
+        for root, _dirs, files in os.walk(path):
+            for filename in files:
+                if filename.endswith(".cache_lock"):
+                    continue
+                file_path = os.path.join(root, filename)
+                try:
+                    size += os.path.getsize(file_path)
+                    file_count += 1
+                except OSError:
+                    pass
+
+        entries.append({"name": name, "path": path, "size": size, "file_count": file_count})
+
+    return entries
+
+
+def delete_installer_cache_entry(path: str) -> None:
+    """Delete one installer cache entry."""
+    cache_path = get_cache_path()
+    if os.path.islink(path):
+        raise ValueError("Refusing to delete symlinked installer cache path: %s" % path)
+    if not path_contains(cache_path, path, resolve_symlinks=True):
+        raise ValueError("Refusing to delete path outside installer cache: %s" % path)
+    if os.path.dirname(os.path.realpath(path)) != os.path.realpath(cache_path):
+        raise ValueError("Refusing to delete nested path inside installer cache: %s" % path)
+    if os.path.isdir(path):
+        shutil.rmtree(path)
+
+
+def get_incomplete_installer_cache_entries() -> list[dict]:
+    """Return incomplete installer download artifacts in the installer cache."""
+    cache_path = get_cache_path()
+    if not os.path.isdir(cache_path):
+        return []
+
+    entries = []
+    seen_paths = set()
+    for root, _dirs, files in os.walk(cache_path):
+        for filename in sorted(files):
+            file_path = os.path.join(root, filename)
+            if file_path in seen_paths:
+                continue
+
+            kind = None
+            if filename.endswith(INCOMPLETE_CACHE_SUFFIXES):
+                kind = _("Temporary download")
+            elif filename.endswith(".cache_lock") and _is_orphaned_downloading_lock(file_path):
+                kind = _("Stale download lock")
+
+            if not kind:
+                continue
+
+            try:
+                size = os.path.getsize(file_path)
+                modified_at = os.path.getmtime(file_path)
+            except OSError:
+                size = 0
+                modified_at = time.time()
+
+            seen_paths.add(file_path)
+            entries.append({"path": file_path, "size": size, "kind": kind, "modified_at": modified_at})
+
+    return entries
+
+
+def _is_orphaned_downloading_lock(lock_path: str) -> bool:
+    """Return True if a cache lock belongs to an incomplete abandoned download."""
+    data_path = lock_path[: -len(".cache_lock")]
+    if os.path.exists(data_path):
+        return False
+
+    try:
+        from lutris.util.download_cache import CacheState, get_cache_state
+
+        return get_cache_state(data_path) == CacheState.DOWNLOADING
+    except Exception:
+        return False
+
+
+def delete_incomplete_installer_cache_entries(paths: list[str]) -> None:
+    """Delete incomplete installer download artifacts."""
+    cache_path = get_cache_path()
+    for path in paths:
+        if os.path.islink(path):
+            raise ValueError("Refusing to delete symlinked incomplete cache path: %s" % path)
+        if not path_contains(cache_path, path, resolve_symlinks=True):
+            raise ValueError("Refusing to delete path outside installer cache: %s" % path)
+        if os.path.isfile(path):
+            os.remove(path)
 
 
 def get_url_cache_path(url: str, file_id: str, game_slug: str, prepare: bool = False) -> str:

--- a/lutris/gui/config/storage_box.py
+++ b/lutris/gui/config/storage_box.py
@@ -323,7 +323,9 @@ class StorageBox(BaseConfigBox):
         list_box = Gtk.ListBox(visible=True, selection_mode=Gtk.SelectionMode.NONE)
         if entries:
             for entry in entries:
-                list_box.add(Gtk.ListBoxRow(child=self.get_incomplete_download_row(entry), visible=True, activatable=False))
+                list_box.add(
+                    Gtk.ListBoxRow(child=self.get_incomplete_download_row(entry), visible=True, activatable=False)
+                )
         else:
             empty_label = Label()
             empty_label.set_markup("<i>%s</i>" % _("No incomplete downloads found."))

--- a/lutris/gui/config/storage_box.py
+++ b/lutris/gui/config/storage_box.py
@@ -3,15 +3,24 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 
-from lutris.cache import get_custom_cache_path, save_custom_cache_path, validate_custom_cache_path
+from lutris.cache import (
+    delete_incomplete_installer_cache_entries,
+    delete_installer_cache_entry,
+    get_custom_cache_path,
+    get_incomplete_installer_cache_entries,
+    get_installer_cache_entries,
+    save_custom_cache_path,
+    validate_custom_cache_path,
+)
 from lutris.config import LutrisConfig
 from lutris.gui.config.base_config_box import BaseConfigBox
 from lutris.gui.config.widget_generator import WidgetWarningMessageBox
+from lutris.gui.dialogs import QuestionDialog
 from lutris.gui.widgets.common import FileChooserEntry, Label
 from lutris.runners.runner import Runner
 from lutris.util.jobs import AsyncCall
 from lutris.util.retroarch.firmware import scan_firmware_directory
-from lutris.util.strings import human_size
+from lutris.util.strings import gtk_safe, human_size
 
 
 class StorageBox(BaseConfigBox):
@@ -20,10 +29,13 @@ class StorageBox(BaseConfigBox):
             "bios_path": StoragePathMessageBox(),
             "pga_cache_path": StoragePathMessageBox(),
         }
+        self.cache_entry_checkbuttons = []
 
         self.add(self.get_section_label(_("Paths")))
         path_widgets = self.get_path_widgets()
         self.pack_start(self._get_framed_options_list_box(path_widgets), False, False, 0)
+        self.pack_start(self.get_cached_installers_section(), False, False, 0)
+        self.pack_start(self.get_incomplete_downloads_section(), False, False, 0)
         self.update_pga_cache_path_warning()
 
     def get_path_widgets(self):
@@ -161,6 +173,211 @@ class StorageBox(BaseConfigBox):
 
         error_box = self.error_boxes["pga_cache_path"]
         error_box.show_markup(markup if markup and not valid else None)
+
+    def get_cached_installers_section(self):
+        box = Gtk.VBox(spacing=12, visible=True)
+        box.pack_start(self.get_section_label(_("Cached installers")), False, False, 0)
+
+        self.cached_installers_frame = Gtk.Frame(visible=True, shadow_type=Gtk.ShadowType.ETCHED_IN)
+        box.pack_start(self.cached_installers_frame, False, False, 0)
+
+        self.delete_cache_button = Gtk.Button(label=_("Delete selected cached installers"), visible=True)
+        self.delete_cache_button.connect("clicked", self.on_delete_cached_installers_clicked)
+        box.pack_start(self.delete_cache_button, False, False, 0)
+
+        self.refresh_cached_installers_async()
+        return box
+
+    def refresh_cached_installers_async(self):
+        self.display_cached_installers_loading()
+        AsyncCall(get_installer_cache_entries, self.on_cached_installers_loaded)
+
+    def display_cached_installers_loading(self):
+        loading_label = Label()
+        loading_label.set_markup("<i>%s</i>" % _("Scanning cached installers..."))
+        loading_label.set_margin_top(12)
+        loading_label.set_margin_bottom(12)
+        loading_label.set_margin_left(12)
+        loading_label.set_margin_right(12)
+        list_box = Gtk.ListBox(visible=True, selection_mode=Gtk.SelectionMode.NONE)
+        list_box.add(Gtk.ListBoxRow(child=loading_label, visible=True, activatable=False))
+        self.set_cached_installers_child(list_box)
+        self.delete_cache_button.set_sensitive(False)
+
+    def on_cached_installers_loaded(self, result, error):
+        if error:
+            self.refresh_cached_installers([])
+            return
+        self.refresh_cached_installers(result)
+
+    def refresh_cached_installers(self, entries):
+        self.cache_entry_checkbuttons = []
+
+        list_box = Gtk.ListBox(visible=True, selection_mode=Gtk.SelectionMode.NONE)
+        if entries:
+            for entry in entries:
+                list_box.add(Gtk.ListBoxRow(child=self.get_cache_entry_row(entry), visible=True, activatable=False))
+        else:
+            empty_label = Label()
+            empty_label.set_markup("<i>%s</i>" % _("No cached installers found."))
+            empty_label.set_margin_top(12)
+            empty_label.set_margin_bottom(12)
+            empty_label.set_margin_left(12)
+            empty_label.set_margin_right(12)
+            list_box.add(Gtk.ListBoxRow(child=empty_label, visible=True, activatable=False))
+
+        self.set_cached_installers_child(list_box)
+        self.delete_cache_button.set_sensitive(bool(entries))
+
+    def set_cached_installers_child(self, child):
+        current_child = self.cached_installers_frame.get_child()
+        if current_child:
+            self.cached_installers_frame.remove(current_child)
+        self.cached_installers_frame.add(child)
+        self.cached_installers_frame.show_all()
+
+    def get_cache_entry_row(self, entry):
+        checkbutton = Gtk.CheckButton(visible=True, valign=Gtk.Align.CENTER)
+        checkbutton.cache_entry_path = entry["path"]
+        self.cache_entry_checkbuttons.append(checkbutton)
+
+        label = Label()
+        label.set_markup(
+            "<b>{name}</b>\n{size}, {file_count} files\n<small>{path}</small>".format(
+                name=gtk_safe(entry["name"]),
+                size=human_size(entry["size"]),
+                file_count=entry["file_count"],
+                path=gtk_safe(entry["path"]),
+            )
+        )
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, visible=True)
+        row.set_margin_top(12)
+        row.set_margin_bottom(12)
+        row.set_margin_left(12)
+        row.set_margin_right(12)
+        row.pack_start(checkbutton, False, False, 0)
+        row.pack_start(label, True, True, 0)
+        return row
+
+    def on_delete_cached_installers_clicked(self, _button):
+        selected_paths = [
+            checkbutton.cache_entry_path for checkbutton in self.cache_entry_checkbuttons if checkbutton.get_active()
+        ]
+        if not selected_paths:
+            return
+
+        dlg = QuestionDialog(
+            {
+                "parent": self.get_toplevel(),
+                "title": _("Delete cached installers?"),
+                "question": _("Delete %d selected cached installer(s)?") % len(selected_paths),
+            }
+        )
+        if dlg.result != Gtk.ResponseType.YES:
+            return
+
+        for path in selected_paths:
+            delete_installer_cache_entry(path)
+        self.refresh_cached_installers_async()
+
+    def get_incomplete_downloads_section(self):
+        box = Gtk.VBox(spacing=12, visible=True)
+        box.pack_start(self.get_section_label(_("Incomplete installer downloads")), False, False, 0)
+
+        self.incomplete_downloads_frame = Gtk.Frame(visible=True, shadow_type=Gtk.ShadowType.ETCHED_IN)
+        box.pack_start(self.incomplete_downloads_frame, False, False, 0)
+
+        self.delete_incomplete_button = Gtk.Button(label=_("Delete incomplete downloads"), visible=True)
+        self.delete_incomplete_button.connect("clicked", self.on_delete_incomplete_downloads_clicked)
+        box.pack_start(self.delete_incomplete_button, False, False, 0)
+
+        self.refresh_incomplete_downloads_async()
+        return box
+
+    def refresh_incomplete_downloads_async(self):
+        self.display_incomplete_downloads_loading()
+        AsyncCall(get_incomplete_installer_cache_entries, self.on_incomplete_downloads_loaded)
+
+    def display_incomplete_downloads_loading(self):
+        loading_label = Label()
+        loading_label.set_markup("<i>%s</i>" % _("Scanning incomplete downloads..."))
+        loading_label.set_margin_top(12)
+        loading_label.set_margin_bottom(12)
+        loading_label.set_margin_left(12)
+        loading_label.set_margin_right(12)
+        list_box = Gtk.ListBox(visible=True, selection_mode=Gtk.SelectionMode.NONE)
+        list_box.add(Gtk.ListBoxRow(child=loading_label, visible=True, activatable=False))
+        self.set_incomplete_downloads_child(list_box)
+        self.delete_incomplete_button.set_sensitive(False)
+
+    def on_incomplete_downloads_loaded(self, result, error):
+        if error:
+            self.refresh_incomplete_downloads([])
+            return
+        self.refresh_incomplete_downloads(result)
+
+    def refresh_incomplete_downloads(self, entries):
+        self.incomplete_download_entries = entries
+
+        list_box = Gtk.ListBox(visible=True, selection_mode=Gtk.SelectionMode.NONE)
+        if entries:
+            for entry in entries:
+                list_box.add(Gtk.ListBoxRow(child=self.get_incomplete_download_row(entry), visible=True, activatable=False))
+        else:
+            empty_label = Label()
+            empty_label.set_markup("<i>%s</i>" % _("No incomplete downloads found."))
+            empty_label.set_margin_top(12)
+            empty_label.set_margin_bottom(12)
+            empty_label.set_margin_left(12)
+            empty_label.set_margin_right(12)
+            list_box.add(Gtk.ListBoxRow(child=empty_label, visible=True, activatable=False))
+
+        self.set_incomplete_downloads_child(list_box)
+        self.delete_incomplete_button.set_sensitive(bool(entries))
+
+    def set_incomplete_downloads_child(self, child):
+        current_child = self.incomplete_downloads_frame.get_child()
+        if current_child:
+            self.incomplete_downloads_frame.remove(current_child)
+        self.incomplete_downloads_frame.add(child)
+        self.incomplete_downloads_frame.show_all()
+
+    def get_incomplete_download_row(self, entry):
+        label = Label()
+        label.set_markup(
+            "<b>{kind}</b>\n{size}\n<small>{path}</small>".format(
+                kind=gtk_safe(entry["kind"]),
+                size=human_size(entry["size"]),
+                path=gtk_safe(entry["path"]),
+            )
+        )
+
+        row = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=12, visible=True)
+        row.set_margin_top(12)
+        row.set_margin_bottom(12)
+        row.set_margin_left(12)
+        row.set_margin_right(12)
+        row.pack_start(label, True, True, 0)
+        return row
+
+    def on_delete_incomplete_downloads_clicked(self, _button):
+        if not self.incomplete_download_entries:
+            return
+
+        dlg = QuestionDialog(
+            {
+                "parent": self.get_toplevel(),
+                "title": _("Delete incomplete downloads?"),
+                "question": _("Delete %d incomplete download artifact(s)?")
+                % len(self.incomplete_download_entries),
+            }
+        )
+        if dlg.result != Gtk.ResponseType.YES:
+            return
+
+        delete_incomplete_installer_cache_entries([entry["path"] for entry in self.incomplete_download_entries])
+        self.refresh_incomplete_downloads_async()
 
 
 class StoragePathMessageBox(WidgetWarningMessageBox):

--- a/lutris/gui/config/storage_box.py
+++ b/lutris/gui/config/storage_box.py
@@ -371,8 +371,7 @@ class StorageBox(BaseConfigBox):
             {
                 "parent": self.get_toplevel(),
                 "title": _("Delete incomplete downloads?"),
-                "question": _("Delete %d incomplete download artifact(s)?")
-                % len(self.incomplete_download_entries),
+                "question": _("Delete %d incomplete download artifact(s)?") % len(self.incomplete_download_entries),
             }
         )
         if dlg.result != Gtk.ResponseType.YES:

--- a/lutris/gui/dialogs/cache.py
+++ b/lutris/gui/dialogs/cache.py
@@ -2,18 +2,28 @@ from gettext import gettext as _
 
 from gi.repository import Gtk
 
-from lutris.cache import get_custom_cache_path, save_custom_cache_path
-from lutris.gui.dialogs import ModalDialog
+from lutris.cache import (
+    delete_installer_cache_entry,
+    get_custom_cache_path,
+    get_installer_cache_entries,
+    save_custom_cache_path,
+)
+from lutris.gui.dialogs import ModalDialog, QuestionDialog
 from lutris.gui.widgets.common import FileChooserEntry
+from lutris.util.strings import gtk_safe, human_size
 
 
 class CacheConfigurationDialog(ModalDialog):
     def __init__(self, parent=None):
-        super().__init__(_("Download cache configuration"), parent=parent, flags=Gtk.DialogFlags.MODAL, border_width=10)
+        super().__init__(
+            _("Download cache configuration"), parent=parent, flags=Gtk.DialogFlags.MODAL, border_width=10
+        )
         self.timer_id = None
-        self.set_size_request(480, 150)
+        self.set_size_request(640, 380)
 
         self.cache_path = get_custom_cache_path() or ""
+        self.cache_entries_store = Gtk.ListStore(str, str, str)
+        self.cache_entries_view = None
         self.get_content_area().add(self.get_cache_config())
 
         self.add_button(Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL)
@@ -29,7 +39,7 @@ class CacheConfigurationDialog(ModalDialog):
 
     def get_cache_config(self):
         """Return the widgets for the cache configuration"""
-        prefs_box = Gtk.VBox()
+        prefs_box = Gtk.VBox(spacing=12)
 
         box = Gtk.Box(spacing=12, margin_right=12, margin_left=12)
         label = Gtk.Label(_("Cache path"))
@@ -55,7 +65,72 @@ class CacheConfigurationDialog(ModalDialog):
             )
         )
         prefs_box.pack_start(cache_help_label, False, False, 6)
+        prefs_box.pack_start(self.get_cache_entries_box(), True, True, 6)
         return prefs_box
+
+    def get_cache_entries_box(self):
+        box = Gtk.VBox(spacing=6)
+        box.set_margin_left(12)
+        box.set_margin_right(12)
+
+        heading = Gtk.Label(label=_("Cached installers"))
+        heading.set_alignment(0, 0)
+        box.pack_start(heading, False, False, 0)
+
+        self.cache_entries_view = Gtk.TreeView(model=self.cache_entries_store)
+        self.cache_entries_view.set_headers_visible(True)
+        self.cache_entries_view.get_selection().set_mode(Gtk.SelectionMode.SINGLE)
+
+        name_renderer = Gtk.CellRendererText()
+        name_column = Gtk.TreeViewColumn(_("Game"), name_renderer, text=0)
+        name_column.set_expand(True)
+        self.cache_entries_view.append_column(name_column)
+
+        size_renderer = Gtk.CellRendererText()
+        self.cache_entries_view.append_column(Gtk.TreeViewColumn(_("Size"), size_renderer, text=1))
+
+        path_renderer = Gtk.CellRendererText()
+        path_column = Gtk.TreeViewColumn(_("Location"), path_renderer, text=2)
+        path_column.set_expand(True)
+        self.cache_entries_view.append_column(path_column)
+
+        scrolled = Gtk.ScrolledWindow(hexpand=True, vexpand=True, child=self.cache_entries_view)
+        scrolled.set_shadow_type(Gtk.ShadowType.ETCHED_IN)
+        box.pack_start(scrolled, True, True, 0)
+
+        delete_button = Gtk.Button(label=_("Delete selected cached installer"))
+        delete_button.connect("clicked", self._on_delete_cache_entry_clicked)
+        box.pack_start(delete_button, False, False, 0)
+
+        self.refresh_cache_entries()
+        return box
+
+    def refresh_cache_entries(self):
+        self.cache_entries_store.clear()
+        for entry in get_installer_cache_entries():
+            self.cache_entries_store.append([entry["name"], human_size(entry["size"]), entry["path"]])
+
+    def _on_delete_cache_entry_clicked(self, _button):
+        if not self.cache_entries_view:
+            return
+
+        model, tree_iter = self.cache_entries_view.get_selection().get_selected()
+        if tree_iter is None:
+            return
+
+        path = model[tree_iter][2]
+        dlg = QuestionDialog(
+            {
+                "parent": self,
+                "title": _("Delete cached installer?"),
+                "question": _("Delete the cached installer files in %s?") % gtk_safe(path),
+            }
+        )
+        if dlg.result != Gtk.ResponseType.YES:
+            return
+
+        delete_installer_cache_entry(path)
+        self.refresh_cache_entries()
 
     def _on_cache_path_set(self, entry):
         self.cache_path = entry.get_text()

--- a/lutris/gui/dialogs/cache.py
+++ b/lutris/gui/dialogs/cache.py
@@ -15,9 +15,7 @@ from lutris.util.strings import gtk_safe, human_size
 
 class CacheConfigurationDialog(ModalDialog):
     def __init__(self, parent=None):
-        super().__init__(
-            _("Download cache configuration"), parent=parent, flags=Gtk.DialogFlags.MODAL, border_width=10
-        )
+        super().__init__(_("Download cache configuration"), parent=parent, flags=Gtk.DialogFlags.MODAL, border_width=10)
         self.timer_id = None
         self.set_size_request(640, 380)
 

--- a/lutris/gui/installer/file_box.py
+++ b/lutris/gui/installer/file_box.py
@@ -23,7 +23,7 @@ class InstallerFileBox(Gtk.VBox):
         "file-unready": (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
-    def __init__(self, installer_file):
+    def __init__(self, installer_file, use_cached_file=True):
         super().__init__()
         self.installer_file = installer_file
         self.cache_to_pga = self.installer_file.uses_pga_cache()
@@ -34,6 +34,8 @@ class InstallerFileBox(Gtk.VBox):
         self.set_margin_left(12)
         self.set_margin_right(12)
         self.provider = self.installer_file.default_provider
+        if not use_cached_file and self.provider == "pga" and "download" in self.installer_file.providers:
+            self.provider = "download"
         self.file_provider_widget = None
         self.add(self.get_widgets())
 

--- a/lutris/gui/installer/files_box.py
+++ b/lutris/gui/installer/files_box.py
@@ -22,7 +22,7 @@ class InstallerFilesBox(Gtk.ListBox):
         self.installer_files_boxes = {}
         self._file_queue = []
 
-    def load_installer(self, installer):
+    def load_installer(self, installer, use_cached_files=True):
         self.stop_all()
 
         self.installer = installer
@@ -35,7 +35,7 @@ class InstallerFilesBox(Gtk.ListBox):
             child.destroy()
 
         for installer_file in installer.files:
-            installer_file_box = InstallerFileBox(installer_file)
+            installer_file_box = InstallerFileBox(installer_file, use_cached_file=use_cached_files)
             installer_file_box.connect("file-ready", self.on_file_ready)
             installer_file_box.connect("file-unready", self.on_file_unready)
             installer_file_box.connect("file-available", self.on_file_available)

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -73,6 +73,8 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         self.selected_extras = []
         self.install_in_progress = False
         self.install_complete = False
+        self.download_only = False
+        self.use_cached_installer_files = True
         self.interpreter = None
         self.installation_kind = installation_kind
         self.continue_handler = None
@@ -132,6 +134,11 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         self.cache_button.is_available = lambda: not self.interpreter or bool(self.interpreter.installer.script_files)
 
         self.source_button = self.add_menu_button(_("View installer source"), self.on_source_clicked)
+        self.download_only_button = self.add_end_button(
+            _("Download only"),
+            self.on_files_download_only_confirmed,
+            tooltip=_("Download installer files to the cache without installing the game."),
+        )
 
         # Pre-create some UI bits we need to refer to in several places.
         # (We lazy allocate more of it, but these are a pain.)
@@ -309,6 +316,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         self.stack.add_named_factory("spinner", self.create_spinner_page)
         self.stack.add_named_factory("log", self.create_log_page)
         self.stack.add_named_factory("error", self.create_error_page)
+        self.stack.add_named_factory("download_only_complete", self.create_download_only_complete_page)
         self.stack.add_named_factory("nothing", lambda *x: Gtk.Box())
 
     def load_first_page(self) -> None:
@@ -683,9 +691,62 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
             self.launch_installer_commands()
             return
 
+        self.use_cached_installer_files = self.ask_use_cached_installer_files()
+
         logger.debug("Game files prepared.")
-        self.installer_files_box.load_installer(self.interpreter.installer)
+        self.installer_files_box.load_installer(
+            self.interpreter.installer, use_cached_files=self.use_cached_installer_files
+        )
         self.stack.navigate_to_page(self.present_installer_files_page)
+
+    def ask_use_cached_installer_files(self):
+        """Ask whether to use cached installer files when all required files are present."""
+        if not self.interpreter or not self.interpreter.installer.files:
+            return True
+
+        if not self.supports_download_only_installer_cache:
+            return True
+
+        if not all(installer_file.has_valid_cache for installer_file in self.interpreter.installer.files):
+            return True
+
+        locations = {os.path.dirname(path) for path in self.get_cached_installer_file_paths()}
+        if len(locations) == 1:
+            location_text = _("Location: %s") % next(iter(locations))
+        else:
+            location_text = _("Locations:\n%s") % "\n".join(sorted(locations))
+
+        dlg = QuestionDialog(
+            {
+                "parent": self,
+                "title": _("Cached installer found"),
+                "question": _(
+                    "Cached installer files were found for this game.\n\n"
+                    "Would you like to install using the cached installer?"
+                ),
+                "widgets": [Gtk.Label(label=location_text, selectable=True, wrap=True, visible=True)],
+            }
+        )
+        return dlg.result == Gtk.ResponseType.YES
+
+    @property
+    def supports_download_only_installer_cache(self):
+        """Return whether this installer supports the GOG download-only cache flow."""
+        return bool(
+            self.installation_kind == InstallationKind.INSTALL
+            and self.interpreter
+            and self.interpreter.installer.service
+            and self.interpreter.installer.service.id == "gog"
+        )
+
+    def get_cached_installer_file_paths(self):
+        if not self.interpreter:
+            return []
+
+        paths = []
+        for installer_file in self.interpreter.installer.files:
+            paths.extend(installer_file.get_dest_files_by_id().values())
+        return [path for path in paths if path]
 
     def create_installer_files_page(self):
         return Gtk.ScrolledWindow(
@@ -720,6 +781,15 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         """Call this when the user confirms the install files
         This will start the downloads.
         """
+        self.download_only = False
+        self.start_installer_file_downloads()
+
+    def on_files_download_only_confirmed(self, _button):
+        """Download installer files and stop before launching the installer."""
+        self.download_only = True
+        self.start_installer_file_downloads()
+
+    def start_installer_file_downloads(self):
         try:
             self.installer_files_box.start_all()
             self.stack.jump_to_page(self.present_downloading_files_page)
@@ -730,10 +800,69 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         """All files are available, continue the install"""
         logger.info("All files are available, continuing install")
         self.interpreter.game_files = widget.get_game_files()
+        if self.download_only:
+            GLib.idle_add(self.load_download_only_complete_page)
+            return
         # Idle-add here to ensure that the launch occurs after
         # on_files_confirmed(), since they can race when no actual
         # download is required.
         GLib.idle_add(self.launch_installer_commands)
+
+    def load_download_only_complete_page(self):
+        logger.info("Installer files downloaded; skipping installation")
+        self.install_complete = True
+        self.stack.jump_to_page(self.present_download_only_complete_page)
+        self.stack.discard_navigation()
+        self.cancel_button.grab_focus()
+
+    def create_download_only_complete_page(self):
+        box = Gtk.Box(
+            orientation=Gtk.Orientation.VERTICAL,
+            spacing=12,
+            halign=Gtk.Align.CENTER,
+            valign=Gtk.Align.START,
+        )
+        box.set_margin_top(36)
+
+        explanation = MarkupLabel(
+            _(
+                "The installer files are cached locally and can be reused by Lutris "
+                "for a later offline installation."
+            )
+        )
+        box.pack_start(explanation, False, False, 0)
+
+        self.download_only_location_label = Gtk.Label(
+            selectable=True,
+            use_markup=True,
+            wrap=True,
+            justify=Gtk.Justification.CENTER,
+        )
+        self.download_only_location_label.set_alignment(0.5, 0)
+        box.pack_start(self.download_only_location_label, False, False, 0)
+
+        return box
+
+    def present_download_only_complete_page(self):
+        self.set_status(_("Installer files downloaded to the cache."))
+        self.stack.present_page("download_only_complete")
+        self.download_only_location_label.set_markup(self.get_download_only_location_markup())
+        self.display_cancel_button()
+
+    def get_download_only_location_markup(self):
+        locations = set()
+        if self.interpreter and self.interpreter.game_files:
+            locations = {os.path.dirname(path) for path in self.interpreter.game_files.values() if path}
+
+        if not locations and self.interpreter:
+            locations = {self.interpreter.cache_path}
+
+        if len(locations) == 1:
+            location = next(iter(locations))
+            return _("Location: <tt>%s</tt>") % gtk_safe(location)
+
+        location_list = "\n".join("<tt>%s</tt>" % gtk_safe(location) for location in sorted(locations))
+        return _("Locations:\n%s") % location_list
 
     def launch_installer_commands(self):
         logger.info("Launching installer commands")
@@ -1095,8 +1224,12 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
 
     def display_install_button(self, handler, sensitive=True):
         """Displays the continue button, but labels it 'Install'."""
+        extra_buttons = [self.source_button]
+        if self.supports_download_only_installer_cache and self.interpreter.installer.files:
+            self.download_only_button.set_sensitive(sensitive)
+            extra_buttons.append(self.download_only_button)
         self.display_continue_button(
-            handler, continue_button_label=_("_Install"), sensitive=sensitive, extra_buttons=[self.source_button]
+            handler, continue_button_label=_("_Install"), sensitive=sensitive, extra_buttons=extra_buttons
         )
 
     def display_cancel_button(self, extra_buttons=None):
@@ -1122,7 +1255,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
 
         self.cancel_button.set_sensitive(cancel_sensitive)
 
-        all_buttons = [self.cache_button, self.source_button, self.continue_button]
+        all_buttons = [self.cache_button, self.source_button, self.continue_button, self.download_only_button]
 
         for b in all_buttons:
             available = not hasattr(b, "is_available") or b.is_available()

--- a/lutris/gui/installerwindow.py
+++ b/lutris/gui/installerwindow.py
@@ -825,10 +825,7 @@ class InstallerWindow(ModelessDialog, DialogInstallUIDelegate, ScriptInterpreter
         box.set_margin_top(36)
 
         explanation = MarkupLabel(
-            _(
-                "The installer files are cached locally and can be reused by Lutris "
-                "for a later offline installation."
-            )
+            _("The installer files are cached locally and can be reused by Lutris for a later offline installation.")
         )
         box.pack_start(explanation, False, False, 0)
 

--- a/lutris/installer/installer_file.py
+++ b/lutris/installer/installer_file.py
@@ -303,8 +303,32 @@ class InstallerFile:
 
     @property
     def is_cached(self):
-        """Is the file available in the local PGA cache?"""
-        return self.uses_pga_cache() and system.path_exists(self.dest_file)
+        """Is the file available in the installer cache?"""
+        return system.path_exists(self.dest_file)
+
+    @property
+    def has_valid_cache(self):
+        """Is the cached file present and compatible with known metadata?"""
+        if not self.is_cached or not os.path.isfile(self.dest_file):
+            return False
+
+        if self.size is not None:
+            try:
+                if os.path.getsize(self.dest_file) != self.size:
+                    return False
+            except OSError:
+                return False
+
+        if self.checksum:
+            try:
+                hash_type, expected_hash = self.checksum.split(":", 1)
+                calculated_hash = system.get_file_checksum(self.dest_file, hash_type)
+            except (OSError, ValueError):
+                return False
+            if calculated_hash != expected_hash:
+                return False
+
+        return True
 
     def save_to_cache(self):
         """Copy the file into the PGA cache."""

--- a/lutris/installer/installer_file_collection.py
+++ b/lutris/installer/installer_file_collection.py
@@ -156,14 +156,25 @@ class InstallerFileCollection:
     @property
     def is_cached(self):
         """Are the files available in the local PGA cache?"""
-        if self.uses_pga_cache():
-            # check if every file is in cache, without checking
-            # uses_pga_cache() on each.
-            for installer_file in self.files_list:
-                if not system.path_exists(installer_file.dest_file):
-                    return False
-            return True
-        return False
+        for installer_file in self.files_list:
+            if not system.path_exists(installer_file.dest_file):
+                return False
+        return True
+
+    @property
+    def has_valid_cache(self):
+        """Are all cached files present and compatible with known metadata?"""
+        for installer_file in self.files_list:
+            if not installer_file.has_valid_cache:
+                return False
+        if self.full_size:
+            try:
+                cached_size = sum(system.get_disk_size(installer_file.dest_file) for installer_file in self.files_list)
+            except OSError:
+                return False
+            if cached_size != self.full_size:
+                return False
+        return True
 
     def save_to_cache(self):
         """Copy the files into the PGA cache."""

--- a/tests/_test_cache.py
+++ b/tests/_test_cache.py
@@ -1,162 +1,163 @@
-import os
 import json
-
-import pytest
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
 
 from lutris import cache
 
 
-def test_get_installer_cache_entries(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    game_cache = cache_root / "some-game" / "gog"
-    game_cache.mkdir(parents=True)
-    installer = game_cache / "setup.exe"
-    installer.write_bytes(b"installer")
-    (game_cache / "setup.exe.cache_lock").write_text("{}", encoding="utf-8")
+class TestInstallerCache(TestCase):
+    def test_get_installer_cache_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            game_cache = os.path.join(cache_root, "some-game", "gog")
+            os.makedirs(game_cache)
+            installer = os.path.join(game_cache, "setup.exe")
+            with open(installer, "wb") as installer_file:
+                installer_file.write(b"installer")
+            with open(os.path.join(game_cache, "setup.exe.cache_lock"), "w", encoding="utf-8") as lock_file:
+                lock_file.write("{}")
 
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+            with patch.object(cache, "get_cache_path", return_value=cache_root):
+                entries = cache.get_installer_cache_entries()
 
-    entries = cache.get_installer_cache_entries()
+            self.assertEqual(
+                entries,
+                [
+                    {
+                        "name": "some-game",
+                        "path": os.path.join(cache_root, "some-game"),
+                        "size": len(b"installer"),
+                        "file_count": 1,
+                    }
+                ],
+            )
 
-    assert entries == [
-        {
-            "name": "some-game",
-            "path": str(cache_root / "some-game"),
-            "size": len(b"installer"),
-            "file_count": 1,
-        }
-    ]
+    def test_delete_installer_cache_entry_refuses_outside_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            os.makedirs(cache_root)
+            outside = os.path.join(tmpdir, "outside")
+            os.makedirs(outside)
 
+            with patch.object(cache, "get_cache_path", return_value=cache_root), self.assertRaises(ValueError):
+                cache.delete_installer_cache_entry(outside)
 
-def test_delete_installer_cache_entry_refuses_outside_cache(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    cache_root.mkdir()
-    outside = tmp_path / "outside"
-    outside.mkdir()
+            self.assertTrue(os.path.isdir(outside))
 
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+    def test_delete_installer_cache_entry_refuses_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            os.makedirs(cache_root)
+            target = os.path.join(tmpdir, "target")
+            os.makedirs(target)
+            link = os.path.join(cache_root, "linked-cache")
+            os.symlink(target, link)
 
-    with pytest.raises(ValueError):
-        cache.delete_installer_cache_entry(str(outside))
+            with patch.object(cache, "get_cache_path", return_value=cache_root), self.assertRaises(ValueError):
+                cache.delete_installer_cache_entry(link)
 
-    assert os.path.isdir(outside)
+            self.assertTrue(os.path.islink(link))
+            self.assertTrue(os.path.isdir(target))
 
+    def test_delete_installer_cache_entry_refuses_nested_path(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            nested = os.path.join(cache_root, "game", "gog")
+            os.makedirs(nested)
 
-def test_delete_installer_cache_entry_refuses_symlink(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    cache_root.mkdir()
-    target = tmp_path / "target"
-    target.mkdir()
-    link = cache_root / "linked-cache"
-    link.symlink_to(target)
+            with patch.object(cache, "get_cache_path", return_value=cache_root), self.assertRaises(ValueError):
+                cache.delete_installer_cache_entry(nested)
 
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+            self.assertTrue(os.path.isdir(nested))
 
-    with pytest.raises(ValueError):
-        cache.delete_installer_cache_entry(str(link))
+    def test_get_incomplete_installer_cache_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            download_dir = os.path.join(cache_root, "game", "gog")
+            os.makedirs(download_dir)
+            tmp_file = os.path.join(download_dir, "setup.exe.tmp")
+            with open(tmp_file, "wb") as partial_file:
+                partial_file.write(b"partial")
+            progress_file = os.path.join(download_dir, "setup.exe.progress")
+            with open(progress_file, "w", encoding="utf-8") as progress:
+                progress.write("{}")
 
-    assert link.is_symlink()
-    assert os.path.isdir(target)
+            with patch.object(cache, "get_cache_path", return_value=cache_root):
+                entries = cache.get_incomplete_installer_cache_entries()
 
+            self.assertEqual([entry["path"] for entry in entries], [progress_file, tmp_file])
+            self.assertEqual([entry["size"] for entry in entries], [2, len(b"partial")])
 
-def test_delete_installer_cache_entry_refuses_nested_path(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    nested = cache_root / "game" / "gog"
-    nested.mkdir(parents=True)
+    def test_get_incomplete_installer_cache_entries_includes_orphaned_downloading_lock(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            download_dir = os.path.join(cache_root, "game", "gog")
+            os.makedirs(download_dir)
+            lock_file = os.path.join(download_dir, "setup.exe.cache_lock")
+            with open(lock_file, "w", encoding="utf-8") as lock:
+                json.dump({"state": "downloading"}, lock)
 
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+            with patch.object(cache, "get_cache_path", return_value=cache_root):
+                entries = cache.get_incomplete_installer_cache_entries()
 
-    with pytest.raises(ValueError):
-        cache.delete_installer_cache_entry(str(nested))
+            self.assertEqual(len(entries), 1)
+            self.assertEqual(entries[0]["path"], lock_file)
 
-    assert os.path.isdir(nested)
+    def test_get_incomplete_installer_cache_entries_ignores_lock_with_final_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            download_dir = os.path.join(cache_root, "game", "gog")
+            os.makedirs(download_dir)
+            final_file = os.path.join(download_dir, "setup.exe")
+            with open(final_file, "wb") as setup:
+                setup.write(b"complete")
+            lock_file = os.path.join(download_dir, "setup.exe.cache_lock")
+            with open(lock_file, "w", encoding="utf-8") as lock:
+                json.dump({"state": "downloading"}, lock)
 
+            with patch.object(cache, "get_cache_path", return_value=cache_root):
+                self.assertEqual(cache.get_incomplete_installer_cache_entries(), [])
 
-def test_get_incomplete_installer_cache_entries(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    download_dir = cache_root / "game" / "gog"
-    download_dir.mkdir(parents=True)
-    tmp_file = download_dir / "setup.exe.tmp"
-    tmp_file.write_bytes(b"partial")
-    progress_file = download_dir / "setup.exe.progress"
-    progress_file.write_text("{}", encoding="utf-8")
+    def test_delete_incomplete_installer_cache_entries(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            os.makedirs(cache_root)
+            tmp_file = os.path.join(cache_root, "setup.exe.tmp")
+            with open(tmp_file, "wb") as partial_file:
+                partial_file.write(b"partial")
 
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+            with patch.object(cache, "get_cache_path", return_value=cache_root):
+                cache.delete_incomplete_installer_cache_entries([tmp_file])
 
-    entries = cache.get_incomplete_installer_cache_entries()
+            self.assertFalse(os.path.exists(tmp_file))
 
-    assert [entry["path"] for entry in entries] == [str(progress_file), str(tmp_file)]
-    assert [entry["size"] for entry in entries] == [2, len(b"partial")]
+    def test_delete_incomplete_installer_cache_entries_refuses_outside_cache(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            os.makedirs(cache_root)
+            outside = os.path.join(tmpdir, "setup.exe.tmp")
+            with open(outside, "wb") as partial_file:
+                partial_file.write(b"partial")
 
+            with patch.object(cache, "get_cache_path", return_value=cache_root), self.assertRaises(ValueError):
+                cache.delete_incomplete_installer_cache_entries([outside])
 
-def test_get_incomplete_installer_cache_entries_includes_orphaned_downloading_lock(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    download_dir = cache_root / "game" / "gog"
-    download_dir.mkdir(parents=True)
-    lock_file = download_dir / "setup.exe.cache_lock"
-    lock_file.write_text(json.dumps({"state": "downloading"}), encoding="utf-8")
+            self.assertTrue(os.path.exists(outside))
 
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+    def test_delete_incomplete_installer_cache_entries_refuses_symlink(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            cache_root = os.path.join(tmpdir, "installer")
+            os.makedirs(cache_root)
+            target = os.path.join(tmpdir, "target.tmp")
+            with open(target, "wb") as partial_file:
+                partial_file.write(b"partial")
+            link = os.path.join(cache_root, "setup.exe.tmp")
+            os.symlink(target, link)
 
-    entries = cache.get_incomplete_installer_cache_entries()
+            with patch.object(cache, "get_cache_path", return_value=cache_root), self.assertRaises(ValueError):
+                cache.delete_incomplete_installer_cache_entries([link])
 
-    assert len(entries) == 1
-    assert entries[0]["path"] == str(lock_file)
-
-
-def test_get_incomplete_installer_cache_entries_ignores_lock_with_final_file(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    download_dir = cache_root / "game" / "gog"
-    download_dir.mkdir(parents=True)
-    final_file = download_dir / "setup.exe"
-    final_file.write_bytes(b"complete")
-    lock_file = download_dir / "setup.exe.cache_lock"
-    lock_file.write_text(json.dumps({"state": "downloading"}), encoding="utf-8")
-
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
-
-    assert cache.get_incomplete_installer_cache_entries() == []
-
-
-def test_delete_incomplete_installer_cache_entries(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    cache_root.mkdir()
-    tmp_file = cache_root / "setup.exe.tmp"
-    tmp_file.write_bytes(b"partial")
-
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
-
-    cache.delete_incomplete_installer_cache_entries([str(tmp_file)])
-
-    assert not tmp_file.exists()
-
-
-def test_delete_incomplete_installer_cache_entries_refuses_outside_cache(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    cache_root.mkdir()
-    outside = tmp_path / "setup.exe.tmp"
-    outside.write_bytes(b"partial")
-
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
-
-    with pytest.raises(ValueError):
-        cache.delete_incomplete_installer_cache_entries([str(outside)])
-
-    assert outside.exists()
-
-
-def test_delete_incomplete_installer_cache_entries_refuses_symlink(monkeypatch, tmp_path):
-    cache_root = tmp_path / "installer"
-    cache_root.mkdir()
-    target = tmp_path / "target.tmp"
-    target.write_bytes(b"partial")
-    link = cache_root / "setup.exe.tmp"
-    link.symlink_to(target)
-
-    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
-
-    with pytest.raises(ValueError):
-        cache.delete_incomplete_installer_cache_entries([str(link)])
-
-    assert link.is_symlink()
-    assert target.exists()
+            self.assertTrue(os.path.islink(link))
+            self.assertTrue(os.path.exists(target))

--- a/tests/_test_cache.py
+++ b/tests/_test_cache.py
@@ -1,0 +1,162 @@
+import os
+import json
+
+import pytest
+
+from lutris import cache
+
+
+def test_get_installer_cache_entries(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    game_cache = cache_root / "some-game" / "gog"
+    game_cache.mkdir(parents=True)
+    installer = game_cache / "setup.exe"
+    installer.write_bytes(b"installer")
+    (game_cache / "setup.exe.cache_lock").write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    entries = cache.get_installer_cache_entries()
+
+    assert entries == [
+        {
+            "name": "some-game",
+            "path": str(cache_root / "some-game"),
+            "size": len(b"installer"),
+            "file_count": 1,
+        }
+    ]
+
+
+def test_delete_installer_cache_entry_refuses_outside_cache(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    cache_root.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    with pytest.raises(ValueError):
+        cache.delete_installer_cache_entry(str(outside))
+
+    assert os.path.isdir(outside)
+
+
+def test_delete_installer_cache_entry_refuses_symlink(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    cache_root.mkdir()
+    target = tmp_path / "target"
+    target.mkdir()
+    link = cache_root / "linked-cache"
+    link.symlink_to(target)
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    with pytest.raises(ValueError):
+        cache.delete_installer_cache_entry(str(link))
+
+    assert link.is_symlink()
+    assert os.path.isdir(target)
+
+
+def test_delete_installer_cache_entry_refuses_nested_path(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    nested = cache_root / "game" / "gog"
+    nested.mkdir(parents=True)
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    with pytest.raises(ValueError):
+        cache.delete_installer_cache_entry(str(nested))
+
+    assert os.path.isdir(nested)
+
+
+def test_get_incomplete_installer_cache_entries(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    download_dir = cache_root / "game" / "gog"
+    download_dir.mkdir(parents=True)
+    tmp_file = download_dir / "setup.exe.tmp"
+    tmp_file.write_bytes(b"partial")
+    progress_file = download_dir / "setup.exe.progress"
+    progress_file.write_text("{}", encoding="utf-8")
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    entries = cache.get_incomplete_installer_cache_entries()
+
+    assert [entry["path"] for entry in entries] == [str(progress_file), str(tmp_file)]
+    assert [entry["size"] for entry in entries] == [2, len(b"partial")]
+
+
+def test_get_incomplete_installer_cache_entries_includes_orphaned_downloading_lock(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    download_dir = cache_root / "game" / "gog"
+    download_dir.mkdir(parents=True)
+    lock_file = download_dir / "setup.exe.cache_lock"
+    lock_file.write_text(json.dumps({"state": "downloading"}), encoding="utf-8")
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    entries = cache.get_incomplete_installer_cache_entries()
+
+    assert len(entries) == 1
+    assert entries[0]["path"] == str(lock_file)
+
+
+def test_get_incomplete_installer_cache_entries_ignores_lock_with_final_file(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    download_dir = cache_root / "game" / "gog"
+    download_dir.mkdir(parents=True)
+    final_file = download_dir / "setup.exe"
+    final_file.write_bytes(b"complete")
+    lock_file = download_dir / "setup.exe.cache_lock"
+    lock_file.write_text(json.dumps({"state": "downloading"}), encoding="utf-8")
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    assert cache.get_incomplete_installer_cache_entries() == []
+
+
+def test_delete_incomplete_installer_cache_entries(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    cache_root.mkdir()
+    tmp_file = cache_root / "setup.exe.tmp"
+    tmp_file.write_bytes(b"partial")
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    cache.delete_incomplete_installer_cache_entries([str(tmp_file)])
+
+    assert not tmp_file.exists()
+
+
+def test_delete_incomplete_installer_cache_entries_refuses_outside_cache(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    cache_root.mkdir()
+    outside = tmp_path / "setup.exe.tmp"
+    outside.write_bytes(b"partial")
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    with pytest.raises(ValueError):
+        cache.delete_incomplete_installer_cache_entries([str(outside)])
+
+    assert outside.exists()
+
+
+def test_delete_incomplete_installer_cache_entries_refuses_symlink(monkeypatch, tmp_path):
+    cache_root = tmp_path / "installer"
+    cache_root.mkdir()
+    target = tmp_path / "target.tmp"
+    target.write_bytes(b"partial")
+    link = cache_root / "setup.exe.tmp"
+    link.symlink_to(target)
+
+    monkeypatch.setattr(cache, "get_cache_path", lambda: str(cache_root))
+
+    with pytest.raises(ValueError):
+        cache.delete_incomplete_installer_cache_entries([str(link)])
+
+    assert link.is_symlink()
+    assert target.exists()

--- a/tests/_test_installer_file_cache.py
+++ b/tests/_test_installer_file_cache.py
@@ -1,86 +1,92 @@
 import hashlib
+import os
+import tempfile
+from unittest import TestCase
+from unittest.mock import patch
 
 from lutris.installer.installer_file import InstallerFile
 from lutris.installer.installer_file_collection import InstallerFileCollection
 
 
-def _installer_file(monkeypatch, tmp_path, file_meta):
-    monkeypatch.setattr("lutris.installer.installer_file.get_url_cache_path", lambda *_args, **_kwargs: str(tmp_path))
-    return InstallerFile("test-game", "setup", file_meta)
+def _installer_file(tmpdir, file_meta):
+    with patch("lutris.installer.installer_file.get_url_cache_path", return_value=tmpdir):
+        return InstallerFile("test-game", "setup", file_meta)
 
 
-def test_installer_file_valid_cache_requires_matching_size(monkeypatch, tmp_path):
-    installer_file = _installer_file(
-        monkeypatch,
-        tmp_path,
-        {"url": "https://example.com/setup.exe", "filename": "setup.exe", "size": 4},
-    )
-    installer_file.dest_file = str(tmp_path / "setup.exe")
-    (tmp_path / "setup.exe").write_bytes(b"bad")
+class TestInstallerFileCache(TestCase):
+    def test_installer_file_valid_cache_requires_matching_size(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            installer_file = _installer_file(
+                tmpdir,
+                {"url": "https://example.com/setup.exe", "filename": "setup.exe", "size": 4},
+            )
+            installer_file.dest_file = os.path.join(tmpdir, "setup.exe")
+            with open(installer_file.dest_file, "wb") as setup:
+                setup.write(b"bad")
 
-    assert installer_file.is_cached
-    assert not installer_file.has_valid_cache
+            self.assertTrue(installer_file.is_cached)
+            self.assertFalse(installer_file.has_valid_cache)
 
+    def test_installer_file_valid_cache_requires_matching_checksum(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            expected_hash = hashlib.md5(b"good", usedforsecurity=False).hexdigest()
+            installer_file = _installer_file(
+                tmpdir,
+                {
+                    "url": "https://example.com/setup.exe",
+                    "filename": "setup.exe",
+                    "checksum": "md5:%s" % expected_hash,
+                },
+            )
+            installer_file.dest_file = os.path.join(tmpdir, "setup.exe")
+            with open(installer_file.dest_file, "wb") as setup:
+                setup.write(b"bad")
 
-def test_installer_file_valid_cache_requires_matching_checksum(monkeypatch, tmp_path):
-    expected_hash = hashlib.md5(b"good", usedforsecurity=False).hexdigest()
-    installer_file = _installer_file(
-        monkeypatch,
-        tmp_path,
-        {
-            "url": "https://example.com/setup.exe",
-            "filename": "setup.exe",
-            "checksum": "md5:%s" % expected_hash,
-        },
-    )
-    installer_file.dest_file = str(tmp_path / "setup.exe")
-    (tmp_path / "setup.exe").write_bytes(b"bad")
+            self.assertTrue(installer_file.is_cached)
+            self.assertFalse(installer_file.has_valid_cache)
 
-    assert installer_file.is_cached
-    assert not installer_file.has_valid_cache
+    def test_installer_file_collection_valid_cache_requires_all_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            valid = _installer_file(
+                tmpdir,
+                {"url": "https://example.com/valid.exe", "filename": "valid.exe", "size": 5},
+            )
+            valid.dest_file = os.path.join(tmpdir, "valid.exe")
+            with open(valid.dest_file, "wb") as valid_file:
+                valid_file.write(b"valid")
 
+            invalid = _installer_file(
+                tmpdir,
+                {"url": "https://example.com/invalid.exe", "filename": "invalid.exe", "size": 7},
+            )
+            invalid.dest_file = os.path.join(tmpdir, "invalid.exe")
+            with open(invalid.dest_file, "wb") as invalid_file:
+                invalid_file.write(b"short")
 
-def test_installer_file_collection_valid_cache_requires_all_files(monkeypatch, tmp_path):
-    valid = _installer_file(
-        monkeypatch,
-        tmp_path,
-        {"url": "https://example.com/valid.exe", "filename": "valid.exe", "size": 5},
-    )
-    valid.dest_file = str(tmp_path / "valid.exe")
-    (tmp_path / "valid.exe").write_bytes(b"valid")
+            collection = InstallerFileCollection("test-game", "setup", [valid, invalid])
 
-    invalid = _installer_file(
-        monkeypatch,
-        tmp_path,
-        {"url": "https://example.com/invalid.exe", "filename": "invalid.exe", "size": 7},
-    )
-    invalid.dest_file = str(tmp_path / "invalid.exe")
-    (tmp_path / "invalid.exe").write_bytes(b"short")
+            self.assertTrue(collection.is_cached)
+            self.assertFalse(collection.has_valid_cache)
 
-    collection = InstallerFileCollection("test-game", "setup", [valid, invalid])
+    def test_installer_file_collection_valid_cache_requires_total_size(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first = _installer_file(
+                tmpdir,
+                {"url": "https://example.com/part1.bin", "filename": "part1.bin", "total_size": 10},
+            )
+            first.dest_file = os.path.join(tmpdir, "part1.bin")
+            with open(first.dest_file, "wb") as first_file:
+                first_file.write(b"12345")
 
-    assert collection.is_cached
-    assert not collection.has_valid_cache
+            second = _installer_file(
+                tmpdir,
+                {"url": "https://example.com/part2.bin", "filename": "part2.bin"},
+            )
+            second.dest_file = os.path.join(tmpdir, "part2.bin")
+            with open(second.dest_file, "wb") as second_file:
+                second_file.write(b"1234")
 
+            collection = InstallerFileCollection("test-game", "setup", [first, second])
 
-def test_installer_file_collection_valid_cache_requires_total_size(monkeypatch, tmp_path):
-    first = _installer_file(
-        monkeypatch,
-        tmp_path,
-        {"url": "https://example.com/part1.bin", "filename": "part1.bin", "total_size": 10},
-    )
-    first.dest_file = str(tmp_path / "part1.bin")
-    (tmp_path / "part1.bin").write_bytes(b"12345")
-
-    second = _installer_file(
-        monkeypatch,
-        tmp_path,
-        {"url": "https://example.com/part2.bin", "filename": "part2.bin"},
-    )
-    second.dest_file = str(tmp_path / "part2.bin")
-    (tmp_path / "part2.bin").write_bytes(b"1234")
-
-    collection = InstallerFileCollection("test-game", "setup", [first, second])
-
-    assert collection.is_cached
-    assert not collection.has_valid_cache
+            self.assertTrue(collection.is_cached)
+            self.assertFalse(collection.has_valid_cache)

--- a/tests/_test_installer_file_cache.py
+++ b/tests/_test_installer_file_cache.py
@@ -1,0 +1,86 @@
+import hashlib
+
+from lutris.installer.installer_file import InstallerFile
+from lutris.installer.installer_file_collection import InstallerFileCollection
+
+
+def _installer_file(monkeypatch, tmp_path, file_meta):
+    monkeypatch.setattr("lutris.installer.installer_file.get_url_cache_path", lambda *_args, **_kwargs: str(tmp_path))
+    return InstallerFile("test-game", "setup", file_meta)
+
+
+def test_installer_file_valid_cache_requires_matching_size(monkeypatch, tmp_path):
+    installer_file = _installer_file(
+        monkeypatch,
+        tmp_path,
+        {"url": "https://example.com/setup.exe", "filename": "setup.exe", "size": 4},
+    )
+    installer_file.dest_file = str(tmp_path / "setup.exe")
+    (tmp_path / "setup.exe").write_bytes(b"bad")
+
+    assert installer_file.is_cached
+    assert not installer_file.has_valid_cache
+
+
+def test_installer_file_valid_cache_requires_matching_checksum(monkeypatch, tmp_path):
+    expected_hash = hashlib.md5(b"good", usedforsecurity=False).hexdigest()
+    installer_file = _installer_file(
+        monkeypatch,
+        tmp_path,
+        {
+            "url": "https://example.com/setup.exe",
+            "filename": "setup.exe",
+            "checksum": "md5:%s" % expected_hash,
+        },
+    )
+    installer_file.dest_file = str(tmp_path / "setup.exe")
+    (tmp_path / "setup.exe").write_bytes(b"bad")
+
+    assert installer_file.is_cached
+    assert not installer_file.has_valid_cache
+
+
+def test_installer_file_collection_valid_cache_requires_all_files(monkeypatch, tmp_path):
+    valid = _installer_file(
+        monkeypatch,
+        tmp_path,
+        {"url": "https://example.com/valid.exe", "filename": "valid.exe", "size": 5},
+    )
+    valid.dest_file = str(tmp_path / "valid.exe")
+    (tmp_path / "valid.exe").write_bytes(b"valid")
+
+    invalid = _installer_file(
+        monkeypatch,
+        tmp_path,
+        {"url": "https://example.com/invalid.exe", "filename": "invalid.exe", "size": 7},
+    )
+    invalid.dest_file = str(tmp_path / "invalid.exe")
+    (tmp_path / "invalid.exe").write_bytes(b"short")
+
+    collection = InstallerFileCollection("test-game", "setup", [valid, invalid])
+
+    assert collection.is_cached
+    assert not collection.has_valid_cache
+
+
+def test_installer_file_collection_valid_cache_requires_total_size(monkeypatch, tmp_path):
+    first = _installer_file(
+        monkeypatch,
+        tmp_path,
+        {"url": "https://example.com/part1.bin", "filename": "part1.bin", "total_size": 10},
+    )
+    first.dest_file = str(tmp_path / "part1.bin")
+    (tmp_path / "part1.bin").write_bytes(b"12345")
+
+    second = _installer_file(
+        monkeypatch,
+        tmp_path,
+        {"url": "https://example.com/part2.bin", "filename": "part2.bin"},
+    )
+    second.dest_file = str(tmp_path / "part2.bin")
+    (tmp_path / "part2.bin").write_bytes(b"1234")
+
+    collection = InstallerFileCollection("test-game", "setup", [first, second])
+
+    assert collection.is_cached
+    assert not collection.has_valid_cache


### PR DESCRIPTION
## Summary

  Adds a GOG-focused download-only installer flow so users can download
  and keep installer files in the Lutris installer cache without
  immediately installing the game.

  This helps with offline or later installs by reusing cached GOG
  installer files instead of requiring the user to manually find the
  downloaded executable.

  Fixes #6656.

  ## Changes

  - Add a `Download only` action for supported GOG installers.
  - Store downloaded installer files in the installer cache.
  - Show the cached installer location after a download-only run
  completes.
  - Detect valid cached GOG installer files when starting an install.
  - Prompt the user to install from the cached installer when available.
  - Validate cached files by existence, size, and checksum where
  metadata is available.
  - Add cached installer management to Settings > Storage.
  - Add incomplete installer download cleanup in Settings > Storage.
  - Add tests for installer cache listing, deletion, and cached file
  validation.

  ## Scope

  This is intentionally limited to GOG installers. Other sources such as
  Epic, EA, and live-service launcher installs do not expose the same
  installer-file download flow.

  ## Testing

  Manually tested with a GOG game:

  - Download-only flow completed successfully.
  - Completion page showed the cached installer path.
  - Restarted Lutris and started the install again.
  - Lutris detected the cached installer and prompted to use it.
  - Installed successfully from the cached installer.
  - Verified cached installers appear in Settings > Storage.
  - Verified cached installer cleanup UI is present.
