### PR TITLE
Fixed Unit Test builds when running on CI / Enabled util test

### DIFF
--- a/tests/services/_test_gog_dlcs.py
+++ b/tests/services/_test_gog_dlcs.py
@@ -9,153 +9,11 @@ Tests the ability to:
 5. Merge results into unified JSON
 """
 
-import importlib.util
-import os
-import sys
-import types
 import unittest
+from unittest.mock import MagicMock, patch
 
-REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-GOG_PATH = os.path.join(REPO_ROOT, "lutris", "services", "gog.py")
+import lutris.services.gog as GOG
 
-
-def _make_module(name, **attrs):
-    """Create a mock module for testing."""
-    module = types.ModuleType(name)
-    module.__dict__.update(attrs)
-    return module
-
-
-def _install_stubs():
-    """Install all required module stubs for testing."""
-    if "lutris.services.gog" in sys.modules:
-        return sys.modules["lutris.services.gog"]
-
-    lutris_pkg = _make_module("lutris")
-    lutris_pkg.__path__ = []
-
-    settings_mod = _make_module(
-        "lutris.settings",
-        CACHE_DIR="/tmp/lutris-test-cache",
-    )
-
-    exceptions_mod = _make_module(
-        "lutris.exceptions",
-        AuthenticationError=type("AuthenticationError", (Exception,), {}),
-        UnavailableGameError=type("UnavailableGameError", (Exception,), {}),
-    )
-
-    installer_mod = _make_module(
-        "lutris.installer",
-        AUTO_ELF_EXE="AUTO_ELF_EXE",
-        AUTO_WIN32_EXE="AUTO_WIN32_EXE",
-    )
-    installer_mod.__path__ = []
-
-    installer_file_mod = _make_module(
-        "lutris.installer.installer_file",
-        InstallerFile=type("InstallerFile", (object,), {}),
-    )
-    installer_file_collection_mod = _make_module(
-        "lutris.installer.installer_file_collection",
-        InstallerFileCollection=type("InstallerFileCollection", (object,), {}),
-    )
-
-    runners_mod = _make_module("lutris.runners", get_runner_human_name=lambda runner: runner)
-
-    service_base_mod = _make_module(
-        "lutris.services.base",
-        SERVICE_LOGIN=object(),
-        AuthTokenExpiredError=type("AuthTokenExpiredError", (Exception,), {}),
-        OnlineService=type(
-            "OnlineService",
-            (object,),
-            {
-                "__init__": lambda self: None,
-                "get_installed_slug": lambda self, db_game: db_game.get("slug", "installed-game"),
-                "is_authenticated": lambda self: True,
-            },
-        ),
-    )
-
-    service_game_mod = _make_module("lutris.services.service_game", ServiceGame=type("ServiceGame", (object,), {}))
-    service_media_mod = _make_module("lutris.services.service_media", ServiceMedia=type("ServiceMedia", (object,), {}))
-
-    util_pkg = _make_module("lutris.util")
-    util_pkg.__path__ = []
-    i18n_mod = _make_module("lutris.util.i18n", get_lang=lambda: "en")
-    system_mod = _make_module("lutris.util.system", path_exists=lambda path: False)
-    gog_downloader_mod = _make_module("lutris.util.gog_downloader", GOGDownloader=type("GOGDownloader", (object,), {}))
-    http_mod = _make_module(
-        "lutris.util.http",
-        HTTPError=type("HTTPError", (Exception,), {}),
-        UnauthorizedAccessError=type("UnauthorizedAccessError", (Exception,), {}),
-        Request=type("Request", (object,), {}),
-    )
-    log_mod = _make_module(
-        "lutris.util.log",
-        logger=types.SimpleNamespace(
-            debug=lambda *args, **kwargs: None,
-            info=lambda *args, **kwargs: None,
-            warning=lambda *args, **kwargs: None,
-            error=lambda *args, **kwargs: None,
-            exception=lambda *args, **kwargs: None,
-        ),
-    )
-    strings_mod = _make_module(
-        "lutris.util.strings",
-        human_size=lambda size: str(size),
-        slugify=lambda value: value.lower().replace(" ", "-"),
-    )
-
-    util_pkg.i18n = i18n_mod
-    util_pkg.system = system_mod
-
-    services_pkg = _make_module("lutris.services")
-    services_pkg.__path__ = []
-    services_pkg.base = service_base_mod
-    services_pkg.service_game = service_game_mod
-    services_pkg.service_media = service_media_mod
-
-    lutris_pkg.settings = settings_mod
-    lutris_pkg.exceptions = exceptions_mod
-    lutris_pkg.installer = installer_mod
-    lutris_pkg.runners = runners_mod
-    lutris_pkg.services = services_pkg
-    lutris_pkg.util = util_pkg
-
-    sys.modules.update(
-        {
-            "lutris": lutris_pkg,
-            "lutris.settings": settings_mod,
-            "lutris.exceptions": exceptions_mod,
-            "lutris.installer": installer_mod,
-            "lutris.installer.installer_file": installer_file_mod,
-            "lutris.installer.installer_file_collection": installer_file_collection_mod,
-            "lutris.runners": runners_mod,
-            "lutris.services": services_pkg,
-            "lutris.services.base": service_base_mod,
-            "lutris.services.service_game": service_game_mod,
-            "lutris.services.service_media": service_media_mod,
-            "lutris.util": util_pkg,
-            "lutris.util.i18n": i18n_mod,
-            "lutris.util.system": system_mod,
-            "lutris.util.gog_downloader": gog_downloader_mod,
-            "lutris.util.http": http_mod,
-            "lutris.util.log": log_mod,
-            "lutris.util.strings": strings_mod,
-        }
-    )
-
-    spec = importlib.util.spec_from_file_location("lutris.services.gog", GOG_PATH)
-    module = importlib.util.module_from_spec(spec)
-    sys.modules["lutris.services.gog"] = module
-    assert spec.loader is not None
-    spec.loader.exec_module(module)
-    return module
-
-
-GOG = _install_stubs()
 GOGService = GOG.GOGService
 
 
@@ -272,17 +130,20 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify
-        assert isinstance(result, list), "Result should be a list"
-        assert len(result) == len(dlc_ids), f"Expected {len(dlc_ids)} DLCs, got {len(result)}"
-        assert len(self.make_api_request_calls) == 1, "Should make exactly 1 API request for <50 DLCs"
-        assert all("expanded_all_products_url" in game_details["dlcs"] for _ in [None])
+            # Verify
+            assert isinstance(result, list), "Result should be a list"
+            assert len(result) == len(dlc_ids), f"Expected {len(dlc_ids)} DLCs, got {len(result)}"
+            assert len(self.make_api_request_calls) == 1, "Should make exactly 1 API request for <50 DLCs"
+            assert all("expanded_all_products_url" in game_details["dlcs"] for _ in [None])
 
     def test_multi_request_path_with_many_dlcs(self):
         """Test get_game_dlcs with exactly 72 DLCs (like Europa Universalis IV)."""
@@ -291,24 +152,27 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
+            # Verify
+            assert isinstance(result, list), "Result should be a list"
+            assert len(result) == 72, f"Expected 72 DLCs, got {len(result)}"
+            # 72 DLCs should be split into 2 requests: 50 + 22
+            assert len(self.make_api_request_calls) == 2, (
+                f"Expected 2 API requests for 72 DLCs, got {len(self.make_api_request_calls)}"
+            )
 
-        # Verify
-        assert isinstance(result, list), "Result should be a list"
-        assert len(result) == 72, f"Expected 72 DLCs, got {len(result)}"
-        # 72 DLCs should be split into 2 requests: 50 + 22
-        assert len(self.make_api_request_calls) == 2, (
-            f"Expected 2 API requests for 72 DLCs, got {len(self.make_api_request_calls)}"
-        )
-
-        # Verify all DLCs are present in result
-        result_ids = {item["id"] for item in result}
-        expected_ids = set(dlc_ids)
-        assert result_ids == expected_ids, "All DLC IDs should be present in the result"
+            # Verify all DLCs are present in result
+            result_ids = {item["id"] for item in result}
+            expected_ids = set(dlc_ids)
+            assert result_ids == expected_ids, "All DLC IDs should be present in the result"
 
     def test_multi_request_batching_exactly_100_dlcs(self):
         """Test batching with exactly 100 DLCs (2 full batches)."""
@@ -317,22 +181,25 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
+            # Verify
+            assert len(result) == 100, f"Expected 100 DLCs, got {len(result)}"
+            assert len(self.make_api_request_calls) == 2, "Expected 2 API requests for 100 DLCs"
 
-        # Verify
-        assert len(result) == 100, f"Expected 100 DLCs, got {len(result)}"
-        assert len(self.make_api_request_calls) == 2, "Expected 2 API requests for 100 DLCs"
-
-        # Verify batches are correctly sized
-        for i, url in enumerate(self.make_api_request_calls):
-            start = url.find("ids=") + 4
-            end = url.find("&", start) if "&" in url[start:] else len(url)
-            ids_in_batch = len(url[start:end].split(","))
-            assert ids_in_batch <= 50, f"Batch {i} has {ids_in_batch} IDs, should be <= 50"
+            # Verify batches are correctly sized
+            for i, url in enumerate(self.make_api_request_calls):
+                start = url.find("ids=") + 4
+                end = url.find("&", start) if "&" in url[start:] else len(url)
+                ids_in_batch = len(url[start:end].split(","))
+                assert ids_in_batch <= 50, f"Batch {i} has {ids_in_batch} IDs, should be <= 50"
 
     def test_multi_request_batching_151_dlcs(self):
         """Test batching with 151 DLCs (4 batches: 50 + 50 + 50 + 1)."""
@@ -341,15 +208,18 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify
-        assert len(result) == 151, f"Expected 151 DLCs, got {len(result)}"
-        assert len(self.make_api_request_calls) == 4, "Expected 4 API requests for 151 DLCs (50+50+50+1)"
+            # Verify
+            assert len(result) == 151, f"Expected 151 DLCs, got {len(result)}"
+            assert len(self.make_api_request_calls) == 4, "Expected 4 API requests for 151 DLCs (50+50+50+1)"
 
     def test_empty_dlc_list(self):
         """Test get_game_dlcs when game has no DLCs."""
@@ -361,16 +231,19 @@ class TestGOGDLCFetcher(unittest.TestCase):
             "title": "Game Without DLCs",
             "dlcs": {"products": [], "expanded_all_products_url": "", "all_products_url": ""},
         }
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify
-        assert isinstance(result, list), "Result should be a list"
-        assert len(result) == 0, "Result should be empty for game with no DLCs"
-        assert len(self.make_api_request_calls) == 0, "No API requests should be made for empty DLC list"
+            # Verify
+            assert isinstance(result, list), "Result should be a list"
+            assert len(result) == 0, "Result should be empty for game with no DLCs"
+            assert len(self.make_api_request_calls) == 0, "No API requests should be made for empty DLC list"
 
     def test_no_dlcs_key(self):
         """Test get_game_dlcs when game details have no 'dlcs' key."""
@@ -381,15 +254,18 @@ class TestGOGDLCFetcher(unittest.TestCase):
             "id": int(product_id) if product_id.isdigit() else 999,
             "title": "Game Without DLCs Key",
         }
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify
-        assert isinstance(result, list), "Result should be a list"
-        assert len(result) == 0, "Result should be empty when 'dlcs' key is missing"
+            # Verify
+            assert isinstance(result, list), "Result should be a list"
+            assert len(result) == 0, "Result should be empty when 'dlcs' key is missing"
 
     def test_unified_json_structure(self):
         """Test that unified JSON has consistent structure across all DLCs."""
@@ -398,28 +274,31 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
+            # Verify structure consistency
+            assert len(result) > 0, "Result should not be empty"
 
-        # Verify structure consistency
-        assert len(result) > 0, "Result should not be empty"
+            # Get keys from first item as reference
+            first_item_keys = set(result[0].keys())
 
-        # Get keys from first item as reference
-        first_item_keys = set(result[0].keys())
+            # Verify all items have same keys
+            for item in result:
+                assert isinstance(item, dict), "Each item should be a dictionary"
+                assert set(item.keys()) == first_item_keys, "All items should have same keys"
 
-        # Verify all items have same keys
-        for item in result:
-            assert isinstance(item, dict), "Each item should be a dictionary"
-            assert set(item.keys()) == first_item_keys, "All items should have same keys"
-
-        # Verify required keys exist
-        required_keys = {"id", "title", "slug", "downloads", "dlcs"}
-        assert required_keys.issubset(first_item_keys), (
-            f"Missing required keys. Expected {required_keys}, got {first_item_keys}"
-        )
+            # Verify required keys exist
+            required_keys = {"id", "title", "slug", "downloads", "dlcs"}
+            assert required_keys.issubset(first_item_keys), (
+                f"Missing required keys. Expected {required_keys}, got {first_item_keys}"
+            )
 
     def test_product_ids_correctly_extracted(self):
         """Test that product IDs are correctly extracted from game details."""
@@ -428,16 +307,19 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify IDs match
-        result_ids = sorted([item["id"] for item in result])
-        expected_ids = sorted([int(pid) for pid in dlc_ids])
-        assert result_ids == expected_ids, f"IDs don't match. Expected {expected_ids}, got {result_ids}"
+            # Verify IDs match
+            result_ids = sorted([item["id"] for item in result])
+            expected_ids = sorted([int(pid) for pid in dlc_ids])
+            assert result_ids == expected_ids, f"IDs don't match. Expected {expected_ids}, got {result_ids}"
 
     def test_batching_with_exact_50_boundary(self):
         """Test batching behavior with exactly 50 DLCs."""
@@ -446,15 +328,18 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify - with exactly 50, should still use multi-request path if > 50
-        # But since it's exactly 50, let's check if it uses the expanded_all_products_url
-        assert len(result) == 50, f"Expected 50 DLCs, got {len(result)}"
+            # Verify - with exactly 50, should still use multi-request path if > 50
+            # But since it's exactly 50, let's check if it uses the expanded_all_products_url
+            assert len(result) == 50, f"Expected 50 DLCs, got {len(result)}"
 
     def test_returns_list_of_dicts(self):
         """Test that the function always returns a list of dictionaries."""
@@ -463,15 +348,18 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            result = self.service.get_game_dlcs(product_id)
 
-        # Execute
-        result = self.service.get_game_dlcs(product_id)
-
-        # Verify
-        assert isinstance(result, list), "Return type must be a list"
-        assert all(isinstance(item, dict) for item in result), "All items in list must be dictionaries"
+            # Verify
+            assert isinstance(result, list), "Return type must be a list"
+            assert all(isinstance(item, dict) for item in result), "All items in list must be dictionaries"
 
     def test_api_url_construction(self):
         """Test that API URLs are correctly constructed."""
@@ -480,18 +368,21 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute
+            self.service.get_game_dlcs(product_id)
 
-        # Execute
-        self.service.get_game_dlcs(product_id)
-
-        # Verify API URLs
-        assert len(self.make_api_request_calls) > 0, "At least one API request should be made"
-        for url in self.make_api_request_calls:
-            assert "api.gog.com" in url, f"URL should contain api.gog.com: {url}"
-            assert "ids=" in url, f"URL should contain ids parameter: {url}"
-            assert "expand=downloads" in url, f"URL should request downloads expansion: {url}"
+            # Verify API URLs
+            assert len(self.make_api_request_calls) > 0, "At least one API request should be made"
+            for url in self.make_api_request_calls:
+                assert "api.gog.com" in url, f"URL should contain api.gog.com: {url}"
+                assert "ids=" in url, f"URL should contain ids parameter: {url}"
+                assert "expand=downloads" in url, f"URL should request downloads expansion: {url}"
 
     def test_deterministic_output_order(self):
         """Test that output maintains consistent ordering."""
@@ -500,19 +391,22 @@ class TestGOGDLCFetcher(unittest.TestCase):
 
         # Setup mocks
         game_details = self._create_game_details_response(product_id, dlc_ids)
-        self.service.get_game_details = lambda pid: game_details
-        self.service.make_api_request = self._mock_make_api_request
+        with (
+            patch.object(
+                self.service, "get_game_details", MagicMock(side_effect=lambda pid: game_details)
+            ) as _mock_game_details,
+            patch.object(self.service, "make_api_request", MagicMock(side_effect=self._mock_make_api_request)),
+        ):
+            # Execute twice
+            result1 = self.service.get_game_dlcs(product_id)
+            self.requested_urls.clear()
+            self.make_api_request_calls.clear()
+            result2 = self.service.get_game_dlcs(product_id)
 
-        # Execute twice
-        result1 = self.service.get_game_dlcs(product_id)
-        self.requested_urls.clear()
-        self.make_api_request_calls.clear()
-        result2 = self.service.get_game_dlcs(product_id)
-
-        # Verify order is the same
-        ids1 = [item["id"] for item in result1]
-        ids2 = [item["id"] for item in result2]
-        assert ids1 == ids2, "Output order should be deterministic"
+            # Verify order is the same
+            ids1 = [item["id"] for item in result1]
+            ids2 = [item["id"] for item in result2]
+            assert ids1 == ids2, "Output order should be deterministic"
 
 
 if __name__ == "__main__":

--- a/tests/util/_test_collection_progress.py
+++ b/tests/util/_test_collection_progress.py
@@ -8,103 +8,14 @@ The module is loaded via importlib to avoid the normal lutris.gui package
 chain that requires a real GTK installation / display.
 """
 
-import importlib
-import importlib.util
-import os
-import sys
-import types
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-import pytest
-
-# ── Load the target module in isolation ──────────────────────────────
-#
-# We can't ``import lutris.gui.widgets.download_collection_progress_box``
-# normally because the package __init__.py files pull in real GTK /
-# GObject, which requires a display.  Instead we:
-#
-#  1. Temporarily inject ``gi`` / ``gi.repository`` stubs into
-#     sys.modules (only if they are NOT already loaded — if real gi is
-#     present we leave it).
-#  2. Load the single .py file via importlib.util.spec_from_file_location
-#     under its fully qualified name so that ``patch()`` calls work.
-#  3. After loading, remove temporary stubs (but keep the target module
-#     and its own ``gi.repository`` references alive — they are already
-#     bound in the module's global namespace).
-
-_SRC_ROOT = os.path.join(os.path.dirname(__file__), "..", "..")
-_MOD_NAME = "lutris.gui.widgets.download_collection_progress_box"
-_MOD_PATH = os.path.join(_SRC_ROOT, "lutris", "gui", "widgets", "download_collection_progress_box.py")
-
-
-def _load_module() -> types.ModuleType:
-    """Load the target module, stubbing GTK if necessary."""
-    # If the module was already loaded (e.g. in a previous test-collection
-    # pass), just reuse it.
-    if _MOD_NAME in sys.modules:
-        return sys.modules[_MOD_NAME]
-
-    # Track what we add so we can clean up only our additions.
-    # We use setdefault so we NEVER overwrite a real module — this avoids
-    # poisoning sys.modules["gi"] when real GTK is installed.
-    added: list[str] = []
-
-    def _ensure(name: str, mod: types.ModuleType) -> None:
-        if name not in sys.modules:
-            sys.modules[name] = mod
-            added.append(name)
-
-    # gi / gi.repository stubs — only if not already present
-    _gi = types.ModuleType("gi")
-    _gi.require_version = lambda *a, **kw: None  # type: ignore[attr-defined]
-    _ensure("gi", _gi)
-
-    _mock_gtk = MagicMock()
-    _mock_gtk.Box = type("Box", (), {"__init__": lambda self, **kw: None})
-    _mock_gtk.Orientation.VERTICAL = 0
-
-    _mock_gobject = MagicMock()
-    _mock_gobject.SignalFlags.RUN_LAST = 1
-    _mock_gobject.TYPE_PYOBJECT = object
-
-    _gi_repo = types.ModuleType("gi.repository")
-    _gi_repo.Gtk = _mock_gtk  # type: ignore[attr-defined]
-    _gi_repo.GLib = MagicMock()  # type: ignore[attr-defined]
-    _gi_repo.GObject = _mock_gobject  # type: ignore[attr-defined]
-    _gi_repo.Pango = MagicMock()  # type: ignore[attr-defined]
-    _ensure("gi.repository", _gi_repo)
-
-    # Ensure parent package stubs so importlib can place our module
-    for pkg in ("lutris.gui", "lutris.gui.widgets", "lutris.gui.dialogs"):
-        stub = types.ModuleType(pkg)
-        stub.__path__ = []  # type: ignore[attr-defined]
-        _ensure(pkg, stub)
-
-    # The module imports display_error from lutris.gui.dialogs
-    sys.modules["lutris.gui.dialogs"].display_error = MagicMock()  # type: ignore[attr-defined]
-
-    # Load the module
-    spec = importlib.util.spec_from_file_location(_MOD_NAME, _MOD_PATH)
-    assert spec is not None and spec.loader is not None
-    mod = importlib.util.module_from_spec(spec)
-    sys.modules[_MOD_NAME] = mod
-    spec.loader.exec_module(mod)
-
-    # Clean up ALL stubs we added — the loaded module's globals already
-    # captured their references to Gtk, GObject, etc., so removing the
-    # sys.modules entries doesn't break the module.
-    for key in added:
-        sys.modules.pop(key, None)
-
-    return mod
-
-
-_mod = _load_module()
-
-MAX_CONCURRENT_FILES = _mod.MAX_CONCURRENT_FILES
-DownloadCollectionProgressBox = _mod.DownloadCollectionProgressBox
-_ActiveDownload = _mod._ActiveDownload
-
+from lutris.gui.widgets.download_collection_progress_box import (
+    MAX_CONCURRENT_FILES,
+    DownloadCollectionProgressBox,
+    _ActiveDownload,
+)
 
 # ── Helpers ──────────────────────────────────────────────────────────
 
@@ -159,16 +70,6 @@ def _make_downloader(state="DOWNLOADING", downloaded_size=0):
 # ── Fixture ──────────────────────────────────────────────────────────
 
 
-@pytest.fixture
-def two_files():
-    """Two files for typical multi-file test."""
-    return [
-        _make_file("part1.bin", dest="/tmp/dl/part1.bin"),
-        _make_file("part2.bin", dest="/tmp/dl/part2.bin"),
-    ]
-
-
-@pytest.fixture
 def three_files():
     """Three files for prefetch boundary test."""
     return [
@@ -181,7 +82,7 @@ def three_files():
 # ── Tests: _ActiveDownload ───────────────────────────────────────────
 
 
-class TestActiveDownload:
+class TestActiveDownload(TestCase):
     def test_init_sets_fields(self):
         f = _make_file()
         dl = _make_downloader()
@@ -199,7 +100,7 @@ class TestActiveDownload:
 # ── Tests: Initialisation ───────────────────────────────────────────
 
 
-class TestInit:
+class TestInit(TestCase):
     def test_active_downloads_initially_empty(self):
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
         box._active_downloads = []
@@ -217,7 +118,7 @@ class TestInit:
 # ── Tests: _create_downloader ───────────────────────────────────────
 
 
-class TestCreateDownloader:
+class TestCreateDownloader(TestCase):
     @patch("lutris.gui.widgets.download_collection_progress_box.create_cache_lock")
     @patch("lutris.gui.widgets.download_collection_progress_box.SimpleDownloader")
     @patch("lutris.gui.widgets.download_collection_progress_box.os.path.exists", return_value=False)
@@ -276,7 +177,7 @@ class TestCreateDownloader:
 # ── Tests: _pop_next_downloadable_file ───────────────────────────────
 
 
-class TestPopNextDownloadableFile:
+class TestPopNextDownloadableFile(TestCase):
     def test_returns_file_when_not_cached(self):
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
         f = _make_file(dest="/tmp/dl/notexist.bin")
@@ -318,7 +219,7 @@ class TestPopNextDownloadableFile:
 # ── Tests: Aggregate progress ────────────────────────────────────────
 
 
-class TestAggregateDownloadedSize:
+class TestAggregateDownloadedSize(TestCase):
     def test_sums_completed_and_active(self):
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
         box._completed_sizes = {"/a": 100, "/b": 200}
@@ -341,7 +242,7 @@ class TestAggregateDownloadedSize:
 # ── Tests: File labels ───────────────────────────────────────────────
 
 
-class TestUpdateActiveFileLabels:
+class TestUpdateActiveFileLabels(TestCase):
     def test_comma_separated_names(self):
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
         box.file_name_label = MagicMock()
@@ -378,11 +279,14 @@ class TestUpdateActiveFileLabels:
 # ── Tests: Start / prefetch ──────────────────────────────────────────
 
 
-class TestStartPrefetch:
-    def test_start_launches_two_downloads(self, three_files):
+class TestStartPrefetch(TestCase):
+    def setUp(self):
+        self.three_files = three_files()
+
+    def test_start_launches_two_downloads(self):
         """start() should launch primary + prefetch = 2 concurrent downloads."""
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
-        box._file_queue = three_files.copy()
+        box._file_queue = self.three_files.copy()
         box.downloader = None
         box.is_complete = False
         box.num_files_downloaded = 0
@@ -456,7 +360,7 @@ class TestStartPrefetch:
 # ── Tests: Progress callback ─────────────────────────────────────────
 
 
-class TestProgress:
+class TestProgress(TestCase):
     def _setup_box(self):
         """Create a box ready for _progress() calls."""
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
@@ -591,7 +495,7 @@ class TestProgress:
 # ── Tests: Cancel ────────────────────────────────────────────────────
 
 
-class TestCancel:
+class TestCancel(TestCase):
     def test_cancel_stops_all_active(self):
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)
         dl1 = _make_downloader()
@@ -629,7 +533,7 @@ class TestCancel:
 # ── Tests: Edge cases ────────────────────────────────────────────────
 
 
-class TestEdgeCases:
+class TestEdgeCases(TestCase):
     def test_single_file_collection(self):
         """A single-file collection should work normally without prefetch."""
         box = DownloadCollectionProgressBox.__new__(DownloadCollectionProgressBox)

--- a/tests/util/_test_download_cache.py
+++ b/tests/util/_test_download_cache.py
@@ -2,10 +2,10 @@
 
 import json
 import os
-import tempfile
 import time
-
-import pytest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
 
 from lutris.util.download_cache import (
     CacheState,
@@ -18,14 +18,6 @@ from lutris.util.download_cache import (
 )
 
 
-@pytest.fixture
-def temp_dir():
-    """Create a temporary directory for test files."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        yield tmpdir
-
-
-@pytest.fixture
 def temp_file(temp_dir):
     """Create a temporary file for testing."""
     path = os.path.join(temp_dir, "test_game_installer.bin")
@@ -34,7 +26,7 @@ def temp_file(temp_dir):
     return path
 
 
-class TestCacheState:
+class TestCacheState(TestCase):
     """Test CacheState enum values."""
 
     def test_state_values(self):
@@ -49,165 +41,194 @@ class TestCacheState:
         assert CacheState("installed") == CacheState.INSTALLED
 
 
-class TestCreateCacheLock:
+class TestCreateCacheLock(TestCase):
     """Test cache lock file creation."""
 
-    def test_creates_lock_file(self, temp_file):
-        create_cache_lock(temp_file)
-        lock_path = temp_file + ".cache_lock"
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_file = temp_file(self.tmp_path)
+
+    def test_creates_lock_file(self):
+        create_cache_lock(self.tmp_file)
+        lock_path = self.tmp_file + ".cache_lock"
         assert os.path.exists(lock_path)
 
-    def test_lock_contains_correct_state(self, temp_file):
-        create_cache_lock(temp_file, CacheState.DOWNLOADING)
-        lock_path = temp_file + ".cache_lock"
+    def test_lock_contains_correct_state(self):
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADING)
+        lock_path = self.tmp_file + ".cache_lock"
         with open(lock_path) as f:
             data = json.load(f)
         assert data["state"] == "downloading"
-        assert data["file_path"] == temp_file
+        assert data["file_path"] == self.tmp_file
         assert "created_at" in data
         assert "updated_at" in data
 
-    def test_lock_with_custom_state(self, temp_file):
-        create_cache_lock(temp_file, CacheState.DOWNLOADED)
-        assert get_cache_state(temp_file) == CacheState.DOWNLOADED
+    def test_lock_with_custom_state(self):
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADED)
+        assert get_cache_state(self.tmp_file) == CacheState.DOWNLOADED
 
-    def test_creates_directory_if_needed(self, temp_dir):
-        nested_path = os.path.join(temp_dir, "subdir", "file.bin")
+    def test_creates_directory_if_needed(self):
+        nested_path = os.path.join(self.tmp_path, "subdir", "file.bin")
         create_cache_lock(nested_path)
         assert os.path.exists(nested_path + ".cache_lock")
 
 
-class TestUpdateCacheLock:
+class TestUpdateCacheLock(TestCase):
     """Test cache lock state updates."""
 
-    def test_updates_state(self, temp_file):
-        create_cache_lock(temp_file, CacheState.DOWNLOADING)
-        update_cache_lock(temp_file, CacheState.DOWNLOADED)
-        assert get_cache_state(temp_file) == CacheState.DOWNLOADED
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_file = temp_file(self.tmp_path)
 
-    def test_updates_timestamp(self, temp_file):
-        create_cache_lock(temp_file, CacheState.DOWNLOADING)
-        lock_path = temp_file + ".cache_lock"
+    def test_updates_state(self):
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADING)
+        update_cache_lock(self.tmp_file, CacheState.DOWNLOADED)
+        assert get_cache_state(self.tmp_file) == CacheState.DOWNLOADED
+
+    def test_updates_timestamp(self):
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADING)
+        lock_path = self.tmp_file + ".cache_lock"
         with open(lock_path) as f:
             data1 = json.load(f)
 
         time.sleep(0.1)
-        update_cache_lock(temp_file, CacheState.INSTALLED)
+        update_cache_lock(self.tmp_file, CacheState.INSTALLED)
         with open(lock_path) as f:
             data2 = json.load(f)
 
         assert data2["updated_at"] >= data1["updated_at"]
 
-    def test_update_nonexistent_lock(self, temp_file):
+    def test_update_nonexistent_lock(self):
         """Update should create the lock if it doesn't exist."""
-        update_cache_lock(temp_file, CacheState.INSTALLED)
-        assert get_cache_state(temp_file) == CacheState.INSTALLED
+        update_cache_lock(self.tmp_file, CacheState.INSTALLED)
+        assert get_cache_state(self.tmp_file) == CacheState.INSTALLED
 
-    def test_full_lifecycle(self, temp_file):
+    def test_full_lifecycle(self):
         """Test transition through all states."""
-        create_cache_lock(temp_file, CacheState.DOWNLOADING)
-        assert get_cache_state(temp_file) == CacheState.DOWNLOADING
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADING)
+        assert get_cache_state(self.tmp_file) == CacheState.DOWNLOADING
 
-        update_cache_lock(temp_file, CacheState.DOWNLOADED)
-        assert get_cache_state(temp_file) == CacheState.DOWNLOADED
+        update_cache_lock(self.tmp_file, CacheState.DOWNLOADED)
+        assert get_cache_state(self.tmp_file) == CacheState.DOWNLOADED
 
-        update_cache_lock(temp_file, CacheState.INSTALLING)
-        assert get_cache_state(temp_file) == CacheState.INSTALLING
+        update_cache_lock(self.tmp_file, CacheState.INSTALLING)
+        assert get_cache_state(self.tmp_file) == CacheState.INSTALLING
 
-        update_cache_lock(temp_file, CacheState.INSTALLED)
-        assert get_cache_state(temp_file) == CacheState.INSTALLED
+        update_cache_lock(self.tmp_file, CacheState.INSTALLED)
+        assert get_cache_state(self.tmp_file) == CacheState.INSTALLED
 
 
-class TestGetCacheState:
+class TestGetCacheState(TestCase):
     """Test reading cache state."""
 
-    def test_returns_none_for_no_lock(self, temp_file):
-        assert get_cache_state(temp_file) is None
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_file = temp_file(self.tmp_path)
 
-    def test_returns_correct_state(self, temp_file):
-        create_cache_lock(temp_file, CacheState.INSTALLING)
-        assert get_cache_state(temp_file) == CacheState.INSTALLING
+    def test_returns_none_for_no_lock(self):
+        assert get_cache_state(self.tmp_file) is None
 
-    def test_handles_corrupted_lock(self, temp_file):
-        lock_path = temp_file + ".cache_lock"
+    def test_returns_correct_state(self):
+        create_cache_lock(self.tmp_file, CacheState.INSTALLING)
+        assert get_cache_state(self.tmp_file) == CacheState.INSTALLING
+
+    def test_handles_corrupted_lock(self):
+        lock_path = self.tmp_file + ".cache_lock"
         with open(lock_path, "w") as f:
             f.write("not valid json{{{")
-        assert get_cache_state(temp_file) is None
+        assert get_cache_state(self.tmp_file) is None
 
 
-class TestRemoveCacheLock:
+class TestRemoveCacheLock(TestCase):
     """Test cache lock removal."""
 
-    def test_removes_lock(self, temp_file):
-        create_cache_lock(temp_file)
-        remove_cache_lock(temp_file)
-        assert not os.path.exists(temp_file + ".cache_lock")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_file = temp_file(self.tmp_path)
 
-    def test_no_error_for_nonexistent_lock(self, temp_file):
-        remove_cache_lock(temp_file)  # Should not raise
+    def test_removes_lock(self):
+        create_cache_lock(self.tmp_file)
+        remove_cache_lock(self.tmp_file)
+        assert not os.path.exists(self.tmp_file + ".cache_lock")
+
+    def test_no_error_for_nonexistent_lock(self):
+        remove_cache_lock(self.tmp_file)  # Should not raise
 
 
-class TestIsSafeToDelete:
+class TestIsSafeToDelete(TestCase):
     """Test deletion safety checks."""
 
-    def test_no_lock_is_safe(self, temp_file):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_file = temp_file(self.tmp_path)
+
+    def test_no_lock_is_safe(self):
         """Legacy files without locks can be deleted."""
-        assert is_safe_to_delete(temp_file) is True
+        assert is_safe_to_delete(self.tmp_file) is True
 
-    def test_installed_is_safe(self, temp_file):
-        create_cache_lock(temp_file, CacheState.INSTALLED)
-        assert is_safe_to_delete(temp_file) is True
+    def test_installed_is_safe(self):
+        create_cache_lock(self.tmp_file, CacheState.INSTALLED)
+        assert is_safe_to_delete(self.tmp_file) is True
 
-    def test_downloading_is_not_safe(self, temp_file):
-        create_cache_lock(temp_file, CacheState.DOWNLOADING)
-        assert is_safe_to_delete(temp_file) is False
+    def test_downloading_is_not_safe(self):
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADING)
+        assert is_safe_to_delete(self.tmp_file) is False
 
-    def test_downloaded_is_not_safe(self, temp_file):
-        create_cache_lock(temp_file, CacheState.DOWNLOADED)
-        assert is_safe_to_delete(temp_file) is False
+    def test_downloaded_is_not_safe(self):
+        create_cache_lock(self.tmp_file, CacheState.DOWNLOADED)
+        assert is_safe_to_delete(self.tmp_file) is False
 
-    def test_installing_is_not_safe(self, temp_file):
-        create_cache_lock(temp_file, CacheState.INSTALLING)
-        assert is_safe_to_delete(temp_file) is False
+    def test_installing_is_not_safe(self):
+        create_cache_lock(self.tmp_file, CacheState.INSTALLING)
+        assert is_safe_to_delete(self.tmp_file) is False
 
-    def test_failed_recent_is_not_safe(self, temp_file):
+    def test_failed_recent_is_not_safe(self):
         """Failed installations less than 7 days old should be preserved."""
-        create_cache_lock(temp_file, CacheState.FAILED)
-        assert is_safe_to_delete(temp_file) is False
+        create_cache_lock(self.tmp_file, CacheState.FAILED)
+        assert is_safe_to_delete(self.tmp_file) is False
 
-    def test_failed_old_is_safe(self, temp_file):
+    def test_failed_old_is_safe(self):
         """Failed installations older than 7 days can be cleaned."""
-        create_cache_lock(temp_file, CacheState.FAILED)
-        lock_path = temp_file + ".cache_lock"
+        create_cache_lock(self.tmp_file, CacheState.FAILED)
+        lock_path = self.tmp_file + ".cache_lock"
         with open(lock_path) as f:
             data = json.load(f)
         # Set updated_at to 8 days ago
         data["updated_at"] = time.time() - (8 * 86400)
         with open(lock_path, "w") as f:
             json.dump(data, f)
-        assert is_safe_to_delete(temp_file) is True
+        assert is_safe_to_delete(self.tmp_file) is True
 
 
-class TestSafeDeleteFolder:
+class TestSafeDeleteFolder(TestCase):
     """Test cache-aware folder deletion."""
 
-    def test_deletes_unlocked_files(self, temp_dir):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_deletes_unlocked_files(self):
         """Files without locks should be deleted."""
-        file1 = os.path.join(temp_dir, "file1.bin")
-        file2 = os.path.join(temp_dir, "file2.bin")
+        file1 = os.path.join(self.tmp_path, "file1.bin")
+        file2 = os.path.join(self.tmp_path, "file2.bin")
         with open(file1, "w") as f:
             f.write("data1")
         with open(file2, "w") as f:
             f.write("data2")
 
-        result = safe_delete_folder(temp_dir)
+        result = safe_delete_folder(str(self.tmp_path))
         assert result is True
-        assert not os.path.exists(temp_dir)
+        assert not os.path.exists(self.tmp_path)
 
-    def test_preserves_locked_files(self, temp_dir):
+    def test_preserves_locked_files(self):
         """Files with active cache locks should be preserved."""
-        safe_file = os.path.join(temp_dir, "safe.bin")
-        locked_file = os.path.join(temp_dir, "locked.bin")
+        safe_file = os.path.join(self.tmp_path, "safe.bin")
+        locked_file = os.path.join(self.tmp_path, "locked.bin")
         with open(safe_file, "w") as f:
             f.write("safe")
         with open(locked_file, "w") as f:
@@ -215,32 +236,32 @@ class TestSafeDeleteFolder:
 
         create_cache_lock(locked_file, CacheState.DOWNLOADED)
 
-        result = safe_delete_folder(temp_dir)
+        result = safe_delete_folder(str(self.tmp_path))
         assert result is False  # Not fully cleaned
         assert not os.path.exists(safe_file)
         assert os.path.exists(locked_file)
 
-    def test_deletes_installed_files(self, temp_dir):
+    def test_deletes_installed_files(self):
         """Files marked as installed can be deleted."""
-        file1 = os.path.join(temp_dir, "game.bin")
+        file1 = os.path.join(self.tmp_path, "game.bin")
         with open(file1, "w") as f:
             f.write("data")
 
         create_cache_lock(file1, CacheState.INSTALLED)
 
-        result = safe_delete_folder(temp_dir)
+        result = safe_delete_folder(str(self.tmp_path))
         assert result is True
 
-    def test_nonexistent_folder(self, temp_dir):
+    def test_nonexistent_folder(self):
         """Non-existent folder should return True."""
-        result = safe_delete_folder(os.path.join(temp_dir, "nonexistent"))
+        result = safe_delete_folder(os.path.join(self.tmp_path, "nonexistent"))
         assert result is True
 
-    def test_mixed_states(self, temp_dir):
+    def test_mixed_states(self):
         """Mix of safe and unsafe files."""
-        installed = os.path.join(temp_dir, "installed.bin")
-        downloading = os.path.join(temp_dir, "downloading.bin")
-        no_lock = os.path.join(temp_dir, "no_lock.bin")
+        installed = os.path.join(self.tmp_path, "installed.bin")
+        downloading = os.path.join(self.tmp_path, "downloading.bin")
+        no_lock = os.path.join(self.tmp_path, "no_lock.bin")
 
         for f in [installed, downloading, no_lock]:
             with open(f, "w") as fp:
@@ -249,14 +270,14 @@ class TestSafeDeleteFolder:
         create_cache_lock(installed, CacheState.INSTALLED)
         create_cache_lock(downloading, CacheState.DOWNLOADING)
 
-        result = safe_delete_folder(temp_dir)
+        result = safe_delete_folder(str(self.tmp_path))
         assert result is False
         assert not os.path.exists(installed)
         assert os.path.exists(downloading)
         assert not os.path.exists(no_lock)
 
 
-class TestDownloaderChunkSize:
+class TestDownloaderChunkSize(TestCase):
     """Test that the Downloader uses the new chunk size."""
 
     def test_default_chunk_size(self):

--- a/tests/util/_test_download_progress.py
+++ b/tests/util/_test_download_progress.py
@@ -3,19 +3,18 @@
 import json
 import os
 import threading
-
-import pytest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
 
 from lutris.util.download_progress import DownloadProgress
 
 
-@pytest.fixture
 def tmp_dest(tmp_path):
     """Return a temporary download destination path."""
     return str(tmp_path / "installer.exe")
 
 
-@pytest.fixture
 def progress(tmp_dest):
     """Return a fresh DownloadProgress instance."""
     return DownloadProgress(tmp_dest)
@@ -26,19 +25,25 @@ def progress(tmp_dest):
 # ------------------------------------------------------------------
 
 
-class TestInit:
-    def test_progress_path_derived_from_dest(self, tmp_dest):
-        dp = DownloadProgress(tmp_dest)
-        assert dp.progress_path == tmp_dest + ".progress"
+class TestInit(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_progress_path_for_static_helper(self, tmp_dest):
-        assert DownloadProgress.progress_path_for(tmp_dest) == tmp_dest + ".progress"
+    def test_progress_path_derived_from_dest(self):
+        dp = DownloadProgress(self.tmp_dest)
+        assert dp.progress_path == self.tmp_dest + ".progress"
 
-    def test_initial_data_is_empty(self, progress):
-        assert progress.file_size == 0
-        assert progress.url == ""
-        assert progress.completed_ranges == []
-        assert progress.total_ranges == []
+    def test_progress_path_for_static_helper(self):
+        assert DownloadProgress.progress_path_for(self.tmp_dest) == self.tmp_dest + ".progress"
+
+    def test_initial_data_is_empty(self):
+        assert self.progress.file_size == 0
+        assert self.progress.url == ""
+        assert self.progress.completed_ranges == []
+        assert self.progress.total_ranges == []
 
 
 # ------------------------------------------------------------------
@@ -46,17 +51,23 @@ class TestInit:
 # ------------------------------------------------------------------
 
 
-class TestCreate:
-    def test_create_writes_progress_file(self, progress, tmp_dest):
+class TestCreate(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
+
+    def test_create_writes_progress_file(self):
         ranges = [(0, 99), (100, 199)]
-        progress.create("https://example.com/file", 200, ranges)
-        assert os.path.exists(tmp_dest + ".progress")
+        self.progress.create("https://example.com/file", 200, ranges)
+        assert os.path.exists(self.tmp_dest + ".progress")
 
-    def test_create_stores_expected_fields(self, progress):
+    def test_create_stores_expected_fields(self):
         ranges = [(0, 49), (50, 99)]
-        progress.create("https://cdn.gog.com/game.bin", 100, ranges)
+        self.progress.create("https://cdn.gog.com/game.bin", 100, ranges)
 
-        with open(progress.progress_path, "r") as f:
+        with open(self.progress.progress_path, "r") as f:
             data = json.load(f)
         assert data["url"] == "https://cdn.gog.com/game.bin"
         assert data["file_size"] == 100
@@ -65,13 +76,13 @@ class TestCreate:
         assert "created_at" in data
         assert "updated_at" in data
 
-    def test_properties_after_create(self, progress):
+    def test_properties_after_create(self):
         ranges = [(0, 999), (1000, 1999)]
-        progress.create("https://example.com/f", 2000, ranges)
-        assert progress.url == "https://example.com/f"
-        assert progress.file_size == 2000
-        assert progress.total_ranges == [(0, 999), (1000, 1999)]
-        assert progress.completed_ranges == []
+        self.progress.create("https://example.com/f", 2000, ranges)
+        assert self.progress.url == "https://example.com/f"
+        assert self.progress.file_size == 2000
+        assert self.progress.total_ranges == [(0, 999), (1000, 1999)]
+        assert self.progress.completed_ranges == []
 
 
 # ------------------------------------------------------------------
@@ -79,36 +90,42 @@ class TestCreate:
 # ------------------------------------------------------------------
 
 
-class TestLoad:
-    def test_load_returns_false_when_no_file(self, progress):
-        assert progress.load() is False
+class TestLoad(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_load_returns_true_for_valid_progress(self, progress):
-        progress.create("https://example.com", 500, [(0, 499)])
-        fresh = DownloadProgress(progress.dest_path)
+    def test_load_returns_false_when_no_file(self):
+        assert self.progress.load() is False
+
+    def test_load_returns_true_for_valid_progress(self):
+        self.progress.create("https://example.com", 500, [(0, 499)])
+        fresh = DownloadProgress(self.progress.dest_path)
         assert fresh.load() is True
         assert fresh.file_size == 500
 
-    def test_load_returns_false_for_corrupt_json(self, progress, tmp_dest):
-        path = tmp_dest + ".progress"
+    def test_load_returns_false_for_corrupt_json(self):
+        path = self.tmp_dest + ".progress"
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             f.write("{invalid json!!!")
-        assert progress.load() is False
+        assert self.progress.load() is False
 
-    def test_load_returns_false_for_missing_fields(self, progress, tmp_dest):
-        path = tmp_dest + ".progress"
+    def test_load_returns_false_for_missing_fields(self):
+        path = self.tmp_dest + ".progress"
         os.makedirs(os.path.dirname(path), exist_ok=True)
         with open(path, "w") as f:
             json.dump({"url": "x"}, f)  # missing required fields
-        assert progress.load() is False
+        assert self.progress.load() is False
 
-    def test_load_restores_completed_ranges(self, progress):
-        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
-        progress.mark_range_complete(0, 99)
-        progress.mark_range_complete(200, 299)
+    def test_load_restores_completed_ranges(self):
+        self.progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        self.progress.mark_range_complete(0, 99)
+        self.progress.mark_range_complete(200, 299)
 
-        fresh = DownloadProgress(progress.dest_path)
+        fresh = DownloadProgress(self.progress.dest_path)
         assert fresh.load() is True
         assert (0, 99) in fresh.completed_ranges
         assert (200, 299) in fresh.completed_ranges
@@ -120,30 +137,36 @@ class TestLoad:
 # ------------------------------------------------------------------
 
 
-class TestMarkRangeComplete:
-    def test_marks_single_range(self, progress):
-        progress.create("https://example.com", 200, [(0, 99), (100, 199)])
-        progress.mark_range_complete(0, 99)
-        assert progress.completed_ranges == [(0, 99)]
+class TestMarkRangeComplete(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_marks_multiple_ranges(self, progress):
-        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
-        progress.mark_range_complete(100, 199)
-        progress.mark_range_complete(0, 99)
-        assert (0, 99) in progress.completed_ranges
-        assert (100, 199) in progress.completed_ranges
+    def test_marks_single_range(self):
+        self.progress.create("https://example.com", 200, [(0, 99), (100, 199)])
+        self.progress.mark_range_complete(0, 99)
+        assert self.progress.completed_ranges == [(0, 99)]
 
-    def test_duplicate_mark_is_idempotent(self, progress):
-        progress.create("https://example.com", 100, [(0, 99)])
-        progress.mark_range_complete(0, 99)
-        progress.mark_range_complete(0, 99)
-        assert progress.completed_ranges.count((0, 99)) == 1
+    def test_marks_multiple_ranges(self):
+        self.progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        self.progress.mark_range_complete(100, 199)
+        self.progress.mark_range_complete(0, 99)
+        assert (0, 99) in self.progress.completed_ranges
+        assert (100, 199) in self.progress.completed_ranges
 
-    def test_persists_to_disk_after_mark(self, progress):
-        progress.create("https://example.com", 100, [(0, 99)])
-        progress.mark_range_complete(0, 99)
+    def test_duplicate_mark_is_idempotent(self):
+        self.progress.create("https://example.com", 100, [(0, 99)])
+        self.progress.mark_range_complete(0, 99)
+        self.progress.mark_range_complete(0, 99)
+        assert self.progress.completed_ranges.count((0, 99)) == 1
 
-        fresh = DownloadProgress(progress.dest_path)
+    def test_persists_to_disk_after_mark(self):
+        self.progress.create("https://example.com", 100, [(0, 99)])
+        self.progress.mark_range_complete(0, 99)
+
+        fresh = DownloadProgress(self.progress.dest_path)
         fresh.load()
         assert (0, 99) in fresh.completed_ranges
 
@@ -153,24 +176,30 @@ class TestMarkRangeComplete:
 # ------------------------------------------------------------------
 
 
-class TestGetRemainingRanges:
-    def test_all_remaining_when_none_completed(self, progress):
-        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
-        remaining = progress.get_remaining_ranges()
+class TestGetRemainingRanges(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
+
+    def test_all_remaining_when_none_completed(self):
+        self.progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        remaining = self.progress.get_remaining_ranges()
         assert remaining == [(0, 99), (100, 199), (200, 299)]
 
-    def test_some_remaining(self, progress):
-        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
-        progress.mark_range_complete(0, 99)
-        progress.mark_range_complete(200, 299)
-        remaining = progress.get_remaining_ranges()
+    def test_some_remaining(self):
+        self.progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        self.progress.mark_range_complete(0, 99)
+        self.progress.mark_range_complete(200, 299)
+        remaining = self.progress.get_remaining_ranges()
         assert remaining == [(100, 199)]
 
-    def test_none_remaining_when_all_complete(self, progress):
-        progress.create("https://example.com", 200, [(0, 99), (100, 199)])
-        progress.mark_range_complete(0, 99)
-        progress.mark_range_complete(100, 199)
-        assert progress.get_remaining_ranges() == []
+    def test_none_remaining_when_all_complete(self):
+        self.progress.create("https://example.com", 200, [(0, 99), (100, 199)])
+        self.progress.mark_range_complete(0, 99)
+        self.progress.mark_range_complete(100, 199)
+        assert self.progress.get_remaining_ranges() == []
 
 
 # ------------------------------------------------------------------
@@ -178,23 +207,29 @@ class TestGetRemainingRanges:
 # ------------------------------------------------------------------
 
 
-class TestGetCompletedSize:
-    def test_zero_when_none_completed(self, progress):
-        progress.create("https://example.com", 200, [(0, 99), (100, 199)])
-        assert progress.get_completed_size() == 0
+class TestGetCompletedSize(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_partial_completed_size(self, progress):
-        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
-        progress.mark_range_complete(0, 99)
+    def test_zero_when_none_completed(self):
+        self.progress.create("https://example.com", 200, [(0, 99), (100, 199)])
+        assert self.progress.get_completed_size() == 0
+
+    def test_partial_completed_size(self):
+        self.progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        self.progress.mark_range_complete(0, 99)
         # Range 0-99 is 100 bytes
-        assert progress.get_completed_size() == 100
+        assert self.progress.get_completed_size() == 100
 
-    def test_full_completed_size(self, progress):
-        progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
-        progress.mark_range_complete(0, 99)
-        progress.mark_range_complete(100, 199)
-        progress.mark_range_complete(200, 299)
-        assert progress.get_completed_size() == 300
+    def test_full_completed_size(self):
+        self.progress.create("https://example.com", 300, [(0, 99), (100, 199), (200, 299)])
+        self.progress.mark_range_complete(0, 99)
+        self.progress.mark_range_complete(100, 199)
+        self.progress.mark_range_complete(200, 299)
+        assert self.progress.get_completed_size() == 300
 
 
 # ------------------------------------------------------------------
@@ -202,23 +237,29 @@ class TestGetCompletedSize:
 # ------------------------------------------------------------------
 
 
-class TestIsCompatible:
-    def test_compatible_when_sizes_match(self, progress):
-        progress.create("https://old-cdn.com/file", 5000, [(0, 4999)])
-        assert progress.is_compatible(5000) is True
+class TestIsCompatible(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_incompatible_when_sizes_differ(self, progress):
-        progress.create("https://example.com", 5000, [(0, 4999)])
-        assert progress.is_compatible(6000) is False
+    def test_compatible_when_sizes_match(self):
+        self.progress.create("https://old-cdn.com/file", 5000, [(0, 4999)])
+        assert self.progress.is_compatible(5000) is True
 
-    def test_incompatible_when_size_is_zero(self, progress):
-        progress.create("https://example.com", 0, [])
-        assert progress.is_compatible(0) is False
+    def test_incompatible_when_sizes_differ(self):
+        self.progress.create("https://example.com", 5000, [(0, 4999)])
+        assert self.progress.is_compatible(6000) is False
 
-    def test_compatible_ignores_url_differences(self, progress):
+    def test_incompatible_when_size_is_zero(self):
+        self.progress.create("https://example.com", 0, [])
+        assert self.progress.is_compatible(0) is False
+
+    def test_compatible_ignores_url_differences(self):
         """CDN URLs rotate between sessions; only size matters."""
-        progress.create("https://old-cdn.com/tokenA/file", 10000, [(0, 9999)])
-        assert progress.is_compatible(10000) is True
+        self.progress.create("https://old-cdn.com/tokenA/file", 10000, [(0, 9999)])
+        assert self.progress.is_compatible(10000) is True
 
 
 # ------------------------------------------------------------------
@@ -226,22 +267,28 @@ class TestIsCompatible:
 # ------------------------------------------------------------------
 
 
-class TestCleanup:
-    def test_cleanup_removes_progress_file(self, progress):
-        progress.create("https://example.com", 100, [(0, 99)])
-        assert os.path.exists(progress.progress_path)
-        progress.cleanup()
-        assert not os.path.exists(progress.progress_path)
+class TestCleanup(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_cleanup_resets_internal_data(self, progress):
-        progress.create("https://example.com", 100, [(0, 99)])
-        progress.cleanup()
-        assert progress.file_size == 0
-        assert progress.completed_ranges == []
+    def test_cleanup_removes_progress_file(self):
+        self.progress.create("https://example.com", 100, [(0, 99)])
+        assert os.path.exists(self.progress.progress_path)
+        self.progress.cleanup()
+        assert not os.path.exists(self.progress.progress_path)
 
-    def test_cleanup_is_safe_when_no_file(self, progress):
+    def test_cleanup_resets_internal_data(self):
+        self.progress.create("https://example.com", 100, [(0, 99)])
+        self.progress.cleanup()
+        assert self.progress.file_size == 0
+        assert self.progress.completed_ranges == []
+
+    def test_cleanup_is_safe_when_no_file(self):
         # Should not raise
-        progress.cleanup()
+        self.progress.cleanup()
 
 
 # ------------------------------------------------------------------
@@ -249,18 +296,24 @@ class TestCleanup:
 # ------------------------------------------------------------------
 
 
-class TestAtomicWrites:
-    def test_progress_file_not_corrupted_by_concurrent_marks(self, progress):
+class TestAtomicWrites(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
+
+    def test_progress_file_not_corrupted_by_concurrent_marks(self):
         """Simulate concurrent range completions from multiple threads."""
         num_ranges = 20
         ranges = [(i * 100, (i + 1) * 100 - 1) for i in range(num_ranges)]
-        progress.create("https://example.com", num_ranges * 100, ranges)
+        self.progress.create("https://example.com", num_ranges * 100, ranges)
 
         errors = []
 
         def mark(start, end):
             try:
-                progress.mark_range_complete(start, end)
+                self.progress.mark_range_complete(start, end)
             except Exception as ex:
                 errors.append(ex)
 
@@ -272,12 +325,12 @@ class TestAtomicWrites:
 
         assert not errors
         # All ranges should be marked — even if ordering varied
-        fresh = DownloadProgress(progress.dest_path)
+        fresh = DownloadProgress(self.progress.dest_path)
         fresh.load()
         assert len(fresh.completed_ranges) == num_ranges
 
-    def test_save_creates_directories(self, tmp_path):
-        deep = str(tmp_path / "a" / "b" / "c" / "file.bin")
+    def test_save_creates_directories(self):
+        deep = str(self.tmp_path / "a" / "b" / "c" / "file.bin")
         dp = DownloadProgress(deep)
         dp.create("https://example.com", 100, [(0, 99)])
         assert os.path.exists(deep + ".progress")
@@ -288,30 +341,36 @@ class TestAtomicWrites:
 # ------------------------------------------------------------------
 
 
-class TestEdgeCases:
-    def test_single_range_covers_full_file(self, progress):
-        progress.create("https://example.com", 1000, [(0, 999)])
-        progress.mark_range_complete(0, 999)
-        assert progress.get_remaining_ranges() == []
-        assert progress.get_completed_size() == 1000
+class TestEdgeCases(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.tmp_dest = tmp_dest(self.tmp_path)
+        self.progress = progress(self.tmp_dest)
 
-    def test_many_small_ranges(self, progress):
+    def test_single_range_covers_full_file(self):
+        self.progress.create("https://example.com", 1000, [(0, 999)])
+        self.progress.mark_range_complete(0, 999)
+        assert self.progress.get_remaining_ranges() == []
+        assert self.progress.get_completed_size() == 1000
+
+    def test_many_small_ranges(self):
         ranges = [(i, i) for i in range(100)]  # 1 byte each
-        progress.create("https://example.com", 100, ranges)
+        self.progress.create("https://example.com", 100, ranges)
         for s, e in ranges[:50]:
-            progress.mark_range_complete(s, e)
-        assert len(progress.get_remaining_ranges()) == 50
-        assert progress.get_completed_size() == 50
+            self.progress.mark_range_complete(s, e)
+        assert len(self.progress.get_remaining_ranges()) == 50
+        assert self.progress.get_completed_size() == 50
 
-    def test_load_after_process_restart(self, tmp_dest):
+    def test_load_after_process_restart(self):
         """Simulate a process restart by creating a new instance."""
-        dp1 = DownloadProgress(tmp_dest)
+        dp1 = DownloadProgress(self.tmp_dest)
         dp1.create("https://example.com", 400, [(0, 99), (100, 199), (200, 299), (300, 399)])
         dp1.mark_range_complete(0, 99)
         dp1.mark_range_complete(100, 199)
 
         # Simulate restart: new instance, same path
-        dp2 = DownloadProgress(tmp_dest)
+        dp2 = DownloadProgress(self.tmp_dest)
         assert dp2.load() is True
         assert dp2.get_completed_size() == 200
         remaining = dp2.get_remaining_ranges()

--- a/tests/util/_test_gog_downloader.py
+++ b/tests/util/_test_gog_downloader.py
@@ -3,16 +3,17 @@
 import os
 import threading
 import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from lutris.util.download_progress import DownloadProgress
 from lutris.util.downloader import DEFAULT_CHUNK_SIZE, BaseDownloader
 from lutris.util.gog_downloader import GOGDownloader
 
 
-class TestGOGDownloaderInit:
+class TestGOGDownloaderInit(TestCase):
     """Test GOGDownloader initialization."""
 
     def test_inherits_from_downloader(self):
@@ -66,7 +67,7 @@ class TestGOGDownloaderInit:
         assert dl.referer == "https://gog.com"
 
 
-class TestBuildRequestHeaders:
+class TestBuildRequestHeaders(TestCase):
     """Test HTTP header construction."""
 
     def test_basic_headers(self):
@@ -90,7 +91,7 @@ class TestBuildRequestHeaders:
         assert headers["X-Custom"] == "value"
 
 
-class TestCalculateRanges:
+class TestCalculateRanges(TestCase):
     """Test byte range calculation for parallel downloads."""
 
     def test_even_split(self):
@@ -133,7 +134,7 @@ class TestCalculateRanges:
             assert ranges[i][1] + 1 == ranges[i + 1][0], f"Gap between range {i} and {i + 1}"
 
 
-class TestProbeServer:
+class TestProbeServer(TestCase):
     """Test server probing for capabilities."""
 
     def test_probe_with_range_support(self):
@@ -197,11 +198,15 @@ class TestProbeServer:
         assert supports is False
 
 
-class TestFallbackToSingleStream:
+class TestFallbackToSingleStream(TestCase):
     """Test cases where parallel download falls back to single-stream."""
 
-    def test_fallback_when_no_range_support(self, tmp_path):
-        dest = str(tmp_path / "file.bin")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_fallback_when_no_range_support(self):
+        dest = str(self.tmp_path / "file.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
 
         test_data = b"Hello, World!"
@@ -227,8 +232,8 @@ class TestFallbackToSingleStream:
         with open(dest, "rb") as f:
             assert f.read() == test_data
 
-    def test_fallback_when_file_too_small(self, tmp_path):
-        dest = str(tmp_path / "small.bin")
+    def test_fallback_when_file_too_small(self):
+        dest = str(self.tmp_path / "small.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
 
         # File smaller than MIN_CHUNK_SIZE * 2
@@ -257,12 +262,16 @@ class TestFallbackToSingleStream:
         assert dl.state == dl.COMPLETED
 
 
-class TestParallelDownload:
+class TestParallelDownload(TestCase):
     """Test multi-connection parallel download."""
 
-    def test_parallel_download_writes_correct_data(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_parallel_download_writes_correct_data(self):
         """Verify parallel download correctly assembles a file from ranges."""
-        dest = str(tmp_path / "parallel.bin")
+        dest = str(self.tmp_path / "parallel.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
 
         file_size = 2000  # 2000 bytes, split into 2x 1000-byte chunks
@@ -306,9 +315,9 @@ class TestParallelDownload:
         assert result == data
         assert dl.downloaded_size == file_size
 
-    def test_parallel_download_with_four_workers(self, tmp_path):
+    def test_parallel_download_with_four_workers(self):
         """Test 4 workers downloading a file."""
-        dest = str(tmp_path / "four_workers.bin")
+        dest = str(self.tmp_path / "four_workers.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=4)
 
         file_size = 4000
@@ -345,11 +354,15 @@ class TestParallelDownload:
         assert result == data
 
 
-class TestDownloadRange:
+class TestDownloadRange(TestCase):
     """Test individual range download worker."""
 
-    def test_download_range_writes_to_correct_offset(self, tmp_path):
-        dest = str(tmp_path / "range_test.bin")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_download_range_writes_to_correct_offset(self):
+        dest = str(self.tmp_path / "range_test.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
         dl.stop_request = threading.Event()
 
@@ -375,8 +388,8 @@ class TestDownloadRange:
 
         assert dl.downloaded_size == 500
 
-    def test_download_range_retries_on_failure(self, tmp_path):
-        dest = str(tmp_path / "retry_test.bin")
+    def test_download_range_retries_on_failure(self):
+        dest = str(self.tmp_path / "retry_test.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
         dl.stop_request = threading.Event()
         dl.RETRY_DELAY = 0  # No delay in tests
@@ -404,8 +417,8 @@ class TestDownloadRange:
 
         assert dl.downloaded_size == 100
 
-    def test_download_range_cancellation(self, tmp_path):
-        dest = str(tmp_path / "cancel_test.bin")
+    def test_download_range_cancellation(self):
+        dest = str(self.tmp_path / "cancel_test.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
         dl.stop_request = threading.Event()
         dl.stop_request.set()  # Pre-cancelled
@@ -425,25 +438,29 @@ class TestDownloadRange:
         assert dl.downloaded_size == 0
 
 
-class TestCancelAndStates:
+class TestCancelAndStates(TestCase):
     """Test cancel and state management."""
 
-    def test_cancel_sets_state(self, tmp_path):
-        dest = str(tmp_path / "cancel.bin")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_cancel_sets_state(self):
+        dest = str(self.tmp_path / "cancel.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
         dl.stop_request = threading.Event()
         dl.cancel()
         assert dl.state == dl.CANCELLED
 
-    def test_cancel_sets_stop_request(self, tmp_path):
-        dest = str(tmp_path / "cancel.bin")
+    def test_cancel_sets_stop_request(self):
+        dest = str(self.tmp_path / "cancel.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
         dl.stop_request = threading.Event()
         dl.cancel()
         assert dl.stop_request.is_set()
 
-    def test_cancel_removes_file(self, tmp_path):
-        dest = str(tmp_path / "cancel.bin")
+    def test_cancel_removes_file(self):
+        dest = str(self.tmp_path / "cancel.bin")
         with open(dest, "w") as f:
             f.write("test")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
@@ -472,19 +489,8 @@ class TestCancelAndStates:
         assert dl.error is error
 
 
-class TestInstallerFileIntegration:
+class TestInstallerFileIntegration(TestCase):
     """Test GOGDownloader integration with InstallerFile."""
-
-    @pytest.fixture(autouse=True)
-    def _setup_gi(self):
-        """Ensure GTK version is required before importing InstallerFile."""
-        try:
-            import gi
-
-            gi.require_version("Gtk", "3.0")
-            gi.require_version("Gdk", "3.0")
-        except (ValueError, ImportError):
-            pytest.skip("GTK 3.0 not available")
 
     def test_installer_file_downloader_class(self):
         """InstallerFile should expose downloader_class from file_meta."""
@@ -527,7 +533,7 @@ class TestInstallerFileIntegration:
         assert file.downloader_class is None
 
 
-class TestGOGServiceIntegration:
+class TestGOGServiceIntegration(TestCase):
     """Test that the GOG service injects GOGDownloader into InstallerFile."""
 
     def test_gog_format_links_includes_downloader_class(self):
@@ -555,12 +561,16 @@ class TestGOGServiceIntegration:
         assert files[0].downloader_class is GOGDownloader
 
 
-class TestProgressTracking:
+class TestProgressTracking(TestCase):
     """Test that progress tracking works with parallel downloads."""
 
-    def test_downloaded_size_thread_safe(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_downloaded_size_thread_safe(self):
         """Verify downloaded_size is correctly accumulated from multiple threads."""
-        dest = str(tmp_path / "progress.bin")
+        dest = str(self.tmp_path / "progress.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=4)
         dl.stop_request = threading.Event()
         dl.progress_event = threading.Event()
@@ -596,12 +606,16 @@ class TestProgressTracking:
 # ==================================================================
 
 
-class TestResumeProgressCreation:
+class TestResumeProgressCreation(TestCase):
     """Test that parallel downloads create progress files."""
 
-    def test_fresh_download_creates_progress_file(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_fresh_download_creates_progress_file(self):
         """A parallel download should create a .progress sidecar file."""
-        dest = str(tmp_path / "fresh.bin")
+        dest = str(self.tmp_path / "fresh.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
 
         file_size = 2000
@@ -635,9 +649,9 @@ class TestResumeProgressCreation:
         # Progress file should be cleaned up on success
         assert not os.path.exists(dest + ".progress")
 
-    def test_progress_file_records_completed_ranges(self, tmp_path):
+    def test_progress_file_records_completed_ranges(self):
         """Ranges that finish should be persisted in the progress file."""
-        dest = str(tmp_path / "track.bin")
+        dest = str(self.tmp_path / "track.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest, num_workers=2)
 
         file_size = 2000
@@ -684,8 +698,12 @@ class TestResumeProgressCreation:
         assert len(progress.completed_ranges) >= 1
 
 
-class TestResumeFromProgress:
+class TestResumeFromProgress(TestCase):
     """Test resuming downloads from existing progress files."""
+
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
 
     def _make_head_resp(self, url, file_size):
         resp = MagicMock()
@@ -697,9 +715,9 @@ class TestResumeFromProgress:
         resp.raise_for_status = MagicMock()
         return resp
 
-    def test_resume_downloads_only_remaining_ranges(self, tmp_path):
+    def test_resume_downloads_only_remaining_ranges(self):
         """Resume should only download ranges not yet completed."""
-        dest = str(tmp_path / "resume.bin")
+        dest = str(self.tmp_path / "resume.bin")
         file_size = 4000
         data = b"A" * 1000 + b"B" * 1000 + b"C" * 1000 + b"D" * 1000
 
@@ -757,9 +775,9 @@ class TestResumeFromProgress:
         # Progress file should be cleaned up
         assert not os.path.exists(dest + ".progress")
 
-    def test_resume_credits_already_downloaded_bytes(self, tmp_path):
+    def test_resume_credits_already_downloaded_bytes(self):
         """Resume should credit bytes from completed ranges to downloaded_size."""
-        dest = str(tmp_path / "credit.bin")
+        dest = str(self.tmp_path / "credit.bin")
         file_size = 2000
 
         with open(dest, "wb") as f:
@@ -793,9 +811,9 @@ class TestResumeFromProgress:
         # Total downloaded = 1000 (already on disk) + 1000 (newly downloaded)
         assert dl.downloaded_size == 2000
 
-    def test_resume_with_incompatible_file_size_starts_fresh(self, tmp_path):
+    def test_resume_with_incompatible_file_size_starts_fresh(self):
         """If file size changed, progress is discarded and we start fresh."""
-        dest = str(tmp_path / "incompat.bin")
+        dest = str(self.tmp_path / "incompat.bin")
         old_size = 3000
 
         with open(dest, "wb") as f:
@@ -831,9 +849,9 @@ class TestResumeFromProgress:
         assert dl.state == dl.COMPLETED
         assert dl.downloaded_size == new_size
 
-    def test_resume_with_missing_dest_starts_fresh(self, tmp_path):
+    def test_resume_with_missing_dest_starts_fresh(self):
         """If dest file is gone but progress exists, start fresh."""
-        dest = str(tmp_path / "missing.bin")
+        dest = str(self.tmp_path / "missing.bin")
         file_size = 2000
 
         # Create progress without the actual file
@@ -865,9 +883,9 @@ class TestResumeFromProgress:
         # Fresh download, should have downloaded full size
         assert dl.downloaded_size == file_size
 
-    def test_resume_skips_when_all_ranges_already_done(self, tmp_path):
+    def test_resume_skips_when_all_ranges_already_done(self):
         """If all ranges complete and file exists, skip download entirely."""
-        dest = str(tmp_path / "skip.bin")
+        dest = str(self.tmp_path / "skip.bin")
         file_size = 2000
         data = b"D" * file_size
 
@@ -897,12 +915,16 @@ class TestResumeFromProgress:
         assert not os.path.exists(dest + ".progress")
 
 
-class TestResumeStartMethod:
+class TestResumeStartMethod(TestCase):
     """Test that start() preserves files when resume is possible."""
 
-    def test_start_preserves_file_when_progress_exists(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_start_preserves_file_when_progress_exists(self):
         """start() should not delete dest if resumable progress is found."""
-        dest = str(tmp_path / "preserve.bin")
+        dest = str(self.tmp_path / "preserve.bin")
         data = b"P" * 1000
 
         with open(dest, "wb") as f:
@@ -926,9 +948,9 @@ class TestResumeStartMethod:
         with open(dest, "rb") as f:
             assert f.read() == data
 
-    def test_start_deletes_file_when_no_progress(self, tmp_path):
+    def test_start_deletes_file_when_no_progress(self):
         """start() should delete dest if no resumable progress exists."""
-        dest = str(tmp_path / "delete.bin")
+        dest = str(self.tmp_path / "delete.bin")
         with open(dest, "wb") as f:
             f.write(b"old data")
 
@@ -943,11 +965,15 @@ class TestResumeStartMethod:
         assert not os.path.isfile(dest)
 
 
-class TestCancelCleansProgress:
+class TestCancelCleansProgress(TestCase):
     """Test that cancel() removes progress files."""
 
-    def test_cancel_removes_progress_file(self, tmp_path):
-        dest = str(tmp_path / "cancel.bin")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_cancel_removes_progress_file(self):
+        dest = str(self.tmp_path / "cancel.bin")
         with open(dest, "wb") as f:
             f.write(b"data")
 
@@ -964,9 +990,9 @@ class TestCancelCleansProgress:
         assert not os.path.exists(dest + ".progress")
         assert dl._progress is None
 
-    def test_cancel_without_progress(self, tmp_path):
+    def test_cancel_without_progress(self):
         """Cancel should work even if no progress was created."""
-        dest = str(tmp_path / "nocancel.bin")
+        dest = str(self.tmp_path / "nocancel.bin")
         with open(dest, "wb") as f:
             f.write(b"data")
 
@@ -977,11 +1003,15 @@ class TestCancelCleansProgress:
         assert not os.path.isfile(dest)
 
 
-class TestCompletionCleansProgress:
+class TestCompletionCleansProgress(TestCase):
     """Test that on_download_completed() removes progress files."""
 
-    def test_completed_removes_progress(self, tmp_path):
-        dest = str(tmp_path / "done.bin")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_completed_removes_progress(self):
+        dest = str(self.tmp_path / "done.bin")
         dl = GOGDownloader("https://cdn.gog.com/file.bin", dest)
         dl.downloaded_size = 1000
         dl.full_size = 1000

--- a/tests/util/_test_pipelining.py
+++ b/tests/util/_test_pipelining.py
@@ -3,15 +3,16 @@
 import os
 import queue
 import threading
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 from lutris.util.download_progress import DownloadProgress
 from lutris.util.gog_downloader import GOGDownloader
 
 
-class TestWriteQueue:
+class TestWriteQueue(TestCase):
     """Test the pipelining write queue setup."""
 
     def test_has_write_queue(self):
@@ -31,12 +32,16 @@ class TestWriteQueue:
         assert dl._writer_error is None
 
 
-class TestWriterLoop:
+class TestWriterLoop(TestCase):
     """Test the _writer_loop() writer thread."""
 
-    def test_writes_data_correctly(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_writes_data_correctly(self):
         """Writer thread should write data at the correct offset."""
-        dest = str(tmp_path / "output.bin")
+        dest = str(self.tmp_path / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
 
@@ -56,9 +61,9 @@ class TestWriterLoop:
         assert content[:4] == b"AAAA"
         assert content[50:54] == b"BBBB"
 
-    def test_updates_downloaded_size(self, tmp_path):
+    def test_updates_downloaded_size(self):
         """Writer should increment downloaded_size after writing."""
-        dest = str(tmp_path / "output.bin")
+        dest = str(self.tmp_path / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
 
@@ -73,9 +78,9 @@ class TestWriterLoop:
 
         assert dl.downloaded_size == 100
 
-    def test_marks_range_complete(self, tmp_path):
+    def test_marks_range_complete(self):
         """Writer marks range complete when range_end is set."""
-        dest = str(tmp_path / "output.bin")
+        dest = str(self.tmp_path / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
 
@@ -96,9 +101,9 @@ class TestWriterLoop:
         remaining = dl._progress.get_remaining_ranges()
         assert len(remaining) == 0
 
-    def test_handles_stop_request(self, tmp_path):
+    def test_handles_stop_request(self):
         """Writer should exit when stop_request is set."""
-        dest = str(tmp_path / "output.bin")
+        dest = str(self.tmp_path / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
         dl.stop_request.set()  # Pre-cancel
@@ -112,9 +117,9 @@ class TestWriterLoop:
 
         dl._writer_loop()  # Should not hang
 
-    def test_sets_error_on_write_failure(self, tmp_path):
+    def test_sets_error_on_write_failure(self):
         """Writer should set error event on disk failure."""
-        dest = str(tmp_path / "readonly_dir" / "output.bin")
+        dest = str(self.tmp_path / "readonly_dir" / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
 
@@ -128,12 +133,16 @@ class TestWriterLoop:
         assert dl._writer_error_event.is_set()
 
 
-class TestPipelineBackpressure:
+class TestPipelineBackpressure(TestCase):
     """Test that backpressure works correctly with bounded queue."""
 
-    def test_queue_blocks_when_full(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_queue_blocks_when_full(self):
         """Workers should block when queue is at maxsize."""
-        dest = str(tmp_path / "output.bin")
+        dest = str(self.tmp_path / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest)
 
         # Fill the queue to capacity
@@ -143,16 +152,20 @@ class TestPipelineBackpressure:
         assert dl._write_queue.full()
 
         # Verify put would block (use put_nowait to test)
-        with pytest.raises(queue.Full):
+        with self.assertRaises(queue.Full):
             dl._write_queue.put_nowait((99, b"overflow", 0, None))
 
 
-class TestGOGDownloaderStallDetection:
+class TestGOGDownloaderStallDetection(TestCase):
     """Test stall detection in GOGDownloader._download_range()."""
 
-    def test_stall_triggers_retry(self, tmp_path):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def test_stall_triggers_retry(self):
         """A stalled range should trigger retry via the existing retry mechanism."""
-        dest = str(tmp_path / "output.bin")
+        dest = str(self.tmp_path / "output.bin")
         dl = GOGDownloader("https://example.com/file.bin", dest, num_workers=1)
         dl.stop_request = threading.Event()
         dl._writer_error_event = threading.Event()
@@ -211,13 +224,17 @@ class TestGOGDownloaderStallDetection:
         assert call_count[0] >= 2
 
 
-class TestPipelinedDownloadEndToEnd:
+class TestPipelinedDownloadEndToEnd(TestCase):
     """Integration test: full pipelined download with mock HTTP."""
 
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
     @patch.object(GOGDownloader, "_probe_server")
-    def test_pipelined_download_completes(self, mock_probe, tmp_path):
+    def test_pipelined_download_completes(self, mock_probe):
         """Full download should complete with pipelining."""
-        dest = str(tmp_path / "game.bin")
+        dest = str(self.tmp_path / "game.bin")
         file_size = 20 * 1024 * 1024  # 20 MB — above MIN_CHUNK_SIZE * 2
 
         dl = GOGDownloader("https://cdn.gog.com/game.bin", dest, num_workers=2)
@@ -265,9 +282,9 @@ class TestPipelinedDownloadEndToEnd:
         assert os.path.getsize(dest) == file_size
 
     @patch.object(GOGDownloader, "_probe_server")
-    def test_small_file_skips_pipelining(self, mock_probe, tmp_path):
+    def test_small_file_skips_pipelining(self, mock_probe):
         """Files below MIN_CHUNK_SIZE * 2 should use single-stream."""
-        dest = str(tmp_path / "small.bin")
+        dest = str(self.tmp_path / "small.bin")
         file_size = 1000  # Very small
 
         dl = GOGDownloader("https://cdn.gog.com/small.bin", dest, num_workers=4)

--- a/tests/util/_test_stall_detection.py
+++ b/tests/util/_test_stall_detection.py
@@ -2,15 +2,17 @@
 
 import threading
 import time
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
-import pytest
 import requests
 
 from lutris.util.downloader import BaseDownloader, DownloadStallError, SimpleDownloader, StallMonitor, get_time
 
 
-class TestDownloadStallError:
+class TestDownloadStallError(TestCase):
     """Test the DownloadStallError exception class."""
 
     def test_carries_throughput(self):
@@ -34,7 +36,7 @@ class TestDownloadStallError:
         assert isinstance(err, Exception)
 
 
-class TestCheckStall:
+class TestCheckStall(TestCase):
     """Test the throughput-window logic in StallMonitor."""
 
     def _make_monitor(self):
@@ -73,17 +75,17 @@ class TestCheckStall:
         monitor.window_start = get_time() - 31.0  # 31 seconds ago
         monitor.bytes_at_window_start = 0
         # 100 bytes in 31 seconds = ~3.2 B/s — below 200 B/s for > 30s
-        with pytest.raises(DownloadStallError) as exc_info:
+        with self.assertRaises(DownloadStallError) as exc_info:
             monitor.check(100)
-        assert exc_info.value.duration >= 30.0
-        assert exc_info.value.throughput < 200.0
+        assert exc_info.exception.duration >= 30.0
+        assert exc_info.exception.throughput < 200.0
 
     def test_zero_bytes_triggers_stall(self):
         """Zero bytes received should eventually trigger stall."""
         monitor = self._make_monitor()
         monitor.window_start = get_time() - 35.0
         monitor.bytes_at_window_start = 0
-        with pytest.raises(DownloadStallError):
+        with self.assertRaises(DownloadStallError):
             monitor.check(0)
 
     def test_recovery_resets_timer(self):
@@ -98,7 +100,7 @@ class TestCheckStall:
         assert monitor.bytes_at_window_start == 5100
 
 
-class TestStallMonitorIsolation:
+class TestStallMonitorIsolation(TestCase):
     """Each download stream must own its StallMonitor.
 
     Regression tests for the parallel-download stall race: GOGDownloader runs
@@ -139,24 +141,28 @@ class TestStallMonitorIsolation:
         monitor = StallMonitor(BaseDownloader.LOW_SPEED_LIMIT, BaseDownloader.LOW_SPEED_TIME)
         monitor.check(0)  # open window
         monitor.window_start = get_time() - 31.0  # 31s elapsed, no progress
-        with pytest.raises(DownloadStallError):
+        with self.assertRaises(DownloadStallError):
             monitor.check(100)  # ~3 B/s for >30s
 
 
-class TestDownloaderRetry:
+class TestDownloaderRetry(TestCase):
     """Test retry logic in SimpleDownloader."""
 
-    def _make_downloader(self, tmp_path):
-        dest = str(tmp_path / "test.bin")
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+
+    def _make_downloader(self):
+        dest = str(self.tmp_path / "test.bin")
         dl = SimpleDownloader("https://example.com/file.bin", dest)
         dl.stop_request = threading.Event()
         return dl
 
     @patch.object(SimpleDownloader, "on_download_completed")
     @patch.object(SimpleDownloader, "_do_download")
-    def test_success_on_first_try(self, mock_do, mock_complete, tmp_path):
+    def test_success_on_first_try(self, mock_do, mock_complete):
         """Successful download should not retry."""
-        dl = self._make_downloader(tmp_path)
+        dl = self._make_downloader()
         mock_do.return_value = None  # Success
 
         dl.async_download()
@@ -166,9 +172,9 @@ class TestDownloaderRetry:
 
     @patch.object(SimpleDownloader, "on_download_completed")
     @patch.object(SimpleDownloader, "_do_download")
-    def test_retries_on_stall_error(self, mock_do, mock_complete, tmp_path):
+    def test_retries_on_stall_error(self, mock_do, mock_complete):
         """DownloadStallError should trigger retry."""
-        dl = self._make_downloader(tmp_path)
+        dl = self._make_downloader()
         # Fail twice with stall, succeed on third
         mock_do.side_effect = [
             DownloadStallError(throughput=50.0, duration=31.0),
@@ -186,9 +192,9 @@ class TestDownloaderRetry:
         mock_complete.assert_called_once()
 
     @patch.object(SimpleDownloader, "_do_download")
-    def test_fails_after_max_retries(self, mock_do, tmp_path):
+    def test_fails_after_max_retries(self, mock_do):
         """Should fail after RETRY_ATTEMPTS exhausted."""
-        dl = self._make_downloader(tmp_path)
+        dl = self._make_downloader()
         stall_err = DownloadStallError(throughput=10.0, duration=30.0)
         mock_do.side_effect = stall_err
 
@@ -203,9 +209,9 @@ class TestDownloaderRetry:
         assert dl.error is stall_err
 
     @patch.object(SimpleDownloader, "_do_download")
-    def test_no_retry_on_404(self, mock_do, tmp_path):
+    def test_no_retry_on_404(self, mock_do):
         """HTTP 404 should not retry."""
-        dl = self._make_downloader(tmp_path)
+        dl = self._make_downloader()
         response = MagicMock()
         response.status_code = 404
         http_err = requests.HTTPError(response=response)
@@ -218,9 +224,9 @@ class TestDownloaderRetry:
 
     @patch.object(SimpleDownloader, "on_download_completed")
     @patch.object(SimpleDownloader, "_do_download")
-    def test_retry_on_500(self, mock_do, mock_complete, tmp_path):
+    def test_retry_on_500(self, mock_do, mock_complete):
         """HTTP 500 should trigger retry."""
-        dl = self._make_downloader(tmp_path)
+        dl = self._make_downloader()
         response = MagicMock()
         response.status_code = 500
         http_err = requests.HTTPError(response=response)
@@ -237,9 +243,9 @@ class TestDownloaderRetry:
 
     @patch.object(SimpleDownloader, "on_download_completed")
     @patch.object(SimpleDownloader, "_do_download")
-    def test_retry_on_429(self, mock_do, mock_complete, tmp_path):
+    def test_retry_on_429(self, mock_do, mock_complete):
         """HTTP 429 (rate limit) should trigger retry."""
-        dl = self._make_downloader(tmp_path)
+        dl = self._make_downloader()
         response = MagicMock()
         response.status_code = 429
         http_err = requests.HTTPError(response=response)


### PR DESCRIPTION
Removed the importlib machinery used in `_test_gog_dlcs.py` and `_test_collection_progress.py` to fix issues with due to test module discovery order causing bespoke mocked modules to be placed in the sys.modules.

Instead the builtin Python UnitTest Mock and Patch framework is used to properly patch the methods needed to run the UnitTest instead of manipulating the importlibs in a bespoke manner.

Added missing `__init__.py` to the `lutris/tests/util` directory to allow discovery of those UnitTest by the nose2 and the Python builtin UnitTest framework. Those test weren't not being run by either `nose2` nor the `UnitTest` framework.

Fixed the UnitTest that imports the pytest module. Replaced the usage of `pytest` inside of the `lutris/tests/util` directory to use the python UnitTest framework. Lutris does NOT specify a dependency on `pytest `and therefore when those test were actually enabled to be run, they would complain about the missing `pytest` import.