### PR TITLE
Fix OS name blank in system info on Mint and other distros

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -217,7 +217,7 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
         if self.is_flatpak():
             host_distro = distro.LinuxDistribution(root_dir="/run/host")
             return host_distro.name(), host_distro.version(), host_distro.codename()
-        return distro.linux_distribution()
+        return distro.name(), distro.version(), distro.codename()
 
     @staticmethod
     def get_arch() -> str | None:
@@ -530,7 +530,7 @@ def gather_system_info_dict() -> dict[str, Any]:
     system_info_readable = {}
     # Add system information
     system_dict = {}
-    system_dict["OS"] = " ".join(system_info["dist"])
+    system_dict["OS"] = " ".join(x for x in system_info["dist"] if x)
     system_dict["Arch"] = system_info["arch"]
     system_dict["Kernel"] = system_info["kernel"]
     system_dict["Lutris Version"] = settings.VERSION


### PR DESCRIPTION
distro.linux_distribution() has been deprecated since distro 1.6.0 and returns empty strings on newer versions for some distros (Linux Mint, etc.). The Flatpak path already used the correct modern API; align the non-Flatpak path to match.

Also filter empty strings from the OS join so distros without a codename don't produce trailing whitespace in the system info output.

Fixes #6757