### PR TITLE
Deprecated/removed attributes in GnomeDesktop

### DIFF
--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -14,9 +14,11 @@ import gi
 try:
     gi.require_version("GnomeDesktop", "3.0")
     from gi.repository import GnomeDesktop  # type: ignore
+    # check for AttributeError on newer systems on which the deprecated attributes have been removed
+    GnomeDesktop.RRScreen  # type: ignore
 
     LIB_GNOME_DESKTOP_AVAILABLE = True
-except ValueError:
+except (ValueError, AttributeError):
     LIB_GNOME_DESKTOP_AVAILABLE = False
     GnomeDesktop = None
 

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -14,6 +14,7 @@ import gi
 try:
     gi.require_version("GnomeDesktop", "3.0")
     from gi.repository import GnomeDesktop  # type: ignore
+
     # check for AttributeError on newer systems on which the
     # deprecated attributes have been removed
     GnomeDesktop.RRScreen  # type: ignore

--- a/lutris/util/display.py
+++ b/lutris/util/display.py
@@ -14,7 +14,8 @@ import gi
 try:
     gi.require_version("GnomeDesktop", "3.0")
     from gi.repository import GnomeDesktop  # type: ignore
-    # check for AttributeError on newer systems on which the deprecated attributes have been removed
+    # check for AttributeError on newer systems on which the
+    # deprecated attributes have been removed
     GnomeDesktop.RRScreen  # type: ignore
 
     LIB_GNOME_DESKTOP_AVAILABLE = True


### PR DESCRIPTION
This PR solves https://github.com/lutris/lutris/issues/6828 by checking whether the - previously deprecated - attributes of GnomeDesktop have actually been removed