### PR TITLE
build: fix readme path and avoid importing lutris in setup.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ description = """
 Lutris is a video game preservation platform that helps you install and play video games from all eras and from most gaming systems.
 By leveraging and combining existing emulators, engine re-implementations and compatibility layers, it gives you a central interface to launch all your games.
 """
-readme = "README.md"
+readme = "README.rst"
 requires-python = ">=3.10"
 
 license = "GPL-3.0-or-later"

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 import os
+import re
 import sys
 
 from setuptools import setup
 
-from lutris import __version__ as VERSION
+# Read the version without importing the lutris package, which would
+# require PyGObject/Gtk to be installed just to build an sdist.
+with open(os.path.join("lutris", "__init__.py"), encoding="utf-8") as version_file:
+    version_match = re.search(r'__version__\s*=\s*"([^"]+)"', version_file.read())
+    VERSION = version_match.group(1) if version_match else "0.0.0"
 
 if sys.version_info < (3, 10):
     sys.exit("Python >= 3.10 is required to run Lutris")


### PR DESCRIPTION
Two build fixes:

1. `pyproject.toml` referenced `README.md` but the repository only contains `README.rst`, breaking PEP 621 builds (e.g. the AppImage build fails with `File '/src/README.md' cannot be found`).

2. `setup.py` did `from lutris import __version__`, which imports `lutris/__init__.py` and its `gi.require_version("Gtk", "3.0")` calls. That forces PyGObject/Gtk to be installed just to build an sdist. Read the version string from the file instead.