### PR TITLE
wine: Remove silent option from regedit

### DIFF
--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -76,7 +76,7 @@ def set_regedit_file(filename, wine_path=None, prefix=None, arch=WINE_DEFAULT_AR
 
     wineexec(
         "regedit",
-        args="/S '%s'" % filename,
+        args="'%s'" % filename,
         wine_path=wine_path,
         prefix=prefix,
         arch=arch,
@@ -93,7 +93,7 @@ def delete_registry_key(key, wine_path=None, prefix=None, arch=WINE_DEFAULT_ARCH
 
     wineexec(
         "regedit",
-        args='/S /D "%s"' % key,
+        args='/D "%s"' % key,
         wine_path=wine_path,
         prefix=prefix,
         arch=arch,


### PR DESCRIPTION
# Description
For properly formatted reg files (including ones generated by `set_regedit`) this option is never required. However it suppresses errors for incorrectly formatted files, giving users and troubleshooters no indication of what happened (or didn't happen as the case may be).

# Motivation
I just spent a couple hours trying to write a proof-of-concept installer. It ultimately turned out to be an issue with the guy sitting in front of the computer, but that guy would have appreciated seeing the errors resulting from an incorrect registry key.

The silent flag was added in e60c9d46ade6471fdd89a073efc954a3af0aa7b0, however I can't find what the reason for this was. IMHO it's not productive to add this for the reasons described above.

On a side note: Installers proceed without issue even when using an incorrect registry key, whether `/S` was used or not. I assume this is an issue with `wine` (or `regedit` itself) not returning a different exit code.
But arguably that is all the more reason not to use silent mode, since the install not outright failing implies everything went fine when it didn't.

# Testing
After applying the patch, I tried using my incorrect registry key again:
```yaml
  - task:
      name: set_regedit
      path: Software\Wine\Drives
      key: 'i:'
      value: 'cdrom'
```

And this time I was greeted by an error as expected:
<img width="269" height="114" alt="image" src="https://github.com/user-attachments/assets/d0943f22-035b-4645-a1e5-c2c9be4d4ede" />

After correcting the key (by adding `HKEY_LOCAL_MACHINE\`), the install remained silent.