### PR TITLE
fix(ea_app): assign unique slug per imported EA game

### DIFF
--- a/lutris/services/ea_app.py
+++ b/lutris/services/ea_app.py
@@ -514,7 +514,7 @@ class EAAppService(OnlineService):
         game_config = LutrisConfig(game_config_id=ea_game["configpath"]).game_level
         game_config["game"]["args"] = get_launch_arguments(",".join(content_ids))
         configpath = write_game_config(lutris_game_id, game_config)
-        slug = self.get_installed_slug(ea_game)
+        slug = lutris_game_id
         add_game(
             name=service_game["name"],
             runner=ea_game["runner"],


### PR DESCRIPTION
Fixes #6811.

EA App bundle imports used the EA App client's slug for every game, so all games collided on the 'ea-app' slug and their cover art/banner files overwrote each other.

This derives the per-game slug from the already-computed `lutris_game_id` (name + service id), so each game gets a unique slug.

Tested: `ruff check` passes, full unit test suite passes (473 tests with `--exclude-ci`).