### PR TITLE
Let installer scripts run their own engine over a gogdl depot download

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -975,7 +975,9 @@ the user to be connected to GOG in Lutris.
 
 Parameters:
 
-- ``game_id``: the GOG product ID (required). Can be looked up on
+- ``game_id``: the GOG product ID. Defaults to the installer's ``gogid``, so
+  you normally only set it once; an explicit value still wins (for instance to
+  download a DLC). Product IDs can be looked up on
   https://www.gogdb.org/products
 - ``platform``: ``windows`` or ``linux`` (defaults to the installer's runner).
 - ``lang``: language code (defaults to the system locale).
@@ -1003,7 +1005,6 @@ III Arena::
         exe: quake3e-vulkan.x64
       installer:
       - gogdl_setup:
-          game_id: 1441704920
           platform: windows
       - merge:
           src: $GAMEDIR/Quake III

--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -489,6 +489,12 @@ actions accordingly.
 If the source is a ``file ID``, it will be updated with the new destination
 path. It can then be used in following commands to access the copied file.
 
+Set the optional ``remove_source`` parameter to ``true`` to delete the source
+directory once its contents have been merged. This is useful when the source is
+throwaway scaffolding (for instance the install-directory subfolder a
+``gogdl_setup`` depot download creates) that would otherwise duplicate the
+merged data.
+
 Example::
 
     - merge:
@@ -957,6 +963,56 @@ Example gog linux game, alternative::
       - merge:
           dst: $GAMEDIR
           src: $CACHE/GOG/data/noarch/
+
+
+Downloading GOG games from the depot (gogdl)
+--------------------------------------------
+
+The ``gogdl_setup`` directive downloads a GOG game's files directly from GOG's
+CDN using ``gogdl`` (the depot downloader from the Heroic Games Launcher),
+instead of requiring the user to provide an offline installer. This requires
+the user to be connected to GOG in Lutris.
+
+Parameters:
+
+- ``game_id``: the GOG product ID (required). Can be looked up on
+  https://www.gogdb.org/products
+- ``platform``: ``windows`` or ``linux`` (defaults to the installer's runner).
+- ``lang``: language code (defaults to the system locale).
+- ``dlcs``: ``all``, ``none``, or comma-separated DLC IDs.
+- ``command``: ``download`` (default), ``update`` or ``repair``.
+
+``gogdl`` downloads into a subfolder of the destination named after the game's
+install directory, so a following ``merge`` is typically used to lift the data
+up into ``$GAMEDIR``.
+
+Example of a native source port (Quake3e) running over the GOG data of Quake
+III Arena::
+
+    name: Quake III Arena
+    game_slug: quake-iii-arena
+    version: GOG depot + Quake3e
+    slug: quake-iii-arena-gog-depot-quake3e
+    runner: linux
+    gogid: 1441704920
+
+    script:
+      files:
+      - engine: https://github.com/ec-/Quake3e/releases/download/latest/quake3e-linux-x86_64.zip
+      game:
+        exe: quake3e-vulkan.x64
+      installer:
+      - gogdl_setup:
+          game_id: 1441704920
+          platform: windows
+      - merge:
+          src: $GAMEDIR/Quake III
+          dst: $GAMEDIR
+          remove_source: true
+      - extract:
+          dst: $GAMEDIR
+          file: engine
+      - chmodx: $GAMEDIR/quake3e-vulkan.x64
 
 
 Example steam Linux game::

--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -299,6 +299,12 @@ class CommandsMixin:
                 self.game_files[params["src"]] = os.path.join(dst, os.path.basename(src))
             return
         self._killable_process(system.merge_folders, src, dst)
+        # Optionally drop the source tree once its contents have been merged.
+        # Useful when the source is throwaway scaffolding (e.g. the
+        # installDirectory subfolder a gogdl depot download creates) that
+        # would otherwise duplicate the merged data.
+        if params.get("remove_source") and os.path.isdir(src):
+            self._killable_process(shutil.rmtree, src)
 
     def copy(self, params):
         """Alias for merge"""
@@ -749,7 +755,9 @@ class CommandsMixin:
         """Download and set up a GOG game via depot/CDN using heroic-gogdl.
 
         Params:
-            game_id: GOG product ID
+            game_id: GOG product ID (defaults to the installer's resolved
+                gogid, so scripts only need to set it once; an explicit value
+                still wins, e.g. for downloading a DLC)
             platform: "windows" or "linux" (default: based on runner)
             lang: language code (default: system locale)
             dlcs: "all", "none", or comma-separated DLC IDs (optional)
@@ -759,9 +767,14 @@ class CommandsMixin:
                 as missing)
             command: "download" | "update" | "repair" (default: "download")
         """
-        self._check_required_params("game_id", data, "gogdl_setup")
+        game_id = data.get("game_id") or self.installer.service_appid
+        if not game_id:
+            raise ScriptingError(
+                _("gogdl_setup requires a game_id, or a gogid set on the installer."),
+                data,
+            )
 
-        game_id = str(data["game_id"])
+        game_id = str(game_id)
         command = data.get("command", "download")
         platform = data.get("platform")
         lang = data.get("lang")
@@ -887,7 +900,14 @@ class CommandsMixin:
                 if os.path.isfile(start_sh):
                     lutris_config["exe"] = start_sh
                     system.make_executable(start_sh)
-            self.installer.script["game"].update(lutris_config)
+            # Don't clobber config the script set explicitly: a community
+            # installer may ship its own engine (e.g. a native source port
+            # run over GOG game data), in which case its exe must win over the
+            # Windows exe detected from goggame-*.info. Auto-generated GOG
+            # installers leave these unset, so detection still fills them in.
+            game_config = self.installer.script["game"]
+            for key, value in lutris_config.items():
+                game_config.setdefault(key, value)
 
     def _configure_dosbox_from_depot(self, install_path, gog_config):
         """Configure a DOSBox game from depot download using playTasks args.

--- a/lutris/installer/interpreter.py
+++ b/lutris/installer/interpreter.py
@@ -377,8 +377,13 @@ class ScriptInterpreter(GObject.Object, CommandsMixin):
         # Mark cached files as successfully installed so cleanup can remove them
         self._update_cache_locks_state("installed")
 
-        # Check that the game's executable can actually be found
+        # Check that the game's executable can actually be found. A relative
+        # entry point is resolved against the install directory, the same way
+        # the runner resolves it at launch time, so we don't warn spuriously
+        # for scripts that use a relative exe.
         exe_path = get_entry_point_path(game_config.get("game", {})) if game_config else ""
+        if exe_path and not os.path.isabs(exe_path) and self.target_path:
+            exe_path = os.path.join(self.target_path, exe_path)
 
         if exe_path and not os.path.isfile(exe_path) and self.installer.runner != "web":
             status = (


### PR DESCRIPTION
Makes the `gogdl_setup` depot-download path usable by community installer
scripts, not just the auto-generated GOG installers. Motivating case: a
native source port (Quake3e) running over the GOG game data of Quake III
Arena, downloaded from the depot instead of via an offline installer.

### Changes
- `_apply_gogdl_post_install` now uses `setdefault` instead of `dict.update`,
  so config detected from `goggame-*.info` only fills gaps and never clobbers
  an `exe` (or other entry point) the script set explicitly. Auto-generated
  installers leave these unset, so they're unaffected.
- `merge` gains an opt-in `remove_source` parameter to delete the source tree
  after merging — lets the install-directory subfolder a depot download
  creates be flattened into `$GAMEDIR` without duplicating the game data.
- `gogdl_setup`'s `game_id` now defaults to the installer's resolved `gogid`,
  so scripts don't repeat the product id. An explicit `game_id` still wins
  (e.g. for downloading a DLC).
- `_finish_install` resolves a relative entry point against the install dir
  before its existence check, matching how the runner resolves it at launch,
  removing a spurious "No executable found" warning.
- Docs: new `gogdl_setup` reference section, the `remove_source` parameter,
  and a worked Quake III Arena + Quake3e example.

### Testing
Installed Quake III Arena end-to-end via the depot path: data downloads from
GOG's CDN, merges into `$GAMEDIR` with no duplicate (837 MB vs 1.7 GB before),
and the game launches and runs on the Quake3e engine. No install warning.
Re-verified with `game_id` omitted from `gogdl_setup` (resolved from `gogid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
