### PR TITLE
 Fix libretro cores not found when retroarch.cfg already exists

### DIFF
--- a/lutris/runners/libretro.py
+++ b/lutris/runners/libretro.py
@@ -361,6 +361,13 @@ class libretro(Runner):
             retro_config.save()
         else:
             retro_config = RetroConfig(config_file)
+            # Always keep the cores path aligned with where Lutris installs them,
+            # even when loading an existing config (e.g. one created by a standalone
+            # RetroArch installation that may point to a different directory).
+            lutris_cores_dir = get_default_config_path("cores")
+            if retro_config.get("libretro_directory") != lutris_cores_dir:
+                retro_config["libretro_directory"] = lutris_cores_dir
+                retro_config.save()
 
         core = self.game_config.get("core")
         info_file = os.path.join(RETROARCH_DIR, f"info/{core}_libretro.info")


### PR DESCRIPTION

`prelaunch()` only set `libretro_directory` (where RetroArch looks for cores)
when creating `retroarch.cfg` from scratch. If the config file already existed
— from a standalone RetroArch install, or from RetroArch's Flatpak defaults
pointing to `config/retroarch/cores` — the wrong directory was used at runtime.

Lutris installs cores to `RUNNER_DIR/retroarch/cores`
(`~/.var/app/net.lutris.Lutris/data/lutris/runners/retroarch/cores` on Flatpak)
but an existing config could point anywhere else, so no cores were found.

## Fix

On every launch, compare the current `libretro_directory` in the config against
the Lutris-managed cores directory. If they differ, update and save the config.
This is a no-op when already correct, and self-healing when mismatched.