### PR TITLE
Don't prevent sleep by default

### DIFF
--- a/lutris/sysoptions.py
+++ b/lutris/sysoptions.py
@@ -206,7 +206,7 @@ system_options: list[dict[str, Any]] = [  # pylint: disable=invalid-name
         "option": "disable_screen_saver",
         "label": _("Prevent sleep"),
         "type": "bool",
-        "default": SCREEN_SAVER_INHIBITOR is not None,
+        "default": False,
         "advanced": True,
         "condition": SCREEN_SAVER_INHIBITOR is not None,
         "help": _("Prevents the computer from suspending when a game is running."),


### PR DESCRIPTION
This change prevents Lutris from interfering with system power management without the user's knowledge/request. Considering this is hidden with the "Advanced" options, many users will likely not know it is enabled by default.

Background:
I created a service to allow programs to request sleep inhibitors in Bazzite/SteamOS game mode: https://github.com/addmix/Bazzite-Deck-Sleep-Inhibitor
Naturally, programs inhibiting sleep without user knowledge/consent or an active reason to inhibit sleep (playing non-interactive content, downloading, background processing) becomes an issue, especially in the context of handheld devices. I believe that this new default should benefit the large majority of users, and hopefully avoid inconsistency with system sleep.