### PR TITLE
wine: Allow deleting single registry values

### DIFF
--- a/lutris/installer/commands.py
+++ b/lutris/installer/commands.py
@@ -430,6 +430,8 @@ class CommandsMixin:
 
         for key in data:
             value = data[key]
+            if value is None and task_name == "set_regedit":
+                continue
             if isinstance(value, dict):
                 for inner_key in value:
                     value[inner_key] = self._substitute(value[inner_key])

--- a/lutris/runners/commands/wine.py
+++ b/lutris/runners/commands/wine.py
@@ -38,7 +38,7 @@ if TYPE_CHECKING:
 def set_regedit(
     path,
     key,
-    value="",
+    value,
     type="REG_SZ",  # pylint: disable=redefined-builtin
     wine_path=None,
     prefix=None,
@@ -48,13 +48,18 @@ def set_regedit(
 
     Path is something like HKEY_CURRENT_USER/Software/Wine/Direct3D
     """
-    formatted_value = {
-        "REG_SZ": '"%s"' % value,
-        "REG_DWORD": "dword:" + value,
-        "REG_BINARY": "hex:" + value.replace(" ", ","),
-        "REG_MULTI_SZ": "hex(2):" + value,
-        "REG_EXPAND_SZ": "hex(7):" + value,
-    }
+    # we don't care about the value type when nulling, so just ignore it
+    if value is None:
+        logger.debug("value is Null, using - for value deletion.")
+        formatted_value = {type: "-"}
+    else:
+        formatted_value = {
+            "REG_SZ": '"%s"' % value,
+            "REG_DWORD": "dword:" + value,
+            "REG_BINARY": "hex:" + value.replace(" ", ","),
+            "REG_MULTI_SZ": "hex(2):" + value,
+            "REG_EXPAND_SZ": "hex(7):" + value,
+        }
     # Make temporary reg file
     reg_path = os.path.join(settings.CACHE_DIR, "winekeys.reg")
     with open(reg_path, "w", encoding="utf-8") as reg_file:


### PR DESCRIPTION
Deleting a value in regedit files can be done like this:
```ini
[PATH/TO/KEY]
"ValueName"=-
```

Note this is a literal dash, *not* a string.

Currently due to how tasks are read we cannot have users assign a dash as a value. The most they can do is assign a dash as a string, which doesn't have the same effect. This enables users to explicitly pass `value: null` in the `set_regedit` task, which mirrors the behaviour of a dash in registry files.

Currently NoneType values (resulting from explicit `null`) are replaced by an empty string during substitution. We are introducing an exception for this task here to not inadvertently affect other NoneType values.

* Fixes #6885 