### PR TITLE
ensure unique slug on add_game to prevent collision

### DIFF
--- a/lutris/database/games.py
+++ b/lutris/database/games.py
@@ -166,11 +166,22 @@ def get_games_by_slug(slug: str) -> list[DbGameDict]:
     return _stringify_game_ids(sql.db_select(settings.DB_PATH, "games", condition=("slug", slug)))
 
 
+def get_unique_slug(base_slug: str) -> str:
+    """Return the first unused slug for a base: base, base-2, base-3, ..."""
+    slug = base_slug
+    counter = 2
+    while get_games_by_slug(slug):
+        slug = f"{base_slug}-{counter}"
+        counter += 1
+    return slug
+
+
 def add_game(**game_data: Any) -> str:
-    """Add a game to the database."""
+    """Add a game to the database, ensuring the slug is unique to avoid
+    coverart/config collisions (coverart/<slug>.png)."""
     game_data["installed_at"] = int(time.time())
-    if "slug" not in game_data:
-        game_data["slug"] = slugify(game_data["name"])
+    base_slug = game_data.get("slug") or slugify(game_data["name"])
+    game_data["slug"] = get_unique_slug(base_slug)
     return str(sql.db_insert(settings.DB_PATH, "games", game_data))
 
 

--- a/tests/test_duplicate_slug.py
+++ b/tests/test_duplicate_slug.py
@@ -1,0 +1,71 @@
+"""Ensure add_game() produces unique slugs to prevent coverart collision.
+
+Regression test for duplicate slug bug: two different games could share the
+same slug, so coverart/<slug>.png was shared (setting a poster on one
+changed both).
+
+Intentional behavior documented here:
+- Creation (add_game) ALWAYS dedups: undertail, undertail-2, undertail-3, ...
+- Rename does NOT auto-change slug (only creation guarantees uniqueness).
+- No DB UNIQUE constraint (would break service imports on legacy dup DBs).
+"""
+
+import os
+import unittest
+
+from lutris import settings
+from lutris.database import games as games_db
+from lutris.database import schema
+from lutris.util.test_config import setup_test_environment
+
+setup_test_environment()
+
+
+class TestUniqueSlug(unittest.TestCase):
+    def setUp(self):
+        if os.path.exists(settings.DB_PATH):
+            os.remove(settings.DB_PATH)
+        schema.syncdb()
+
+    def _slug_of(self, game_id):
+        game = games_db.get_game_by_field(game_id, "id")
+        assert game is not None
+        return game["slug"]
+
+    def test_duplicate_name_gets_unique_slug(self):
+        first_id = games_db.add_game(name="Undertail", runner="linux")
+        second_id = games_db.add_game(name="Undertail", runner="linux")
+        self.assertEqual(self._slug_of(first_id), "undertail")
+        self.assertEqual(self._slug_of(second_id), "undertail-2")
+
+    def test_third_duplicate_goes_to_3(self):
+        games_db.add_game(name="Undertail", runner="linux")
+        games_db.add_game(name="Undertail", runner="linux")
+        third_id = games_db.add_game(name="Undertail", runner="linux")
+        self.assertEqual(self._slug_of(third_id), "undertail-3")
+
+    def test_explicit_duplicate_slug_gets_suffixed(self):
+        first_id = games_db.add_game(name="Plants vs Zombie", runner="linux", slug="undertail")
+        second_id = games_db.add_game(name="Undertail", runner="linux", slug="undertail")
+        self.assertEqual(self._slug_of(first_id), "undertail")
+        self.assertEqual(self._slug_of(second_id), "undertail-2")
+
+    def test_suffix_gap_is_skipped(self):
+        """If base-2 is already taken, next add must go to -3 (loop, not single if)."""
+        games_db.add_game(name="Undertail", runner="linux")
+        games_db.add_game(name="Undertail", runner="linux", slug="undertail-2")
+        third_id = games_db.add_game(name="Undertail", runner="linux")
+        self.assertEqual(self._slug_of(third_id), "undertail-3")
+
+    def test_rename_keeps_slug(self):
+        """Document intentional behavior: updating a game does not auto-change slug."""
+        game_id = games_db.add_game(name="Undertail", runner="linux")
+        games_db.add_or_update(id=game_id, name="Undertail Remastered", slug="undertail", runner="linux")
+        game = games_db.get_game_by_field(game_id, "id")
+        assert game is not None
+        self.assertEqual(game["name"], "Undertail Remastered")
+        self.assertEqual(game["slug"], "undertail")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes duplicate `slug` rows.

Repro: add two games then i found out that both get `slug='undertail'`,
with one shared `coverart/undertail.png` which is unwanted behavior.

i changed `lutris/database/games.py`: `add_game()` now dedups via new
`get_unique_slug()` helper that generate something like
`undertail, undertail-2, ...` a while loop so taken `-2` skips to `-3`
and so on... Explicit `slug=` gets the same treatment. No rename change

before: `undertail.png` (shared)
after: `undertail.png`, `undertail-2.png`

added new tests `tests/test_duplicate_slug.py`

python -m pytest tests/test_duplicate_slug.py tests/_test_pga.py -v
5 + 16 passed