### PR TITLE
fix: detect 64-bit Vulkan on WoW64-only systems

### DIFF
--- a/lutris/util/linux.py
+++ b/lutris/util/linux.py
@@ -482,7 +482,10 @@ class LinuxSystem:  # pylint: disable=too-many-public-methods
         return not self.get_missing_requirement_libs(feature)[0]
 
     def is_vulkan_supported(self) -> bool:
-        return not LINUX_SYSTEM.get_missing_lib_arch("VULKAN") and vkquery.is_vulkan_supported()
+        missing = LINUX_SYSTEM.get_missing_lib_arch("VULKAN")
+        # WoW64-only systems lack 32-bit Vulkan but still run Vulkan games;
+        # only require the 64-bit library so such systems are detected correctly.
+        return "x86_64" not in missing and vkquery.is_vulkan_supported()
 
 
 class SharedLibrary:


### PR DESCRIPTION
Fixes #6808.

`is_vulkan_supported()` required `libvulkan.so.1` for every runtime architecture, so a system with only 64-bit Vulkan libraries (e.g. Wine compiled with WoW64 and multilib disabled) was incorrectly reported as "Vulkan is not installed".

Only require the 64-bit Vulkan library; `vkquery.is_vulkan_supported()` still validates the library actually loads and enumerates devices.

Tested: `ruff check` passes, full unit test suite passes.