### PR TITLE
Fix missing game path cache handling

### DIFF
--- a/lutris/util/path_cache.py
+++ b/lutris/util/path_cache.py
@@ -15,6 +15,27 @@ from lutris.util.log import logger
 GAME_PATH_CACHE_PATH = os.path.join(settings.CACHE_DIR, "game-paths.json")
 
 
+def _ensure_cache_dir():
+    cache_dir = os.path.dirname(GAME_PATH_CACHE_PATH)
+    if cache_dir and not os.path.isdir(cache_dir):
+        os.makedirs(cache_dir, exist_ok=True)
+
+
+def _write_path_cache(cache):
+    _ensure_cache_dir()
+    temp_path = GAME_PATH_CACHE_PATH + ".tmp"
+    try:
+        with open(temp_path, "w", encoding="utf-8") as cache_file:
+            json.dump(cache, cache_file, indent=2)
+        os.replace(temp_path, GAME_PATH_CACHE_PATH)
+    finally:
+        if os.path.exists(temp_path):
+            try:
+                os.unlink(temp_path)
+            except OSError:
+                pass
+
+
 def get_game_paths():
     game_paths = {}
     all_games = get_games(filters={"installed": 1})
@@ -34,9 +55,7 @@ def build_path_cache(recreate=False):
     if os.path.exists(GAME_PATH_CACHE_PATH) and not recreate:
         return
     start_time = time.time()
-    with open(GAME_PATH_CACHE_PATH, "w", encoding="utf-8") as cache_file:
-        game_paths = get_game_paths()
-        json.dump(game_paths, cache_file, indent=2)
+    _write_path_cache(get_game_paths())
     end_time = time.time()
     get_path_cache.cache_clear()
     logger.debug("Game path cache built in %0.2f seconds", end_time - start_time)
@@ -51,8 +70,7 @@ def add_to_path_cache(game):
         return
     current_cache = read_path_cache()
     current_cache[game.id] = path
-    with open(GAME_PATH_CACHE_PATH, "w", encoding="utf-8") as cache_file:
-        json.dump(current_cache, cache_file, indent=2)
+    _write_path_cache(current_cache)
     get_path_cache.cache_clear()
 
 
@@ -65,11 +83,14 @@ def get_path_cache():
 
 def read_path_cache():
     """Read the contents of the path cache file, and does not cache it."""
-    with open(GAME_PATH_CACHE_PATH, encoding="utf-8") as cache_file:
-        try:
-            return json.load(cache_file)
-        except json.JSONDecodeError:
-            return {}
+    try:
+        with open(GAME_PATH_CACHE_PATH, encoding="utf-8") as cache_file:
+            try:
+                return json.load(cache_file)
+            except json.JSONDecodeError:
+                return {}
+    except FileNotFoundError:
+        return {}
 
 
 def remove_from_path_cache(game):
@@ -79,8 +100,7 @@ def remove_from_path_cache(game):
         logger.warning("Game %s (id=%s) not in cache path", game, game.id)
         return
     del current_cache[game.id]
-    with open(GAME_PATH_CACHE_PATH, "w", encoding="utf-8") as cache_file:
-        json.dump(current_cache, cache_file, indent=2)
+    _write_path_cache(current_cache)
     get_path_cache.cache_clear()
 
 

--- a/tests/util/_test_path_cache.py
+++ b/tests/util/_test_path_cache.py
@@ -1,0 +1,91 @@
+import builtins
+import json
+import os
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+from unittest.mock import patch
+
+import lutris.util.path_cache as path_cache
+from lutris import settings
+
+
+class FakeGame:
+    def __init__(self, game_id, path):
+        self.id = game_id
+        self._path = path
+
+    def get_path_from_config(self):
+        return self._path
+
+    def __str__(self):
+        return f"FakeGame({self.id})"
+
+
+class TestPathCache(TestCase):
+    def setUp(self):
+        self.tmp_dir = TemporaryDirectory()
+        self.tmp_path = Path(self.tmp_dir.name)
+        self.original_cache_dir = settings.CACHE_DIR
+        self.original_cache_path = path_cache.GAME_PATH_CACHE_PATH
+        settings.CACHE_DIR = str(self.tmp_path)
+        path_cache.GAME_PATH_CACHE_PATH = os.path.join(settings.CACHE_DIR, "game-paths.json")
+        path_cache.get_path_cache.cache_clear()
+
+    def tearDown(self):
+        settings.CACHE_DIR = self.original_cache_dir
+        path_cache.GAME_PATH_CACHE_PATH = self.original_cache_path
+        path_cache.get_path_cache.cache_clear()
+        self.tmp_dir.cleanup()
+
+    def test_read_missing_cache_returns_empty(self):
+        assert path_cache.read_path_cache() == {}
+
+    def test_write_creates_parent_directory(self):
+        nested = self.tmp_path / "nested" / "cache"
+        settings.CACHE_DIR = str(nested)
+        path_cache.GAME_PATH_CACHE_PATH = os.path.join(settings.CACHE_DIR, "game-paths.json")
+
+        path_cache._write_path_cache({"1": "/path/to/game"})
+        assert os.path.exists(path_cache.GAME_PATH_CACHE_PATH)
+        with open(path_cache.GAME_PATH_CACHE_PATH, encoding="utf-8") as f:
+            assert json.load(f) == {"1": "/path/to/game"}
+
+    def test_preserve_and_update_valid_cache(self):
+        path_cache._write_path_cache({"1": "/path/to/game"})
+        path_cache.add_to_path_cache(FakeGame("2", "/path/to/second"))
+
+        assert path_cache.get_path_cache() == {"1": "/path/to/game", "2": "/path/to/second"}
+
+    def test_repeated_reads_writes_after_cache_directory_removed(self):
+        path_cache._write_path_cache({"1": "/path/to/game"})
+        os.remove(path_cache.GAME_PATH_CACHE_PATH)
+
+        assert path_cache.read_path_cache() == {}
+
+        path_cache.add_to_path_cache(FakeGame("2", "/path/to/second"))
+        assert path_cache.get_path_cache() == {"2": "/path/to/second"}
+
+    def test_written_cache_is_valid_json(self):
+        path_cache._write_path_cache({"1": "/path/to/game"})
+        with open(path_cache.GAME_PATH_CACHE_PATH, encoding="utf-8") as f:
+            data = json.load(f)
+        assert data == {"1": "/path/to/game"}
+
+    def test_failed_write_does_not_replace_existing_cache(self):
+        path_cache._write_path_cache({"1": "/path/to/game"})
+        temp_path = path_cache.GAME_PATH_CACHE_PATH + ".tmp"
+
+        def fail_open(path, *args, **kwargs):
+            if path == temp_path:
+                raise OSError("disk error")
+            return builtins.open(path, *args, **kwargs)
+
+        with patch("lutris.util.path_cache.open", side_effect=fail_open):
+            try:
+                path_cache._write_path_cache({"2": "/path/to/second"})
+            except OSError:
+                pass
+
+        with open(path_cache.GAME_PATH_CACHE_PATH, encoding="utf-8") as f:
+            assert json.load(f) == {"1": "/path/to/game"}


### PR DESCRIPTION
## Problem

Lutris currently treats a missing `game-paths.json` cache file as an application error. When `add_to_path_cache()` reads the cache after the file was removed, `read_path_cache()` raises `FileNotFoundError`, causing repeated error messages and crash behavior around path cache updates.

## Solution

This patch makes `read_path_cache()` return an empty cache when the file is missing. It also writes the cache atomically using a temporary `.tmp` file and `os.replace()`, creating the parent directory if needed. Existing valid cache data is preserved and stale partial writes are not left behind.

## Tests

- Added regression tests for missing cache reads, parent directory creation on write, preserving/updating an existing cache, repeated reads/writes after cache removal, valid JSON output, and failed write protection.

## Manual testing

No manual GUI testing was performed in this environment because the current container lacks the `gi` Python binding and Gtk dependencies.

## Scope

Limited to issue #6822 and path cache behavior only. No unrelated refactoring.

Fixes #6822