### PR TITLE
Add devcontainer configuration for Lutris development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,23 @@
+FROM mcr.microsoft.com/devcontainers/universal:2-linux
+
+# Lutris needs the GObject introspection (GI) bindings and the GTK/WebKit
+# typelibs to import the `gi` module and build the C extension dependencies
+# (PyGObject, pycairo, dbus-python). Install everything here so the image
+# works out of the box and tests/builds run without extra setup.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        python3-gi \
+        python3-dbus \
+        python3-gi-cairo \
+        python3-venv \
+        libgirepository-2.0-dev \
+        gir1.2-gtk-3.0 \
+        gir1.2-webkit2-4.1 \
+        libgnome-desktop-3-dev \
+        libcairo2-dev \
+        libgtk-3-dev \
+        libgdk-pixbuf-2.0-dev \
+        libdbus-1-dev \
+        libdbus-glib-1-dev \
+        pkg-config \
+        gettext \
+    && rm -rf /var/lib/apt/lists/*

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,21 @@
+{
+    "name": "Lutris",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-python.python",
+                "ms-python.vscode-pylance",
+                "charliermarsh.ruff"
+            ],
+            "settings": {
+                "python.defaultInterpreterPath": "/usr/bin/python3",
+                "python.testing.unittestEnabled": true
+            }
+        }
+    },
+    "postCreateCommand": "bash .devcontainer/post-create.sh",
+    "remoteUser": "vscode"
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Use the system Python (which has gi/dbus/cairo via apt) and a venv that
+# sees those system packages, so C extensions don't need to be built against
+# a static libpython.
+python3 -m venv --system-site-packages /workspaces/lutris/.venv
+/workspaces/lutris/.venv/bin/pip install --upgrade pip
+
+# Runtime and development dependencies.
+/workspaces/lutris/.venv/bin/pip install \
+    PyYAML lxml requests Pillow setproctitle python-magic distro \
+    types-requests types-PyYAML evdev pypresence protobuf moddb
+
+/workspaces/lutris/.venv/bin/pip install \
+    "ruff==0.12.1" "mypy==1.16.1" mypy-baseline nose2
+
+/workspaces/lutris/.venv/bin/pip install \
+    "pygobject-stubs>=2.17.0" --no-cache-dir --config-settings=config=Gtk3,Gdk3,Soup2
+
+echo "Lutris devcontainer ready. Use /workspaces/lutris/.venv/bin/python"


### PR DESCRIPTION
GitHub codespaces for this repo don't work out of the box:

- The default (Oryx) Python uses a static libpython, so pip builds of C extensions (dbus-python, PyGObject 4.x, pycairo) fail to link libm.
- The GI typelibs (Gtk, WebKit2, Gdk) aren't installed, so `import gi` fails.

This adds a `.devcontainer/` with a Dockerfile installing the system dependencies and a post-create script that sets up a venv with system site-packages, so tests, static analysis and builds work immediately.