### PR TITLE
Add Category action to games that are not installed

### DIFF
--- a/lutris/database/services.py
+++ b/lutris/database/services.py
@@ -42,3 +42,23 @@ class ServiceGameCollection:
         if len(results) > 1:
             logger.warning("More than one game found for %s on %s", appid, service)
         return results[0]
+
+    @classmethod
+    def link_service_game(cls, service: str, appid: str, lutris_slug: str) -> None:
+        """Update a service game to point to a Lutris game slug."""
+        sql.db_update(
+            settings.DB_PATH,
+            "service_games",
+            {"lutris_slug": lutris_slug},
+            conditions={"appid": appid, "service": service},
+        )
+
+    @classmethod
+    def link_lutris_game(cls, service: str, appid: str, lutris_game_id: str) -> None:
+        """Update a Lutris game to point to a service game."""
+        sql.db_update(
+            settings.DB_PATH,
+            "games",
+            {"service": service, "service_id": appid},
+            conditions={"id": lutris_game_id},
+        )

--- a/lutris/game_actions.py
+++ b/lutris/game_actions.py
@@ -13,12 +13,13 @@ from gi.repository import Gio, Gtk
 from lutris.config import duplicate_game_config
 from lutris.database import games
 from lutris.database.games import add_game, get_game_by_field
-from lutris.game import Game
+from lutris.database.services import ServiceGameCollection
+from lutris.game import GAME_UPDATED, Game
 from lutris.gui import dialogs
 from lutris.gui.config.add_game_dialog import AddGameDialog
 from lutris.gui.config.edit_game import EditGameConfigDialog
 from lutris.gui.config.edit_game_categories import EditGameCategoriesDialog
-from lutris.gui.dialogs import InputDialog
+from lutris.gui.dialogs import InputDialog, display_error
 from lutris.gui.dialogs.delegates import LaunchUIDelegate
 from lutris.gui.dialogs.log import LogWindow
 from lutris.gui.dialogs.uninstall_dialog import UninstallDialog
@@ -520,6 +521,7 @@ class ServiceGameActions(GameActions):
 
     def get_game_actions(self) -> list[tuple[str | None, str, Callable[..., None] | None]]:
         return [
+            ("category", _("Categories"), self.on_edit_game_categories),
             ("install", _("Install"), self.on_install_clicked),
             ("add", _("Locate installed game"), self.on_locate_installed_game),
             ("view", _("View on Lutris.net"), self.on_view_game),
@@ -529,11 +531,46 @@ class ServiceGameActions(GameActions):
     def get_displayed_entries(self) -> dict[str, bool]:
         """Return a dictionary of actions that should be shown for a game"""
         return {
+            "category": True,
             "install": self.is_installable,
             "add": self.is_installable,
             "view": True,
             "view-store": bool(self.game.service and self._get_store_url(self.game)),
         }
+
+    def on_edit_game_categories(self, _widget: Gtk.Widget) -> None:
+        def on_game_shown(updated_id: str, error: Exception | None) -> None:
+            if error:
+                display_error(error, parent=self.window)
+                return
+
+            self.application.show_window(EditGameCategoriesDialog, game=Game(updated_id), parent=self.window)
+
+        AsyncCall(self.show_in_games, on_game_shown, self.game)
+
+    def show_in_games(self, game: Game) -> str:
+        if game.is_db_stored:
+            return game.id
+
+        existing = get_game_by_field(game.slug, field="slug")
+        if existing:
+            if existing.get("service") and existing.get("service_id"):
+                if existing["service"] == game.service and existing["service_id"] == game.appid:
+                    return existing["id"]
+
+                service_name = SERVICES[existing["service"]].name
+                raise RuntimeError(_("The game '%s' is already linked to the %s service.") % (game.name, service_name))
+
+            # Link to an existing Lutris game without changing its current setup.
+            ServiceGameCollection.link_lutris_game(game.service, game.appid, existing["id"])
+            ServiceGameCollection.link_service_game(game.service, game.appid, game.slug)
+            GAME_UPDATED.fire(game)
+            download_lutris_media(game.slug)
+            return existing["id"]
+
+        game.save()
+        download_lutris_media(game.slug)
+        return game.id
 
 
 def get_game_actions(

--- a/lutris/services/base.py
+++ b/lutris/services/base.py
@@ -237,12 +237,10 @@ class BaseService:
         """Match a service game to a lutris game referenced by its slug"""
         if not service_game:
             return
-        sql.db_update(
-            settings.DB_PATH,
-            "service_games",
-            {"lutris_slug": lutris_game["slug"]},
-            conditions={"appid": service_game["appid"], "service": self.id},
-        )
+
+        appid = service_game["appid"]
+        ServiceGameCollection.link_service_game(self.id, appid, lutris_game["slug"])
+
         unmatched_lutris_games = get_games(
             searches={"installer_slug": self.matcher},
             filters={"slug": lutris_game["slug"]},
@@ -250,12 +248,7 @@ class BaseService:
         )
         for game in unmatched_lutris_games:
             logger.debug("Updating unmatched game %s", game)
-            sql.db_update(
-                settings.DB_PATH,
-                "games",
-                {"service": self.id, "service_id": service_game["appid"]},
-                conditions={"id": game["id"]},
-            )
+            ServiceGameCollection.link_lutris_game(self.id, appid, game["id"])
 
     def match_games(self):
         """Matching of service games to lutris games"""


### PR DESCRIPTION
This PR adapts a minimal set of the changes in https://github.com/lutris/lutris/pull/5615/changes in order to allow adding categories to add categories to games which aren't currently installed, without exposing database internals to the users.

Resolves https://github.com/lutris/lutris/issues/5606.