### PR TITLE
fix(proton): stop game XDG dirs leaking into umu runtime download

### DIFF
--- a/lutris/util/wine/proton.py
+++ b/lutris/util/wine/proton.py
@@ -207,6 +207,13 @@ def update_proton_env(wine_path: str, env: dict[str, str], game_id: str = DEFAUL
 
     This also propagates LC_ALL to HOST_LC_ALL, if LC_ALL is set."""
 
+    # umu-launcher stores the Proton/Steam runtime under $XDG_DATA_HOME/umu and
+    # caches under $XDG_CACHE_HOME. Reset those to Lutris's own directories so the
+    # game's overridden XDG dirs (from Game execution -> Environment variables)
+    # cannot leak into the runtime download.
+    env["XDG_DATA_HOME"] = os.path.dirname(settings.DATA_DIR)
+    env["XDG_CACHE_HOME"] = os.path.dirname(settings.CACHE_DIR)
+
     if "PROTONPATH" not in env:
         if is_umu_path(wine_path):
             env["PROTONPATH"] = "GE-Proton"


### PR DESCRIPTION
Fixes #6814.

When a user sets `XDG_DATA_HOME`/`XDG_CACHE_HOME` in "Game execution -> Environment variables", those values leaked into the umu-launch environment. umu-launcher stores the Proton/Steam runtime under `$XDG_DATA_HOME/umu`, so runtimes were re-downloaded into the user's custom directory instead of Lutris's location.

This resets `XDG_DATA_HOME`/`XDG_CACHE_HOME` to Lutris's own directories in `update_proton_env()` before the umu launch.

Tested: `ruff check` passes, full unit test suite passes. Note: this is best-effort without a live umu/GE-Proton install to reproduce the original download path.