### PR TITLE
Update pre-commit

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -18,10 +18,6 @@ def main():
     comp_process = subprocess.run(
         ["git", "config", "--type=bool", "hooks.skip-static-analysis-checks"], capture_output=True
     )
-    # FIX: bool() on a non-empty string is always True in Python, so the
-    # original `bool(comp_process.stdout.decode("utf-8"))` treated the
-    # literal string "false\n" as truthy and skipped checks incorrectly.
-    # We now compare the decoded, stripped output against "true" explicitly.
     skip_static_analysis_checks: bool = comp_process.stdout.decode("utf-8").strip() == "true"
     if not skip_static_analysis_checks:
         diff_against_rev: str = "HEAD"
@@ -41,10 +37,6 @@ def main():
             for command in ["mypy", "ruff", "nose2"]:
                 command_path = shutil.which(command)
                 if not command_path:
-                    # FIX: the original message interpolated `command_path`,
-                    # which is None here (that's why we're in this branch),
-                    # so it always printed "None command is missing".
-                    # We now report the actual command name that's missing.
                     error_list.append(
                         f"{command} command is missing: Have you run `make dev` to install it or sourced your virtual env?"
                     )

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,13 +1,11 @@
-#!/bin/env python
+#!/usr/bin/env python
 """
 An hook script to verify what is about to be committed.
 Called by "git commit" with no arguments.  The hook should
 exit with non-zero status after issuing an appropriate message if
 it wants to stop the commit.
-
 This validates that the Lutris static analysis checks from .github/workflows/static.yml
 """
-
 import shutil
 import subprocess
 from os.path import devnull
@@ -17,12 +15,14 @@ from pathlib import Path
 
 def main():
     error_list: list[str] = []
-
     comp_process = subprocess.run(
         ["git", "config", "--type=bool", "hooks.skip-static-analysis-checks"], capture_output=True
     )
-    skip_static_analysis_checks: bool = bool(comp_process.stdout.decode("utf-8"))
-
+    # FIX: bool() on a non-empty string is always True in Python, so the
+    # original `bool(comp_process.stdout.decode("utf-8"))` treated the
+    # literal string "false\n" as truthy and skipped checks incorrectly.
+    # We now compare the decoded, stripped output against "true" explicitly.
+    skip_static_analysis_checks: bool = comp_process.stdout.decode("utf-8").strip() == "true"
     if not skip_static_analysis_checks:
         diff_against_rev: str = "HEAD"
         comp_process = subprocess.run(["git", "rev-parse", "--verify", "HEAD"], stdout=subprocess.DEVNULL)
@@ -30,23 +30,24 @@ def main():
             # This would be the initial commit, so diff against an empty tree object
             comp_process = subprocess.run(["git", "hash-object", "-t", "tree", devnull], capture_output=True)
             diff_against_rev = comp_process.stdout.decode("utf-8")
-
         comp_process = subprocess.run(
             ["git", "diff-index", "--cached", "--name-only", "--diff-filter=ACMR", "-z", diff_against_rev],
             capture_output=True,
         )
         modified_files: list[Path] = [Path(f.decode("utf-8")) for f in comp_process.stdout.split(b"\0") if f]
         modified_python_files: list[Path] = [f for f in modified_files if f.suffix == '.py']
-
         if modified_python_files:
             # Run command existence checks
             for command in ["mypy", "ruff", "nose2"]:
                 command_path = shutil.which(command)
                 if not command_path:
+                    # FIX: the original message interpolated `command_path`,
+                    # which is None here (that's why we're in this branch),
+                    # so it always printed "None command is missing".
+                    # We now report the actual command name that's missing.
                     error_list.append(
-                        f"{command_path} command is missing: Have you run `make dev` to install it or sourced your virtual env?"
+                        f"{command} command is missing: Have you run `make dev` to install it or sourced your virtual env?"
                     )
-
             checks_to_run: list[list[str]] = [
                 ["mypy", "--python-version=3.10"] + [str(f) for f in modified_python_files],
                 [sys.executable, "utils/check_annotations.py"],
@@ -59,12 +60,10 @@ def main():
                 if comp_process.returncode != 0:
                     # Store both the stdout and stderr of the failed check in the error list
                     error_list.append(f"{comp_process.stdout.decode('utf-8')}{comp_process.stderr.decode('utf-8')}")
-
     # If any of the return codes are non-zero then return a non-zero rc
     if error_list:
         print("".join(error_list))
         sys.exit(1)
-
     sys.exit(0)
 
 


### PR DESCRIPTION
This PR fixes two logic bugs in `.hooks/pre-commit`:

1. `skip_static_analysis_checks` was computed with `bool(stdout)`, which
   is always True for any non-empty string — including the literal text
   "false\n" returned by `git config --type=bool`. This meant explicitly
   setting the config to false was silently treated as true, skipping
   checks when it shouldn't. Fixed by comparing the stripped output
   against "true" explicitly.

2. The "command is missing" error message interpolated `command_path`
   (which is always None in that branch — that's why we're reporting
   it as missing) instead of `command`, so it always printed "None
   command is missing" regardless of which tool was actually absent.
   Fixed to reference the actual command name.