### PR TITLE
docs: Mounting directory as a drive/disc

### DIFF
--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -448,6 +448,67 @@ Example::
     - insert-disc:
         requires: diablosetup.exe
 
+Mounting a directory as a drive or disc
+---------------------------------------
+
+Wine (and by extension Proton) recognises entries in ``<prefix>/dosdevices`` and will
+add them as drives automatically. So in `most` cases simply creating a symlink like
+this is enough::
+
+    - execute:
+        command: cd "$GAMEDIR/dosdevices" ; ln -s "../CD_CONTENT_DIRECTORY" "i:"
+
+When you check in ``winecfg`` you will see the drive listed, pointing to your directory.
+
+You can use any drive letter you like, but avoid ``c:``, ``x:``, and ``z:``. They are
+used for default mappings in Wine.
+
+If the game requires a mounted drive at runtime you should store its content in the
+prefix and use relative paths for the symlink like in the example above. This ensures
+that users can relocate their entire prefix without risking game breakage. For
+persistent mounts it is also recommended to add a drive label::
+
+    - write_file:
+        content: "your_label"
+        file: $GAMEDIR/CD_CONTENT_DIRECTORY/.windows-label
+
+In some cases a Windows installer might insist on wanting a CD-ROM drive. If that is the
+case you can explicitly tell Wine to treat a drive mapping as a CD-ROM drive in ``winecfg``.
+
+Since ``winecfg`` is a GUI-only tool there are no command line options, which makes it
+impractical to use in a Lutris installer. But luckily everything it does is stored in
+one of Wine's registry files. Forcing a CD-ROM drive is therefore as simple as adding
+the corresponding registry key. You can do this using the ``set_regedit`` task::
+
+    - task:
+        name: set_regedit
+        path: HKEY_LOCAL_MACHINE\Software\Wine\Drives
+        key: 'i:'
+        value: 'cdrom'
+
+Note: If you only create the registry key without creating the symlink, you will
+not see an entry in ``winecfg``. Wine actually checks that there is a symlink with
+the corresponding drive letter under ``<prefix>/dosdevices`` (oddly it doesn't
+even accept a real directory there, only a symlink to one).
+
+When you open ``explorer.exe`` in this prefix, you will also see the difference to
+only creating the symlink in the first step. Drives created with this registry key
+show a disc in their icon.
+
+If the drives are not required after the installation finishes, make sure to clean
+up after yourself by removing the CD directory (automatically done if you're using
+a ``$CACHE`` directory) and the registry keys::
+
+    - execute
+        command: rm -rf "$GAMEDIR/CD_CONTENT_DIRECTORY"
+    - task:
+        name: delete_registry_key
+        key: HKEY_LOCAL_MACHINE\Software\Wine\Drives
+
+Currently it is not easily possible to delete only a single key-value pair (i.e.
+drive). If you created multiple drives and wanted to keep only one, you'll need
+to recreate it (again) after this.
+
 Moving files and directories
 ----------------------------
 

--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -737,11 +737,8 @@ Currently, the following tasks are implemented:
     Example::
 
         - task:
-            name: set_regedit
-            path: HKEY_CURRENT_USER\Software\Valve\Steam
-            key: SuppressAutoRun
-            value: '00000000'
-            type: REG_DWORD
+            name: delete_registry_key
+            key: HKEY_CURRENT_USER\Software\Valve\Steam
 
 * wine: ``set_regedit_file`` Apply a regedit file to the
   registry, Parameters are ``filename`` (regfile name),

--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -40,7 +40,7 @@ installer has finished.
 The configuration for a game is constructed from its installer. The `files` and
 `installer` sections are removed from the script, some variables such as
 $GAMEDIR are substituted and the results is saved in:
-~/.local/share/lutris/games/<game>-<timestamp>.yml.
+``~/.config/lutris/games/<game>-<timestamp>.yml``.
 
 Published installers can be accessed from a command line by using the ``lutris:``
 URL prefix followed by the installer slug.

--- a/docs/installers.rst
+++ b/docs/installers.rst
@@ -466,10 +466,10 @@ used for default mappings in Wine.
 If the game requires a mounted drive at runtime you should store its content in the
 prefix and use relative paths for the symlink like in the example above. This ensures
 that users can relocate their entire prefix without risking game breakage. For
-persistent mounts it is also recommended to add a drive label::
+persistent mounts it is also recommended to add a drive label (max 32 characters)::
 
     - write_file:
-        content: "your_label"
+        content: 'your_label'
         file: $GAMEDIR/CD_CONTENT_DIRECTORY/.windows-label
 
 In some cases a Windows installer might insist on wanting a CD-ROM drive. If that is the
@@ -484,7 +484,7 @@ the corresponding registry key. You can do this using the ``set_regedit`` task::
         name: set_regedit
         path: HKEY_LOCAL_MACHINE\Software\Wine\Drives
         key: 'i:'
-        value: 'cdrom'
+        value: cdrom
 
 Note: If you only create the registry key without creating the symlink, you will
 not see an entry in ``winecfg``. Wine actually checks that there is a symlink with
@@ -505,9 +505,8 @@ a ``$CACHE`` directory) and the registry keys::
         name: delete_registry_key
         key: HKEY_LOCAL_MACHINE\Software\Wine\Drives
 
-Currently it is not easily possible to delete only a single key-value pair (i.e.
-drive). If you created multiple drives and wanted to keep only one, you'll need
-to recreate it (again) after this.
+If at least one drive is required at runtime you can also delete single drives
+using ``set_regedit`` as documented below.
 
 Moving files and directories
 ----------------------------
@@ -780,7 +779,8 @@ Currently, the following tasks are implemented:
     are ``path`` (the registry path, use backslashes), ``key``, ``value``,
     ``type`` (optional value type, default is REG_SZ (string)), ``prefix``
     (optional WINEPREFIX), ``arch``
-    (optional architecture of the prefix).
+    (optional architecture of the prefix). Use the special value ``null`` to
+    delete a single value (as opposed to an entire key with ``delete_registry_key``).
 
     Example::
 


### PR DESCRIPTION
2 small corrections:

* the config path was replaced in 1d40df3cf2eb4d8595eed151c77ccc9a497035ad, but that's not where game config files live (unless that's just because I'm on an older/migrated install?)
* `delete_registry_key` was seemingly a copy-paste mistake and listing unrecognised parameters that would lead to an error

1 new block:

Mounting directories as a drive has been done in various installers now, but there is no documentation on doing it. It's mostly useful when extracting ISOs or when users already copied the data off a disc and have it in a plain directory structure.
Forcing CD-ROM mode is needed by some (weak?) DRMs that check for a "physical" disc instead of a directory structure.
Some stronger DRMs will still refuse to work because they require access to the physical hardware and not just a drive mapping (for reading sectors outside the filesystem), but that is not something we can solve.