### PR TITLE
handle offline mode gracefully with passive banner and friendly errors

### DIFF
--- a/lutris/gui/application.py
+++ b/lutris/gui/application.py
@@ -50,7 +50,7 @@ from lutris.services import get_enabled_services
 from lutris.startup import init_lutris, run_all_checks
 from lutris.style_manager import StyleManager
 from lutris.util import datapath, log, resources, system
-from lutris.util.http import HTTPError, Request
+from lutris.util.http import HTTPError, Request, is_connection_error
 from lutris.util.log import file_handler, logger
 from lutris.util.savesync import save_check, show_save_stats, upload_save
 from lutris.util.steam.appmanifest import AppManifest, get_appmanifests
@@ -426,7 +426,10 @@ class LutrisApplication(Gtk.Application):
     def show_lutris_installer_window(self, game_slug: str) -> None:
         def on_installers_ready(installers: list[dict[str, Any]], error: BaseException) -> None:
             if error and self.window:
-                display_error(error, parent=self.window)
+                if is_connection_error(error):
+                    ErrorDialog(_("You are offline"), parent=self.window)
+                else:
+                    display_error(error, parent=self.window)
             elif installers:
                 self.show_installer_window(installers)
             else:

--- a/lutris/gui/dialogs/runner_install.py
+++ b/lutris/gui/dialogs/runner_install.py
@@ -18,6 +18,7 @@ from lutris.gui.widgets.stock_icon_image import StockIconImage
 from lutris.util import jobs, system
 from lutris.util.downloader import SimpleDownloader
 from lutris.util.extract import extract_archive
+from lutris.util.http import is_connection_error
 from lutris.util.jobs import schedule_repeating_at_idle
 from lutris.util.log import logger
 
@@ -173,7 +174,10 @@ class RunnerInstallDialog(ModelessDialog):
 
         if error:
             logger.error(error)
-            ErrorDialog(_("Unable to get runner versions: %s") % error, parent=self)
+            if is_connection_error(error):
+                ErrorDialog(_("You are offline"), parent=self)
+            else:
+                ErrorDialog(_("Unable to get runner versions: %s") % error, parent=self)
             return
 
         self.runner_info, self.runner_store = result

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -71,6 +71,7 @@ from lutris.services.lutris import LutrisService, sync_media
 from lutris.style_manager import THEME_CHANGED
 from lutris.util import datapath
 from lutris.util.busy import BUSY_STARTED, BUSY_STOPPED
+from lutris.util.http import is_connection_error
 from lutris.util.jobs import COMPLETED_IDLE_TASK, AsyncCall, schedule_at_idle
 from lutris.util.library_sync import LOCAL_LIBRARY_UPDATED, LibrarySyncer
 from lutris.util.linux import LINUX_SYSTEM
@@ -1207,7 +1208,10 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
     def _service_reloaded_cb(self, error):
         if error:
-            dialogs.display_error(error, parent=self)
+            if is_connection_error(error):
+                ErrorDialog(_("You are offline"), parent=self)
+            else:
+                dialogs.display_error(error, parent=self)
 
     def on_service_logout(self, service):
         self.update_notification()

--- a/lutris/gui/lutriswindow.py
+++ b/lutris/gui/lutriswindow.py
@@ -106,6 +106,7 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     lutris_log_in_label: Gtk.Label = GtkTemplate.Child()
     version_notification_revealer: Gtk.Revealer = GtkTemplate.Child()
     version_notification_label: Gtk.Label = GtkTemplate.Child()
+    offline_notification_revealer: Gtk.Revealer = GtkTemplate.Child()
     show_hidden_games_button: Gtk.ModelButton = GtkTemplate.Child()
 
     def __init__(self, application=None, **kwargs) -> None:
@@ -206,6 +207,11 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
         self.update_action_state()
         self.update_notification()
+        self.update_offline_banner()
+        try:
+            Gio.NetworkMonitor.get_default().connect("network-changed", self._on_network_changed)
+        except Exception:  # noqa: BLE001 - banner is best-effort, never break startup
+            logger.debug("Could not monitor network changes", exc_info=True)
 
         BUSY_STARTED.register(self.on_busy_started)
         BUSY_STOPPED.register(self.on_busy_stopped)
@@ -341,6 +347,8 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
 
     def sync_library(self, force: bool = False) -> None:
         """Tasks that can be run after the UI has been initialized."""
+        if not force and self._is_offline():
+            return
 
         def on_library_synced(_result, error):
             """Sync media after the library is loaded"""
@@ -1121,6 +1129,20 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
             self.lutris_log_in_label.show()
         self.login_notification_revealer.set_reveal_child(show_notification)
 
+    def _is_offline(self) -> bool:
+        """Return True when the system reports no network connection."""
+        try:
+            return not Gio.NetworkMonitor.get_default().get_network_available()
+        except Exception:  # noqa: BLE001 - connectivity check must never break the UI
+            return False
+
+    def update_offline_banner(self) -> None:
+        """Show or hide the passive 'You are offline' banner."""
+        self.offline_notification_revealer.set_reveal_child(self._is_offline())
+
+    def _on_network_changed(self, _monitor, _available) -> None:
+        self.update_offline_banner()
+
     @GtkTemplate.Callback
     def on_lutris_log_in_label_activate_link(self, _label, _url):
         def on_connect_success(widget, _username):
@@ -1540,6 +1562,9 @@ class LutrisWindow(Gtk.ApplicationWindow, DialogLaunchUIDelegate, DialogInstallU
     def start_runtime_updates(self, force_updates: bool) -> None:
         """Starts the process of applying runtime updates, asynchronously. No UI appears until
         we can determine that there are updates to perform."""
+        if self._is_offline():
+            logger.debug("Skipping runtime updates while offline")
+            return
 
         def create_runtime_updater():
             """This function runs on a worker thread and decides what component updates are

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -19,7 +19,7 @@ from lutris.gui.config.edit_saved_search import EditSavedSearchDialog
 from lutris.gui.config.runner import RunnerConfigDialog
 from lutris.gui.config.runner_box import RunnerBox
 from lutris.gui.config.services_box import ServicesBox
-from lutris.gui.dialogs import display_error
+from lutris.gui.dialogs import ErrorDialog, display_error
 from lutris.gui.dialogs.runner_install import RunnerInstallDialog
 from lutris.gui.widgets.stock_icon_image import StockIconImage
 from lutris.gui.widgets.utils import get_widget_children
@@ -34,6 +34,7 @@ from lutris.services.base import (
     AuthTokenExpiredError,
 )
 from lutris.util.jobs import schedule_at_idle
+from lutris.util.http import is_connection_error
 from lutris.util.library_sync import LOCAL_LIBRARY_SYNCED, LOCAL_LIBRARY_SYNCING
 from lutris.util.log import logger
 from lutris.util.strings import get_natural_sort_key
@@ -176,6 +177,8 @@ class ServiceSidebarRow(SidebarRow):
             if isinstance(error, AuthTokenExpiredError):
                 self.service.logout()
                 self.service.login(parent=self.get_toplevel())  # login will trigger reload if successful
+            elif is_connection_error(error):
+                ErrorDialog(_("You are offline"), parent=self.get_toplevel())
             else:
                 display_error(error, parent=self.get_toplevel())
         schedule_at_idle(self.enable_refresh_button, delay_seconds=2.0)

--- a/lutris/gui/widgets/sidebar.py
+++ b/lutris/gui/widgets/sidebar.py
@@ -33,8 +33,8 @@ from lutris.services.base import (
     SERVICE_LOGOUT,
     AuthTokenExpiredError,
 )
-from lutris.util.jobs import schedule_at_idle
 from lutris.util.http import is_connection_error
+from lutris.util.jobs import schedule_at_idle
 from lutris.util.library_sync import LOCAL_LIBRARY_SYNCED, LOCAL_LIBRARY_SYNCING
 from lutris.util.log import logger
 from lutris.util.strings import get_natural_sort_key

--- a/lutris/util/http.py
+++ b/lutris/util/http.py
@@ -44,6 +44,12 @@ class UnauthorizedAccessError(Exception):
     """Exception raised for 401 HTTP errors"""
 
 
+def is_connection_error(exc: BaseException) -> bool:
+    """Return True if the exception is a connection failure (offline, DNS,
+    refused, timeout) as wrapped by Request._request."""
+    return isinstance(exc, HTTPError) and "Unable to connect to server" in str(exc)
+
+
 class Request:
     def __init__(
         self,

--- a/share/lutris/ui/lutris-window.ui
+++ b/share/lutris/ui/lutris-window.ui
@@ -97,6 +97,41 @@
                 <property name="hexpand">True</property>
                 <property name="orientation">vertical</property>
                 <child>
+                  <object class="GtkRevealer" id="offline_notification_revealer">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="transition-type">none</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="spacing">6</property>
+                        <child>
+                          <object class="GtkLabel" id="offline_notification_label">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">You are offline</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <style>
+                          <class name="in-app-notification"/>
+                          <class name="app-notification"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
                   <object class="GtkRevealer" id="login_notification_revealer">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -152,7 +187,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">0</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
                 <child>
@@ -210,7 +245,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">1</property>
+                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
@@ -260,7 +295,7 @@
                   <packing>
                     <property name="expand">True</property>
                     <property name="fill">True</property>
-                    <property name="position">2</property>
+                    <property name="position">3</property>
                   </packing>
                 </child>
                 <child>
@@ -275,7 +310,7 @@
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="position">4</property>
                   </packing>
                 </child>
               </object>

--- a/tests/test_offline_errors.py
+++ b/tests/test_offline_errors.py
@@ -1,0 +1,26 @@
+"""Offline helpers: connection errors get a friendly message, not a traceback."""
+
+import unittest
+
+from lutris.util.http import HTTPError, UnauthorizedAccessError, is_connection_error
+
+
+class TestIsConnectionError(unittest.TestCase):
+    def test_connection_error_is_detected(self):
+        err = HTTPError(
+            "Unable to connect to server https://lutris.net/api/installers/undertail: "
+            "<urlopen error [Errno -3] Temporary failure in name resolution>"
+        )
+        self.assertTrue(is_connection_error(err))
+
+    def test_other_http_errors_are_not_connection_errors(self):
+        self.assertFalse(is_connection_error(HTTPError("404 Not Found", code=404)))
+        self.assertFalse(is_connection_error(HTTPError("Request timed out")))
+
+    def test_non_http_errors_are_not_connection_errors(self):
+        self.assertFalse(is_connection_error(ValueError("bad value")))
+        self.assertFalse(is_connection_error(UnauthorizedAccessError("Access denied")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
when offline, Lutris fires background requests one by one (each waiting
out its timeout) and pops a full traceback when opening an installer:

  Unable to connect to server https://lutris.net/api/installers/...:
  <urlopen error [Errno -3] Temporary failure in name resolution>

This changes that to:

- added "You are offline" banner at the top of the main window
  (auto-hides on reconnect via NetworkMonitor), app stays fully usable
- library auto-sync and runtime updates are skipped while offline
- installer / runner-version / service-reload failures show a short
  "You are offline" dialog instead of a traceback; real errors still
  go through display_error with details

Added `is_connection_error()` in lutris/util/http.py to tell
connection failures apart from real bugs.

Tests: new tests/test_offline_errors.py. Verified with upstream.