### PR TITLE
fix(steam): set UTF-8 locale for Flatpak shortcuts

### DIFF
--- a/lutris/util/steam/shortcut.py
+++ b/lutris/util/steam/shortcut.py
@@ -152,7 +152,7 @@ def generate_shortcut(game: "Game", launch_config_name: str) -> SteamShortcut:
 
     if is_flatpak_lutris():
         lutris_binary = "/usr/bin/flatpak"
-        launch_options = "run net.lutris.Lutris " + launch_options
+        launch_options = "LC_ALL=C.UTF-8 %command% run net.lutris.Lutris " + launch_options
     return {
         "appid": generate_shortcut_id(game),
         "AppName": game.name,

--- a/tests/_test_steam.py
+++ b/tests/_test_steam.py
@@ -1,0 +1,26 @@
+"""Tests for Steam shortcut generation."""
+
+import unittest
+from unittest.mock import patch
+
+from lutris.util.steam import shortcut
+
+
+class Game:
+    id = "game-1"
+    slug = "game"
+    name = "Game"
+    runner_name = "wine"
+
+
+class TestSteamShortcut(unittest.TestCase):
+    @patch.object(shortcut, "is_flatpak_lutris", return_value=True)
+    @patch.object(shortcut.resources, "get_icon_path", return_value="icon")
+    def test_flatpak_shortcut_uses_utf8_locale(self, _get_icon_path, _is_flatpak):
+        generated = shortcut.generate_shortcut(Game(), "default")
+
+        self.assertEqual(
+            generated["LaunchOptions"],
+            "LC_ALL=C.UTF-8 %command% run net.lutris.Lutris "
+            "lutris:rungameid/game-1/default",
+        )


### PR DESCRIPTION
Closes #6827

Flatpak-generated Steam shortcuts now prefix the launch options with `LC_ALL=C.UTF-8 %command%`, preserving UTF-8 game paths when Steam starts the outer Flatpak process with `LC_ALL=C`. The existing executable and shortcut ID remain unchanged.

Tested the shortcut generator with a focused regression harness; the assertion fails without the change and passes with it. The repository unit test is included in `tests/_test_steam.py` (the full Lutris test environment requires the unavailable PyGObject/GTK dependency locally).

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.