### PR TITLE
fix(steam): supplement API sync with local .acf manifests for F2P games

### DIFF
--- a/lutris/services/steam.py
+++ b/lutris/services/steam.py
@@ -96,8 +96,24 @@ class SteamService(BaseService):
         steam_games = get_steam_library(steamid)
         if not steam_games:
             raise RuntimeError(_("Failed to load games. Check that your profile is set to public during the sync."))
+
+        # The Steam API omits F2P games that have never been launched and titles
+        # with "Profile Features Limited" status. Supplement from local .acf
+        # manifests so these appear in the library after a sync.
+        api_appids = {str(g["appid"]) for g in steam_games}
+        for steamapps_path in get_steamapps_dirs():
+            for appmanifest_file in get_appmanifests(steamapps_path):
+                app_manifest_path = os.path.join(steamapps_path, appmanifest_file)
+                try:
+                    manifest = AppManifest(app_manifest_path)
+                    if manifest.steamid not in api_appids and manifest.steamid not in self.excluded_appids:
+                        steam_games.append({"appid": manifest.steamid, "name": manifest.name, "playtime_forever": 0})
+                        api_appids.add(manifest.steamid)
+                except Exception as ex:
+                    logger.error("Failed to read app manifest %s: %s", app_manifest_path, ex)
+
         for steam_game in steam_games:
-            if steam_game["appid"] in self.excluded_appids:
+            if str(steam_game["appid"]) in self.excluded_appids:
                 continue
             game = self.game_class.new_from_steam_game(steam_game)
             game.save()


### PR DESCRIPTION
Fixes #6509

### Problem

The Steam `GetOwnedGames` API silently omits two categories of games even when `include_played_free_games=1` is set:

- **Free-to-play games that have never been launched** — Steam doesn't expose these via the API until the user has at least opened them once.
- **"Profile Features Limited" titles** — games that don't expose library info publicly also don't appear in the owned games response.

Users experience this as certain games simply never appearing in the Lutris Steam source list after a sync, with no error or indication of why.

### Fix

After fetching the API results, scan all local steamapps directories (via the existing `get_steamapps_dirs()` + `get_appmanifests()` + `AppManifest` infrastructure already used by `add_installed_games()`) and append any installed games whose appids are not already in the API response.

Manifest-sourced entries get `playtime_forever: 0` since the API has no record of them.

Also fixes the `excluded_appids` check to use `str()`, so it correctly matches both int appids from the API response and string appids from manifest-sourced games.

No new imports — `AppManifest`, `get_appmanifests`, and `get_steamapps_dirs` were already imported.