### PR TITLE
Fix/tray exits on external game stop

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -702,15 +702,18 @@ class LutrisApplication(Gtk.Application):
         if game_slug and not service:
             if action == "rungameid":
                 # Force db_game to use game id
-                self.quit_on_game_exit = True
+                if not self.has_tray_icon() and (not self.window or not self.window.is_visible()):
+                    self.quit_on_game_exit = True
                 db_game = games_db.get_game_by_field(game_slug, "id")
             elif action == "rungame":
                 # Force db_game to use game slug
-                self.quit_on_game_exit = True
+                if not self.has_tray_icon() and (not self.window or not self.window.is_visible()):
+                    self.quit_on_game_exit = True
                 db_game = games_db.get_game_by_field(game_slug, "slug")
             elif action == "install":
                 # Installers can use game or installer slugs
-                self.quit_on_game_exit = True
+                if not self.has_tray_icon() and (not self.window or not self.window.is_visible()):
+                    self.quit_on_game_exit = True
                 db_game = games_db.get_game_by_field(game_slug, "slug") or games_db.get_game_by_field(
                     game_slug, "installer_slug"
                 )


### PR DESCRIPTION
Fixes #6749

## Root cause

When a game is launched via a `lutris:` URI (which is what every Lutris
.desktop file does), `do_command_line()` unconditionally sets
`quit_on_game_exit = True`. This flag bypasses the tray icon check in
`_quit_if_hidden_and_idle()`, causing Lutris to quit when that game exits
— even when Lutris was already running with a tray icon and/or an open window.

## Fix

Only set `quit_on_game_exit = True` when Lutris has no persistent presence
at the time the URI is received — no tray icon and no visible window. This
preserves the original behaviour (launch-game-and-quit) for headless/scripted
use, while letting an already-running Lutris stay alive after a .desktop-launched
game closes.