### PR TITLE
update ruffle runner to stable version 0.5.0

### DIFF
--- a/share/lutris/json/ruffle.json
+++ b/share/lutris/json/ruffle.json
@@ -4,7 +4,7 @@
     "description": "Emulates Flash games",
     "platforms": ["Flash"],
     "runner_executable": "ruffle",
-    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/v0.3.0/ruffle-0.3.0-linux-x86_64.tar.gz",
+    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/v0.5.0/ruffle-0.5.0-linux-x86_64.tar.gz",
     "game_options": [
         {
             "option": "main_file",

--- a/share/lutris/json/ruffle.json
+++ b/share/lutris/json/ruffle.json
@@ -4,7 +4,7 @@
     "description": "Emulates Flash games",
     "platforms": ["Flash"],
     "runner_executable": "ruffle",
-    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/v0.5.0/ruffle-0.5.0-linux-x86_64.tar.gz",
+    "download_url": "https://github.com/ruffle-rs/ruffle/releases/download/v0.6.0/ruffle-0.6.0-linux-x86_64.tar.gz",
     "game_options": [
         {
             "option": "main_file",


### PR DESCRIPTION
this commit updates the ruffle runner to use the 0.5.0 stable release, which has 8% increased support for avm2 and 1% increase to avm1 support