### PR TITLE
Prevent crashes from numeric Wine component versions

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -281,7 +281,9 @@ Example: ``version: staging-2.21-x86_64``
 
 ``dxvk``: Use this to disable DXVK if needed. (``dxvk: false``)
 
-``dxvk_version``: Use this to define a specific DXVK version. (``dxvk_version: 1.10.3``)
+``dxvk_version``: Use this to define a specific DXVK version. Version values
+must be quoted because YAML can parse numeric-looking versions as numbers.
+(``dxvk_version: "1.10.3"``)
 
 ``esync``: Use this to disable esync. (``esync: false``)
 

--- a/lutris/runners/wine.py
+++ b/lutris/runners/wine.py
@@ -168,6 +168,8 @@ def _get_dxvk_version_warning(_option_key: str, config: LutrisConfig) -> str | N
     runner_config = config.runner_config
     if runner_config.get("dxvk") and LINUX_SYSTEM.is_vulkan_supported():
         version = runner_config.get("dxvk_version")
+        if version is not None:
+            version = str(version)
         if version and not version.startswith("v1."):
             library_api_version = vkquery.get_vulkan_api_version()
             if library_api_version and library_api_version < REQUIRED_VULKAN_API_VERSION:

--- a/lutris/util/wine/dll_manager.py
+++ b/lutris/util/wine/dll_manager.py
@@ -30,7 +30,7 @@ class DLLManager:
     def __init__(self, prefix=None, arch="win64", version=None):
         self.prefix = prefix
         self._versions = []
-        self._version = version
+        self._version = None if version is None else str(version)
         self.wine_arch = arch
 
     @property

--- a/schema/installer.schema.yml
+++ b/schema/installer.schema.yml
@@ -528,6 +528,9 @@ definitions:
       dxvk:
         type: boolean
         description: Enable DXVK
+      dxvk_version:
+        type: string
+        description: DXVK version override
       esync:
         type: boolean
         description: Enable ESync

--- a/tests/_test_wine.py
+++ b/tests/_test_wine.py
@@ -1,7 +1,10 @@
+from types import SimpleNamespace
 from unittest import TestCase
+from unittest.mock import patch
 
 from lutris.runners import wine
 from lutris.util.test_config import setup_test_environment
+from lutris.util.wine.dll_manager import DLLManager
 
 setup_test_environment()
 
@@ -18,3 +21,19 @@ class TestDllOverrides(TestCase):
         }
         env_string = wine.get_overrides_env(overrides)
         self.assertEqual(env_string, "d3dcompiler_43,d3dcompiler_47=n,b;dnsapi=b;rasapi32=n;dwrite,winemenubuilder=")
+
+
+class TestDllManager(TestCase):
+    def test_numeric_version_is_normalized(self):
+        manager = DLLManager(version=2.6)
+        self.assertEqual(manager.version, "2.6")
+
+
+class TestDxvkVersionWarning(TestCase):
+    def test_numeric_version_does_not_raise(self):
+        config = SimpleNamespace(runner_config={"dxvk": True, "dxvk_version": 2.6})
+        with (
+            patch.object(wine.LINUX_SYSTEM, "is_vulkan_supported", return_value=True),
+            patch.object(wine.vkquery, "get_vulkan_api_version", return_value=None),
+        ):
+            self.assertIsNone(wine._get_dxvk_version_warning("dxvk_version", config))


### PR DESCRIPTION
# Prevent crashes from numeric Wine component versions

## Summary

- Normalize Wine component version overrides to strings before they are used by
  the DLL managers.
- Normalize `dxvk_version` before checking Vulkan compatibility warnings.
- Document that numeric-looking YAML versions must be quoted.
- Add `dxvk_version` to the installer schema.

## Problem

YAML parses an unquoted value such as `dxvk_version: 2.6` as a `float`. A game
configuration loaded from disk can therefore reach the Wine runner as a number.
The current code calls string methods on that value:

```text
AttributeError: 'float' object has no attribute 'lower'
```

The same type mismatch can reach the DXVK compatibility warning path, where
`startswith()` is called on the version.

## Root Cause

Installer substitutions already produce strings, but persisted or manually
edited YAML is loaded without coercing version values. The DLL manager and the
DXVK warning path assumed the value was always a string.

## Fix

- Convert non-`None` DLL manager versions to strings in `DLLManager.__init__`.
- Convert a configured DXVK version to a string before using string methods.
- Make the schema and documentation identify the expected string type.

The patch does not silently reinterpret unsupported configuration nesting such
as a top-level `config:` key. That is not a Lutris game configuration section;
the executable and runner sections must remain at the YAML top level.

## Verification

- `PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 -m nose2 --exclude-ci -v`
  - 469 tests passed.
- `PYTHONDONTWRITEBYTECODE=1 python3 -m compileall -q lutris tests`
- `git diff --check`
- `dpkg-buildpackage -us -uc -b`
  - produced `lutris_0.5.23_all.deb`.
