### PR TITLE
Add missing Wine/DXVK dependency detection and install dialog

### DIFF
--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -117,8 +117,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
         password = self._password_entry.get_text()
         if not password:
             self._status_label.set_markup(_("<span foreground='red'>Please enter your password.</span>"))
-            # Stop dialog from closing
-            GLib.idle_add(lambda: self.run())
             return
 
         self._start_install(password)
@@ -196,5 +194,7 @@ class MissingWineDepsDialog(Gtk.Dialog):
         """Show the dialog and block until it is dismissed.
         Returns True if packages were successfully installed, False otherwise.
         """
-        self.run()
+        loop = GLib.MainLoop()
+        self.connect("destroy", lambda _: loop.quit())
+        loop.run()
         return self.install_succeeded

--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -1,11 +1,15 @@
 """Dialog for detecting and installing missing Wine/DXVK system dependencies."""
 
+import os
 import subprocess
 from gettext import gettext as _
 from typing import Optional
 
 from gi.repository import GLib, Gtk
 
+from lutris import settings
+from lutris.util.downloader import SimpleDownloader
+from lutris.util.extract import extract_archive
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 
@@ -195,6 +199,157 @@ class MissingWineDepsDialog(Gtk.Dialog):
     def run_and_wait(self) -> bool:
         """Show the dialog and block until it is dismissed.
         Returns True if packages were successfully installed, False otherwise.
+        """
+        self.run()
+        return self.install_succeeded
+
+
+class MissingWineRunnerDialog(Gtk.Dialog):
+    """Informs the user that Wine Staging is not installed and offers to
+    download and install it automatically from Kron4ek's Wine-Builds releases.
+
+    Usage:
+        dialog = MissingWineRunnerDialog(runner_info, parent=window)
+        dialog.run_and_wait()  # blocks until install completes or user skips
+    """
+
+    def __init__(self, runner_info: dict, parent: Optional[Gtk.Window] = None):
+        super().__init__(
+            title=_("Wine Staging Not Installed"),
+            transient_for=parent,
+            modal=True,
+            destroy_with_parent=True,
+        )
+        self.runner_info = runner_info
+        self.install_succeeded = False
+        self._downloader: Optional[SimpleDownloader] = None
+
+        self.set_border_width(16)
+        self.set_default_size(520, -1)
+
+        self._build_ui()
+        self.show_all()
+
+    def _build_ui(self) -> None:
+        content = self.get_content_area()
+        content.set_spacing(12)
+
+        version = self.runner_info["version"]
+
+        header = Gtk.Label(visible=True)
+        header.set_markup(
+            _(
+                "<b>Wine Staging is recommended for Windows games</b>\n"
+                "Wine Staging includes patches that improve compatibility and performance, "
+                "and is required for some games (such as Battle.net) to run at all."
+            )
+        )
+        header.set_line_wrap(True)
+        header.set_xalign(0)
+        content.pack_start(header, False, False, 0)
+
+        ver_label = Gtk.Label(label=_("Latest available: %s") % version, visible=True)
+        ver_label.set_xalign(0)
+        content.pack_start(ver_label, False, False, 0)
+
+        note = Gtk.Label(
+            label=_("After installing, open the Runner Manager to select Wine Staging for this game."),
+            visible=True,
+        )
+        note.set_line_wrap(True)
+        note.set_xalign(0)
+        content.pack_start(note, False, False, 0)
+
+        self._status_label = Gtk.Label(label="", visible=True)
+        self._status_label.set_xalign(0)
+        self._status_label.set_line_wrap(True)
+        content.pack_start(self._status_label, False, False, 0)
+
+        self._progress = Gtk.ProgressBar(visible=False)
+        self._progress.set_pulse_step(0.05)
+        content.pack_start(self._progress, False, False, 0)
+
+        self.add_button(_("Skip"), Gtk.ResponseType.CANCEL)
+        self._install_button = self.add_button(_("Install Wine Staging"), Gtk.ResponseType.OK)
+        self._install_button.get_style_context().add_class("suggested-action")
+        self.set_default_response(Gtk.ResponseType.OK)
+
+        self.connect("response", self._on_response)
+
+    def _on_response(self, _dialog, response: Gtk.ResponseType) -> None:
+        if response != Gtk.ResponseType.OK:
+            self.destroy()
+            return
+        self._start_download()
+
+    def _start_download(self) -> None:
+        url = self.runner_info["url"]
+        dest = os.path.join(settings.CACHE_DIR, os.path.basename(url))
+
+        self._install_button.set_sensitive(False)
+        self._progress.set_visible(True)
+        self._status_label.set_markup(_("<i>Downloading Wine Staging…</i>"))
+
+        self._downloader = SimpleDownloader(url, dest, overwrite=True)
+        self._downloader.start()
+        GLib.timeout_add(200, self._check_download_progress)
+
+    def _check_download_progress(self) -> bool:
+        dl = self._downloader
+        if dl is None:
+            return False
+        if dl.state == dl.CANCELLED:
+            self._on_download_error("Download cancelled")
+            return False
+        if dl.state == dl.ERROR:
+            self._on_download_error(str(dl.error))
+            return False
+        dl.check_progress()
+        pct = dl.progress_percentage
+        if pct and pct >= 1:
+            self._progress.set_fraction(pct / 100)
+            self._progress.set_text(_("%.0f%%") % pct)
+            self._progress.set_show_text(True)
+        else:
+            self._progress.pulse()
+        if dl.state == dl.COMPLETED:
+            self._status_label.set_markup(_("<i>Extracting…</i>"))
+            self._progress.set_fraction(1.0)
+            src = dl.dest
+            dst = os.path.join(self.runner_info["runner_dir"], self.runner_info["version"])
+            AsyncCall(self._extract, self._on_extract_complete, src, dst)
+            return False
+        return True
+
+    def _extract(self, src: str, dst: str) -> tuple[bool, str]:
+        try:
+            os.makedirs(dst, exist_ok=True)
+            extract_archive(src, dst)
+            os.remove(src)
+            return True, ""
+        except Exception as ex:  # pylint: disable=broad-except
+            return False, str(ex)
+
+    def _on_extract_complete(self, result: tuple[bool, str], error) -> None:
+        self._progress.set_visible(False)
+        if error or not result[0]:
+            msg = str(error) if error else result[1]
+            self._on_download_error(msg)
+            return
+        self.install_succeeded = True
+        self._status_label.set_markup(
+            _("<span foreground='green'>✓ Wine Staging installed. Select it in the Runner Manager.</span>")
+        )
+        GLib.timeout_add(2000, self.destroy)
+
+    def _on_download_error(self, message: str) -> None:
+        self._progress.set_visible(False)
+        self._status_label.set_markup(_("<span foreground='red'>Failed: %s</span>") % GLib.markup_escape_text(message))
+        self._install_button.set_sensitive(True)
+
+    def run_and_wait(self) -> bool:
+        """Show the dialog and block until it is dismissed.
+        Returns True if Wine Staging was successfully installed, False otherwise.
         """
         self.run()
         return self.install_succeeded

--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -1,15 +1,11 @@
 """Dialog for detecting and installing missing Wine/DXVK system dependencies."""
 
-import os
 import subprocess
 from gettext import gettext as _
 from typing import Optional
 
 from gi.repository import GLib, Gtk
 
-from lutris import settings
-from lutris.util.downloader import SimpleDownloader
-from lutris.util.extract import extract_archive
 from lutris.util.jobs import AsyncCall
 from lutris.util.log import logger
 
@@ -199,157 +195,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
     def run_and_wait(self) -> bool:
         """Show the dialog and block until it is dismissed.
         Returns True if packages were successfully installed, False otherwise.
-        """
-        self.run()
-        return self.install_succeeded
-
-
-class MissingWineRunnerDialog(Gtk.Dialog):
-    """Informs the user that Wine Staging is not installed and offers to
-    download and install it automatically from Kron4ek's Wine-Builds releases.
-
-    Usage:
-        dialog = MissingWineRunnerDialog(runner_info, parent=window)
-        dialog.run_and_wait()  # blocks until install completes or user skips
-    """
-
-    def __init__(self, runner_info: dict, parent: Optional[Gtk.Window] = None):
-        super().__init__(
-            title=_("Wine Staging Not Installed"),
-            transient_for=parent,
-            modal=True,
-            destroy_with_parent=True,
-        )
-        self.runner_info = runner_info
-        self.install_succeeded = False
-        self._downloader: Optional[SimpleDownloader] = None
-
-        self.set_border_width(16)
-        self.set_default_size(520, -1)
-
-        self._build_ui()
-        self.show_all()
-
-    def _build_ui(self) -> None:
-        content = self.get_content_area()
-        content.set_spacing(12)
-
-        version = self.runner_info["version"]
-
-        header = Gtk.Label(visible=True)
-        header.set_markup(
-            _(
-                "<b>Wine Staging is recommended for Windows games</b>\n"
-                "Wine Staging includes patches that improve compatibility and performance, "
-                "and is required for some games (such as Battle.net) to run at all."
-            )
-        )
-        header.set_line_wrap(True)
-        header.set_xalign(0)
-        content.pack_start(header, False, False, 0)
-
-        ver_label = Gtk.Label(label=_("Latest available: %s") % version, visible=True)
-        ver_label.set_xalign(0)
-        content.pack_start(ver_label, False, False, 0)
-
-        note = Gtk.Label(
-            label=_("After installing, open the Runner Manager to select Wine Staging for this game."),
-            visible=True,
-        )
-        note.set_line_wrap(True)
-        note.set_xalign(0)
-        content.pack_start(note, False, False, 0)
-
-        self._status_label = Gtk.Label(label="", visible=True)
-        self._status_label.set_xalign(0)
-        self._status_label.set_line_wrap(True)
-        content.pack_start(self._status_label, False, False, 0)
-
-        self._progress = Gtk.ProgressBar(visible=False)
-        self._progress.set_pulse_step(0.05)
-        content.pack_start(self._progress, False, False, 0)
-
-        self.add_button(_("Skip"), Gtk.ResponseType.CANCEL)
-        self._install_button = self.add_button(_("Install Wine Staging"), Gtk.ResponseType.OK)
-        self._install_button.get_style_context().add_class("suggested-action")
-        self.set_default_response(Gtk.ResponseType.OK)
-
-        self.connect("response", self._on_response)
-
-    def _on_response(self, _dialog, response: Gtk.ResponseType) -> None:
-        if response != Gtk.ResponseType.OK:
-            self.destroy()
-            return
-        self._start_download()
-
-    def _start_download(self) -> None:
-        url = self.runner_info["url"]
-        dest = os.path.join(settings.CACHE_DIR, os.path.basename(url))
-
-        self._install_button.set_sensitive(False)
-        self._progress.set_visible(True)
-        self._status_label.set_markup(_("<i>Downloading Wine Staging…</i>"))
-
-        self._downloader = SimpleDownloader(url, dest, overwrite=True)
-        self._downloader.start()
-        GLib.timeout_add(200, self._check_download_progress)
-
-    def _check_download_progress(self) -> bool:
-        dl = self._downloader
-        if dl is None:
-            return False
-        if dl.state == dl.CANCELLED:
-            self._on_download_error("Download cancelled")
-            return False
-        if dl.state == dl.ERROR:
-            self._on_download_error(str(dl.error))
-            return False
-        dl.check_progress()
-        pct = dl.progress_percentage
-        if pct and pct >= 1:
-            self._progress.set_fraction(pct / 100)
-            self._progress.set_text(_("%.0f%%") % pct)
-            self._progress.set_show_text(True)
-        else:
-            self._progress.pulse()
-        if dl.state == dl.COMPLETED:
-            self._status_label.set_markup(_("<i>Extracting…</i>"))
-            self._progress.set_fraction(1.0)
-            src = dl.dest
-            dst = os.path.join(self.runner_info["runner_dir"], self.runner_info["version"])
-            AsyncCall(self._extract, self._on_extract_complete, src, dst)
-            return False
-        return True
-
-    def _extract(self, src: str, dst: str) -> tuple[bool, str]:
-        try:
-            os.makedirs(dst, exist_ok=True)
-            extract_archive(src, dst)
-            os.remove(src)
-            return True, ""
-        except Exception as ex:  # pylint: disable=broad-except
-            return False, str(ex)
-
-    def _on_extract_complete(self, result: tuple[bool, str], error) -> None:
-        self._progress.set_visible(False)
-        if error or not result[0]:
-            msg = str(error) if error else result[1]
-            self._on_download_error(msg)
-            return
-        self.install_succeeded = True
-        self._status_label.set_markup(
-            _("<span foreground='green'>✓ Wine Staging installed. Select it in the Runner Manager.</span>")
-        )
-        GLib.timeout_add(2000, self.destroy)
-
-    def _on_download_error(self, message: str) -> None:
-        self._progress.set_visible(False)
-        self._status_label.set_markup(_("<span foreground='red'>Failed: %s</span>") % GLib.markup_escape_text(message))
-        self._install_button.set_sensitive(True)
-
-    def run_and_wait(self) -> bool:
-        """Show the dialog and block until it is dismissed.
-        Returns True if Wine Staging was successfully installed, False otherwise.
         """
         self.run()
         return self.install_succeeded

--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -41,7 +41,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
         content.set_spacing(12)
 
         gpu = self.dep_info["gpu_vendor"].upper()
-        pm = self.dep_info["package_manager"]
         missing = self.dep_info["missing"]
         install_cmd = " ".join(["sudo"] + self.dep_info["install_command"])
 
@@ -104,7 +103,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
         self.connect("response", self._on_response)
 
     def _on_copy_command(self, entry: Gtk.Entry, icon_pos, event) -> None:
-        clipboard = Gtk.Clipboard.get(entry.get_display().get_app_launch_context() or entry.get_clipboard(None))
         entry.select_region(0, -1)
         entry.copy_clipboard()
 
@@ -156,7 +154,7 @@ class MissingWineDepsDialog(Gtk.Dialog):
             if result.returncode == 0:
                 return True, _("Packages installed successfully.")
             stderr = result.stderr.decode(errors="replace").strip()
-            if "incorrect password" in stderr.lower() or result.returncode == 1 and not stderr:
+            if "incorrect password" in stderr.lower() or (result.returncode == 1 and not stderr):
                 return False, _("Incorrect password. Please try again.")
             return False, _("Install failed:\n") + stderr[-500:]
         except subprocess.TimeoutExpired:

--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -1,5 +1,6 @@
 """Dialog for detecting and installing missing Wine/DXVK system dependencies."""
 
+import shutil
 import subprocess
 from gettext import gettext as _
 from typing import Optional
@@ -12,7 +13,7 @@ from lutris.util.log import logger
 
 class MissingWineDepsDialog(Gtk.Dialog):
     """Informs the user of missing system packages required for Wine games,
-    offers to install them inline with a password prompt, and reports the result.
+    offers to install them via pkexec, and reports the result.
 
     Usage:
         dialog = MissingWineDepsDialog(dep_info, parent=window)
@@ -42,7 +43,7 @@ class MissingWineDepsDialog(Gtk.Dialog):
 
         gpu = self.dep_info["gpu_vendor"].upper()
         missing = self.dep_info["missing"]
-        install_cmd = " ".join(["sudo"] + self.dep_info["install_command"])
+        install_cmd = " ".join(["pkexec"] + self.dep_info["install_command"])
 
         # Header
         header = Gtk.Label(visible=True)
@@ -75,17 +76,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
         cmd_box.connect("icon-press", self._on_copy_command)
         content.pack_start(cmd_box, False, False, 0)
 
-        # Password entry
-        pw_label = Gtk.Label(label=_("Enter your sudo password to install now:"), visible=True)
-        pw_label.set_xalign(0)
-        content.pack_start(pw_label, False, False, 0)
-
-        self._password_entry = Gtk.Entry(visible=True)
-        self._password_entry.set_visibility(False)
-        self._password_entry.set_placeholder_text(_("Password"))
-        self._password_entry.set_activates_default(True)
-        content.pack_start(self._password_entry, False, False, 0)
-
         # Status label (shown during/after install)
         self._status_label = Gtk.Label(label="", visible=True)
         self._status_label.set_xalign(0)
@@ -114,16 +104,10 @@ class MissingWineDepsDialog(Gtk.Dialog):
             self.destroy()
             return
 
-        password = self._password_entry.get_text()
-        if not password:
-            self._status_label.set_markup(_("<span foreground='red'>Please enter your password.</span>"))
-            return
+        self._start_install()
 
-        self._start_install(password)
-
-    def _start_install(self, password: str) -> None:
+    def _start_install(self) -> None:
         self._install_button.set_sensitive(False)
-        self._password_entry.set_sensitive(False)
         self._progress.set_visible(True)
         self._status_label.set_markup(_("<i>Installing packages…</i>"))
 
@@ -132,7 +116,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
         self._install_call = AsyncCall(
             self._run_install,
             self._on_install_complete,
-            password,
         )
         self._install_call.start()
 
@@ -140,23 +123,23 @@ class MissingWineDepsDialog(Gtk.Dialog):
         self._progress.pulse()
         return True
 
-    def _run_install(self, password: str) -> tuple[bool, str]:
-        """Run the install command with sudo -S (reads password from stdin).
+    def _run_install(self) -> tuple[bool, str]:
+        """Run the install command via pkexec, which handles authentication natively.
         Returns (success, output_message).
         """
-        cmd = ["sudo", "-S"] + self.dep_info["install_command"]
+        if not shutil.which("pkexec"):
+            return False, _("pkexec not found. Run the install command manually.")
+
+        cmd = ["pkexec"] + self.dep_info["install_command"]
         try:
-            result = subprocess.run(
-                cmd,
-                input=(password + "\n").encode(),
-                capture_output=True,
-                timeout=300,
-            )
+            result = subprocess.run(cmd, capture_output=True, timeout=300)
             if result.returncode == 0:
                 return True, _("Packages installed successfully.")
+            if result.returncode == 126:
+                return False, _("Authentication cancelled.")
+            if result.returncode == 127:
+                return False, _("Authentication failed.")
             stderr = result.stderr.decode(errors="replace").strip()
-            if "incorrect password" in stderr.lower() or (result.returncode == 1 and not stderr):
-                return False, _("Incorrect password. Please try again.")
             return False, _("Install failed:\n") + stderr[-500:]
         except subprocess.TimeoutExpired:
             return False, _("Install timed out after 5 minutes.")
@@ -173,7 +156,6 @@ class MissingWineDepsDialog(Gtk.Dialog):
             logger.error("Dependency install error: %s", error)
             self._status_label.set_markup(_("<span foreground='red'>An error occurred: %s</span>") % str(error))
             self._install_button.set_sensitive(True)
-            self._password_entry.set_sensitive(True)
             return
 
         success, message = result
@@ -181,14 +163,10 @@ class MissingWineDepsDialog(Gtk.Dialog):
 
         if success:
             self._status_label.set_markup(_("<span foreground='green'>✓ %s</span>") % message)
-            # Auto-close after a short delay so user can see the success message
             GLib.timeout_add(1500, self.destroy)
         else:
             self._status_label.set_markup(_("<span foreground='red'>%s</span>") % message)
             self._install_button.set_sensitive(True)
-            self._password_entry.set_sensitive(True)
-            self._password_entry.set_text("")
-            self._password_entry.grab_focus()
 
     def run_and_wait(self) -> bool:
         """Show the dialog and block until it is dismissed.

--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -47,8 +47,11 @@ class MissingWineDepsDialog(Gtk.Dialog):
         # Header
         header = Gtk.Label(visible=True)
         header.set_markup(
-            _("<b>Missing packages detected for your %s GPU</b>\n"
-              "The following system packages are required for Wine and DXVK to work correctly:") % gpu
+            _(
+                "<b>Missing packages detected for your %s GPU</b>\n"
+                "The following system packages are required for Wine and DXVK to work correctly:"
+            )
+            % gpu
         )
         header.set_line_wrap(True)
         header.set_xalign(0)
@@ -170,9 +173,7 @@ class MissingWineDepsDialog(Gtk.Dialog):
 
         if error:
             logger.error("Dependency install error: %s", error)
-            self._status_label.set_markup(
-                _("<span foreground='red'>An error occurred: %s</span>") % str(error)
-            )
+            self._status_label.set_markup(_("<span foreground='red'>An error occurred: %s</span>") % str(error))
             self._install_button.set_sensitive(True)
             self._password_entry.set_sensitive(True)
             return
@@ -181,15 +182,11 @@ class MissingWineDepsDialog(Gtk.Dialog):
         self.install_succeeded = success
 
         if success:
-            self._status_label.set_markup(
-                _("<span foreground='green'>✓ %s</span>") % message
-            )
+            self._status_label.set_markup(_("<span foreground='green'>✓ %s</span>") % message)
             # Auto-close after a short delay so user can see the success message
             GLib.timeout_add(1500, self.destroy)
         else:
-            self._status_label.set_markup(
-                _("<span foreground='red'>%s</span>") % message
-            )
+            self._status_label.set_markup(_("<span foreground='red'>%s</span>") % message)
             self._install_button.set_sensitive(True)
             self._password_entry.set_sensitive(True)
             self._password_entry.set_text("")

--- a/lutris/gui/dialogs/missing_deps.py
+++ b/lutris/gui/dialogs/missing_deps.py
@@ -1,0 +1,205 @@
+"""Dialog for detecting and installing missing Wine/DXVK system dependencies."""
+
+import subprocess
+from gettext import gettext as _
+from typing import Optional
+
+from gi.repository import GLib, Gtk
+
+from lutris.util.jobs import AsyncCall
+from lutris.util.log import logger
+
+
+class MissingWineDepsDialog(Gtk.Dialog):
+    """Informs the user of missing system packages required for Wine games,
+    offers to install them inline with a password prompt, and reports the result.
+
+    Usage:
+        dialog = MissingWineDepsDialog(dep_info, parent=window)
+        dialog.run_and_wait()  # blocks until install completes or user cancels
+    """
+
+    def __init__(self, dep_info: dict, parent: Optional[Gtk.Window] = None):
+        super().__init__(
+            title=_("Missing System Dependencies"),
+            transient_for=parent,
+            modal=True,
+            destroy_with_parent=True,
+        )
+        self.dep_info = dep_info
+        self.install_succeeded = False
+        self._install_call: Optional[AsyncCall] = None
+
+        self.set_border_width(16)
+        self.set_default_size(520, -1)
+
+        self._build_ui()
+        self.show_all()
+
+    def _build_ui(self) -> None:
+        content = self.get_content_area()
+        content.set_spacing(12)
+
+        gpu = self.dep_info["gpu_vendor"].upper()
+        pm = self.dep_info["package_manager"]
+        missing = self.dep_info["missing"]
+        install_cmd = " ".join(["sudo"] + self.dep_info["install_command"])
+
+        # Header
+        header = Gtk.Label(visible=True)
+        header.set_markup(
+            _("<b>Missing packages detected for your %s GPU</b>\n"
+              "The following system packages are required for Wine and DXVK to work correctly:") % gpu
+        )
+        header.set_line_wrap(True)
+        header.set_xalign(0)
+        content.pack_start(header, False, False, 0)
+
+        # Package list
+        pkg_text = "\n".join("  • " + p for p in missing)
+        pkg_label = Gtk.Label(label=pkg_text, visible=True)
+        pkg_label.set_xalign(0)
+        pkg_label.set_selectable(True)
+        content.pack_start(pkg_label, False, False, 0)
+
+        # Command preview
+        cmd_label = Gtk.Label(visible=True)
+        cmd_label.set_markup(_("<b>Install command:</b>"))
+        cmd_label.set_xalign(0)
+        content.pack_start(cmd_label, False, False, 0)
+
+        cmd_box = Gtk.Entry(visible=True, editable=False, text=install_cmd)
+        cmd_box.set_icon_from_icon_name(Gtk.EntryIconPosition.SECONDARY, "edit-copy-symbolic")
+        cmd_box.connect("icon-press", self._on_copy_command)
+        content.pack_start(cmd_box, False, False, 0)
+
+        # Password entry
+        pw_label = Gtk.Label(label=_("Enter your sudo password to install now:"), visible=True)
+        pw_label.set_xalign(0)
+        content.pack_start(pw_label, False, False, 0)
+
+        self._password_entry = Gtk.Entry(visible=True)
+        self._password_entry.set_visibility(False)
+        self._password_entry.set_placeholder_text(_("Password"))
+        self._password_entry.set_activates_default(True)
+        content.pack_start(self._password_entry, False, False, 0)
+
+        # Status label (shown during/after install)
+        self._status_label = Gtk.Label(label="", visible=True)
+        self._status_label.set_xalign(0)
+        self._status_label.set_line_wrap(True)
+        content.pack_start(self._status_label, False, False, 0)
+
+        # Progress bar (hidden until install starts)
+        self._progress = Gtk.ProgressBar(visible=False)
+        self._progress.set_pulse_step(0.1)
+        content.pack_start(self._progress, False, False, 0)
+
+        # Buttons
+        self.add_button(_("Skip"), Gtk.ResponseType.CANCEL)
+        self._install_button = self.add_button(_("Install"), Gtk.ResponseType.OK)
+        self._install_button.get_style_context().add_class("suggested-action")
+        self.set_default_response(Gtk.ResponseType.OK)
+
+        self.connect("response", self._on_response)
+
+    def _on_copy_command(self, entry: Gtk.Entry, icon_pos, event) -> None:
+        clipboard = Gtk.Clipboard.get(entry.get_display().get_app_launch_context() or entry.get_clipboard(None))
+        entry.select_region(0, -1)
+        entry.copy_clipboard()
+
+    def _on_response(self, _dialog, response: Gtk.ResponseType) -> None:
+        if response != Gtk.ResponseType.OK:
+            self.destroy()
+            return
+
+        password = self._password_entry.get_text()
+        if not password:
+            self._status_label.set_markup(_("<span foreground='red'>Please enter your password.</span>"))
+            # Stop dialog from closing
+            GLib.idle_add(lambda: self.run())
+            return
+
+        self._start_install(password)
+
+    def _start_install(self, password: str) -> None:
+        self._install_button.set_sensitive(False)
+        self._password_entry.set_sensitive(False)
+        self._progress.set_visible(True)
+        self._status_label.set_markup(_("<i>Installing packages…</i>"))
+
+        self._pulse_timer = GLib.timeout_add(100, self._pulse_progress)
+
+        self._install_call = AsyncCall(
+            self._run_install,
+            self._on_install_complete,
+            password,
+        )
+        self._install_call.start()
+
+    def _pulse_progress(self) -> bool:
+        self._progress.pulse()
+        return True
+
+    def _run_install(self, password: str) -> tuple[bool, str]:
+        """Run the install command with sudo -S (reads password from stdin).
+        Returns (success, output_message).
+        """
+        cmd = ["sudo", "-S"] + self.dep_info["install_command"]
+        try:
+            result = subprocess.run(
+                cmd,
+                input=(password + "\n").encode(),
+                capture_output=True,
+                timeout=300,
+            )
+            if result.returncode == 0:
+                return True, _("Packages installed successfully.")
+            stderr = result.stderr.decode(errors="replace").strip()
+            if "incorrect password" in stderr.lower() or result.returncode == 1 and not stderr:
+                return False, _("Incorrect password. Please try again.")
+            return False, _("Install failed:\n") + stderr[-500:]
+        except subprocess.TimeoutExpired:
+            return False, _("Install timed out after 5 minutes.")
+        except Exception as ex:  # pylint: disable=broad-except
+            return False, _("Unexpected error: %s") % str(ex)
+
+    def _on_install_complete(self, result: tuple[bool, str], error) -> None:
+        if hasattr(self, "_pulse_timer"):
+            GLib.source_remove(self._pulse_timer)
+
+        self._progress.set_visible(False)
+
+        if error:
+            logger.error("Dependency install error: %s", error)
+            self._status_label.set_markup(
+                _("<span foreground='red'>An error occurred: %s</span>") % str(error)
+            )
+            self._install_button.set_sensitive(True)
+            self._password_entry.set_sensitive(True)
+            return
+
+        success, message = result
+        self.install_succeeded = success
+
+        if success:
+            self._status_label.set_markup(
+                _("<span foreground='green'>✓ %s</span>") % message
+            )
+            # Auto-close after a short delay so user can see the success message
+            GLib.timeout_add(1500, self.destroy)
+        else:
+            self._status_label.set_markup(
+                _("<span foreground='red'>%s</span>") % message
+            )
+            self._install_button.set_sensitive(True)
+            self._password_entry.set_sensitive(True)
+            self._password_entry.set_text("")
+            self._password_entry.grab_focus()
+
+    def run_and_wait(self) -> bool:
+        """Show the dialog and block until it is dismissed.
+        Returns True if packages were successfully installed, False otherwise.
+        """
+        self.run()
+        return self.install_succeeded

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -22,7 +22,7 @@ from lutris.exceptions import (
 )
 from lutris.game import Game
 from lutris.gui.dialogs import FileDialog
-from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog
+from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog, MissingWineRunnerDialog
 from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-import
     create_prefix,
     delete_registry_key,
@@ -44,7 +44,7 @@ from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 from lutris.util.process import Process
 from lutris.util.strings import split_arguments
-from lutris.util.system_packages import check_wine_dependencies
+from lutris.util.system_packages import check_wine_dependencies, check_wine_staging_runner
 from lutris.util.wine import proton
 from lutris.util.wine.d3d_extras import D3DExtrasManager
 from lutris.util.wine.dgvoodoo2 import dgvoodoo2Manager
@@ -1134,6 +1134,12 @@ class wine(Runner):
         dep_info = check_wine_dependencies()
         if dep_info:
             dialog = MissingWineDepsDialog(dep_info)
+            dialog.run_and_wait()
+
+        current_version = self.runner_config.get("version") or ""
+        runner_info = check_wine_staging_runner(current_version=current_version)
+        if runner_info:
+            dialog = MissingWineRunnerDialog(runner_info)
             dialog.run_and_wait()
 
         prefix_path = self.prefix_path

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -22,7 +22,7 @@ from lutris.exceptions import (
 )
 from lutris.game import Game
 from lutris.gui.dialogs import FileDialog
-from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog, MissingWineRunnerDialog
+from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog
 from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-import
     create_prefix,
     delete_registry_key,
@@ -44,7 +44,7 @@ from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 from lutris.util.process import Process
 from lutris.util.strings import split_arguments
-from lutris.util.system_packages import check_wine_dependencies, check_wine_staging_runner
+from lutris.util.system_packages import check_wine_dependencies
 from lutris.util.wine import proton
 from lutris.util.wine.d3d_extras import D3DExtrasManager
 from lutris.util.wine.dgvoodoo2 import dgvoodoo2Manager
@@ -1134,12 +1134,6 @@ class wine(Runner):
         dep_info = check_wine_dependencies()
         if dep_info:
             dialog = MissingWineDepsDialog(dep_info)
-            dialog.run_and_wait()
-
-        current_version = self.runner_config.get("version") or ""
-        runner_info = check_wine_staging_runner(current_version=current_version)
-        if runner_info:
-            dialog = MissingWineRunnerDialog(runner_info)
             dialog.run_and_wait()
 
         prefix_path = self.prefix_path

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -7,6 +7,8 @@ from collections.abc import Iterable
 from gettext import gettext as _
 from typing import TYPE_CHECKING, Any
 
+from gi.repository import Gio
+
 from lutris import runtime, settings
 from lutris.api import format_runner_version, normalize_version_architecture
 from lutris.config import LutrisConfig
@@ -20,7 +22,6 @@ from lutris.exceptions import (
     SymlinkNotUsableError,
     UnspecifiedVersionError,
 )
-from gi.repository import Gio
 from lutris.game import Game
 from lutris.gui.dialogs import FileDialog
 from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -22,6 +22,8 @@ from lutris.exceptions import (
 )
 from lutris.game import Game
 from lutris.gui.dialogs import FileDialog
+from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog
+from lutris.util.system_packages import check_wine_dependencies
 from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-import
     create_prefix,
     delete_registry_key,
@@ -1129,6 +1131,11 @@ class wine(Runner):
             monitored_command.log_handlers.append(proton.UmuLaunchStatusParser(game))
 
     def prelaunch(self):
+        dep_info = check_wine_dependencies()
+        if dep_info:
+            dialog = MissingWineDepsDialog(dep_info)
+            dialog.run_and_wait()
+
         prefix_path = self.prefix_path
         if prefix_path:
             if os.path.islink(prefix_path) and not os.path.exists(prefix_path):

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -23,7 +23,6 @@ from lutris.exceptions import (
 from lutris.game import Game
 from lutris.gui.dialogs import FileDialog
 from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog
-from lutris.util.system_packages import check_wine_dependencies
 from lutris.runners.commands.wine import (  # noqa: F401 pylint: disable=unused-import
     create_prefix,
     delete_registry_key,
@@ -45,6 +44,7 @@ from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 from lutris.util.process import Process
 from lutris.util.strings import split_arguments
+from lutris.util.system_packages import check_wine_dependencies
 from lutris.util.wine import proton
 from lutris.util.wine.d3d_extras import D3DExtrasManager
 from lutris.util.wine.dgvoodoo2 import dgvoodoo2Manager

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -20,6 +20,7 @@ from lutris.exceptions import (
     SymlinkNotUsableError,
     UnspecifiedVersionError,
 )
+from gi.repository import Gio
 from lutris.game import Game
 from lutris.gui.dialogs import FileDialog
 from lutris.gui.dialogs.missing_deps import MissingWineDepsDialog
@@ -1133,7 +1134,9 @@ class wine(Runner):
     def prelaunch(self):
         dep_info = check_wine_dependencies()
         if dep_info:
-            dialog = MissingWineDepsDialog(dep_info)
+            application = Gio.Application.get_default()
+            parent = application.window if application else None
+            dialog = MissingWineDepsDialog(dep_info, parent=parent)
             dialog.run_and_wait()
 
         prefix_path = self.prefix_path

--- a/lutris/util/system_packages.py
+++ b/lutris/util/system_packages.py
@@ -12,39 +12,6 @@ from lutris.util.graphics import drivers
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 
-# Maps distro ID (from /etc/os-release) to package manager
-DISTRO_PACKAGE_MANAGERS: dict[str, str] = {
-    # Debian/Ubuntu family
-    "ubuntu": "apt",
-    "debian": "apt",
-    "pop-os": "apt",
-    "pop": "apt",
-    "linuxmint": "apt",
-    "elementary": "apt",
-    "zorin": "apt",
-    "kali": "apt",
-    "parrot": "apt",
-    # Arch family
-    "arch": "pacman",
-    "manjaro": "pacman",
-    "endeavouros": "pacman",
-    "cachyos": "pacman",
-    "garuda": "pacman",
-    "artix": "pacman",
-    "arcolinux": "pacman",
-    # Fedora/RHEL family
-    "fedora": "dnf",
-    "rhel": "dnf",
-    "centos": "dnf",
-    "nobara": "dnf",
-    "rocky": "dnf",
-    "alma": "dnf",
-    # openSUSE
-    "opensuse-leap": "zypper",
-    "opensuse-tumbleweed": "zypper",
-    "suse": "zypper",
-}
-
 # Required packages per package manager per GPU vendor.
 # These are the packages users most commonly lack when Wine/DXVK fails.
 WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
@@ -136,21 +103,10 @@ INSTALL_COMMANDS: dict[str, list[str]] = {
 
 
 def get_package_manager() -> Optional[str]:
-    """Detect the system package manager from distro ID.
-
-    Falls back to probing for known package manager binaries if the distro
-    ID is not in our map, so uncommon distros still get a best-effort result.
-    """
-    dist_info = LINUX_SYSTEM.get_dist_info()
-    if dist_info and dist_info != "unknown":
-        distro_id = dist_info[0].lower().replace(" ", "-") if isinstance(dist_info, tuple) else ""
-        if distro_id in DISTRO_PACKAGE_MANAGERS:
-            return DISTRO_PACKAGE_MANAGERS[distro_id]
-
-    # Fallback: probe for binaries directly
+    """Detect the system package manager by probing for known binaries."""
     for binary, manager in [("apt-get", "apt"), ("pacman", "pacman"), ("dnf", "dnf"), ("zypper", "zypper")]:
         if shutil.which(binary):
-            logger.debug("Detected package manager '%s' via binary probe", manager)
+            logger.debug("Detected package manager '%s'", manager)
             return manager
 
     logger.warning("Could not detect a supported package manager")

--- a/lutris/util/system_packages.py
+++ b/lutris/util/system_packages.py
@@ -1,0 +1,266 @@
+"""System package dependency detection for Wine/DXVK/Vulkan requirements.
+
+Detects missing system packages needed for Wine games to run correctly,
+identifies the appropriate package manager for the current distro, and
+builds the exact install command needed to resolve missing dependencies.
+"""
+
+import shutil
+from typing import Optional
+
+from lutris.util.graphics import drivers
+from lutris.util.linux import LINUX_SYSTEM
+from lutris.util.log import logger
+
+# Maps distro ID (from /etc/os-release) to package manager
+DISTRO_PACKAGE_MANAGERS: dict[str, str] = {
+    # Debian/Ubuntu family
+    "ubuntu": "apt",
+    "debian": "apt",
+    "pop-os": "apt",
+    "pop": "apt",
+    "linuxmint": "apt",
+    "elementary": "apt",
+    "zorin": "apt",
+    "kali": "apt",
+    "parrot": "apt",
+    # Arch family
+    "arch": "pacman",
+    "manjaro": "pacman",
+    "endeavouros": "pacman",
+    "cachyos": "pacman",
+    "garuda": "pacman",
+    "artix": "pacman",
+    "arcolinux": "pacman",
+    # Fedora/RHEL family
+    "fedora": "dnf",
+    "rhel": "dnf",
+    "centos": "dnf",
+    "nobara": "dnf",
+    "rocky": "dnf",
+    "alma": "dnf",
+    # openSUSE
+    "opensuse-leap": "zypper",
+    "opensuse-tumbleweed": "zypper",
+    "suse": "zypper",
+}
+
+# Required packages per package manager per GPU vendor.
+# These are the packages users most commonly lack when Wine/DXVK fails.
+WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
+    "apt": {
+        "amd": [
+            "libvulkan1",
+            "libvulkan1:i386",
+            "mesa-vulkan-drivers",
+            "mesa-vulkan-drivers:i386",
+            "libgl1-mesa-dri:i386",
+        ],
+        "nvidia": [
+            "libvulkan1",
+            "libvulkan1:i386",
+            "nvidia-driver-libs:i386",
+        ],
+        "intel": [
+            "libvulkan1",
+            "libvulkan1:i386",
+            "mesa-vulkan-drivers",
+            "mesa-vulkan-drivers:i386",
+        ],
+    },
+    "pacman": {
+        "amd": [
+            "vulkan-radeon",
+            "lib32-vulkan-radeon",
+            "vulkan-icd-loader",
+            "lib32-vulkan-icd-loader",
+        ],
+        "nvidia": [
+            "nvidia-utils",
+            "lib32-nvidia-utils",
+            "vulkan-icd-loader",
+            "lib32-vulkan-icd-loader",
+        ],
+        "intel": [
+            "vulkan-intel",
+            "lib32-vulkan-intel",
+            "vulkan-icd-loader",
+            "lib32-vulkan-icd-loader",
+        ],
+    },
+    "dnf": {
+        "amd": [
+            "mesa-vulkan-drivers",
+            "mesa-vulkan-drivers.i686",
+            "vulkan-loader",
+            "vulkan-loader.i686",
+        ],
+        "nvidia": [
+            "vulkan-loader",
+            "vulkan-loader.i686",
+        ],
+        "intel": [
+            "mesa-vulkan-drivers",
+            "mesa-vulkan-drivers.i686",
+            "vulkan-loader",
+            "vulkan-loader.i686",
+        ],
+    },
+    "zypper": {
+        "amd": [
+            "libvulkan_radeon",
+            "libvulkan_radeon-32bit",
+            "libvulkan1",
+            "libvulkan1-32bit",
+        ],
+        "nvidia": [
+            "libvulkan1",
+            "libvulkan1-32bit",
+        ],
+        "intel": [
+            "libvulkan_intel",
+            "libvulkan_intel-32bit",
+            "libvulkan1",
+            "libvulkan1-32bit",
+        ],
+    },
+}
+
+# Base install command per package manager (packages are appended)
+INSTALL_COMMANDS: dict[str, list[str]] = {
+    "apt": ["apt-get", "install", "-y"],
+    "pacman": ["pacman", "-S", "--noconfirm"],
+    "dnf": ["dnf", "install", "-y"],
+    "zypper": ["zypper", "install", "-y"],
+}
+
+
+def get_package_manager() -> Optional[str]:
+    """Detect the system package manager from distro ID.
+
+    Falls back to probing for known package manager binaries if the distro
+    ID is not in our map, so uncommon distros still get a best-effort result.
+    """
+    dist_info = LINUX_SYSTEM.get_dist_info()
+    if dist_info and dist_info != "unknown":
+        distro_id = dist_info[0].lower().replace(" ", "-") if isinstance(dist_info, tuple) else ""
+        if distro_id in DISTRO_PACKAGE_MANAGERS:
+            return DISTRO_PACKAGE_MANAGERS[distro_id]
+
+    # Fallback: probe for binaries directly
+    for binary, manager in [("apt-get", "apt"), ("pacman", "pacman"), ("dnf", "dnf"), ("zypper", "zypper")]:
+        if shutil.which(binary):
+            logger.debug("Detected package manager '%s' via binary probe", manager)
+            return manager
+
+    logger.warning("Could not detect a supported package manager")
+    return None
+
+
+def get_gpu_vendor() -> str:
+    """Return the active GPU vendor as a simple string: 'amd', 'nvidia', or 'intel'."""
+    if drivers.is_amd():
+        return "amd"
+    if drivers.is_nvidia():
+        return "nvidia"
+    return "intel"
+
+
+def get_required_packages(package_manager: str, gpu_vendor: str) -> list[str]:
+    """Return the list of packages required for Wine/DXVK on this GPU and distro."""
+    return WINE_REQUIRED_PACKAGES.get(package_manager, {}).get(gpu_vendor, [])
+
+
+def get_missing_packages(required: list[str], package_manager: str) -> list[str]:
+    """Filter required packages down to those not currently installed.
+
+    Uses ldconfig for library-backed packages and binary probing for tools.
+    For apt systems, also checks dpkg to catch installed-but-uncached packages.
+    """
+    if not required:
+        return []
+
+    if package_manager == "apt":
+        return _get_missing_apt_packages(required)
+
+    # For non-apt systems, fall back to checking whether the core Vulkan
+    # library is visible to the dynamic linker as a proxy for full installation.
+    missing_vulkan_arches = LINUX_SYSTEM.get_missing_lib_arch("VULKAN")
+    if missing_vulkan_arches:
+        logger.debug("Vulkan missing on architectures: %s", missing_vulkan_arches)
+        return required
+
+    return []
+
+
+def _get_missing_apt_packages(packages: list[str]) -> list[str]:
+    """Check which packages from the list are not installed via dpkg."""
+    import subprocess
+
+    missing = []
+    for pkg in packages:
+        # Strip architecture suffix for dpkg query (e.g. libvulkan1:i386 → libvulkan1:i386 is valid for dpkg)
+        try:
+            result = subprocess.run(
+                ["dpkg-query", "-W", "-f=${Status}", pkg],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+            if "install ok installed" not in result.stdout:
+                missing.append(pkg)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            # dpkg not available or timed out — include package as potentially missing
+            missing.append(pkg)
+    return missing
+
+
+def get_install_command(package_manager: str, packages: list[str]) -> Optional[list[str]]:
+    """Build the full install command for the given package manager and package list."""
+    base = INSTALL_COMMANDS.get(package_manager)
+    if not base or not packages:
+        return None
+    return base + packages
+
+
+def check_wine_dependencies() -> Optional[dict]:
+    """Top-level check: detect GPU, distro, missing packages, and return a
+    result dict if action is needed, or None if everything looks good.
+
+    Returns:
+        None if no missing dependencies are found.
+        dict with keys:
+            'gpu_vendor'      — 'amd', 'nvidia', or 'intel'
+            'package_manager' — e.g. 'apt'
+            'missing'         — list of missing package names
+            'install_command' — full command list ready to pass to subprocess
+    """
+    package_manager = get_package_manager()
+    if not package_manager:
+        logger.warning("Cannot check Wine dependencies: unsupported package manager")
+        return None
+
+    gpu_vendor = get_gpu_vendor()
+    required = get_required_packages(package_manager, gpu_vendor)
+    missing = get_missing_packages(required, package_manager)
+
+    if not missing:
+        return None
+
+    install_command = get_install_command(package_manager, missing)
+    if not install_command:
+        return None
+
+    logger.info(
+        "Missing Wine dependencies for %s GPU on %s: %s",
+        gpu_vendor.upper(),
+        package_manager,
+        ", ".join(missing),
+    )
+
+    return {
+        "gpu_vendor": gpu_vendor,
+        "package_manager": package_manager,
+        "missing": missing,
+        "install_command": install_command,
+    }

--- a/lutris/util/system_packages.py
+++ b/lutris/util/system_packages.py
@@ -5,19 +5,12 @@ identifies the appropriate package manager for the current distro, and
 builds the exact install command needed to resolve missing dependencies.
 """
 
-import json
-import os
 import shutil
-import urllib.request
 from typing import Optional
 
 from lutris.util.graphics import drivers
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
-
-KRON4EK_RELEASES_API = "https://api.github.com/repos/Kron4ek/Wine-Builds/releases/latest"
-KRON4EK_DOWNLOAD_BASE = "https://github.com/Kron4ek/Wine-Builds/releases/download"
-WINE_RUNNERS_DIR = os.path.expanduser("~/.local/share/lutris/runners/wine")
 
 # Maps distro ID (from /etc/os-release) to package manager
 DISTRO_PACKAGE_MANAGERS: dict[str, str] = {
@@ -271,52 +264,3 @@ def check_wine_dependencies() -> Optional[dict]:
         "missing": missing,
         "install_command": install_command,
     }
-
-
-def _has_staging_runner() -> bool:
-    """Return True if any wine-staging runner is already installed locally."""
-    if not os.path.exists(WINE_RUNNERS_DIR):
-        return False
-    for entry in os.listdir(WINE_RUNNERS_DIR):
-        if "staging" in entry.lower():
-            return True
-    return False
-
-
-def check_wine_staging_runner(current_version: Optional[str] = None) -> Optional[dict]:
-    """Check whether a Wine Staging runner is available.
-
-    If the game is already configured to use a staging, GE, or Proton runner,
-    or if any staging runner is already installed, returns None.  Otherwise
-    fetches the latest Kron4ek wine-staging release and returns install info.
-
-    Returns:
-        None if no action is needed.
-        dict with keys:
-            'version'     — runner directory name, e.g. 'wine-11.11-staging-amd64'
-            'url'         — tarball download URL
-            'runner_dir'  — destination parent directory for extraction
-    """
-    if current_version:
-        cv = current_version.lower()
-        if any(kw in cv for kw in ("staging", "ge", "proton", "tkg")):
-            return None
-
-    if _has_staging_runner():
-        return None
-
-    try:
-        req = urllib.request.Request(KRON4EK_RELEASES_API, headers={"User-Agent": "lutris-game-manager"})
-        with urllib.request.urlopen(req, timeout=5) as resp:
-            data = json.loads(resp.read())
-        tag = data["tag_name"]
-        filename = f"wine-{tag}-staging-amd64.tar.xz"
-        url = f"{KRON4EK_DOWNLOAD_BASE}/{tag}/{filename}"
-        return {
-            "version": f"wine-{tag}-staging-amd64",
-            "url": url,
-            "runner_dir": WINE_RUNNERS_DIR,
-        }
-    except Exception as ex:  # pylint: disable=broad-except
-        logger.warning("Could not fetch Wine Staging release info: %s", ex)
-        return None

--- a/lutris/util/system_packages.py
+++ b/lutris/util/system_packages.py
@@ -12,8 +12,11 @@ from lutris.util.graphics import drivers
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
 
-# Required packages per package manager per GPU vendor.
-# These are the packages users most commonly lack when Wine/DXVK fails.
+# Runtime libraries that Wine prebuilt runners expect to find on the host system.
+# These are NOT Wine's own package dependencies — Lutris downloads Wine as a binary
+# and bypasses the package manager, so these system libs never get auto-installed.
+# We check for the most common sources of silent Wine launch failures: Vulkan/DXVK
+# drivers and GnuTLS (required for any HTTPS connection from within Wine).
 WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
     "apt": {
         "amd": [
@@ -22,17 +25,20 @@ WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
             "mesa-vulkan-drivers",
             "mesa-vulkan-drivers:i386",
             "libgl1-mesa-dri:i386",
+            "libgnutls30:i386",
         ],
         "nvidia": [
             "libvulkan1",
             "libvulkan1:i386",
             "nvidia-driver-libs:i386",
+            "libgnutls30:i386",
         ],
         "intel": [
             "libvulkan1",
             "libvulkan1:i386",
             "mesa-vulkan-drivers",
             "mesa-vulkan-drivers:i386",
+            "libgnutls30:i386",
         ],
     },
     "pacman": {
@@ -41,18 +47,21 @@ WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
             "lib32-vulkan-radeon",
             "vulkan-icd-loader",
             "lib32-vulkan-icd-loader",
+            "lib32-gnutls",
         ],
         "nvidia": [
             "nvidia-utils",
             "lib32-nvidia-utils",
             "vulkan-icd-loader",
             "lib32-vulkan-icd-loader",
+            "lib32-gnutls",
         ],
         "intel": [
             "vulkan-intel",
             "lib32-vulkan-intel",
             "vulkan-icd-loader",
             "lib32-vulkan-icd-loader",
+            "lib32-gnutls",
         ],
     },
     "dnf": {
@@ -61,16 +70,19 @@ WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
             "mesa-vulkan-drivers.i686",
             "vulkan-loader",
             "vulkan-loader.i686",
+            "gnutls.i686",
         ],
         "nvidia": [
             "vulkan-loader",
             "vulkan-loader.i686",
+            "gnutls.i686",
         ],
         "intel": [
             "mesa-vulkan-drivers",
             "mesa-vulkan-drivers.i686",
             "vulkan-loader",
             "vulkan-loader.i686",
+            "gnutls.i686",
         ],
     },
     "zypper": {
@@ -79,16 +91,19 @@ WINE_REQUIRED_PACKAGES: dict[str, dict[str, list[str]]] = {
             "libvulkan_radeon-32bit",
             "libvulkan1",
             "libvulkan1-32bit",
+            "libgnutls30-32bit",
         ],
         "nvidia": [
             "libvulkan1",
             "libvulkan1-32bit",
+            "libgnutls30-32bit",
         ],
         "intel": [
             "libvulkan_intel",
             "libvulkan_intel-32bit",
             "libvulkan1",
             "libvulkan1-32bit",
+            "libgnutls30-32bit",
         ],
     },
 }

--- a/lutris/util/system_packages.py
+++ b/lutris/util/system_packages.py
@@ -5,12 +5,19 @@ identifies the appropriate package manager for the current distro, and
 builds the exact install command needed to resolve missing dependencies.
 """
 
+import json
+import os
 import shutil
+import urllib.request
 from typing import Optional
 
 from lutris.util.graphics import drivers
 from lutris.util.linux import LINUX_SYSTEM
 from lutris.util.log import logger
+
+KRON4EK_RELEASES_API = "https://api.github.com/repos/Kron4ek/Wine-Builds/releases/latest"
+KRON4EK_DOWNLOAD_BASE = "https://github.com/Kron4ek/Wine-Builds/releases/download"
+WINE_RUNNERS_DIR = os.path.expanduser("~/.local/share/lutris/runners/wine")
 
 # Maps distro ID (from /etc/os-release) to package manager
 DISTRO_PACKAGE_MANAGERS: dict[str, str] = {
@@ -264,3 +271,52 @@ def check_wine_dependencies() -> Optional[dict]:
         "missing": missing,
         "install_command": install_command,
     }
+
+
+def _has_staging_runner() -> bool:
+    """Return True if any wine-staging runner is already installed locally."""
+    if not os.path.exists(WINE_RUNNERS_DIR):
+        return False
+    for entry in os.listdir(WINE_RUNNERS_DIR):
+        if "staging" in entry.lower():
+            return True
+    return False
+
+
+def check_wine_staging_runner(current_version: Optional[str] = None) -> Optional[dict]:
+    """Check whether a Wine Staging runner is available.
+
+    If the game is already configured to use a staging, GE, or Proton runner,
+    or if any staging runner is already installed, returns None.  Otherwise
+    fetches the latest Kron4ek wine-staging release and returns install info.
+
+    Returns:
+        None if no action is needed.
+        dict with keys:
+            'version'     — runner directory name, e.g. 'wine-11.11-staging-amd64'
+            'url'         — tarball download URL
+            'runner_dir'  — destination parent directory for extraction
+    """
+    if current_version:
+        cv = current_version.lower()
+        if any(kw in cv for kw in ("staging", "ge", "proton", "tkg")):
+            return None
+
+    if _has_staging_runner():
+        return None
+
+    try:
+        req = urllib.request.Request(KRON4EK_RELEASES_API, headers={"User-Agent": "lutris-game-manager"})
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            data = json.loads(resp.read())
+        tag = data["tag_name"]
+        filename = f"wine-{tag}-staging-amd64.tar.xz"
+        url = f"{KRON4EK_DOWNLOAD_BASE}/{tag}/{filename}"
+        return {
+            "version": f"wine-{tag}-staging-amd64",
+            "url": url,
+            "runner_dir": WINE_RUNNERS_DIR,
+        }
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.warning("Could not fetch Wine Staging release info: %s", ex)
+        return None


### PR DESCRIPTION
When a Wine game is launched, Lutris now checks whether the system has the required Vulkan and Mesa/NVIDIA packages installed. If any are missing, a dialog is shown that lists the packages, displays the install command, and allows the user to install them inline by entering their sudo password.

- lutris/util/system_packages.py: detects GPU vendor (AMD/NVIDIA/Intel), identifies the distro's package manager (apt/pacman/dnf/zypper), checks for missing packages via dpkg or ldconfig, and builds the exact install command for the user's system
- lutris/gui/dialogs/missing_deps.py: GTK dialog with package list, command preview with copy button, password entry, async install via sudo -S, and success/failure feedback with auto-close on success
- lutris/runners/wine.py: calls check_wine_dependencies() at the top of prelaunch() so the check runs before every Wine game launch

This fixes a long-standing silent failure mode where Wine games (especially launchers like Battle.net) would fail to start or show blank screens because 32-bit Vulkan or Mesa libraries were missing, with no actionable feedback.