### PR TITLE
Fix filesystem detection for Btrfs subvolume paths

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -200,6 +200,23 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
         return [drive for drive in json.loads(findmnt_output)["filesystems"] if drive["fstype"] != "squashfs"]
 
     @staticmethod
+    def _iter_filesystems(devices: list[dict[str, Any]]) -> Iterator[dict[str, Any]]:
+        """Yield filesystems and nested filesystems from findmnt output."""
+        devices = list(devices)
+        while devices:
+            device = devices.pop()
+            devices.extend(device.get("children", []))
+            yield device
+
+    @staticmethod
+    def _path_is_on_mount(path: str, mount_point: str) -> bool:
+        try:
+            return os.path.commonpath((path, mount_point)) == mount_point
+        except ValueError:
+            # Paths on different drives can raise ValueError.
+            return False
+
+    @staticmethod
     def get_ram_info() -> dict[str, str]:
         """Parse the output of /proc/meminfo and return RAM information in kB"""
         mem = {}
@@ -305,18 +322,29 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
 
     def get_fs_type_for_path(self, path: str) -> str | None:
         """Return the filesystem type a given path uses"""
-        mount_point = system.find_mount_point(path)
-        devices = list(self.get_drives())
-        while devices:
-            device = devices.pop()
-            devices.extend(device.get("children", []))
-            if mount_point == device.get("target"):
-                fs_type = device["fstype"]
-                if fs_type == "fuseblk":
-                    out = system.read_process_output(["blkid", "-o", "value", "-s", "TYPE", device["source"]])
-                    fs_type = out.strip() if out else fs_type
-                return cast(str, fs_type)
-        return None
+        path = os.path.realpath(os.path.expanduser(path))
+        matching_device = None
+        matching_mount_point = ""
+
+        for device in self._iter_filesystems(self.get_drives()):
+            target = device.get("target")
+            if not target:
+                continue
+
+            mount_point = os.path.realpath(os.path.expanduser(target))
+            if self._path_is_on_mount(path, mount_point) and len(mount_point) > len(matching_mount_point):
+                matching_device = device
+                matching_mount_point = mount_point
+
+        if not matching_device:
+            return None
+
+        fs_type = matching_device["fstype"]
+        if fs_type == "fuseblk":
+            out = system.read_process_output(["blkid", "-o", "value", "-s", "TYPE", matching_device["source"]])
+            fs_type = out.strip() if out else fs_type
+
+        return cast(str, fs_type)
 
     def get_glxinfo(self) -> GlxInfo | None:
         """Return a GlxInfo instance if the gfxinfo tool is available"""

--- a/tests/util/_test_linux.py
+++ b/tests/util/_test_linux.py
@@ -1,0 +1,62 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+from lutris.util import linux
+
+
+class TestLinuxSystem(TestCase):
+    def setUp(self):
+        self.linux_system = linux.LinuxSystem.__new__(linux.LinuxSystem)
+
+    def test_get_fs_type_for_path_uses_parent_mount_for_btrfs_subvolume_path(self):
+        with patch.object(
+            self.linux_system,
+            "get_drives",
+            return_value=[
+                {"target": "/", "source": "/dev/disk0[/@]", "fstype": "btrfs"},
+                {"target": "/home/user", "source": "/dev/disk0[/@home]", "fstype": "btrfs"},
+            ],
+        ):
+            fs_type = self.linux_system.get_fs_type_for_path("/home/user/games/wineprefixes/game")
+
+        self.assertEqual(fs_type, "btrfs")
+
+    def test_get_fs_type_for_path_uses_deepest_containing_mount(self):
+        with patch.object(
+            self.linux_system,
+            "get_drives",
+            return_value=[
+                {"target": "/home/user", "source": "/dev/disk0[/@home]", "fstype": "btrfs"},
+                {"target": "/home/user/games", "source": "/dev/disk0[/@games]", "fstype": "btrfs"},
+            ],
+        ):
+            fs_type = self.linux_system.get_fs_type_for_path("/home/user/games/wineprefixes/game")
+
+        self.assertEqual(fs_type, "btrfs")
+
+    def test_get_fs_type_for_path_does_not_match_partial_path_prefixes(self):
+        with patch.object(
+            self.linux_system,
+            "get_drives",
+            return_value=[
+                {"target": "/mnt/game", "source": "/dev/sda1", "fstype": "ext4"},
+                {"target": "/mnt/games", "source": "/dev/sdb1", "fstype": "xfs"},
+            ],
+        ):
+            fs_type = self.linux_system.get_fs_type_for_path("/mnt/games/library")
+
+        self.assertEqual(fs_type, "xfs")
+
+    def test_get_fs_type_for_path_preserves_fuseblk_detection(self):
+        with (
+            patch.object(
+                self.linux_system,
+                "get_drives",
+                return_value=[{"target": "/media/library", "source": "/dev/sdc1", "fstype": "fuseblk"}],
+            ),
+            patch.object(linux.system, "read_process_output", return_value="ntfs\n") as read_process_output,
+        ):
+            fs_type = self.linux_system.get_fs_type_for_path("/media/library/game")
+
+        self.assertEqual(fs_type, "ntfs")
+        read_process_output.assert_called_once_with(["blkid", "-o", "value", "-s", "TYPE", "/dev/sdc1"])


### PR DESCRIPTION
system.find_mount_point() uses os.path.ismount(), which can treat Btrfs subvolume roots as mount points even when findmnt does not list those roots as separate targets. When a Wine prefix was placed below such a subvolume, get_fs_type_for_path() looked for an exact findmnt target, found none, and returned None. Wine prefix creation then failed with: "Can't create the prefix on a file system that does not support Linux symbolic links."

Instead of matching a single mount point by exact path, choose the deepest findmnt target that contains the requested path. This resolves the backing filesystem for Btrfs subvolume paths and preserves the existing fuseblk type lookup.

Adds unit coverage for filesystem type detection across Btrfs subvolume paths, nested mount targets, partial path-prefix matches, and existing fuseblk handling.