### PR TITLE
Fix Ubisoft Connect reload crash when a game config has a null name

### DIFF
--- a/lutris/util/ubisoft/parser.py
+++ b/lutris/util/ubisoft/parser.py
@@ -248,7 +248,7 @@ class UbisoftParser(object):
         field_value = ""
 
         if field in game_yaml["root"]:
-            field_value = game_yaml["root"][field]
+            field_value = game_yaml["root"][field] or ""
         # Fallback 1
         if field == "name" and field_value.lower() in UBISOFT_CONFIGURATIONS_BLACKLISTED_NAMES:
             if "installer" in game_yaml["root"] and "game_identifier" in game_yaml["root"]["installer"]:


### PR DESCRIPTION
## Problem

Reloading the Ubisoft Connect source crashes with `AttributeError: 'NoneType' object has no attribute 'lower'` when any game's configuration YAML has a `name:` entry with a null value (see #6838 for the full traceback).

In `_get_field_from_yaml()`, `field_value` is initialized to `""` but then overwritten with `game_yaml["root"][field]` — which can be `None`. The very next check calls `field_value.lower()`, raising the `AttributeError` and aborting the entire source reload.

## Fix

Fall back to an empty string (`or ""`) so the existing blacklisted-name fallback logic (`installer.game_identifier`, then localizations) can run instead of crashing.

## Testing

- Applied the identical one-line change to the distro install of Lutris 0.5.22 (Python 3.14) where the crash reproduced on every Ubisoft Connect reload; after the change, the reload completes and the library populates. Games with a null name appear as a card without name/image — improving that display fallback is out of scope here.
- `python3 -m py_compile` passes on the modified file.

Fixes #6838
