### PR TITLE
steamfamily: harden access token cache parsing

### DIFF
--- a/lutris/services/steamfamily.py
+++ b/lutris/services/steamfamily.py
@@ -3,6 +3,7 @@
 import json
 import os
 from gettext import gettext as _
+from typing import Any
 
 import requests
 
@@ -65,19 +66,34 @@ class SteamFamilyService(SteamService, OnlineService):
     def fetch_access_token(self):
         """Fetch the access token from the store, save to disk and set"""
         token_data = self.get_access_token()
-        if not token_data:
+        access_token = self.extract_access_token(token_data)
+        if not access_token:
             raise RuntimeError("Failed to get access token")
         with open(self.token_path, "w", encoding="utf-8") as token_file:
             token_file.write(json.dumps(token_data, indent=2))
         self.access_token = self.load_access_token()
 
+    @staticmethod
+    def extract_access_token(token_data: Any) -> str:
+        if not isinstance(token_data, dict):
+            return ""
+        data = token_data.get("data")
+        if not isinstance(data, dict):
+            return ""
+        access_token = data.get("webapi_token", "")
+        return access_token if isinstance(access_token, str) else ""
+
     def load_access_token(self):
         """Load the access token from disk"""
         if not os.path.exists(self.token_path):
             return ""
-        with open(self.token_path, encoding="utf-8") as token_file:
-            token_data = json.load(token_file)
-            return token_data.get("data").get("webapi_token", "")
+        try:
+            with open(self.token_path, encoding="utf-8") as token_file:
+                token_data = json.load(token_file)
+        except (OSError, ValueError) as ex:
+            logger.warning("Failed to read Steam Family token cache '%s': %s", self.token_path, ex)
+            return ""
+        return self.extract_access_token(token_data)
 
     def get_access_token(self):
         """Request an access token from steam and return dump"""

--- a/tests/_test_steamfamily.py
+++ b/tests/_test_steamfamily.py
@@ -1,0 +1,26 @@
+"""Tests for the Steam Family service."""
+
+import unittest
+
+from lutris.services.steamfamily import SteamFamilyService
+
+
+class TestSteamFamilyAccessToken(unittest.TestCase):
+    def test_extract_access_token(self):
+        self.assertEqual(
+            SteamFamilyService.extract_access_token({"data": {"webapi_token": "test-token"}}),
+            "test-token",
+        )
+
+    def test_extract_access_token_rejects_invalid_payloads(self):
+        invalid_payloads = [
+            [],
+            {"data": []},
+            {"data": {}},
+            {"data": {"webapi_token": 123}},
+            {"response": {"webapi_token": "test-token"}},
+        ]
+
+        for token_data in invalid_payloads:
+            with self.subTest(token_data=token_data):
+                self.assertEqual(SteamFamilyService.extract_access_token(token_data), "")


### PR DESCRIPTION
Summary
- validate Steam Family token payload shape before accepting and using a token
- handle malformed or unreadable steam token cache files without crashing\n- centralize token extraction in one helper used by fetch and load

Why
load_access_token currently assumes the token JSON is always an object with data.webapi_token. If cache content is list-shaped or malformed, Lutris crashes with AttributeError list object has no attribute get.

Validation
- python3 -m py_compile lutris/services/steamfamily.py
- reproduced old failure mode with list-shaped JSON and confirmed hardened logic fails safe