### PR TITLE
installer: fall back to file selection when ModDB resolution fails

### DIFF
--- a/lutris/installer/installer.py
+++ b/lutris/installer/installer.py
@@ -5,6 +5,8 @@ from functools import cached_property
 from gettext import gettext as _
 from pathlib import Path
 
+import requests
+
 from lutris.api import get_game_details
 from lutris.config import LutrisConfig, write_game_config
 from lutris.database.games import add_or_update, get_game_by_field
@@ -191,7 +193,17 @@ class LutrisInstaller:  # pylint: disable=too-many-instance-attributes
         for file in files:
             file.set_url(self.interpreter._substitute(file.url))
             if is_moddb_url(file.url):
-                file.set_url(ModDB().transform_url(file.url))
+                moddb_url = file.url
+                try:
+                    file.set_url(ModDB().transform_url(moddb_url))
+                except requests.RequestException as ex:
+                    logger.warning("Unable to resolve ModDB URL %s: %s", moddb_url, ex)
+                    file.set_url(
+                        "N/A:"
+                        + _("Download from {url} and select the file here").format(
+                            url=moddb_url,
+                        )
+                    )
 
         if installer_file_id and self.service:
             logger.info("Getting files for %s", installer_file_id)

--- a/tests/_test_installer.py
+++ b/tests/_test_installer.py
@@ -1,4 +1,7 @@
 from unittest import TestCase
+from unittest.mock import patch
+
+import requests
 
 from lutris.installer.errors import ScriptingError
 from lutris.installer.interpreter import ScriptInterpreter
@@ -23,6 +26,16 @@ class MockInterpreter(ScriptInterpreter):
 
 
 class TestScriptInterpreter(TestCase):
+    def get_moddb_interpreter(self, moddb_url):
+        installer = {
+            **TEST_INSTALLER,
+            "script": {
+                "files": [{"moddb_file": {"url": moddb_url, "filename": "test-file.zip"}}],
+                "game": {"exe": "test"},
+            },
+        }
+        return MockInterpreter(installer, None)
+
     def test_script_with_correct_values_is_valid(self):
         installer = {
             "runner": "linux",
@@ -61,3 +74,42 @@ class TestScriptInterpreter(TestCase):
         with self.assertRaises(ScriptingError) as ex:
             interpreter._map_command({"_substitute": "foo"})
         self.assertEqual(ex.exception.message, 'The command "substitute" does not exist.')
+
+    def test_prepare_game_files_resolves_moddb_url(self):
+        moddb_url = "https://www.moddb.com/downloads/test-file"
+        mirror_url = "https://www.moddb.com/downloads/mirror/test-file"
+        interpreter = self.get_moddb_interpreter(moddb_url)
+
+        with patch("lutris.installer.installer.ModDB.transform_url", return_value=mirror_url):
+            interpreter.installer.prepare_game_files([])
+
+        installer_file = interpreter.installer.files[0]
+        self.assertEqual(installer_file.url, mirror_url)
+        self.assertEqual(installer_file.default_provider, "download")
+
+    def test_prepare_game_files_keeps_moddb_file_selectable_on_resolution_error(self):
+        moddb_url = "https://www.moddb.com/downloads/test-file"
+        interpreter = self.get_moddb_interpreter(moddb_url)
+
+        with patch(
+            "lutris.installer.installer.ModDB.transform_url",
+            side_effect=requests.HTTPError("403 Client Error"),
+        ):
+            interpreter.installer.prepare_game_files([])
+
+        installer_file = interpreter.installer.files[0]
+        self.assertEqual(
+            installer_file.url,
+            "N/A:Download from https://www.moddb.com/downloads/test-file and select the file here",
+        )
+        self.assertEqual(installer_file.default_provider, "user")
+        self.assertEqual(installer_file.providers, {"user"})
+        self.assertEqual(installer_file.filename, "test-file.zip")
+
+    def test_prepare_game_files_keeps_moddb_configuration_errors_visible(self):
+        moddb_url = "https://www.moddb.com/downloads/test-file"
+        interpreter = self.get_moddb_interpreter(moddb_url)
+
+        with patch("lutris.installer.installer.ModDB.transform_url", side_effect=RuntimeError("Invalid ModDB URL")):
+            with self.assertRaises(RuntimeError):
+                interpreter.installer.prepare_game_files([])


### PR DESCRIPTION
ModDB URL resolution fails before the installer file-selection page is shown, displaying a 403 response from ModDB/Cloudflare. When that happens, the installer currently aborts and the user cannot continue with installation.

This pr keeps the existing automatic ModDB mirror resolution path unchanged if it succeeds. However, if ModDB resolution fails with a request error, Lutris now logs the original URL and falls back to the existing manual file-selection flow for that file, providing a link to the designated installation site as well.

Refs #5703

## Tests completed

- `python -m nose2 tests._test_installer tests._test_moddb_helper`
- `ruff format lutris/installer/installer.py tests/_test_installer.py --check`
- `ruff check lutris/installer/installer.py tests/_test_installer.py`
- `python -m compileall -q lutris/installer/installer.py tests/_test_installer.py`