### PR TITLE
Fix wrong CLI argument for ZX Spectrum +3 in Speccy runner

### DIFF
--- a/share/lutris/json/speccy.json
+++ b/share/lutris/json/speccy.json
@@ -55,7 +55,7 @@
             "type": "bool",
             "label": "128kB ZX Spectrum +3",
             "default": false,
-            "argument": "-3a"
+            "argument": "-3+"
         }
     ]
 }


### PR DESCRIPTION
The `128kB ZX Spectrum +3` model was passing `-3a` to Speccy, but the correct flag is `-3+`.

This follows the same pattern as the other plus models (`-2+` for +2 and `-2a+` for +2A).

Fixes #6751